### PR TITLE
nvidia-jetson-orin: uefi: Add ghaf logo to boot

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
@@ -43,6 +43,8 @@ in
         flashScriptOverrides = {
           flashArgs = lib.mkForce ["-r" config.hardware.nvidia-jetpack.flashScriptOverrides.targetBoard "mmcblk0p1"];
         };
+
+        firmware.uefi.logo = ../../../docs/src/img/1600px-Ghaf_logo.svg;
       };
 
       nixpkgs.hostPlatform.system = "aarch64-linux";


### PR DESCRIPTION
Add ghaf logo to boot screen of edk2 uefi bootloader.