### PR TITLE
doc: update reference implementation

### DIFF
--- a/docs/src/about/overview.md
+++ b/docs/src/about/overview.md
@@ -10,4 +10,5 @@ Embedded virtualization builds on cloud technologies in the development of end-t
 
 ## Reference Implementation
 
-Our work in progress reference implementation on NXP i.MX 8 is available [here](https://github.com/tiiuae/spectrum-config-imx8).
+Ghaf is developing a reference implementation for NVIDIA Jetson devices. See [build instructions](https://github.com/tiiuae/ghaf/#build-instructions) for more info.
+Legacy reference implementation for NXP i.MX8 [is available here](https://github.com/tiiuae/spectrum-config-imx8).


### PR DESCRIPTION
* Reference implementation and link to NVIDIA Jetson with build instructions
* Maintain link to legacy reference - NXP iMX8

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>