### PR TITLE
netvm: basic structure to include the netvm to ghaf

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,21 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "jetpack-nixos": {
       "inputs": {
         "nixpkgs": [
@@ -58,6 +73,48 @@
         "type": "github"
       }
     },
+    "microvm_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "netvm",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1674747738,
+        "narHash": "sha256-FSaBkfXiKo6jdvjUx/SJhM/+h+QQIxFu7cCXs8uxZ6Q=",
+        "owner": "astro",
+        "repo": "microvm.nix",
+        "rev": "0a3d48e06b8c04beb3de0a3283bd1ef29fe4a47d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "astro",
+        "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
+    "netvm": {
+      "inputs": {
+        "microvm": "microvm_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1675150367,
+        "narHash": "sha256-d9Fs4LyXjpEvA7WVYJnDavoqoHXqh8jchGTyoh8JG2c=",
+        "owner": "tiiuae",
+        "repo": "netvm",
+        "rev": "b7103ce47b17cd61403b459e72839f38d68204f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "repo": "netvm",
+        "rev": "b7103ce47b17cd61403b459e72839f38d68204f7",
+        "type": "github"
+      }
+    },
     "nixlib": {
       "locked": {
         "lastModified": 1636849918,
@@ -96,6 +153,20 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1675123384,
+        "narHash": "sha256-RpU+kboEWlIYwbRMGIPBIcztH63CvmqWN1B8GpJogd4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e0fa1ece2f3929726c9b98c539ad14b63ae8e4fd",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1672353432,
         "narHash": "sha256-oZfgp/44/o2tWiylV30cR+DLyWTJ+5dhsdWZVpzs3e4=",
         "owner": "nixos",
@@ -115,8 +186,9 @@
         "flake-utils": "flake-utils",
         "jetpack-nixos": "jetpack-nixos",
         "microvm": "microvm",
+        "netvm": "netvm",
         "nixos-generators": "nixos-generators",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,12 @@
       url = "github:anduril/jetpack-nixos";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # ghaf reference guest virtual machines
+    # - optionally ghaf can be composed of virtual machines from the same repo with dir
+    # that defines the subdirectory
+    netvm = {
+      url = "github:tiiuae/netvm?rev=b7103ce47b17cd61403b459e72839f38d68204f7";
+    };
   };
 
   outputs =
@@ -37,6 +43,7 @@
     , nixos-generators
     , microvm
     , jetpack-nixos
+    , netvm
     ,
     }:
     let
@@ -78,7 +85,7 @@
       }
 
       # Final target images
-      (import ./targets {inherit self nixos-generators microvm jetpack-nixos;})
+      (import ./targets {inherit self nixos-generators microvm jetpack-nixos netvm;})
 
       # Hydra jobs
       (import ./hydrajobs.nix {inherit self;})


### PR DESCRIPTION
- declaration of the netvm using flake
  - optionally could be in-tree flake in subdir with dir
- netvm passed to the targets but not used (yet)
- structure update tested to build with x86 target

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>