### PR TITLE
Fix date and time synchronization issues

### DIFF
--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -66,6 +66,20 @@
             # Only override mesonFlags if colord argument is accepted
             mesonFlags = prevAttrs.mesonFlags ++ ["-Ddeprecated-color-management-colord=false"];
           });
+      systemd = prev.systemd.overrideAttrs (prevAttrs: {
+        patches = prevAttrs.patches ++ [./systemd-timesyncd-disable-nscd.patch];
+        postPatch =
+          prevAttrs.postPatch
+          + ''
+            substituteInPlace units/systemd-timesyncd.service.in \
+              --replace \
+              "Environment=SYSTEMD_NSS_RESOLVE_VALIDATE=0" \
+              "${lib.concatStringsSep "\n" [
+              "Environment=LD_LIBRARY_PATH=$out/lib"
+              "Environment=SYSTEMD_NSS_RESOLVE_VALIDATE=0"
+            ]}"
+          '';
+      });
     })
   ];
 }

--- a/overlays/systemd-timesyncd-disable-nscd.patch
+++ b/overlays/systemd-timesyncd-disable-nscd.patch
@@ -1,0 +1,46 @@
+From bb150a178bebb88ce3bfe8c726c75d495423b4a2 Mon Sep 17 00:00:00 2001
+From: Yuri Nesterov <yuriy.nesterov@unikie.com>
+Date: Wed, 21 Jun 2023 17:17:38 +0300
+Subject: [PATCH] timesyncd: disable NSCD when DNSSEC validation is disabled
+
+Systemd-timesyncd sets SYSTEMD_NSS_RESOLVE_VALIDATE=0 in the unit file
+to disable DNSSEC validation but it doesn't work when NSCD is used in
+the system. This patch disabes NSCD in systemd-timesyncd when
+SYSTEMD_NSS_RESOLVE_VALIDATE is set to 0 so that it uses NSS libraries
+directly.
+---
+ src/timesync/timesyncd.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/timesync/timesyncd.c b/src/timesync/timesyncd.c
+index 1d8ebecc91..2b0ae361ff 100644
+--- a/src/timesync/timesyncd.c
++++ b/src/timesync/timesyncd.c
+@@ -21,6 +21,11 @@
+ #include "timesyncd-conf.h"
+ #include "timesyncd-manager.h"
+ #include "user-util.h"
++#include "env-util.h"
++
++struct traced_file;
++extern void __nss_disable_nscd(void (*)(size_t, struct traced_file *));
++static void register_traced_file(size_t dbidx, struct traced_file *finfo) {}
+ 
+ static int advance_tstamp(int fd, const struct stat *st) {
+         assert_se(fd >= 0);
+@@ -198,6 +203,12 @@ static int run(int argc, char *argv[]) {
+         if (r < 0)
+                 return log_error_errno(r, "Failed to parse fallback server strings: %m");
+ 
++        r = getenv_bool_secure("SYSTEMD_NSS_RESOLVE_VALIDATE");
++        if (r == 0) {
++                log_info("Disabling NSCD because DNSSEC validation is turned off");
++                __nss_disable_nscd(register_traced_file);
++        }
++
+         log_debug("systemd-timesyncd running as pid " PID_FMT, getpid_cached());
+ 
+         notify_message = notify_start("READY=1\n"
+-- 
+2.34.1
+


### PR DESCRIPTION
In Ghaf date and time are synchronized using systemd-timesyncd service. In order to get the correct date and time it requires a working internet connection. However, internet connection doesn't work when the current date and time are not correct because we have Domain Name System Security Extensions (DNSSEC) enabled. This leads to a chicken and egg problem. It's especially bad for Nvidia Orin devices since they don't have batteries for RTC.

Systemd-timesyncd resolves this issue by setting SYSTEMD_NSS_RESOLVE_VALIDATE=0 environmental variable in the unit configuration file. It disables DNSSEC validation for the timesyncd service so that it can connect to the NTP server even if current date and time is incorrect. However, this option doesn't work in Nix because it uses NSCD instead of calling NSS libraries directly. NSCD is a caching service which communicates with glibc over a Unix socket and it doesn't have SYSTEMD_NSS_RESOLVE_VALIDATE=0 set.

This patch disables NSCD in systemd-timesyncd using an internal glibc function when DNSSEC validation is disabled and it also sets LD_LIBRARY_PATH so that the service can find the libnss_resolve.so.2 library in the Nix store.

Testing procedure:
- Stop timesyncd: sudo systemctl stop systemd-timesyncd
- Delete the clock file: sudo rm /var/lib/systemd/timesync/clock
- Set a wrong date and time: sudo date 01010101
- Start timesyncd or reboot the system: sudo systemctl start systemd-timesyncd
- Older versions of Ghaf will not be able to synchronize time and DNS will not work but with this patch the system should get the correct date and time from the NTP server and DNS requests with DNSSEC should work fine.
