### PR TITLE
nvidia-jetson-orin-agx: Fix PCIe port power

### DIFF
--- a/modules/hardware/nvidia-enable-pcie-power.patch
+++ b/modules/hardware/nvidia-enable-pcie-power.patch
@@ -1,0 +1,26 @@
+diff --git a/nvidia/platform/t23x/concord/kernel-dts/cvb/tegra234-p3737-fixed-regulator.dtsi b/nvidia/platform/t23x/concord/kernel-dts/cvb/tegra234-p3737-fixed-regulator.dtsi
+index c246447e0b09..67ef2abff953 100644
+--- a/nvidia/platform/t23x/concord/kernel-dts/cvb/tegra234-p3737-fixed-regulator.dtsi
++++ b/nvidia/platform/t23x/concord/kernel-dts/cvb/tegra234-p3737-fixed-regulator.dtsi
+@@ -65,9 +65,8 @@ p3737_vdd_3v3_pcie: regulator@105 {
+ 			regulator-min-microvolt = <3300000>;
+ 			regulator-max-microvolt = <3300000>;
+ 			vin-supply = <&p3737_vdd_3v3_sys>;
+-			gpio = <&tegra_main_gpio TEGRA234_MAIN_GPIO(Z, 2) 0>;
++			gpio = <&tegra_main_gpio TEGRA234_MAIN_GPIO(H, 4) 0>;
+ 			enable-active-high;
+-			regulator-boot-on;
+ 		};
+ 		p3737_avdd_cam_2v8: regulator@106 {
+ 			compatible = "regulator-fixed";
+@@ -152,7 +151,6 @@ p3737_vdd_12v_pcie: regulator@114 {
+ 			regulator-min-microvolt = <12000000>;
+ 			regulator-max-microvolt = <12000000>;
+ 			gpio = <&tegra_main_gpio TEGRA234_MAIN_GPIO(A, 1) 1>;
+-			regulator-boot-on;
+ 			enable-active-low;
+ 		};
+ 		p3737_vdd_sys_en: regulator@115 {
+-- 
+2.38.4
+

--- a/modules/hardware/nvidia-jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin.nix
@@ -16,6 +16,13 @@
   };
   ghaf.boot.loader.systemd-boot-dtb.enable = true;
 
+  boot.kernelPatches = [
+    {
+      name = "fixed-regulators";
+      patch = ./nvidia-enable-pcie-power.patch;
+    }
+  ];
+
   hardware.deviceTree = {
     enable = true;
     name = "tegra234-p3701-0000-p3737-0000.dtb";


### PR DESCRIPTION
Fix PCIe not powered on during the edk2/UEFI boot phase