### PR TITLE
DRAFT: netvm: writableStoreOverlay

### DIFF
--- a/microvmConfigurations/netvm/default.nix
+++ b/microvmConfigurations/netvm/default.nix
@@ -63,6 +63,8 @@ nixpkgs.lib.nixosSystem {
       };
 
       microvm.qemu.bios.enable = false;
+
+      microvm.writableStoreOverlay = "/nix/netvm/store";
     })
   ];
 }

--- a/modules/hardware/dev-filesystems.nix
+++ b/modules/hardware/dev-filesystems.nix
@@ -1,0 +1,11 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{...}: {
+  fileSystems."/nix/netvm/store" = {
+    device = "none";
+    fsType = "tmpfs"; # ramdisk
+    # TODO: this mount is used as microvm.nix
+    # writableStoreOverlay - so might not need that much
+    options = [ "defaults" "size=2G" "mode=755"];
+  };
+}

--- a/targets/nvidia-jetson-orin.nix
+++ b/targets/nvidia-jetson-orin.nix
@@ -21,6 +21,8 @@
 
           jetpack-nixos.nixosModules.default
           ../modules/hardware/nvidia-jetson-orin.nix
+          # development time filesystem mounts only
+          ../modules/hardware/dev-filesystems.nix
 
           ./common-${variant}.nix
 


### PR DESCRIPTION
* mounts the ramdisk correctly on host
* mounts the overlay on netvm
* runs nix without read-only error
* fails with nix search path entries and nixpkgs not found:

[ghaf@netvm:~]$ nix-shell -p screen
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels/nixos' does not exist, ignoring warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)