### PR TITLE
Host minification module

### DIFF
--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -4,18 +4,60 @@
   self,
   microvm,
   netvm,
-}: {lib, ...}: {
-  imports = [
-    (import ./minimal.nix)
+}: {
+  lib,
+  config,
+  pkgs,
+  ...
+} @ args: let
+  cfg = config.ghaf.host.minification;
+in
+  with lib; {
+    options.ghaf.host.minification = with lib; {
+      reduceProfile = mkEnableOption "reduced profile";
+      disableNetwork = mkEnableOption "disableing of network";
+      disableGetty = mkEnableOption "disabling of getty";
+      removeNix = mkEnableOption "nix tooling";
+      minimalKernelConfig = {
+        enable = mkEnableOption "minimal kernel config";
+        structuredExtraConfig = mkOption {
+          default = types.attrs;
+          example = literalExpression ''
+            with lib.kernel; {
+              SCHED_MUQSS = yes;
+            }'';
+          description = "Extra config for the kernel. See https://nixos.wiki/wiki/Linux_kernel#Custom_configuration.";
+          type = types.attrs;
+        };
+      };
+    };
 
-    microvm.nixosModules.host
+    # HACK: import other modules with explicit passing of arguments, otherwise import
+    # cause infinite recursion.
+    config = lib.mkMerge [
+      {
+        networking.hostName = "ghaf-host";
+        system.stateVersion = lib.trivial.release;
+      }
+      (import ../overlays/custom-packages.nix {inherit lib pkgs;})
+      (lib.mkIf cfg.reduceProfile (import ./minimal.nix {inherit pkgs lib;}))
+      (lib.mkIf (!cfg.disableNetwork) (import ./networking.nix {}))
+      (lib.mkIf cfg.disableGetty {
+        # XXX: Incompatable with `services.getty` options.
+        systemd.services."getty@".enable = lib.mkForce false;
+      })
+      (lib.mkIf cfg.removeNix {
+        # TODO: Patch raw-efi image build script to support building without relying on
+        # image nix tools (replace with packages from nixpkgs).
+        nix.enable = false;
+      })
+      (lib.mkIf cfg.minimalKernelConfig.enable {
+        boot.kernelPatches = lib.singleton {
+          name = "minimal";
+          patch = null;
+          extraStructuredConfig = cfg.minimalKernelConfig.structuredExtraConfig;
+        };
+      })
+    ];
+  }
 
-    ../overlays/custom-packages.nix
-
-    (import ./microvm.nix {inherit self netvm;})
-    ./networking.nix
-  ];
-
-  networking.hostName = "ghaf-host";
-  system.stateVersion = lib.trivial.release;
-}

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -42,10 +42,7 @@ in
       (import ../overlays/custom-packages.nix {inherit lib pkgs;})
       (lib.mkIf cfg.reduceProfile (import ./minimal.nix {inherit pkgs lib;}))
       (lib.mkIf (!cfg.disableNetwork) (import ./networking.nix {}))
