### PR TITLE
Enable vhost virtio-vsock driver

### DIFF
--- a/modules/hardware/nvidia-jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin.nix
@@ -1,6 +1,6 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{...}: {
+{lib, ...}: {
   hardware.nvidia-jetpack = {
     enable = true;
     som = "orin-agx";
@@ -24,6 +24,20 @@
     {
       name = "passthrough-patch";
       patch = ./pci-passthrough-test.patch;
+    }
+    {
+      name = "vsock-config";
+      patch = null;
+      extraStructuredConfig = with lib.kernel; {
+        VHOST = yes;
+        VHOST_MENU = yes;
+        VHOST_IOTLB = yes;
+        VHOST_VSOCK = yes;
+        VSOCKETS = yes;
+        VSOCKETS_DIAG = yes;
+        VSOCKETS_LOOPBACK = yes;
+        VIRTIO_VSOCKETS_COMMON = yes;
+      };
     }
   ];
 


### PR DESCRIPTION
Vhost-vsock support in the host kernel is required for running Cuttlefish Virtual Android Devices. It's used by crosvm for communication between host and guest virtual machines.