### PR TITLE
flake.nix: Fix extra-trusted-substituters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Ghaf - Documentation and implementation for TII SSRC Secure Technologies Ghaf Framework";
 
   nixConfig = {
-    extra-substituters = [
+    extra-trusted-substituters = [
       "https://cache.vedenemo.dev"
       "https://cache.ssrcdevops.tii.ae"
     ];


### PR DESCRIPTION
The attribute that should be used is extra-trusted-substituters, not extra-subtituters

Signed-off-by: Mika Tammi <mika.tammi@unikie.com>