### PR TITLE
x86-nuc: enable flakes via nix-module

### DIFF
--- a/targets/default.nix
+++ b/targets/default.nix
@@ -25,6 +25,7 @@
       microvm.nixosModules.host
       ../configurations/host/configuration.nix
       ../modules/development/intel-nuc-getty.nix
+      ../modules/development/nix.nix
       ../modules/development/authentication.nix
       ../modules/development/ssh.nix
     ];


### PR DESCRIPTION
* enables use of microvm.nix

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>