### PR TITLE
Do not enable systemd-boot in host by default

### DIFF
--- a/modules/host/minimal.nix
+++ b/modules/host/minimal.nix
@@ -23,9 +23,5 @@
     withUserDb = false;
   };
 
-  # Use the systemd-boot EFI boot loader.
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
   boot.enableContainers = false;
 }


### PR DESCRIPTION
* Do not enable systemd-boot in modules/host/minimal.nix
* This commit fixes imx8qm-mek targets, which use GRUB