### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686967443,
-        "narHash": "sha256-PXIDBOVM8JpMBo/oYrfDHD08AfO/rJKredz3yO/gDeA=",
+        "lastModified": 1689964252,
+        "narHash": "sha256-4esn5USqPgWFrmdzaqQUnCwhSW3/Ucg/2RDZLo76MTY=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "ddaff1bfceafb93ea67cb4ef953ba8eff5cf942b",
+        "rev": "ec27d1c4e81d8e5470571782ad58bb1111bce975",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688933605,
-        "narHash": "sha256-eux5CjKmO+6GFoovtckoVo0es1FZ2mzupehDyHuCaCk=",
+        "lastModified": 1689768420,
+        "narHash": "sha256-fW43dx0TqeGyjQ6bImWkhOICODQ4cLbkCjcri0c3bxQ=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "018691bf86a70b7e5d24eb37d6aad05ce1c1b12e",
+        "rev": "4b0f24f26638937036dc0dc9e28d2bab4152ef3d",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     },
     "nixlib": {
       "locked": {
-        "lastModified": 1688259758,
-        "narHash": "sha256-CYVbYQfIm3vwciCf6CCYE+WOOLE3vcfxfEfNHIfKUJQ=",
+        "lastModified": 1689469483,
+        "narHash": "sha256-2SBhY7rZQ/iNCxe04Eqxlz9YK9KgbaTMBssq3/BgdWY=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a92befce80a487380ea5e92ae515fe33cebd3ac6",
+        "rev": "02fea408f27186f139153e1ae88f8ab2abd9c22c",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688738567,
-        "narHash": "sha256-yax5BYOfpE0+95kyJmEcfKEdZBaFvCENDogBB4VQB3Q=",
+        "lastModified": 1690133435,
+        "narHash": "sha256-YNZiefETggroaTLsLJG2M+wpF0pJPwiauKG4q48ddNU=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "9191c85aab6b1a7ad395c13d340f2aa0e3ddf552",
+        "rev": "b1171de4d362c022130c92d7c8adc4bf2b83d586",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1689060619,
-        "narHash": "sha256-vODUkZLWFVCvo1KPK3dC2CbXjxa9antEn5ozwlcTr48=",
+        "lastModified": 1690200740,
+        "narHash": "sha256-aRkEXGmCbAGcvDcdh/HB3YN+EvoPoxmJMOaqRZmf6vM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "44bc025007e5fcc10dbc3d9f96dcbf06fc0e8c1c",
+        "rev": "ba9650b14e83b365fb9e731f7d7c803f22d2aecf",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689209875,
-        "narHash": "sha256-8AVcBV1DiszaZzHFd5iLc8HSLfxRAuqcU0QdfBEF3Ag=",
+        "lastModified": 1690148897,
+        "narHash": "sha256-l/j/AX1d2K79EWslwgWR2+htkzCbtjKZsS5NbWXnhz4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fcc147b1e9358a8386b2c4368bd928e1f63a7df2",
+        "rev": "ac1acba43b2f9db073943ff5ed883ce7e8a40a2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
• Updated input 'jetpack-nixos':
    'github:anduril/jetpack-nixos/ddaff1bfceafb93ea67cb4ef953ba8eff5cf942b' (2023-06-17)
  → 'github:anduril/jetpack-nixos/ec27d1c4e81d8e5470571782ad58bb1111bce975' (2023-07-21)
• Updated input 'microvm':
    'github:astro/microvm.nix/018691bf86a70b7e5d24eb37d6aad05ce1c1b12e' (2023-07-09)
  → 'github:astro/microvm.nix/4b0f24f26638937036dc0dc9e28d2bab4152ef3d' (2023-07-19)
• Updated input 'nixos-generators':
    'github:nix-community/nixos-generators/9191c85aab6b1a7ad395c13d340f2aa0e3ddf552' (2023-07-07)
  → 'github:nix-community/nixos-generators/b1171de4d362c022130c92d7c8adc4bf2b83d586' (2023-07-23)
• Updated input 'nixos-generators/nixlib':
    'github:nix-community/nixpkgs.lib/a92befce80a487380ea5e92ae515fe33cebd3ac6' (2023-07-02)
  → 'github:nix-community/nixpkgs.lib/02fea408f27186f139153e1ae88f8ab2abd9c22c' (2023-07-16)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/44bc025007e5fcc10dbc3d9f96dcbf06fc0e8c1c' (2023-07-11)
  → 'github:NixOS/nixos-hardware/ba9650b14e83b365fb9e731f7d7c803f22d2aecf' (2023-07-24)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/fcc147b1e9358a8386b2c4368bd928e1f63a7df2' (2023-07-13)
  → 'github:NixOS/nixpkgs/ac1acba43b2f9db073943ff5ed883ce7e8a40a2c' (2023-07-23)