### PR TITLE
Add templates to allow easy inheritance of Ghaf

### DIFF
--- a/docs/src/ref_impl/custom_product.md
+++ b/docs/src/ref_impl/custom_product.md
@@ -1,0 +1,27 @@
+<!--
+    Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Derive a Custom Project From Ghaf
+
+Ghaf is a framework for creating virtualized edge devices, it is therefore expected that projects wishing to use Ghaf should import it to create a derived work
+for the specific use case.
+
+Ghaf provides a number templates for the reference hardware to ease this process.
+
+## Creating a custom derivation
+
+1. Check the available target templates
+```
+    nix flake show github:tiiuae/ghaf
+```
+2. Select the appropriate template e.g. `target-aarch64-nvidia-orin-agx`
+```
+    nix flake new --template github:tiiuae/ghaf#target-aarch64-nvidia-orin-agx /my/new/project/folder
+```
+3. Change the placeholder `<PROJ NAME>` to your new projects name e.g. `cool_project`
+```
+    sed -i 's/PROJ_NAME/cool_project/g' flake.nix
+```
+4. Hack, test, commit, contribute back to Ghaf ;) ...

--- a/docs/src/ref_impl/reference_implementations.md
+++ b/docs/src/ref_impl/reference_implementations.md
@@ -40,3 +40,4 @@ The same goes with the architectural variants as headless devices or end-user de
 - [Build and Run](./build_and_run.md)
 - [Development](./development.md)
    - [Cross-Compilation](./cross_compilation.md)
+- [Define a Custom Project from Ghaf](./custom_product.md)

--- a/templates/default.nix
+++ b/templates/default.nix
@@ -1,0 +1,42 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{self}: {
+  templates = {
+    #TODO Enable when module system is in place
+    # # Module template
+    # ghaf-module = {
+    #   path = ./module;
+    #   description = "A config to bootstrap a Ghaf compatible module";
+    # };
+
+    # A Selection of targets that utilize Ghaf to define more feature rich
+    # projects/products.
+
+    # ARM targets
+    target-aarch64-nvidia-orin-agx = {
+      path = ./targets/aarch64/nvidia/orin-agx;
+      description = "A Ghaf based configuration for the Nvidia Orin AGX";
+    };
+    target-aarch64-nvidia-orin-nx = {
+      path = ./targets/aarch64/nvidia/orin-nx;
+      description = "A Ghaf based configuration for the Nvidia Orin NX";
+    };
+    target-aarch64-nxp-imx8 = {
+      path = ./targets/aarch64/nxp/imx8;
+      description = "A Ghaf based configuration for the NXP iMX8";
+    };
+
+    # x86 targets
+    target-x86_64-generic = {
+      path = ./targets/x86_64/generic;
+      description = "A Ghaf based configuration for x86_64 targets";
+    };
+
+    #TODO Enable this when polarfire is merged
+    # # RISC-v targets
+    # target-riscv64-microchip-polarfire = {
+    #   path = ./targets/riscv64/microchip/polarfire;
+    #   description = "A Ghaf based configuration for the Microchip Polarfire";
+    # };
+  };
+}

--- a/templates/targets/aarch64/nvidia/orin-agx/flake.nix
+++ b/templates/targets/aarch64/nvidia/orin-agx/flake.nix
@@ -1,0 +1,72 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  description = "<PROJ NAME> - Ghaf based configuration";
+
+  nixConfig = {
+    extra-trusted-substituters = [
+      "https://cache.vedenemo.dev"
+      "https://cache.ssrcdevops.tii.ae"
+    ];
+    extra-trusted-public-keys = [
+      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
+    ];
+  };
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    jetpack-nixos = {
+      url = "github:anduril/jetpack-nixos";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    ghaf = {
+      url = "github:tiiuae/ghaf";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+        jetpack-nixos.follows = "jetpack-nixos";
+      };
+    };
+  };
+
+  outputs = {
+    self,
+    ghaf,
+    nixpkgs,
+    jetpack-nixos,
+    flake-utils,
+  }: let
+    systems = with flake-utils.lib.system; [
+      x86_64-linux
+      aarch64-linux
+    ];
+    mkFlashScript = import (ghaf + "/modules/hardware/nvidia-jetson-orin/mk-flash-script.nix");
+  in
+    # Combine list of attribute sets together
+    nixpkgs.lib.foldr nixpkgs.lib.recursiveUpdate {} [
+      (flake-utils.lib.eachSystem systems (system: {
+        formatter = nixpkgs.legacyPackages.${system}.alejandra;
+      }))
+
+      {
+        nixosConfigurations.PROJ_NAME-ghaf-debug = ghaf.nixosConfigurations.nvidia-jetson-orin-debug.extendModules {
+          modules = [
+            {
+              #insert your additional modules here e.g.
+              # virtualisation.docker.enable = true;
+              # users.users."ghaf".extraGroups = ["docker"];
+            }
+          ];
+        };
+        packages.aarch64-linux.PROJ_NAME-ghaf-debug = self.nixosConfigurations.PROJ_NAME-ghaf-debug.config.system.build.${self.nixosConfigurations.PROJ_NAME-ghaf-debug.config.formatAttr};
+
+        packages.x86_64-linux.PROJ_NAME-ghaf-debug-flash-script = mkFlashScript {
+          inherit nixpkgs jetpack-nixos;
+          hostConfiguration = self.nixosConfigurations.PROJ_NAME-ghaf-debug;
+          flash-tools-system = flake-utils.lib.system.x86_64-linux;
+        };
+      }
+    ];
+}

