### PR TITLE
Doc: update nvidia_agx_pt_uart.md

### DIFF
--- a/docs/src/build_config/passthrough/nvidia_agx_pt_uart.md
+++ b/docs/src/build_config/passthrough/nvidia_agx_pt_uart.md
@@ -105,19 +105,18 @@ To this device tree add the passthrough devices inside the platform node:
 ```cpp
 	platform@c000000 {
 		interrupt-parent = <0x8001>;
-		ranges = <0x00 0x00 0xc000000 0x2000000>;
+		ranges = <0xc000000 0x00 0xc000000 0x2000000>;
 		#address-cells = <0x01>;
 		#size-cells = <0x01>;
 		compatible = "qemu,platform\0simple-bus";
 
 		uarti: serial@c000000 {
-			compatible = "arm,sbsa-uart";
-			current-speed = <0x1c200>;
-			interrupts = <0x00 0x70 0x04>;
-			reg = <0x00 0x0c000000 0x00 0x10000>;
-			status = "okay";
-		};
-
+		    compatible = "arm,sbsa-uart";
+		    current-speed = <0x1c200>;
+		    interrupts = <0x00 0x70 0x04>;
+		    reg = <0x0c000000 0x10000>;
+		    status = "okay";
+        	};
 	};
 ```
 
@@ -152,10 +151,10 @@ Then run the Guest VM with the following QEMU command:
         -kernel Image \
         -drive file=focal-server-cloudimg-arm64.raw,if=virtio,format=raw \
         -device vfio-platform,host=31d0000.serial\
-        -dtb ./DTB/uart.dtb \
-        -append "rootwait root=/dev/vda1 console=ttyAMA0 init=/bin/bash"
+        -dtb uart.dtb \
+        -append "rootwait root=/dev/vda1 console=ttyAMA0"
 
-After the Guest VM is launched you can see the VM Linux command on the opened
+After the Guest VM is launched you can see the VM Linux command line on the opened
 ttyACM1 terminal. 
 
 

--- a/docs/src/build_config/passthrough/nvidia_agx_pt_uart.md
+++ b/docs/src/build_config/passthrough/nvidia_agx_pt_uart.md
@@ -26,7 +26,7 @@ the last column describes where the UART units are connected to the exterior.
 
 | **Device tree def.**  |  **CPU pin** | **SoC pin** | **Connected to**            |
 |-----------------------|:------------:|:-----------:|-----------------------------|
-| uarta: serial@310000  |     UART1    |    UART1    | 40 pin header 3v3           |
+| uarta: serial@3100000 |     UART1    |    UART1    | 40 pin header 3v3           |
 | uartb: serial@3110000 |     UART2    |    UART5    | M.2 key E (WiFi card)       |
 | uartc: serial@c280000 |     UART3    |    UART3    | USB Debug ttyACM0           |
 | uartd: serial@3130000 |     UART4    |    UART4    | Camera connector            |
@@ -154,7 +154,7 @@ Then run the Guest VM with the following QEMU command:
         -dtb uart.dtb \
         -append "rootwait root=/dev/vda1 console=ttyAMA0"
 
-After the Guest VM is launched you can see the VM Linux command line on the opened
+After the Guest VM is launched you can see the VM Linux command line in the opened
 ttyACM1 terminal. 
 
 


### PR DESCRIPTION
Fix the platform@c000000 ranges, and fix serial@c000000 reg  cells size to 1. Without this fix, the VM was not able to load the virtio disk (vda1), because serial@c000000 registers where  overlapping.