### PR TITLE
doc: add mdbook-footnote plugin

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -10,3 +10,5 @@ src = "src"
 default-theme = "light"
 git-repository-url = "https://github.com/tiiuae/ghaf"
 git-repository-icon = "fa-github"
+
+[preprocessor.footnote]

--- a/docs/doc.nix
+++ b/docs/doc.nix
@@ -1,12 +1,15 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: CC-BY-SA-4.0
 {
+  callPackage,
   runCommandNoCC,
   mdbook,
-}:
-runCommandNoCC "ghaf-doc"
-{
-  nativeBuildInputs = [mdbook];
-} ''
-  ${mdbook}/bin/mdbook build -d $out ${./.}
-''
+}: let
+  footnote = callPackage ./plugins/mdbook-footnote.nix {};
+in
+  runCommandNoCC "ghaf-doc"
+  {
+    nativeBuildInputs = [mdbook footnote];
+  } ''
+    ${mdbook}/bin/mdbook build -d $out ${./.}
+  ''

--- a/docs/plugins/mdbook-footnote.nix
+++ b/docs/plugins/mdbook-footnote.nix
@@ -1,0 +1,19 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: CC-BY-SA-4.0
+{
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-footnote";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "daviddrysdale";
+    repo = "mdbook-footnote";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-WUMgm1hwsU9BeheLfb8Di0AfvVQ6j92kXxH2SyG3ses=";
+  };
+
+  cargoHash = "sha256-Ig+uVCO5oHIkkvFsKiBiUFzjUgH/Pydn4MVJHb2wKGc=";
+}


### PR DESCRIPTION
* on popular demand - example of adding mdbook-plugins, https://github.com/daviddrysdale/mdbook-footnote
* tested to generate footnote with "Normal text{{footnote: Or is it?}} in body." from docs/src/index.md using "nix build .#doc" Test footnote left out of the commit intentionally.