### PR TITLE
Add minimal host module

### DIFF
--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -4,9 +4,9 @@
   self,
   microvm,
   netvm,
-}: {modulesPath, ...}: {
+}: {...}: {
   imports = [
-    (modulesPath + "/profiles/minimal.nix")
+    (import ./minimal.nix)
 
     microvm.nixosModules.host
 

--- a/modules/host/minimal.nix
+++ b/modules/host/minimal.nix
@@ -1,0 +1,31 @@
+{
+  pkgs,
+  modulesPath,
+  ...
+}: {
+  imports = [
+    (modulesPath + "/profiles/minimal.nix")
+  ];
+
+  appstream.enable = false;
+
+  systemd.package = pkgs.systemd.override {
+    withCryptsetup = false;
+    withDocumentation = false;
+    withFido2 = false;
+    withHomed = false;
+    withHwdb = false;
+    withLibBPF = true;
+    withLocaled = false;
+    withPCRE2 = false;
+    withPortabled = false;
+    withTpm2Tss = false;
+    withUserDb = false;
+  };
+
+  # Use the systemd-boot EFI boot loader.
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  boot.enableContainers = false;
+}


### PR DESCRIPTION
Because of the current dependencies of a ghaf (systemd, grub/systemd-boot) it's impossible to reduce size of a host significantly. As main goal of minification ADR is to reduce TCB we can only configure those packages and remove all unnecessary modules.

Other modifications with the same goal can only be applied to specific hardware (e.g. configuring kernel). This can be seen from these two tables.

Timeline of changes of host size:

| State                           | Entries in /nix/store (raw-efi size) |
|---------------------------------|--------------------------------------|
| Default nixos config            | 498 (1.2G)                           |
| Minimal profile enabled         | 423 (1.1G)                           |
| Systemd-boot instead of grub    | 413 (1.1G)                           |
| boot.enableContainers = false   | 406 (1.1G)                           |
| systemd override                | 395 (1.1G)                           |
| Add modules/host/networking.nix | 399 (1.1G)                           |
| Add microvm.nixosModules.host   | 452 (1.2G)                           |
| Add modules/host/microvm.nix    | 709 (2.7G)                           |

Table of 20 heaviest entries in `/nix/store`:

| Size | Entry                                                                    |
|------|--------------------------------------------------------------------------|
| 295M | /nix/store/wnx08nz4b5fh0kx5pply7pqxq8pllb4s-nixos-22.11.20230310.824f886 |
| 122M | /nix/store/g4zdxdxj8sfbv08grmpahzajrm1gm4s8-linux-5.15.97                |
| 92M  | /nix/store/hhk4wr7hwry854sq69chmrjqyi964p7y-python3-3.10.9               |
| 59M  | /nix/store/140qb8c1xs4ksgk8k3d2n2hgggsg5irb-perl-5.36.0                  |
| 32M  | /nix/store/ahd7gadpy67gjiiqr2fwmhkf9wz7g2gw-systemd-251.12               |
| 31M  | /nix/store/2j8jqmnd9l7plihhf713yf291c9vyqjm-glibc-2.35-224               |
| 22M  | /nix/store/12kiiw8raj5halg8hi11fsh23v4sk44h-systemd-251.12               |
| 14M  | /nix/store/pbqjhqmam5wg4x2i14cjfzgk3mhghbvr-systemd-minimal-251.12       |
| 13M  | /nix/store/znn8hhrmr3vy06vi80ffwj74rsn5d9af-nix-2.11.1                   |
| 13M  | /nix/store/i24hsfwpc6qb4hasp4l8ya7yli3wfw5h-coreutils-full-9.1           |
| 12M  | /nix/store/2zcflcg9cdy0fsm5nc9kvmhgbc2yzjd2-initrd-linux-5.15.97         |
| 9.7M | /nix/store/fbvhyi2q19dvc1j5vdxdk4pca4p77n7f-util-linux-2.38.1-lib        |
| 9.0M | /nix/store/rifbaf794vsh5049nphn5rnpj4grnl2h-groff-1.22.4                 |
| 8.8M | /nix/store/r68f43q8xb6mjn2lrcj32kqsbbsdrcpv-bind-9.18.11-lib             |
| 8.3M | /nix/store/irxas03rj8s07xymkskiqlyx2j28vfhv-ncurses-6.3-p20220507        |
| 7.9M | /nix/store/4srfrjjgsg1xhid15yqlw8870k1mihl0-file-5.43                    |
| 7.7M | /nix/store/v8481v3a686aa0pa4d016c0lnz2j0wwb-gcc-11.3.0-lib               |
| 7.7M | /nix/store/p15q75vmlkhvmjgdc18whrn690lkghls-openssh-9.1p1                |
| 7.3M | /nix/store/ymzvdgigvbzhmza0yq27na0n1xicsw4p-util-linux-2.38.1-bin        |
| 7.2M | /nix/store/pvlpc2cifi34vrzbrvz05533vhqaa0hg-aws-sdk-cpp-1.9.294          |

Note that `./mnt/nix/store/wnx08nz4b5fh0kx5pply7pqxq8pllb4s-nixos-22.11.20230310.824f886` is nixpkgs git repo.

In conclusion I can say that further work should be putted in optimization of `microvm.nix` packages, and maybe we should have a second take on minification of minimal host without `microvm.nix`.
