### PR TITLE
switch to nixpkgs branch, which contains recent fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688469905,
-        "narHash": "sha256-zCN4hLZ7CWd+hLO0J4AOXBUWCYAbgpta/dVTo7tSisY=",
+        "lastModified": 1689159766,
+        "narHash": "sha256-QErQ/6J+jv1FrpcDOZtETGC0Mp5Ozyd7965JVAgVrCw=",
         "owner": "avnik",
         "repo": "nixpkgs",
-        "rev": "9e4901e6c13a41fac7ae4f58060cb4773623b7dd",
+        "rev": "c56f6bcc25c0d94039745edb6a0dd86ab2b3b0d2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -114,16 +114,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689048911,
-        "narHash": "sha256-pODI2CkjWbSLo5nPMZoLtkRNJU/Nr3VSITXZqqmNtIk=",
-        "owner": "nixos",
+        "lastModified": 1688469905,
+        "narHash": "sha256-zCN4hLZ7CWd+hLO0J4AOXBUWCYAbgpta/dVTo7tSisY=",
+        "owner": "avnik",
         "repo": "nixpkgs",
-        "rev": "8163a64662b43848802092d52015ef60777d6129",
+        "rev": "9e4901e6c13a41fac7ae4f58060cb4773623b7dd",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.05",
+        "owner": "avnik",
+        "ref": "ghaf-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    nixpkgs.url = "github:avnik/nixpkgs/ghaf-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     nixos-generators = {
       url = "github:nix-community/nixos-generators";


### PR DESCRIPTION
This branch contain fixes for clang (not yet accepted into stable), and fixes for perl-Module-Build