### PR TITLE
Inherit nixos-hardware in generic-x86

### DIFF
--- a/targets/default.nix
+++ b/targets/default.nix
@@ -13,6 +13,6 @@
 nixpkgs.lib.foldr nixpkgs.lib.recursiveUpdate {} [
   (import ./nvidia-jetson-orin.nix {inherit self nixpkgs nixos-generators microvm jetpack-nixos;})
   (import ./vm.nix {inherit self nixpkgs nixos-generators microvm;})
-  (import ./generic-x86_64.nix {inherit self nixpkgs nixos-generators microvm;})
+  (import ./generic-x86_64.nix {inherit self nixpkgs nixos-generators nixos-hardware microvm;})
   (import ./imx8qm-mek.nix {inherit self nixpkgs nixos-generators nixos-hardware microvm;})
 ]

--- a/targets/generic-x86_64.nix
+++ b/targets/generic-x86_64.nix
@@ -6,6 +6,7 @@
   self,
   nixpkgs,
   nixos-generators,
+  nixos-hardware,
   microvm,
 }: let
   name = "generic-x86_64";
@@ -28,11 +29,17 @@
 
           formatModule
 
+          #TODO: how to handle the majority of laptops that need a little
+          # something extra?
+          # SEE: https://github.com/NixOS/nixos-hardware/blob/master/flake.nix
+          # nixos-hardware.nixosModules.lenovo-thinkpad-x1-10th-gen
+
           {
             boot.kernelParams = [
               "intel_iommu=on,igx_off,sm_on"
               "iommu=pt"
 
+              # TODO: Change per your device
               # Passthrough Intel WiFi card
               "vfio-pci.ids=8086:a0f0"
             ];


### PR DESCRIPTION
Inheriting nixos hardware will allow defining
specific fw and drivers for a specific laptop
to specialize in a 'emergency'.

A more clean solution needs to designed by using
ghaf as a module.