-      (lib.mkIf cfg.disableGetty {
-        # XXX: Incompatable with `services.getty` options.
-        systemd.services."getty@".enable = lib.mkForce false;
-      })
+      (lib.mkIf cfg.disableGetty (import ./nogetty.nix lib))
       (lib.mkIf cfg.removeNix {
         # TODO: Patch raw-efi image build script to support building without relying on
         # image nix tools (replace with packages from nixpkgs).

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -18,18 +18,6 @@ in
       disableNetwork = mkEnableOption "disableing of network";
       disableGetty = mkEnableOption "disabling of getty";
       removeNix = mkEnableOption "nix tooling";
-      minimalKernelConfig = {
-        enable = mkEnableOption "minimal kernel config";
-        structuredExtraConfig = mkOption {
-          default = types.attrs;
-          example = literalExpression ''
-            with lib.kernel; {
-              SCHED_MUQSS = yes;
-            }'';
-          description = "Extra config for the kernel. See https://nixos.wiki/wiki/Linux_kernel#Custom_configuration.";
-          type = types.attrs;
-        };
-      };
     };
 
     # HACK: import other modules with explicit passing of arguments, otherwise import
@@ -47,13 +35,6 @@ in
         # TODO: Patch raw-efi image build script to support building without relying on
         # image nix tools (replace with packages from nixpkgs).
         nix.enable = false;
-      })
-      (lib.mkIf cfg.minimalKernelConfig.enable {
-        boot.kernelPatches = lib.singleton {
-          name = "minimal";
-          patch = null;
-          extraStructuredConfig = cfg.minimalKernelConfig.structuredExtraConfig;
-        };
       })
     ];
   }

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -13,11 +13,14 @@
   cfg = config.ghaf.host.minification;
 in
   with lib; {
+    imports = [microvm.nixosModules.host];
+
     options.ghaf.host.minification = with lib; {
       reduceProfile = mkEnableOption "reduced profile";
       disableNetwork = mkEnableOption "disableing of network";
       disableGetty = mkEnableOption "disabling of getty";
       removeNix = mkEnableOption "nix tooling";
+      disableGuestVms = mkEnableOption "guest vms";
     };
 
     # HACK: import other modules with explicit passing of arguments, otherwise import
@@ -36,6 +39,6 @@ in
         # image nix tools (replace with packages from nixpkgs).
         nix.enable = false;
       })
+      (lib.mkIf (!cfg.disableGuestVms) (import ./microvm.nix {inherit self netvm;} {inherit config;}))
     ];
   }
-

--- a/modules/host/minimal.nix
+++ b/modules/host/minimal.nix
@@ -1,11 +1,21 @@
 {
   pkgs,
-  modulesPath,
+  lib,
   ...
-}: {
-  imports = [
-    (modulesPath + "/profiles/minimal.nix")
-  ];
+}:
+with lib; {
+  environment.noXlibs = mkDefault true;
+
+  documentation.enable = mkDefault false;
+
+  documentation.nixos.enable = mkDefault false;
+
+  programs.command-not-found.enable = mkDefault false;
+
+  xdg.autostart.enable = mkDefault false;
+  xdg.icons.enable = mkDefault false;
+  xdg.mime.enable = mkDefault false;
+  xdg.sounds.enable = mkDefault false;
 
   appstream.enable = false;
 

--- a/modules/host/nogetty.nix
+++ b/modules/host/nogetty.nix
@@ -1,0 +1,20 @@
+# Slightly modified version of "${modulesPath}/profiles/headless.nix"
+lib: {
+  boot.kernelParams = let
+    disableVESA = ["vga=0x317" "nomodeset"];
+    rebootOnFail = ["panic=1" "boot.panic_on_fail"];
+  in
+    disableVESA ++ rebootOnFail;
+
+  # Don't start a tty on the serial consoles.
+  systemd.services."serial-getty@ttyS0".enable = lib.mkDefault false;
+  systemd.services."serial-getty@hvc0".enable = false;
+  systemd.services."getty@tty1".enable = false;
+  systemd.services."autovt@".enable = false;
+
+  # Don't allow emergency mode, because we don't have a console.
+  systemd.enableEmergencyMode = false;
+
+  # Being headless, we don't need a GRUB splash image.
+  boot.loader.grub.splashImage = null;
+}

--- a/targets/common-release.nix
+++ b/targets/common-release.nix
@@ -6,4 +6,11 @@
   imports = [
     ./common.nix
   ];
+
+  ghaf.host.minification = {
+    reduceProfile = true;
+    disableNetwork = true;
+    disableGetty = true;
+    disableGuestVms = true;
+  };
 }


### PR DESCRIPTION
Draft implementation of minification ADR in form of nixos module that reflects it's structure.

Some ADR items are not reflected in the module options, since they are not directly related to minification and will be added as a result of code refactoring. Can be refactored to module that will provide options for high-level configuration of ghaf host system (e.g enable/disable gui, update system, read only filesystem). 

Currently implementation is incomplete because of infinite recursion caused by conditional modules importing.