### PR TITLE
Enable audio on host

### DIFF
--- a/modules/audio/default.nix
+++ b/modules/audio/default.nix
@@ -1,0 +1,67 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.ghaf.audio;
+in
+  with lib; {
+    options.ghaf.audio = {
+      enable = mkEnableOption "audio";
+    };
+
+    config = mkIf cfg.enable {
+      sound.enable = true;
+      sound.extraConfig = ''
+        pcm.dmix_44100{
+          type dmix
+          ipc_key 5678293
+          ipc_key_add_uid yes
+          slave{
+            pcm "hw:0,0"
+            period_time 40000
+            format S16_LE
+            rate 44100
+          }
+        }
+
+        pcm.!dsnoop_44100{
+          type dsnoop
+          ipc_key 5778293
+          ipc_key_add_uid yes
+          slave{
+            pcm "hw:0,0"
+            period_time 40000
+            format S16_LE
+            rate 44100
+          }
+        }
+
+        pcm.asymed{
+          type asym
+          playback.pcm "dmix_44100"
+          capture.pcm "dsnoop_44100"
+        }
+
+        pcm.!default{
+          type plug
+          route_policy "average"
+          slave.pcm "asymed"
+        }
+
+        ctl.!default{
+          type hw;
+          card 0;
+        }
+
+        ctl.mixer0{
+          type hw
+          card 0
+        }
+      '';
+      users.users.ghaf.extraGroups = ["audio"];
+    };
+  }

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -16,4 +16,5 @@
   ./version
   ./virtualization/docker.nix
   ./windows-launcher
+  ./audio
 ]

--- a/targets/generic-x86_64.nix
+++ b/targets/generic-x86_64.nix
@@ -60,6 +60,7 @@
                 debug.enable = variant == "debug";
               };
               windows-launcher.enable = true;
+              audio.enable = true;
             };
           }
 

--- a/targets/nvidia-jetson-orin.nix
+++ b/targets/nvidia-jetson-orin.nix
@@ -65,6 +65,7 @@
               };
               # TODO when supported on x86 move under virtualization
               windows-launcher.enable = true;
+              audio.enable = true;
             };
           }
 


### PR DESCRIPTION
Currently we have multiple applications that are running on host and require audio support. This PR adds the ability to use a USB headset as an audio device.

How to test:
1. Connect a USB headset to the device and reboot it.
2. Make sure the headset has 0 index in the cards list `cat /proc/asound/cards`.
3. Open Chromium and play any video with audio.
4. Run `alsamixer` in the terminal in order to change the volume.

Tested on Nvidia Orin AGX with Sennheiser PC 8 USB Headset.