### PR TITLE
doc: refactored instructions to ghaf GH pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,74 +2,22 @@
 
 This repository contains the source code of Ghaf Framework — an open-source project for enhancing security through compartmentalization on edge devices.
 
+The documentation is available on Github Pages at https://tiiuae.github.io/ghaf/
+
+See [reference implementations](https://tiiuae.github.io/ghaf/build_config/reference_implementations.html) for supported hardware, features and build instructions.
+
 Other repositories that are a part of the Ghaf project:
 
 * https://github.com/tiiuae/sbomnix
 
-
-## Build Instructions
-
-Ghaf utilizes a flake only approach to build the framework. To see provided outputs, type `nix flake show`.
-
-
-### x86-64
-
-To build the VM-image for x86-64, use:
-
-    nix build .#packages.x86_64-linux.vm
-
-Run the above x86-64 VM-image inside QEMU:
-
-    nix run .#packages.x86_64-linux.vm
-
-or
-
-    result/bin/run-ghaf-host-vm
-
-
-The development username and password are defined in [authentication module](./modules/development/authentication.nix).
-
-> **NOTE:** this creates `ghaf-host.qcow2` copy-on-write overlay disk image in your current directory. If you do unclean shutdown for the QEMU VM, you might get weird errors the next time you boot. Simply removing `ghaf-host.qcow2` should be enough. To cleanly shut down the VM, from the menu bar of the QEMU Window, click Machine and then click Power Down.
-
-
-### NVIDIA Jetson Orin (AArch64)
-
-To build for the NVIDIA Jetson Orin, use:
-
-    nix build .#packages.aarch64-linux.nvidia-jetson-orin
-
-Flash the resulting `image eg.` to an SD card or USB drive:
-
-    dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M
-
-If you set up development SSH keys into [SSH module](modules/development/ssh.nix), you can use `nixos-rebuild switch` to quickly deploy your configuration changes to the development board over the network using SSH:
-
-    nixos-rebuild --flake .#nvidia-jetson-orin --target-host root@orin-hostname --fast switch
-
-
-### Cross Compilation Complications
-
-As there are some packages that are not cross-compilation aware, set the following in your `configuration.nix` to enable binfmt:
-
-    {
-      boot.binfmt.emulatedSystems = [
-        "riscv64-linux"
-        "aarch64-linux"
-      ];
-    }
-
-For more details, see [Cross Compilation](https://tiiuae.github.io/ghaf/build_config/cross_compilation.html).
-
-
 ### Documentation
 
-This is a source repository for https://tiiuae.github.io/ghaf. 
+The `docs`-folder of this repository is used to generate the documentation site at https://tiiuae.github.io/ghaf
 
 To build the Ghaf documentation, use:
 
     nix build .#doc
     
-  
 See the documentation overview under [docs](./docs/README.md).
 
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
     - [Decision Record](architecture/adr.md)
 - [Technologies](technologies/technologies.md)
 - [Build Configurations](build_config/build_configurations.md)
+    - [Reference Implementations](build_config/reference_implementations.md)
     - [Cross Compilation](build_config/cross_compilation.md)
 - [Supply Chain Security](scs/scs.md)
     - [SLSA Framework](scs/slsa-framework.md)

--- a/docs/src/build_config/build_configurations.md
+++ b/docs/src/build_config/build_configurations.md
@@ -2,11 +2,11 @@
 
 Our hardened operating system (OS) targets are build configurations based on NixOS. The canonical URL for the upstream git repository is: [https://github.com/NixOS](https://github.com/NixOS).
 
-Build configurations define our dependencies and configuration changes to packages and build mechanisms of NixOS. If you want to try and check the details, see the [build-configurations](https://github.com/tiiuae/build-configurations/) repository.
+Build configurations define our dependencies and configuration changes to packages and build mechanisms of NixOS. If you want to try, see the [reference implementations](../build_config/reference_implementations.md).
 
 ## Approach
 
-A build configuration is a target to build our hardened OS for a particular hardware device. The supported development target devices are listed in [build-configurations](https://github.com/tiiuae/build-configurations/). The packages used in a build configuration come from [nixpkgs - NixOS Packages collection](https://github.com/NixOS/nixpkgs).
+A build configuration is a target to build our hardened OS for a particular hardware device. Most packages used in a build configuration come from [nixpkgs - NixOS Packages collection](https://github.com/NixOS/nixpkgs).
 
 The upstream first approach means we aim the fix issues by contributing to nixpkgs. At the same time, we get the maintenance support of NixOS community and the benefits of the Nix language on how to build packages and track the origins of packages in the software supply chain security. For more information, see [Supply Chain Security](scs/scs.md).
 

--- a/docs/src/build_config/reference_implementations.md
+++ b/docs/src/build_config/reference_implementations.md
@@ -1,0 +1,56 @@
+# Reference Implementations
+
+## Supported targets
+
+| Hardware         | Architecture     | Scope         |
+|---               |---               |---            |
+| Generic Intel    | x86              | QEMU          |
+| NVIDIA Orin AGX  | aarch64          | hardware      |
+
+Scope of target support is updated with development progress.
+
+## Build Instructions
+
+Ghaf uses a Nix flake only approach to build the framework targets.
+
+See [Nix installation instructions](https://nixos.org/download.html) for further details.
+Make also sure to [enable flakes](https://nixos.wiki/wiki/Flakes#Enable_flakes).
+
+| Hardware         | architecture     | scope | build command                                           |
+|---               |---               |---    |---                                                      |
+| Generic Intel    | x86              | VM    | `nix build .#packages.x86_64-linux.vm`                  |
+| NVIDIA Orin AGX  | aarch64          | HW    | `nix build .#packages.aarch64-linux.nvidia-jetson-orin` |
+
+To see all Ghaf supported outputs, type `nix flake show`.
+
+## Run Instructions
+
+The development username and password are defined in [authentication module](./modules/development/authentication.nix).
+
+### Virtual machine - ghaf-host
+
+`nix run .#packages.x86_64-linux.vm`
+
+> **NOTE:** this creates `ghaf-host.qcow2` copy-on-write overlay disk image in your current directory. If you do unclean shutdown for the QEMU VM, you might get weird errors the next time you boot. Simply removing `ghaf-host.qcow2` should be enough. To cleanly shut down the VM, from the menu bar of the QEMU Window, click Machine and then click Power Down.
+
+### NVIDIA Jetson Orin AGX
+
+* Prequisite (firmware version): [Update the NVIDIA Jetson Orin AGX UEFI firmware to version r35.1 to boot from USB](https://github.com/mikatammi/jetpack-nixos/tree/flash_orin_hack#hack-for-flashing-nvidia-jetson-orin)
+* Prequisite (cross-compilation support): `binfmt` and NixOS is required.
+  * Enable `binfmt` in your `configuration.nix` with:
+    ```
+    boot.binfmt.emulatedSystems = [
+      "aarch64-linux"
+    ];
+    ```
+  * For more details, see [Cross Compilation](https://tiiuae.github.io/ghaf/build_config/cross_compilation.html).
+* Prepare the USB boot media with the target HW image you built:
+  * `dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M`
+* Boot the hardware from USB media
+
+
+## Development tips
+
+If you set up development SSH keys into [SSH module](https://github.com/tiiuae/ghaf/blob/main/modules/development/ssh.nix#L4), you can use `nixos-rebuild switch` to quickly deploy your configuration changes to the development board over the network using SSH:
+
+    nixos-rebuild --flake .#nvidia-jetson-orin --target-host root@orin-hostname --fast switch


### PR DESCRIPTION
* Main motivation is to ensure the relevant instructions are kept up-to-date with other system documentation instead of maintaining README outside of GH Pages
* Reference implementations added and structured based on testing with NVIDIA Orin AGX. This content is mainly from the old README.md Added prequisities with NVIDIA Orin AGX.

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>