### PR TITLE
nvidia-jetson-orin: Remove GICv3 devicetree patch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671668030,
-        "narHash": "sha256-kmWOB3n+Rt1vRh4Qs4spm6+F0Gl2CuyrTmgowEe8jUs=",
+        "lastModified": 1675319214,
+        "narHash": "sha256-KwxTLLM6Ljnep9tMI4uYL1fYKkF7bq3GS1ctANppZQg=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "0545d8f84152421fc7dcf59678a78b8b8306d5e5",
+        "rev": "108dead5c59ae0cc9a6ad5729f1b4c71ce0e37b8",
         "type": "github"
       },
       "original": {

--- a/modules/hardware/nvidia-jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin.nix
@@ -5,17 +5,4 @@
     carrierBoard = "devkit";
     modesetting.enable = true;
   };
-
-  boot.kernelPatches = [
-    # TODO: Remove when this patch gets merged to mainline.
-    #       Patch to devicetree for getting rust-vmm based VMMs to work on
-    #       NVIDIA Jetson Orin.
-    {
-      name = "gicv3-patch";
-      patch = pkgs.fetchpatch {
-        url = "https://github.com/OE4T/linux-tegra-5.10/commit/9ca6e31d17782e0cf5249eb59f71dcd7d8903303.patch";
-	sha256 = "sha256-PzEQO6Jh/kkoGu329LCYdhdR8mNmo6KGKKVKOeMRZrI=";
-      };
-    }
-  ];
 }


### PR DESCRIPTION
* Bump jetpack-nixos version in flake.lock
* The GICv3 patch is now part of the kernel that is included from jetpack-nixos, so just drop the patch

Signed-off-by: Mika Tammi <mika.tammi@unikie.com>