### PR TITLE
Revert "host: support nested virtualization on x86 vm"

### DIFF
--- a/targets/default.nix
+++ b/targets/default.nix
@@ -8,10 +8,6 @@
     system = "x86_64-linux";
     modules = [
       microvm.nixosModules.host
-      # .microvm for vm-format "host" to nest vms for system development on x86 (Intel)
-      # NOTE: Ghaf nested virtualization is not assumed nor tested yet on AMD
-      microvm.nixosModules.microvm
-
       ../configurations/host/configuration.nix
       ../modules/development/authentication.nix
       ../modules/development/ssh.nix


### PR DESCRIPTION
- Based on Mika's comment at: https://github.com/tiiuae/ghaf/pull/53#discussion_r1083911627

This reverts commit 5ce1cfd9f49caf8dd5719d2a3aeaa96c3ccb288f.

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>