### PR TITLE
nvidia-jetson-orin: GICv3 devicetree patch

### DIFF
--- a/modules/hardware/nvidia-jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin.nix
@@ -5,4 +5,17 @@
     carrierBoard = "devkit";
     modesetting.enable = true;
   };
+
+  boot.kernelPatches = [
+    # TODO: Remove when this patch gets merged to mainline.
+    #       Patch to devicetree for getting rust-vmm based VMMs to work on
+    #       NVIDIA Jetson Orin.
+    {
+      name = "gicv3-patch";
+      patch = pkgs.fetchpatch {
+        url = "https://github.com/OE4T/linux-tegra-5.10/commit/9ca6e31d17782e0cf5249eb59f71dcd7d8903303.patch";
+	sha256 = "sha256-PzEQO6Jh/kkoGu329LCYdhdR8mNmo6KGKKVKOeMRZrI=";
+      };
+    }
+  ];
 }


### PR DESCRIPTION
Patch to NVIDIA Tegra kernel's devicetree to make rustvmm-based hypervisors work on NVIDIA Jetson Orin hardware

Signed-off-by: Mika Tammi <mika.tammi@unikie.com>