### PR TITLE
Hart Software Services for Microchip Polarfire Icicle Kit (RISC-V)

### DIFF
--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -1,6 +1,8 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {self, ...}: {
+  flake.packages.riscv64-linux.hart-software-services =
+    self.nixosConfigurations.microchip-icicle-kit-debug.pkgs.callPackage ./hart-software-services {};
   perSystem = {
     pkgs,
     lib,

--- a/packages/hart-software-services/default.nix
+++ b/packages/hart-software-services/default.nix
@@ -1,0 +1,54 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  fetchFromGitHub,
+  lib,
+  python3,
+  stdenv,
+}: let
+  version = "v2022.09";
+in
+  stdenv.mkDerivation (
+    {
+      pname = "hart-software-services";
+      inherit version;
+
+      src = fetchFromGitHub {
+        owner = "polarfire-soc";
+        repo = "hart-software-services";
+        rev = version;
+        sha256 = "sha256-j/nda7//CjJW09zt/YrBy6h+q+VKE5t/ueXxDzwVWQ0=";
+      };
+
+      depsBuildBuild = [
+        python3
+      ];
+
+      configurePhase = ''
+        runHook preConfigure
+
+        cp boards/mpfs-icicle-kit-es/def_config .config
+
+        runHook postConfigure
+      '';
+
+      makeFlags = [
+        "V=1"
+        "BOARD=mpfs-icicle-kit-es"
+        "PLATFORM_RISCV_ABI=lp64d"
+        "PLATFORM_RISCV_ISA=rv64imadc_zicsr_zifencei"
+      ];
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp Default/*.elf Default/*.bin $out/
+
+        runHook postInstall
+      '';
+    }
+    // lib.optionalAttrs (stdenv.buildPlatform.system != stdenv.hostPlatform.system) {
+      CROSS_COMPILE = stdenv.cc.targetPrefix;
+    }
+  )


### PR DESCRIPTION
Build Hart Software Services (HSS) to be able to ~~run RISC-V images on QEMU~~ build own HSS binary from source and run it on Icicle-Kit board