### PR TITLE
Enable NixOS firewall on NVIDIA Jetson Orin

### DIFF
--- a/modules/hardware/nvidia-jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin.nix
@@ -9,7 +9,4 @@
     carrierBoard = "devkit";
     modesetting.enable = true;
   };
-
-  # TODO: rpfilter module missing from kernel
-  networking.firewall.enable = false;
 }


### PR DESCRIPTION
Enabling systemd-networkd probably caused right kernel modules to get laoded, so that the NixOS firewall started working

Signed-off-by: Mika Tammi <mika.tammi@unikie.com>