### PR TITLE
Create a script to launch Windows VM

### DIFF
--- a/modules/graphics/weston.ini.nix
+++ b/modules/graphics/weston.ini.nix
@@ -1,40 +1,50 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{pkgs, ...}: {
+{
+  pkgs,
+  lib,
+  ...
+}: {
   environment.etc."xdg/weston/weston.ini" = {
-    text = ''
-      # Disable screen locking
-      [core]
-      idle-time=0
+    text =
+      ''
+        # Disable screen locking
+        [core]
+        idle-time=0
 
-      [shell]
-      locking=false
-      background-image=${./assets/wallpaper.jpg}
-      background-type=scale-crop
+        [shell]
+        locking=false
+        background-image=${./assets/wallpaper.jpg}
+        background-type=scale-crop
 
-      # Enable Hack font for weston-terminal
-      [terminal]
-      font=Hack
-      font-size=16
+        # Enable Hack font for weston-terminal
+        [terminal]
+        font=Hack
+        font-size=16
 
-      # Add application launchers
-      # Adding terminal launcher because it is overwritten if other launchers are on the panel
-      [launcher]
-      path=${pkgs.weston}/bin/weston-terminal
-      icon=${pkgs.weston}/share/weston/icon_terminal.png
+        # Add application launchers
+        # Adding terminal launcher because it is overwritten if other launchers are on the panel
+        [launcher]
+        path=${pkgs.weston}/bin/weston-terminal
+        icon=${pkgs.weston}/share/weston/icon_terminal.png
 
-      [launcher]
-      path=${pkgs.chromium}/bin/chromium --enable-features=UseOzonePlatform --ozone-platform=wayland
-      icon=${pkgs.chromium}/share/icons/hicolor/24x24/apps/chromium.png
+        [launcher]
+        path=${pkgs.chromium}/bin/chromium --enable-features=UseOzonePlatform --ozone-platform=wayland
+        icon=${pkgs.chromium}/share/icons/hicolor/24x24/apps/chromium.png
 
-      [launcher]
-      path=${pkgs.element-desktop}/bin/element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland
-      icon=${pkgs.element-desktop}/share/icons/hicolor/24x24/apps/element.png
+        [launcher]
+        path=${pkgs.element-desktop}/bin/element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland
+        icon=${pkgs.element-desktop}/share/icons/hicolor/24x24/apps/element.png
 
-      [launcher]
-      path=${pkgs.gala-app}/bin/gala --enable-features=UseOzonePlatform --ozone-platform=wayland
-      icon=${pkgs.weston}/share/weston/icon_terminal.png
-    '';
+        [launcher]
+        path=${pkgs.gala-app}/bin/gala --enable-features=UseOzonePlatform --ozone-platform=wayland
+        icon=${pkgs.weston}/share/weston/icon_terminal.png
+      ''
+      + lib.optionalString (pkgs.stdenv.isAarch64) ''
+        [launcher]
+        path=${pkgs.windows-launcher}/bin/windows-launcher-ui
+        icon=${pkgs.gnome.adwaita-icon-theme}/share/icons/Adwaita/24x24/devices/computer.png
+      '';
 
     # The UNIX file mode bits
     mode = "0644";

--- a/modules/windows/launcher.nix
+++ b/modules/windows/launcher.nix
@@ -1,0 +1,5 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{pkgs, ...}: {
+  environment.systemPackages = [pkgs.windows-launcher];
+}

--- a/targets/nvidia-jetson-orin.nix
+++ b/targets/nvidia-jetson-orin.nix
@@ -26,6 +26,8 @@
 
           ../modules/graphics/weston.nix
 
+          ../modules/windows/launcher.nix
+
           formatModule
         ]
         ++ extraModules;

--- a/user-apps/default.nix
+++ b/user-apps/default.nix
@@ -4,6 +4,7 @@
   nixpkgs.overlays = [
     (final: prev: {
       gala-app = pkgs.callPackage ./gala {};
+      windows-launcher = pkgs.callPackage ./windows-launcher {};
     })
   ];
 }

--- a/user-apps/windows-launcher/default.nix
+++ b/user-apps/windows-launcher/default.nix
@@ -1,0 +1,97 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenvNoCC,
+  pkgs,
+  lib,
+  ...
+}: let
+  windowsLauncher =
+    pkgs.writeShellScript
+    "windows-launcher"
+    ''
+      if [ $# -eq 0 ]; then
+        echo "Usage: windows-launcher ./Windows11_InsiderPreview_Client_ARM64_en-us_25324.VHDX"
+        exit
+      fi
+
+      if [[ -z "''${WAYLAND_DISPLAY}" ]]; then
+        echo "Wayland display not found"
+        exit
+      fi
+
+      IMG_DIR="$(dirname "$1")"
+      AAVMF_VARS="$IMG_DIR/AAVMF_VARS.fd"
+
+      if [ ! -f $AAVMF_VARS ]; then
+        cp ${pkgs.OVMF.fd}/FV/AAVMF_VARS.fd $AAVMF_VARS
+        chmod 644 $AAVMF_VARS
+      fi
+
+      ${pkgs.qemu}/bin/qemu-system-aarch64 \
+        -name "Windows VM" \
+        -M virt,highmem=on,gic-version=max \
+        -cpu host \
+        -enable-kvm \
+        -smp 6 \
+        -m 12G \
+        -drive file=${pkgs.OVMF.fd}/FV/AAVMF_CODE.fd,format=raw,if=pflash,readonly=on \
+        -drive file=$AAVMF_VARS,format=raw,if=pflash \
+        -device ramfb \
+        -device virtio-gpu-pci \
+        -device qemu-xhci \
+        -device usb-kbd \
+        -device usb-tablet \
+        -drive file=$1,format=vhdx,if=none,id=boot \
+        -device usb-storage,drive=boot,serial=boot \
+        -nic user,model=virtio \
+        ''${@:2}
+    '';
+  windowsLauncherUI =
+    pkgs.writeShellScript
+    "windows-launcher-ui"
+    ''
+      if [[ -z "''${WAYLAND_DISPLAY}" ]]; then
+        echo "Wayland display not found"
+        exit
+      fi
+
+      CONFIG=~/.config/windows-launcher-ui.conf
+      if [ -f "$CONFIG" ]; then
+        source $CONFIG
+      fi
+
+      if [ ! -f "$FILE" ]; then
+        FILE=`${pkgs.gnome.zenity}/bin/zenity --file-selection --title="Select Windows VM image (VHDX)"`
+        if [ ''$? -ne 0 ]; then
+          exit
+        else
+          echo FILE="$FILE" > "$CONFIG"
+        fi
+      fi
+
+      if ! ${windowsLauncher} $FILE; then
+        ${pkgs.gnome.zenity}/bin/zenity --error --text="Failed to run Windows VM: $?"
+      fi
+    '';
+in
+  stdenvNoCC.mkDerivation {
+    name = "windows-launcher";
+
+    buildInputs = [pkgs.gnome.zenity];
+
+    phases = ["installPhase"];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${windowsLauncher} $out/bin/windows-launcher
+      cp ${windowsLauncherUI} $out/bin/windows-launcher-ui
+    '';
+
+    meta = with lib; {
+      description = "Helper scripts for launching Windows ARM64 virtual machines using QEMU";
+      platforms = [
+        "aarch64-linux"
+      ];
+    };
+  }


### PR DESCRIPTION
As Brian requested this pull request adds a script that can launch a Windows 11 virtual machine VHDX image downloaded from the [Windows Insider Preview ARM64 page](https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewARM64).
Example:
`windows-launcher ./Windows11_InsiderPreview_Client_ARM64_en-us_25324.VHDX`

In addition to that it adds an icon to the Weston toolbar. When clicked for the first time it opens a file selection dialog. Once Windows 11 image has been selected it saves the path to the ~/.config/windows-launcher-ui.conf file and launches the virtual machine. When clicked next time it reads the path from the configuration file and immediately launches the VM. This way the user can launch a Windows virtual machine with a single click.

Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>