### PR TITLE
Declarative NetVM

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,17 +64,12 @@
           options = let
             cfg = nixpkgs.lib.nixosSystem {
               inherit system;
-              modules = let
-                filteredModules = builtins.filter (module: !lib.hasSuffix "microvm-host.nix" module) lib.ghaf.modules;
-              in
-                filteredModules
+              modules =
+                lib.ghaf.modules
                 ++ [
-                  (import ./modules/virtualization/microvm/microvm-host.nix {
-                    inherit self microvm;
-                    netvm = "";
-                  })
-                ]
-                ++ [jetpack-nixos.nixosModules.default];
+                  jetpack-nixos.nixosModules.default
+                  microvm.nixosModules.host
+                ];
             };
           in
             cfg.options;

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -1,10 +1,6 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  self,
-  microvm,
-  netvm,
-}: {
   lib,
   pkgs,
   modulesPath,
@@ -17,17 +13,8 @@
 
     ../../overlays/custom-packages.nix
 
-    # TODO Refactor the microvm to be fully declarative
-    # SEE https://astro.github.io/microvm.nix/declarative.html
-    (import ../virtualization/microvm/microvm-host.nix {inherit self microvm netvm;})
+    # TODO: Refactor this under virtualization/microvm/host/networking.nix
     ./networking.nix
-
-    {
-      ghaf = {
-        virtualization.microvm-host.enable = true;
-        host.networking.enable = true;
-      };
-    }
   ];
 
   config = {

--- a/modules/virtualization/microvm/microvm-host.nix
+++ b/modules/virtualization/microvm/microvm-host.nix
@@ -1,10 +1,6 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  self,
-  microvm,
-  netvm,
-}: {
   config,
   lib,
   ...
@@ -16,16 +12,7 @@ in
       enable = mkEnableOption "MicroVM Host";
     };
 
-    imports = [
-      microvm.nixosModules.host
-    ];
-
     config = mkIf cfg.enable {
       microvm.host.enable = true;
-
-      microvm.vms."${netvm}" = {
-        flake = self;
-        autostart = true;
-      };
     };
   }

--- a/targets/vm.nix
+++ b/targets/vm.nix
@@ -15,13 +15,21 @@
       specialArgs = {inherit lib;};
       modules =
         [
-          (import ../modules/host {
-            inherit self microvm netvm;
-          })
+          microvm.nixosModules.host
+          ../modules/host
+          ../modules/virtualization/microvm/microvm-host.nix
+          ../modules/virtualization/microvm/netvm.nix
 
           {
             ghaf = {
               hardware.x86_64.common.enable = true;
+
+              virtualization.microvm-host.enable = true;
+              host.networking.enable = true;
+              # TODO: NetVM enabled, but it does not include anything specific
+              #       for this Virtual Machine target
+              virtualization.microvm.netvm.enable = true;
+
               # Enable all the default UI applications
               profiles = {
                 applications.enable = true;
@@ -36,13 +44,9 @@
         ]
         ++ (import ../modules/module-list.nix);
     };
-    netvm = "netvm-${name}-${variant}";
   in {
-    inherit hostConfiguration netvm;
+    inherit hostConfiguration;
     name = "${name}-${variant}";
-    netvmConfiguration = import ../modules/virtualization/microvm/netvm.nix {
-      inherit lib microvm system;
-    };
     package = hostConfiguration.config.system.build.${hostConfiguration.config.formatAttr};
   };
   targets = [
@@ -51,8 +55,7 @@
   ];
 in {
   nixosConfigurations =
-    builtins.listToAttrs (map (t: lib.nameValuePair t.name t.hostConfiguration) targets)
-    // builtins.listToAttrs (map (t: lib.nameValuePair t.netvm t.netvmConfiguration) targets);
+    builtins.listToAttrs (map (t: lib.nameValuePair t.name t.hostConfiguration) targets);
   packages = {
     x86_64-linux =
       builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);


### PR DESCRIPTION
    * Move from flake-based microvm-configuration to declarative
      configuration.
    * Cross-compilation enabled for NetVM, when host has cross-compilation
      enabled.
    * Refactored modules/host from function to a nixosModule.
    * While building documentation, microvm-host.nix does not need to be
      filtered out anymore.
