### PR TITLE
Cache versions without demo apps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
       (import ./user-apps {inherit lib nixpkgs flake-utils;})
 
       # Hydra jobs
-      (import ./hydrajobs.nix {inherit self;})
+      (import ./hydrajobs.nix {inherit self lib;})
 
       #templates
       (import ./templates)

--- a/hydrajobs.nix
+++ b/hydrajobs.nix
@@ -1,7 +1,14 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{self}: {
-  hydraJobs = {
+{
+  self,
+  lib,
+}: {
+  hydraJobs = let
+    disableDemoAppsModule = {
+      ghaf.graphics.weston.enableDemoApplications = lib.mkForce false;
+    };
+  in {
     generic-x86_64-debug.x86_64-linux = self.packages.x86_64-linux.generic-x86_64-debug;
     nvidia-jetson-orin-agx-debug.aarch64-linux = self.packages.aarch64-linux.nvidia-jetson-orin-agx-debug;
     nvidia-jetson-orin-nx-debug.aarch64-linux = self.packages.aarch64-linux.nvidia-jetson-orin-nx-debug;
@@ -14,5 +21,23 @@
     # Build these toplevel derivations to cache cross-compiled packages
     nvidia-jetson-orin-agx-debug-from-x86_64-toplevel.x86_64-linux = self.nixosConfigurations.nvidia-jetson-orin-agx-debug-from-x86_64.config.system.build.toplevel;
     nvidia-jetson-orin-nx-debug-from-x86_64-toplevel.x86_64-linux = self.nixosConfigurations.nvidia-jetson-orin-nx-debug-from-x86_64.config.system.build.toplevel;
+
+    # Build also cross-compiled toplevel derivations without demo apps
+    nvidia-jetson-orin-agx-debug-from-x86_64-nodemoapps-toplevel.x86_64-linux =
+      (self.nixosConfigurations.nvidia-jetson-orin-agx-debug-from-x86_64.extendModules {
+        modules = [disableDemoAppsModule];
+      })
+      .config
+      .system
+      .build
+      .toplevel;
+    nvidia-jetson-orin-nx-debug-from-x86_64-nodemoapps-toplevel.x86_64-linux =
+      (self.nixosConfigurations.nvidia-jetson-orin-nx-debug-from-x86_64.extendModules {
+        modules = [disableDemoAppsModule];
+      })
+      .config
+      .system
+      .build
+      .toplevel;
   };
 }


### PR DESCRIPTION
Demoapps fail to cross-compile currontly, so add another versions of NVIDIA Jetson Orin cross-compilation hydra jobs, which don't include demo apps.