### PR TITLE
systemd-boot-dtb: Load device tree using systemd-boot

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,6 +6,9 @@
 #
 #   git config --global blame.ignoreRevsFile .git-blame-ignore-revs
 
+# Fix formatting
+5cd87373b733683fa0181f183f7f6de9fdfefe09
+
 # Reformat .nix-files using alejandra
 24c820cace498a4e2e38979539eeb155471f19dd
 

--- a/modules/hardware/nvidia-jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin.nix
@@ -14,4 +14,14 @@
     efi.canTouchEfiVariables = true;
     systemd-boot.enable = true;
   };
+  ghaf.boot.loader.systemd-boot-dtb.enable = true;
+
+  hardware.deviceTree = {
+    enable = true;
+    name = "tegra234-p3701-0000-p3737-0000.dtb";
+  };
+
+  imports = [
+    ../boot/systemd-boot-dtb.nix
+  ];
 }

--- a/modules/hardware/x86_64-linux.nix
+++ b/modules/hardware/x86_64-linux.nix
@@ -1,7 +1,6 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ ... }: {
-
+{...}: {
   nixpkgs.hostPlatform.system = "x86_64-linux";
 
   boot.loader = {

--- a/modules/host/minimal.nix
+++ b/modules/host/minimal.nix
@@ -1,6 +1,7 @@
-{ pkgs
-, modulesPath
-, ...
+{
+  pkgs,
+  modulesPath,
+  ...
 }: {
   imports = [
     (modulesPath + "/profiles/minimal.nix")

--- a/targets/intel-nuc.nix
+++ b/targets/intel-nuc.nix
@@ -2,53 +2,49 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Intel NUC 11 Pro -target
-{ self
-, nixpkgs
-, nixos-generators
-, microvm
-,
-}:
-let
+{
+  self,
+  nixpkgs,
+  nixos-generators,
+  microvm,
+}: let
   name = "intel-nuc";
   system = "x86_64-linux";
   formatModule = nixos-generators.nixosModules.raw-efi;
-  intel-nuc = variant: extraModules:
-    let
-      hostConfiguration = nixpkgs.lib.nixosSystem {
-        inherit system;
-        modules =
-          [
-            (import ../modules/host {
-              inherit self microvm netvm;
-            })
+  intel-nuc = variant: extraModules: let
+    hostConfiguration = nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules =
+        [
+          (import ../modules/host {
+            inherit self microvm netvm;
+          })
 
-            ../modules/hardware/x86_64-linux.nix
+          ../modules/hardware/x86_64-linux.nix
 
-            ./common-${variant}.nix
+          ./common-${variant}.nix
 
-            ../modules/graphics/weston.nix
+          ../modules/graphics/weston.nix
 
-            formatModule
-          ]
-          ++ extraModules;
-      };
-      netvm = "netvm-${name}-${variant}";
-    in
-    {
-      inherit hostConfiguration netvm;
-      name = "${name}-${variant}";
-      netvmConfiguration = import ../microvmConfigurations/netvm {
-        inherit nixpkgs microvm system;
-      };
-      package = hostConfiguration.config.system.build.${hostConfiguration.config.formatAttr};
+          formatModule
+        ]
+        ++ extraModules;
     };
-  debugModules = [ ../modules/development/intel-nuc-getty.nix ];
+    netvm = "netvm-${name}-${variant}";
+  in {
+    inherit hostConfiguration netvm;
+    name = "${name}-${variant}";
+    netvmConfiguration = import ../microvmConfigurations/netvm {
+      inherit nixpkgs microvm system;
+    };
+    package = hostConfiguration.config.system.build.${hostConfiguration.config.formatAttr};
+  };
+  debugModules = [../modules/development/intel-nuc-getty.nix];
   targets = [
     (intel-nuc "debug" debugModules)
-    (intel-nuc "release" [ ])
+    (intel-nuc "release" [])
   ];
-in
-{
+in {
   nixosConfigurations =
     builtins.listToAttrs (map (t: nixpkgs.lib.nameValuePair t.name t.hostConfiguration) targets)
     // builtins.listToAttrs (map (t: nixpkgs.lib.nameValuePair t.netvm t.netvmConfiguration) targets);

--- a/targets/vm.nix
+++ b/targets/vm.nix
@@ -1,49 +1,45 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ self
-, nixpkgs
-, nixos-generators
-, microvm
-,
-}:
-let
+{
+  self,
+  nixpkgs,
+  nixos-generators,
+  microvm,
+}: let
   name = "vm";
   system = "x86_64-linux";
   formatModule = nixos-generators.nixosModules.vm;
-  vm = variant:
-    let
-      hostConfiguration = nixpkgs.lib.nixosSystem {
-        inherit system;
-        modules = [
-          (import ../modules/host {
-            inherit self microvm netvm;
-          })
+  vm = variant: let
+    hostConfiguration = nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        (import ../modules/host {
+          inherit self microvm netvm;
+        })
 
-          ../modules/hardware/x86_64-linux.nix
+        ../modules/hardware/x86_64-linux.nix
 
-          ./common-${variant}.nix
+        ./common-${variant}.nix
 
-          ../modules/graphics/weston.nix
+        ../modules/graphics/weston.nix
 
-          formatModule
-        ];
-      };
-      netvm = "netvm-${name}-${variant}";
-    in
-    {
-      inherit hostConfiguration netvm;
-      name = "${name}-${variant}";
-      netvmConfiguration = import ../microvmConfigurations/netvm {
-        inherit nixpkgs microvm system;
-      };
-      package = hostConfiguration.config.system.build.${hostConfiguration.config.formatAttr};
+        formatModule
+      ];
     };
+    netvm = "netvm-${name}-${variant}";
+  in {
+    inherit hostConfiguration netvm;
+    name = "${name}-${variant}";
+    netvmConfiguration = import ../microvmConfigurations/netvm {
+      inherit nixpkgs microvm system;
+    };
+    package = hostConfiguration.config.system.build.${hostConfiguration.config.formatAttr};
+  };
   targets = [
     (vm "debug")
     (vm "release")
   ];
-in
-{
+in {
   nixosConfigurations =
     builtins.listToAttrs (map (t: nixpkgs.lib.nameValuePair t.name t.hostConfiguration) targets)
     // builtins.listToAttrs (map (t: nixpkgs.lib.nameValuePair t.netvm t.netvmConfiguration) targets);


### PR DESCRIPTION
- Fix formatting
- Use systemd-boot to load device tree
- Add new module to copy device tree into right place
- Make NVIDIA Jetson Orin target use the new module