### PR TITLE
dev: login to VM with preset development user account

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ or
 
     result/bin/run-nixos-vm
 
+
+The development username and password are defined in [authentication module](./modules/development/authentication.nix).
+
 Note: this creates nixos.qcow2 copy-on-write overlay disk image in your current directory. If you do unclean shutdown for the QEMU Virtual Machine, you might get weird errors the next time you boot. Simply removing the nixos.qcow2 should be enough. To cleanly shut down the VM, from the menu bar of the QEMU Window, click Machine and then click Power Down.
 
 

--- a/modules/development/authentication.nix
+++ b/modules/development/authentication.nix
@@ -1,0 +1,15 @@
+{pkgs, ...}:
+# account for the development time login with sudo rights
+let
+  user = "ghaf";
+  password = "ghaf";
+in {
+  users = {
+    mutableUsers = true;
+    users."${user}" = {
+      isNormalUser = true;
+      password = password;
+      extraGroups = [ "wheel" ];
+    };
+  };
+}

--- a/targets.nix
+++ b/targets.nix
@@ -8,6 +8,7 @@
     system = "x86_64-linux";
     modules = [
       microvm.nixosModules.host
+      modules/development/authentication.nix
     ];
     format = "vm";
   };


### PR DESCRIPTION
* Default account implemented as module. Easy to remove/harden.
* Tested with: nix build .#packages.x86_64-linux.vm result/bin/run-nixos-vm login with module configured username and password
* Module included only for "x86_64-linux" for now

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>