### PR TITLE
weston.ini: Keep weston-terminal launcher

### DIFF
--- a/modules/graphics/weston.ini.nix
+++ b/modules/graphics/weston.ini.nix
@@ -26,14 +26,16 @@
   mkLaunchers = lib.concatMapStrings mkLauncher;
 
   gala-app = pkgs.callPackage ../../user-apps/gala {};
-  demoLaunchers = [
-    # Add application launchers
-    # Adding terminal launcher because it is overwritten if other launchers are on the panel
+  defaultLauncher = [
+    # Keep weston-terminal launcher always enabled explicitly since if someone adds
+    # a launcher on the panel, the launcher will replace weston-terminal launcher.
     {
       path = "${pkgs.weston}/bin/weston-terminal";
       icon = "${pkgs.weston}/share/weston/icon_terminal.png";
     }
-
+  ];
+  demoLaunchers = [
+    # Add application launchers
     {
       path = "${pkgs.chromium}/bin/chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
       icon = "${pkgs.chromium}/share/icons/hicolor/24x24/apps/chromium.png";
@@ -76,7 +78,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    ghaf.graphics.weston.launchers = lib.optionals cfg.enableDemoApplications demoLaunchers;
+    ghaf.graphics.weston.launchers = defaultLauncher ++ lib.optionals cfg.enableDemoApplications demoLaunchers;
     environment.systemPackages = with pkgs;
       lib.optionals cfg.enableDemoApplications [
         # Graphical applications


### PR DESCRIPTION
When adding launchers on weston panel, new launchers override existing weston-terminal launcher which has to be enabled explicitly in this case.