--- a/templates/targets/aarch64/nvidia/orin-nx/flake.nix
+++ b/templates/targets/aarch64/nvidia/orin-nx/flake.nix
@@ -1,0 +1,72 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  description = "PROJ_NAME - Ghaf based configuration";
+
+  nixConfig = {
+    extra-trusted-substituters = [
+      "https://cache.vedenemo.dev"
+      "https://cache.ssrcdevops.tii.ae"
+    ];
+    extra-trusted-public-keys = [
+      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
+    ];
+  };
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    jetpack-nixos = {
+      url = "github:anduril/jetpack-nixos";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    ghaf = {
+      url = "github:tiiuae/ghaf";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+        jetpack-nixos.follows = "jetpack-nixos";
+      };
+    };
+  };
+
+  outputs = {
+    self,
+    ghaf,
+    nixpkgs,
+    jetpack-nixos,
+    flake-utils,
+  }: let
+    systems = with flake-utils.lib.system; [
+      x86_64-linux
+      aarch64-linux
+    ];
+    mkFlashScript = import (ghaf + "/modules/hardware/nvidia-jetson-orin/mk-flash-script.nix");
+  in
+    # Combine list of attribute sets together
+    nixpkgs.lib.foldr nixpkgs.lib.recursiveUpdate {} [
+      (flake-utils.lib.eachSystem systems (system: {
+        formatter = nixpkgs.legacyPackages.${system}.alejandra;
+      }))
+
+      {
+        nixosConfigurations.PROJ_NAME-ghaf-debug = ghaf.nixosConfigurations.nvidia-jetson-orin-debug.extendModules {
+          modules = [
+            {
+              #insert your additional modules here e.g.
+              # virtualisation.docker.enable = true;
+              # users.users."ghaf".extraGroups = ["docker"];
+            }
+          ];
+        };
+        packages.aarch64-linux.PROJ_NAME-ghaf-debug = self.nixosConfigurations.PROJ_NAME-ghaf-debug.config.system.build.${self.nixosConfigurations.fog-ghaf-debug.config.formatAttr};
+
+        packages.x86_64-linux.PROJ_NAME-ghaf-debug-flash-script = mkFlashScript {
+          inherit nixpkgs jetpack-nixos;
+          hostConfiguration = self.nixosConfigurations.PROJ_NAME-ghaf-debug;
+          flash-tools-system = flake-utils.lib.system.x86_64-linux;
+        };
+      }
+    ];
+}

--- a/templates/targets/x86_64/generic/flake.nix
+++ b/templates/targets/x86_64/generic/flake.nix
@@ -1,0 +1,65 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  description = "PROJ_NAME - Ghaf based configuration";
+
+  nixConfig = {
+    extra-trusted-substituters = [
+      "https://cache.vedenemo.dev"
+      "https://cache.ssrcdevops.tii.ae"
+    ];
+    extra-trusted-public-keys = [
+      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
+    ];
+  };
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    nixos-hardware.url = "github:nixos/nixos-hardware";
+    ghaf = {
+      url = "github:tiiuae/ghaf";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+        nixos-hardware.follows = "nixos-hardware";
+      };
+    };
+  };
+
+  outputs = {
+    self,
+    ghaf,
+    nixpkgs,
+    nixos-hardware,
+    flake-utils,
+  }: let
+    systems = with flake-utils.lib.system; [
+      x86_64-linux
+    ];
+  in
+    # Combine list of attribute sets together
+    nixpkgs.lib.foldr nixpkgs.lib.recursiveUpdate {} [
+      (flake-utils.lib.eachSystem systems (system: {
+        formatter = nixpkgs.legacyPackages.${system}.alejandra;
+      }))
+
+      {
+        nixosConfigurations.PROJ_NAME-ghaf-debug = ghaf.nixosConfigurations.generic-x86_64-debug.extendModules {
+          modules = [
+            {
+              #insert your additional modules here e.g.
+              # virtualisation.docker.enable = true;
+              # users.users."ghaf".extraGroups = ["docker"];
+
+              # To handle the majority of laptops we need a little something extra
+              # TODO:: SEE: https://github.com/NixOS/nixos-hardware/blob/master/flake.nix
+              # nixos-hardware.nixosModules.lenovo-thinkpad-x1-10th-gen
+            }
+          ];
+        };
+        packages.x86_64-linux.PROJ_NAME-ghaf-debug = self.nixosConfigurations.PROJ_NAME-ghaf-debug.config.system.build.${self.nixosConfigurations.PROJ_NAME-ghaf-debug.config.formatAttr};
+      }
+    ];
+}


### PR DESCRIPTION
Ghaf is a framework to allow the easy creation of
virtualized edge devices. As such it should be
used to derive projects that are configured to
the specific use cases.

These templates allow for that easy creation.