### PR TITLE
Docs: update glossary, add shields (badges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TII SSRC Secure Technologies: Ghaf Framework
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC_BY--SA_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0/)
+
 This repository contains the source files (code and documentation) of Ghaf Framework — an open-source project for enhancing security through compartmentalization on edge devices.
 
 For inforamtion on build instructions and supported hardware, see the [Reference Implementations](https://tiiuae.github.io/ghaf/build_config/reference_implementations.html) section of the Ghaf documentation.
@@ -29,4 +31,6 @@ If you find any bugs or errors in the content, feel free just to create an [issu
 
 ## License
 
-Ghaf is made available under the Apache License, Version 2.0. See [LICENSE](./LICENSE) for the full license text.
+Ghaf source code is made available under the Apache License, Version 2.0 (Apache-2.0). See [LICENSE](./LICENSE) for the full license text.
+
+Ghaf documentation is licensed under Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,14 @@
 # Working with Documentation
 
+[![Style Guide](https://img.shields.io/badge/docs-Style%20Guide-blueviolet)](https://github.com/tiiuae/ghaf/blob/main/docs/style_guide.md)
+
 This guidelines provide information on wotking with source files. For information on manual of style recommended practices, see [Documentation Style Guide](./style_guide.md).
 
 - [Working with Documentation](#working-with-documentation)
   - [Directory Structure](#directory-structure)
   - [Adding New Files](#adding-new-files)
     - [Naming](#naming)
+  - [Managing Content](#managing-content)
   - [Contributing](#contributing)
 
 Please note that improvements to the documentation are welcome.
@@ -95,6 +98,23 @@ Make sure you are following the file/image naming rules:
 * Use meaningful abbreviations. The file/image names should be as short as possible while retaining enough meaning to make them identifiable.
 
 
+## Managing Content
+
+Use paragraphs to organize information in chapters, sections, and subsections.
+
+To help others browse through content more effectively and make your topics clearer, follow the next guidelines:
+
+* One idea per paragraph.
+* Keep the number of sentences in each paragraph between 3 and 5. 
+* The first two paragraphs in each topic must state the most important information.
+
+Build each topic based on the following structure:
+* First paragraph. Introduction, main idea. [1-2 paragraphs]
+* Develop the idea, add details. [1 paragraph]
+* More information, less important. [optional, 1 paragraph]
+* Conclusion. Transition to the next paragraph. [1-2 sentences]
+
+  
 ## Contributing
 
 If you would like to contribute, please read [CONTRIBUTING.md](../CONTRIBUTING.md) and consider opening a pull request. One or more maintainers will use GitHub's review feature to review your pull request.

--- a/docs/src/appendices/glossary.md
+++ b/docs/src/appendices/glossary.md
@@ -37,56 +37,167 @@ Wikipedia is not a dictionary.
 ### Ghaf
 
 _The project code name that represents the Ghaf tree._  
-Source: [https://connectwithnature.ae/knowledge-hub/ghaf-tree](https://connectwithnature.ae/knowledge-hub/ghaf-tree)
+Source: <https://connectwithnature.ae/knowledge-hub/ghaf-tree>
 
 ### SSRC
 
 _Secure Systems Research Center is a global center of excellence in the development of end-to-end security and resilience for cyber-physical and autonomous systems. SSRC is a part of TII._  
-Source: [https://www.tii.ae/secure-systems](https://www.tii.ae/secure-systems)
+Source: <https://www.tii.ae/secure-systems>
 
 ### TII
 
 _Technology Innovation Institute is a UAE-based research center that aims to lead global advances in artificial intelligence, autonomous robotics, quantum computing, cryptography and quantum communications, directed energy, secure communication, smart devices, advanced materials, and propulsion and space technologies._  
-Source: [https://www.tii.ae/](https://www.tii.ae/)
+Source: <https://www.tii.ae/>
 
 ## Core Concepts
+
+### ADR
+
+_An Architecture Decision (AD) is a justified software design choice that addresses a functional or non-functional requirement that is architecturally significant. An Architectural Decision Record (ADR) captures a single AD and its rationale; the collection of ADRs created and maintained in a project constitute its decision log._  
+Source: <https://adr.github.io/>
+
+### BSP
+
+_A board support package is a collection of software used to boot and run the embedded system._
+
+### DMA
+
+_A direct memory access is a process in which data may be moved directly to or from the main memory of a computer system by operations not under the control of the central processing unit._  
+Source: <https://www.collinsdictionary.com/dictionary/english/direct-memory-access>
+
+### EULA
+
+_end-user license agreement_
+
+### KVM
+
+_Kernel-based Virtual Machine, an open-source virtualization technology built into Linux._
+
+### KVMS
+
+_Kernel-based Virtual Machine Secured, an open-source project._  
+Source: <https://github.com/jkrh/kvms>
+
+### MMU
+
+_memory management unit_
+
+### NixOS
+
+_A Linux distribution based on the Nix package manager and build system._  
+Source: <https://nixos.wiki/wiki/Overview_of_the_NixOS_Linux_distribution>
+
+### OS
+
+_operating system_
+
+### QEMU
+
+_A generic and open source machine emulator and virtualizer._  
+Source: <https://www.qemu.org/docs/master/about/index.html>
 
 ### TCB
 
 _Trusted computing base defines the security requirements by providing separation of users and data or resources._  
 Source: [Department of Defense trusted computer system evaluation criteria, DoD 5200.28-STD, 1985.](https://csrc.nist.gov/csrc/media/publications/conference-paper/1998/10/08/proceedings-of-the-21st-nissc-1998/documents/early-cs-papers/dod85.pdf)
 
-* VM — virtual machine
-* app — application
-* OS — operating system
-* ADR — [Architecture Decision Record](https://adr.github.io/)
-* KVM — Kernel-based Virtual Machine is an open-source virtualization technology built into Linux.
-* KVMS — [Kernel-based Virtual Machine Secured](https://github.com/jkrh/kvms) is an open-source project.
-* VMM — Virtual Machine Manager
-* MMU — memory management unit
-* DMA — direct memory access
-* Spectrum 
-* NixOS
-* hardened OS
-* QEMU
-* BSP — board support package
-* EULA — end-user license agreement
-* UI — user interface
-* TLS
+### TLS
+
+_Transport Layer Security, a security protocol._
+
+### UI
+
+_user interface_
+
+### VM
+
+_virtual machine_
+
+### VMM
+
+_Virtual Machine Manager_
+
+
+## Build Configurations Related
+
+### UART
+
+_An universal asynchronous receiver-transmitter, a hardware communication protocol._
+
+### SoC
+
+_A system on chip, a microchip that contains the necessary electronic circuits for a fully functional system on a single integrated circuit (IC)._
+
+### SBSA
+
+_The Server Base System Architecture specifies a hardware system architecture, based on Arm 64-bit architecture, that server system software, for example operating systems, hypervisors, and firmware can rely on._  
+Source: [Arm® Server Base System Architecture 7.1 Platform Design Document](https://developer.arm.com/documentation/den0029/latest)
+
+### ISA
+
+_An Instruction Set Architecture is part of the abstract model of a computer that defines how the CPU is controlled by the software._  
+Source: <https://www.arm.com/glossary/isa>
+
 
 ## SCS Related
 
-* SCS — supply chain security
-* SBOM — software bill of materials
-* PKI — public key infrastructure
-* CA — certificate authority
-* RA — registration authority
-* SLSA — [Supply chain Levels for Software Artifacts](https://slsa.dev/)
-* PyNaCl
-* EdDSA
-* GPG
-* CMS — Certificate Management System
-* OpenSSL
-* HSM — hardware security module
-* secure cryptoprocessor
-* software artifact
+### CA
+
+_certificate authority_
+
+### CMS
+
+_Certificate Management System_
+
+### EdDSA
+
+_Edwards-curve Digital Signature Algorithm_
+
+### GPG
+
+_The GNU Privacy Guard (also GnuPG) is a complete and free implementation of the OpenPGP standard as defined by RFC4880._  
+Source: <https://gnupg.org/>
+
+### HSM
+
+_A hardware security module is a crypto processor designed for the crypto key lifecycle protection._
+
+### OpenSSL
+
+_Cryptography and SSL/TLS Toolkit._  
+Source: <https://www.openssl.org/>
+
+### PKI
+
+_A public key infrastructure is the framework of encryption and cybersecurity._
+
+### PyNaCl
+
+_A Python binding to libsodium, which is a fork of the Networking and Cryptography library._  
+Source: <https://pypi.org/project/PyNaCl/>
+
+### RA
+
+_registration authority_
+
+### SBOM
+
+_A software bill of materials is a machine-readable documentan of all software components, open source licenses, and dependencies in a target software._
+
+### SCS
+
+_A supply chain security is a process of securing the machinery of the development, building, and release environment._
+
+### secure cryptoprocessor
+
+_A security chip that performs encryption and decryption operations._
+
+### software artifact
+
+_An immutable blob of data; primarily refers to software, but SLSA can be used for any artifact._  
+Source: <https://slsa.dev/spec/v0.1/terminology>
+
+### SLSA
+
+_Supply chain Levels for Software Artifacts is a security framework, a check-list of standards and controls to prevent tampering, improve integrity, and secure packages and infrastructure in your projects, businesses or enterprises._  
+Source: <https://slsa.dev/>

--- a/docs/src/build_config/build_configurations.md
+++ b/docs/src/build_config/build_configurations.md
@@ -26,3 +26,11 @@ To support a reference board without a vendor board support package (BSP) — bo
 Often the vendor BSPs are also open source but sometimes contain unfree binary blobs from the vendor's hardware. Those are handled by allowing ``unfree`` - if the user agrees with the end-user license agreement (EULA). If not, ``unfree`` support can be dropped along with that part of the BSP support.
 
 The same goes with the architectural variants as headless devices or end-user devices differ in terms what kind of virtual machines (VM) they contain. The user needs graphics architecture and VM support for the user interface (UI) whereas a headless device is more like a small server without the UI.
+
+
+## In This Chapter
+
+- [Reference Implementations](../build_config/reference_implementations.md)
+- [Cross Compilation](../build_config/cross_compilation.md)
+- [Devices Passthrough](../build_config/passthrough/passthrough.md)
+  - [NVIDIA Jetson AGX Orin: UART Passthrough](../build_config/passthrough/nvidia_agx_pt_uart.md)

--- a/docs/src/build_config/passthrough/nvidia_agx_pt_uart.md
+++ b/docs/src/build_config/passthrough/nvidia_agx_pt_uart.md
@@ -1,6 +1,6 @@
-# Nvidia Jetson AGX Orin - UART Passthrough
+# NVIDIA Jetson AGX Orin: UART Passthrough
 
-This document describes the UART passthrough implementations on the Nvidia Jetson 
+This document describes the UART passthrough implementations on the NVIDIA Jetson 
 AGX Orin board. The goal of this document is to guide more complex devices 
 passthrough implementations.
 
@@ -134,7 +134,7 @@ the following commands:
     echo vfio-platform > /sys/bus/platform/devices/31d0000.serial/driver_override
     echo 31d0000.serial > /sys/bus/platform/drivers/vfio-platform/bind
 
-Before start the Guest VM, connect the Nvidia Jetson AGX Orin Debug USB to your PC, and 
+Before start the Guest VM, connect the NVIDIA Jetson AGX Orin Debug USB to your PC, and 
 open the serial port ttyACM1 at 115200 bps. You can use picocom with the next
 command:
 

--- a/docs/src/build_config/passthrough/passthrough.md
+++ b/docs/src/build_config/passthrough/passthrough.md
@@ -1,9 +1,8 @@
+# Devices Passthrough
+
 Devices passthrough to virtual machines (VM) allows us to isolate the device drivers 
-and their memory access in one or several VMs. This reduces the Trusted Code Base (TCB) 
-in the host, due to the passed-through device drivers can be removed completely
+and their memory access in one or several VMs. This reduces the Trusted Code Base (TCB) in the host, due to the passed-through device drivers can be removed completely
 from the host kernel.
 
-
-Next, we describe the current supported passthrough devices implementations:
-
+Our current supported passthrough devices implementations:
 - [Nvidia AGX Orin - UART Passthrough](nvidia_agx_pt_uart.md)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,12 @@
 # TII SSRC Secure Technologies: Ghaf Framework
 
-Secure Tech-project studies secure technologies in the context of embedded virtualization. This documentation-project, named after Ghaf tree, provides a landing site to our work. Our applied software research supports [Secure Systems Research Center](https://www.tii.ae/secure-systems) focus areas.
+_[Ghaf](./appendices/glossary.md#ghaf) Framework_ is an open-source project that provides information about our work and studies in the security technologies field in the context of embedded virtualization.
+
+The applied software research supports _[Secure Systems Research Center](./appendices/glossary.md#ssrc)_ focus areas.
 
 ## Embedded Virtualization
 
-Embedded virtualization builds on cloud technologies in the development of end-to-end security. With hardware support for virtualization, we provide hardened system of small trusted computing base (TCB) - thin host - that enables isolation of use cases and their resources. Use cases are protected in guest virtual machines. Embedded targets small devices - personal or headless - instead of high performance cloud servers. Our scope is illustrated in the following diagram.
+Embedded virtualization builds on cloud technologies in the development of end-to-end security. With hardware support for virtualization, we provide a hardened system of a small _[trusted computing base (TCB)](./appendices/glossary.md#tcb)_ — thin host — that enables isolation of use cases and their resources. Use cases are protected in guest virtual machines (VMs). Embedded targets are small devices (personal or headless) instead of high-performance cloud servers. Our scope is illustrated in the following diagram.
 
 ![Scope!](img/overview.png "Embedded Virtualization Scope")
 

--- a/docs/src/scs/scs.md
+++ b/docs/src/scs/scs.md
@@ -6,7 +6,7 @@ To be aware of what is exactly in our software supply chain, it is reviewed for 
 
 We implement a _supply chain security (SCS)_ — process of securing the machinery of the development, building, and release environment. That means that every component that a software artifact might be touching on its way from the developer to the consumer will be secured.
 
-The software artifact should be encrypted on each possible transition phase and its integrity should be verified at each destination. Each build should be accompanied by means of [_software bill of materials (SBOM)_](https://fossa.com/blog/software-bill-of-materials-formats-use-cases-tools/), identifying all the components that the software package consists of.
+The software artifact should be encrypted on each possible transition phase and its integrity should be verified at each destination. Each build should be accompanied by means of [_software bill of materials (SBOM)_](../appendices/glossary.md#sbom), identifying all the components that the software package consists of.
 
 SBOM containing reference to each dependency, its source and version together with provenance, containing build information are collected at the build time, signed, and used for vulnerability analysis during the next steps.
 

--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -5,7 +5,6 @@ Here you can find the standards we follow for writing, formatting, and organizin
 Writing guidelines:
 - [Documentation Style Guide](#documentation-style-guide)
   - [(WIP) Markdown Syntax](#wip-markdown-syntax)
-  - [Managing Content](#managing-content)
   - [Headings](#headings)
   - [Plain English](#plain-english)
   - [Spelling and Punctuation](#spelling-and-punctuation)
@@ -27,23 +26,6 @@ To make Markdown files maintainable over time and across teams, please follow th
 * Lists
 * Images
 * Tables
-
-
-## Managing Content
-
-Use paragraphs to organize information in chapters, sections, and subsections.
-
-To help others browse through content more effectively and make your topics clearer, follow the next guidelines:
-
-* One idea per paragraph.
-* Keep the number of sentences in each paragraph between 3 and 5. 
-* The first two paragraphs in each topic must state the most important information.
-
-Build each topic based on the following structure:
-* First paragraph. Introduction, main idea. [1-2 paragraphs]
-* Develop the idea, add details. [1 paragraph]
-* More information, less important. [optional, 1 paragraph]
-* Conclusion. Transition to the next paragraph. [1-2 sentences]
 
 
 ## Headings


### PR DESCRIPTION
Made terms in the glossary in alphabetical order,
changed some links to terms in the glossary in a test mode.

Shields or badges are used in Markdown as cool link substitutes, another kind of label.

Signed-off-by: Jenni Nikolaenko <evgeniia.nikolaenko@unikie.com>