### PR TITLE
Limit DHCPServer to virbr0 network

### DIFF
--- a/modules/host/networking.nix
+++ b/modules/host/networking.nix
@@ -16,6 +16,7 @@
       matchConfig.Name = "virbr0";
       networkConfig.DHCPServer = true;
       dhcpServerConfig = {
+        ServerAddress = "192.168.100.1/24";
         EmitRouter = true;
         Router = "192.168.100.2";
       };


### PR DESCRIPTION
DHCPServer should only listen to network interface provided by virbr0, instead of globally listening to 0.0.0.0