### PR TITLE
dev: enable nix configuration as module

### DIFF
--- a/modules/development/nix.nix
+++ b/modules/development/nix.nix
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache 2.0
+{ ... }:
+{
+  nix.extraOptions = ''
+    experimental-features = nix-command flakes
+    keep-outputs          = true
+    keep-derivations      = true
+    '';
+}
+

--- a/targets/nvidia-jetson-orin.nix
+++ b/targets/nvidia-jetson-orin.nix
@@ -9,7 +9,11 @@
 
     microvm.nixosModules.host
     ../configurations/host/configuration.nix
+
+   #### on-host development supporting modules ####
+   # drop/replace modules below this line for any real use
     ../modules/development/authentication.nix
     ../modules/development/ssh.nix
+    ../modules/development/nix.nix
   ];
 }


### PR DESCRIPTION
* import and configure as module
* enables flakes and nix-command to build ghaf image on host. NVIDIA Orin AGX is powerful after all.

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>