### PR TITLE
Fixing some cross-compilation issues

### DIFF
--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -10,6 +10,8 @@
 
     microvm.nixosModules.host
 
+    ../overlays/custom-packages.nix
+
     (import ./microvm.nix {inherit self netvm;})
     ./networking.nix
   ];

--- a/modules/overlays/custom-packages.nix
+++ b/modules/overlays/custom-packages.nix
@@ -1,0 +1,30 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# This overlay is for custom packages - new packages, like Gala, or
+# fixed/adjusted packages from nixpkgs
+# The overlay might be used as an example and starting point for
+# any other overlays.
+# !!!!!!! HINT !!!!!!!!
+# Use final/prev pair in your overlays instead of other variations
+# since it looks more logical:
+# previous (unmodified) package vs final (finalazed, adjusted) package.
+# !!!!!!! HINT !!!!!!!!
+# Use deps[X][Y] variations instead of juggling dependencies between
+# nativeBuildInputs and buildInputs where possible.
+# It makes things clear and robust.
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  nixpkgs.overlays = [
+    (final: prev: {
+      # TODO: Remove this override if/when the fix is upstreamed.
+      # Adding missing dependencies for pipewire
+      pipewire = prev.pipewire.overrideAttrs (prevAttrs: {
+        nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [pkgs.glib];
+        depsBuildBuild = [pkgs.gettext];
+      });
+    })
+  ];
+}

--- a/modules/overlays/custom-packages.nix
+++ b/modules/overlays/custom-packages.nix
@@ -1,17 +1,21 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+#
 # This overlay is for custom packages - new packages, like Gala, or
 # fixed/adjusted packages from nixpkgs
 # The overlay might be used as an example and starting point for
 # any other overlays.
+#
 # !!!!!!! HINT !!!!!!!!
 # Use final/prev pair in your overlays instead of other variations
 # since it looks more logical:
 # previous (unmodified) package vs final (finalazed, adjusted) package.
+#
 # !!!!!!! HINT !!!!!!!!
 # Use deps[X][Y] variations instead of juggling dependencies between
 # nativeBuildInputs and buildInputs where possible.
 # It makes things clear and robust.
+#
 {
   lib,
   pkgs,
@@ -25,6 +29,20 @@
         nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [pkgs.glib];
         depsBuildBuild = [pkgs.gettext];
       });
+      # TODO: Remove this override if/when the fix is upstreamed.
+      # Disabling colord dependency for weston. Colord has argyllcms as
+      # a dependency, and this package is not cross-compilable.
+      # Nowadays, colord even marked as deprecated option for weston.
+      weston =
+        # First, weston package is overridden (passing colord = null)
+        (prev.weston.override {
+          colord = null;
+        })
+        # and then this overridden package's attributes are overridden
+        .overrideAttrs (prevAttrs: {
+          mesonFlags = prevAttrs.mesonFlags ++ ["-Ddeprecated-color-management-colord=false"];
+          depsBuildBuild = [pkgs.pkg-config];
+        });
     })
   ];
 }

--- a/modules/overlays/custom-packages.nix
+++ b/modules/overlays/custom-packages.nix
@@ -43,6 +43,13 @@
           mesonFlags = prevAttrs.mesonFlags ++ ["-Ddeprecated-color-management-colord=false"];
           depsBuildBuild = [pkgs.pkg-config];
         });
+      # TODO: Remove this override if/when the fix is upstreamed.
+      # Removing wayland dependency from runtime dependencies and making it
+      # native build time dependency
+      freerdp = prev.freerdp.overrideAttrs (prevAttrs: {
+        buildInputs = lib.remove pkgs.wayland prevAttrs.buildInputs;
+        depsBuildBuild = [pkgs.wayland];
+      });
     })
   ];
 }


### PR DESCRIPTION
This PR contains temporary fixes for cross-compilation issues which are present in `nixos-22.11` branch of `nixpkgs` that we are using as a dependency.

I decided to add fixes this way, because some of them are already fixed in newer branches of `nixpkgs`, but there is still no official release of next stable version of `nixpkgs` (nixos-23.05). I will re-check everything when we'll switch to nixos-23.05 and upstream all fixes that are not yet there.

Cross-compilation issues summary:
- Before this PR there were 3 packages which failed to build: `argyllcms`, `vte` and `pipewire`. `pipewire` is fixed by this PR, `argyllcms` is removed from `weston` dependencies by this PR.
- After fixing previous, build proceeds and 2 new packages with issues appeared: `freerdp` and `weston`. Those are fixed by this PR as well.
- After fixing previous, build proceeds and 1 new package with issue appeared: `qemu-7.1.0`. That one is **not fixed**.
- `nixpkgs` itself needs to be patched to fix `vte` package. The fix is already in `master` branch of `nixpkgs`. It is possible to cherry-pick specific commit, but haven't found how to do this through Ghaf.
- Currently it is impossible to cross-compile Ghaf (even if all issues are fixed) because `microvm` use incorrect `nixpkgs` configuration in case of cross-compilation - will be fixed soon.

So, why do we need this PR at all, since it basically fixes nothing? Because we need some base for integrating custom packages which are not in `nixpkgs` - GALA App is the best example. Also I believe this is also a good example of using overlays/overrides, which will help others to understand Nix better. And it should not add any new issues/errors and affect on native builds.
**Native build for Orin is successful, but I did not test how it actually works.**