### PR TITLE
Correct target name in Nvidia Jetson Agx template flake

### DIFF
--- a/templates/targets/aarch64/nvidia/orin-agx/flake.nix
+++ b/templates/targets/aarch64/nvidia/orin-agx/flake.nix
@@ -51,7 +51,7 @@
       }))
 
       {
-        nixosConfigurations.PROJ_NAME-ghaf-debug = ghaf.nixosConfigurations.nvidia-jetson-orin-debug.extendModules {
+        nixosConfigurations.PROJ_NAME-ghaf-debug = ghaf.nixosConfigurations.nvidia-jetson-orin-agx-debug.extendModules {
           modules = [
             {
               #insert your additional modules here e.g.


### PR DESCRIPTION
I was testing the Jetson Orin Agx flake template and git an error when running `nix flake check`. I think the target name was incorrect when checking the available outputs from Ghaf where agx and nx targets had been separated.