### PR TITLE
Add nuc and remove vm from hydra builds

### DIFF
--- a/hydrajobs.nix
+++ b/hydrajobs.nix
@@ -1,6 +1,6 @@
 {self}: {
   hydraJobs = {
-    vm.x86_64-linux = self.packages.x86_64-linux.vm;
+    intel-nuc.x86_64-linux = self.packages.x86_64-linux.intel-nuc;
     nvidia-jetson-orin.aarch64-linux = self.packages.aarch64-linux.nvidia-jetson-orin;
   };
 }


### PR DESCRIPTION
Nuc build is needed for CI automatic testing.
VM is pretty unnecessary at least in it's current form for CI.

Signed-off-by: Tero Tervala <tero.tervala@unikie.com>