### PR TITLE
host: support nested virtualization on x86 vm

### DIFF
--- a/targets/default.nix
+++ b/targets/default.nix
@@ -8,6 +8,10 @@
     system = "x86_64-linux";
     modules = [
       microvm.nixosModules.host
+      # .microvm for vm-format "host" to nest vms for system development on x86 (Intel)
+      # NOTE: Ghaf nested virtualization is not assumed nor tested yet on AMD
+      microvm.nixosModules.microvm
+
       ../configurations/host/configuration.nix
       ../modules/development/authentication.nix
       ../modules/development/ssh.nix


### PR DESCRIPTION
* requires vnclient to access the host - ::5900
* includes microvm and it's default VMMs to "host" VM
* enables microvm.nix defined guest VMs

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>