### PR TITLE
Create overlay specific to cross-compilation

### DIFF
--- a/modules/overlays/cross-compilation.nix
+++ b/modules/overlays/cross-compilation.nix
@@ -1,0 +1,28 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This overlay is for specific fixes needed only to enable cross-compilation.
+#
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  nixpkgs.overlays = [
+    (final: prev: {
+      # TODO: Remove this override if/when the fix is upstreamed.
+      # Adding missing dependencies for pipewire
+      #
+      # Overriding pipewire causes massive rebuild of chromium, so putting it
+      # into this separate overlay, so all targets don't need to rebuild
+      # chromium.
+      #
+      # This can be removed when we move to NixOS 23.05
+      #
+      pipewire = prev.pipewire.overrideAttrs (prevAttrs: {
+        nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [pkgs.glib];
+        depsBuildBuild = [pkgs.gettext];
+      });
+    })
+  ];
+}

--- a/targets/nvidia-jetson-orin.nix
+++ b/targets/nvidia-jetson-orin.nix
@@ -74,6 +74,8 @@
           {
             nixpkgs.buildPlatform.system = "x86_64-linux";
           }
+
+          ../modules/overlays/cross-compilation.nix
         ];
       };
       package = hostConfiguration.config.system.build.${hostConfiguration.config.formatAttr};


### PR DESCRIPTION
Overrides to pipewire are causing massive rebuilds for chromium for every target. Create separate overlay for fixes needed only for the cross-compilation.