### PR TITLE
windows-launcher package only for aarch64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
       (import ./targets {inherit self lib nixpkgs nixos-generators nixos-hardware microvm jetpack-nixos;})
 
       # User apps
-      (import ./user-apps {inherit nixpkgs flake-utils;})
+      (import ./user-apps {inherit lib nixpkgs flake-utils;})
 
       # Hydra jobs
       (import ./hydrajobs.nix {inherit self;})

--- a/user-apps/default.nix
+++ b/user-apps/default.nix
@@ -1,6 +1,7 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
+  lib,
   nixpkgs,
   flake-utils,
 }: let
@@ -9,11 +10,17 @@
     aarch64-linux
   ];
 in
-  flake-utils.lib.eachSystem systems (system: {
-    packages = let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      gala-app = pkgs.callPackage ./gala {};
-      windows-launcher = pkgs.callPackage ./windows-launcher {};
-    };
-  })
+  # Combine list of attribute sets together
+  lib.foldr lib.recursiveUpdate {} [
+    (flake-utils.lib.eachSystem systems (system: {
+      packages = let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        gala-app = pkgs.callPackage ./gala {};
+      };
+    }))
+
+    {
+      packages.aarch64-linux.windows-launcher = nixpkgs.legacyPackages.aarch64-linux.callPackage ./windows-launcher {};
+    }
+  ]


### PR DESCRIPTION
Export windows-launcher package only for aarch64-linux from flake packages.