### PR TITLE
Add GALA app as an example of user application

### DIFF
--- a/modules/graphics/weston.ini.nix
+++ b/modules/graphics/weston.ini.nix
@@ -28,6 +28,10 @@
       [launcher]
       path=${pkgs.element-desktop}/bin/element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland
       icon=${pkgs.element-desktop}/share/icons/hicolor/24x24/apps/element.png
+
+      [launcher]
+      path=${pkgs.gala-app}/bin/gala --enable-features=UseOzonePlatform --ozone-platform=wayland
+      icon=${pkgs.weston}/share/weston/icon_terminal.png
     '';
 
     # The UNIX file mode bits

--- a/modules/graphics/weston.nix
+++ b/modules/graphics/weston.nix
@@ -21,6 +21,7 @@
     # Probably, we'll want to re/move it from here later
     chromium
     element-desktop
+    gala-app
   ];
 
   # Next 4 services/targets are taken from official weston documentation:

--- a/targets/common.nix
+++ b/targets/common.nix
@@ -5,5 +5,6 @@
 {
   imports = [
     # TODO: Add modules common to all targets here in the future
+    ../user-apps/default.nix
   ];
 }

--- a/user-apps/default.nix
+++ b/user-apps/default.nix
@@ -1,0 +1,9 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{pkgs, ...}: {
+  nixpkgs.overlays = [
+    (final: prev: {
+      gala-app = pkgs.callPackage ./gala {};
+    })
+  ];
+}

--- a/user-apps/gala/default.nix
+++ b/user-apps/gala/default.nix
@@ -1,0 +1,138 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  stdenv,
+  pkgs,
+  gtk3,
+  atk,
+  glib,
+  pango,
+  gdk-pixbuf,
+  cairo,
+  freetype,
+  fontconfig,
+  dbus,
+  libXi,
+  libXcursor,
+  libXdamage,
+  libXrandr,
+  libXcomposite,
+  libXext,
+  libXfixes,
+  libxcb,
+  libXrender,
+  libX11,
+  libXtst,
+  libXScrnSaver,
+  nss,
+  nspr,
+  alsa-lib,
+  cups,
+  expat,
+  udev,
+  libpulseaudio,
+  at-spi2-atk,
+  at-spi2-core,
+  libxshmfence,
+  libdrm,
+  libxkbcommon,
+  mesa,
+  unzip,
+  wayland,
+}: let
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
+
+  libPath = lib.makeLibraryPath [
+    stdenv.cc.cc
+    gtk3
+    atk
+    glib
+    pango
+    gdk-pixbuf
+    cairo
+    freetype
+    fontconfig
+    dbus
+    libXi
+    libXcursor
+    libXdamage
+    libXrandr
+    libXcomposite
+    libXext
+    libXfixes
+    libxcb
+    libXrender
+    libX11
+    libXtst
+    libXScrnSaver
+    nss
+    nspr
+    alsa-lib
+    cups
+    expat
+    udev
+    libpulseaudio
+    at-spi2-atk
+    at-spi2-core
+    libxshmfence
+    libdrm
+    libxkbcommon
+    mesa
+    wayland
+  ];
+in
+  stdenv.mkDerivation rec {
+    name = "gala";
+
+    nativeBuildInputs = [unzip];
+
+    buildInputs = [unzip];
+
+    # See meta.platforms section for supported platforms
+    src =
+      if stdenv.isAarch64
+      then
+        pkgs.fetchurl {
+          url = "https://vedenemo.dev/files/dev.scpp.saca.gala-0.0.1-arm64.zip";
+          sha256 = "sha256-tpCTCxElij92p0eiF7/E3UuOJfz8eKNBd/XgSd3dcaI=";
+        }
+      else
+        pkgs.fetchurl {
+          url = "https://vedenemo.dev/files/dev.scpp.saca.gala-0.0.1.zip";
+          sha256 = "sha256-dIDlgg/YAIYCgVodycghwrjf89Jm0faInsiUoGvEscU=";
+        };
+
+    phases = "unpackPhase fixupPhase";
+    targetPath = "$out/gala";
+    intLibPath = "$out/gala/swiftshader";
+
+    unpackPhase = ''
+      mkdir -p ${targetPath}
+      unzip $src -d ${targetPath}
+    '';
+
+    rpath = lib.concatStringsSep ":" [
+      libPath
+      targetPath
+      intLibPath
+    ];
+
+    fixupPhase = ''
+      patchelf \
+        --set-interpreter "${dynamic-linker}" \
+        --set-rpath "${rpath}" \
+        ${targetPath}/dev.scpp.saca.gala
+
+      mkdir -p $out/bin
+      ln -s $out/gala/dev.scpp.saca.gala $out/bin/gala
+    '';
+
+    meta = with lib; {
+      description = "Google Android look-alike";
+      platforms = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+    };
+  }


### PR DESCRIPTION
As GALA app is a closed source peace of software yet, let's have it as pre-built for now.

I'd like to discuss directory structure for adding user applications - I've added new directory into the srcroot for now.
I also do not like the idea of having monolithic `weston.ini` file, but I did not get how to append text from other files/nixos modules.
Ideally, I'd like to add, for instance, weston launcher from the package's .nix file.

And yes, currently there is a mock icon used for Gala launcher.