### PR TITLE
Cache NVIDIA Jetson Orin cross-compiled packages

### DIFF
--- a/hydrajobs.nix
+++ b/hydrajobs.nix
@@ -10,5 +10,9 @@
     docs.x86_64-linux = self.packages.x86_64-linux.doc;
     docs.aarch64-linux = self.packages.aarch64-linux.doc;
     microchip-icicle-kit-debug.x86_64-linux = self.packages.riscv64-linux.microchip-icicle-kit-debug;
+
+    # Build these toplevel derivations to cache cross-compiled packages
+    nvidia-jetson-orin-agx-debug-from-x86_64-toplevel.x86_64-linux = self.nixosConfigurations.nvidia-jetson-orin-agx-debug-from-x86_64.config.system.build.toplevel;
+    nvidia-jetson-orin-nx-debug-from-x86_64-toplevel.x86_64-linux = self.nixosConfigurations.nvidia-jetson-orin-nx-debug-from-x86_64.config.system.build.toplevel;
   };
 }


### PR DESCRIPTION
Add toplevel derivations of cross-compiled NVIDIA Jetson Orin configurations to Hydra jobs, to cache cross-compiled packages.