### PR TITLE
config: introduce host configuration.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ To run the above x86\_64 VM-image inside QEMU:
 
 or
 
-    result/bin/run-nixos-vm
+    result/bin/run-ghaf-host-vm
 
 
 The development username and password are defined in [authentication module](./modules/development/authentication.nix).
 
-Note: this creates nixos.qcow2 copy-on-write overlay disk image in your current directory. If you do unclean shutdown for the QEMU Virtual Machine, you might get weird errors the next time you boot. Simply removing the nixos.qcow2 should be enough. To cleanly shut down the VM, from the menu bar of the QEMU Window, click Machine and then click Power Down.
+Note: this creates ghaf-host.qcow2 copy-on-write overlay disk image in your current directory. If you do unclean shutdown for the QEMU Virtual Machine, you might get weird errors the next time you boot. Simply removing the ghaf-host.qcow2 should be enough. To cleanly shut down the VM, from the menu bar of the QEMU Window, click Machine and then click Power Down.
 
 
 ### NVIDIA Jetson Orin (aarch64)

--- a/configurations/host/configuration.nix
+++ b/configurations/host/configuration.nix
@@ -1,0 +1,5 @@
+{ ... }:
+{
+  networking.hostName = "ghaf-host";
+  system.stateVersion = "22.11";
+}

--- a/targets.nix
+++ b/targets.nix
@@ -8,6 +8,7 @@
     system = "x86_64-linux";
     modules = [
       microvm.nixosModules.host
+      configurations/host/configuration.nix
       modules/development/authentication.nix
     ];
     format = "vm";


### PR DESCRIPTION
* set initial host name to ghaf-host
* fix trace warning with "system.stateVersion"
* update documentation to run the host as VM and clean the qcow2 file

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>