### PR TITLE
Passthrough NVIDIA Jetson AGX Orin WiFi card to NetVM

### DIFF
--- a/microvmConfigurations/netvm/default.nix
+++ b/microvmConfigurations/netvm/default.nix
@@ -23,7 +23,8 @@ nixpkgs.lib.nixosSystem {
       # For WLAN firmwares
       hardware.enableRedistributableFirmware = true;
 
-      microvm.hypervisor = "crosvm";
+      # TODO: change back to crosvm after tested working
+      microvm.hypervisor = "qemu";
 
       networking.enableIPv6 = false;
       networking.interfaces.eth0.useDHCP = true;
@@ -39,16 +40,12 @@ nixpkgs.lib.nixosSystem {
       #     path = "vendorid=0x050d,productid=0x2103";
       #   }
       # ];
-      # microvm.devices = [
-      #   {
-      #     bus = "pci";
-      #     path = "0001:00:00.0";
-      #   }
-      #   {
-      #     bus = "pci";
-      #     path = "0001:01:00.0";
-      #   }
-      # ];
+      microvm.devices = [
+        {
+          bus = "pci";
+          path = "0001:01:00.0";
+        }
+      ];
 
       # TODO: Move to user specified module - depending on the use x86_64
       #       laptop pci path

--- a/modules/hardware/nvidia-jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin.nix
@@ -1,6 +1,6 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{...}: {
+{config, ...}: {
   hardware.nvidia-jetpack = {
     enable = true;
     som = "orin-agx";
@@ -10,8 +10,19 @@
 
   nixpkgs.hostPlatform.system = "aarch64-linux";
 
-  boot.loader = {
-    efi.canTouchEfiVariables = true;
-    systemd-boot.enable = true;
+  hardware.deviceTree = {
+    enable = true;
+    name = "tegra234-p3701-0000-p3737-0000.dtb";
+  };
+
+  boot.loader.efi.canTouchEfiVariables = true;
+  boot.loader.systemd-boot = {
+    enable = true;
+    # TODO: Maybe add store path or some unique identifier to the filename
+    extraFiles."dtbs/${config.hardware.deviceTree.name}" = "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
+    extraInstallCommands = ''
+      default_cfg=$(cat /boot/loader/loader.conf | grep default | awk '{print $2}')
+      echo "devicetree /dtbs/${config.hardware.deviceTree.name}" >> /boot/loader/entries/$default_cfg
+    '';
   };
 }

--- a/modules/hardware/nvidia-jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin.nix
@@ -10,10 +10,23 @@
 
   nixpkgs.hostPlatform.system = "aarch64-linux";
 
+  boot.kernelPatches = [
+    {
+      name = "passthrough-patch";
+      patch = ./pci-passthrough-test.patch;
+    }
+  ];
+
   hardware.deviceTree = {
     enable = true;
-    name = "tegra234-p3701-0000-p3737-0000.dtb";
+    name = "tegra234-p3701-host-passthrough.dtb";
   };
+
+  # Passthrough Jetson Orin WiFi card
+  boot.kernelParams = [
+    "vfio-pci" "ids=10ec:c82f"
+    "vfio_iommu_type1.allow_unsafe_interrupts=1"
+  ];
 
   boot.loader.efi.canTouchEfiVariables = true;
   boot.loader.systemd-boot = {

--- a/modules/hardware/pci-passthrough-test.patch
+++ b/modules/hardware/pci-passthrough-test.patch
@@ -1,0 +1,32 @@
+diff --git a/nvidia/platform/t23x/concord/kernel-dts/Makefile b/nvidia/platform/t23x/concord/kernel-dts/Makefile
+index 1be5b3f76bf8..01d3dea90cb5 100644
+--- a/nvidia/platform/t23x/concord/kernel-dts/Makefile
++++ b/nvidia/platform/t23x/concord/kernel-dts/Makefile
+@@ -23,6 +23,9 @@ dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-as-p3767-0001-p3737-0000.dtb
+ dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-as-pxxxx-p3737-0000.dtb
+ dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-p3737-0000-kexec.dtb
+ dtb-$(BUILD_ENABLE) += tegra234-p3701-0004-p3737-0000.dtb
++
++dtb-$(BUILD_ENABLE) += tegra234-p3701-host-passthrough.dtb
++
+ dtbo-$(BUILD_ENABLE) += tegra234-p3737-a03-overlay.dtbo
+ dtbo-$(BUILD_ENABLE) += tegra234-p3737-a04-overlay.dtbo
+ dtbo-$(BUILD_ENABLE) += tegra234-p3737-overlay-pcie.dtbo
+diff --git a/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-host-passthrough.dts b/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-host-passthrough.dts
+new file mode 100644
+index 000000000000..e4656287da82
+--- /dev/null
++++ b/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-host-passthrough.dts
+@@ -0,0 +1,12 @@
++/dts-v1/;
++#include "tegra234-p3701-0000-p3737-0000.dts"
++
++/*
++ * Update the pci-e wifi to be accessible from vfio/guest
++ */
++&pcie_c1_rp {
++    interconnect-names = "dma-mem", "write";
++    /delete-property/ iommus;
++    /delete-property/ msi-parent;
++    /delete-property/ msi-map;
++};

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -16,4 +16,7 @@
 
   networking.hostName = "ghaf-host";
   system.stateVersion = "22.11";
+
+  # PCI passthrough needs larger locked-in-memory space than default
+  systemd.services."microvm@".serviceConfig.LimitMEMLOCK = 999999999;
 }

--- a/modules/host/networking.nix
+++ b/modules/host/networking.nix
@@ -6,6 +6,12 @@
     firewall.allowedUDPPorts = [67]; # DHCP
     useNetworkd = true;
   };
+
+  networking.nat = {
+    enable = true;
+    internalInterfaces = [ "virbr0" ];
+  };
+
   systemd.network = {
     netdevs."virbr0".netdevConfig = {
       Kind = "bridge";


### PR DESCRIPTION
Using qemu as hypervisor instead of crosvm because current version of crosvm didn't support passthrough.