### PR TITLE
Orin Nx Ethernet Passthrough

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
@@ -4,7 +4,9 @@
 # Configuration for NVIDIA Jetson Orin AGX/NX reference boards
 {
   lib,
+  pkgs,
   config,
+  nixpkgs,
   ...
 }: let
   cfg = config.ghaf.hardware.nvidia.orin;
@@ -14,14 +16,48 @@
       passthrough-patch = ./pci-passthrough-agx-test.patch;
       vfio-pci = "vfio-pci.ids=10ec:c82f";
       deviceTree = "tegra234-p3701-host-passthrough.dtb";
+      buspath = [
+        {
+          bus = "pci";
+          path = "0001:01:00.0";
+        }
+      ];
+      kernelParams = [];
     };
     "nx" = {
       flashArgs = ["-r" config.hardware.nvidia-jetpack.flashScriptOverrides.targetBoard "nvme0n1p1"];
+      # This patch uses Alex Williamson's patch for enabling overrides for missing ACS capabilities on pci
+      # bus which could be accessed from following link: https://lkml.org/lkml/2013/5/30/513
       passthrough-patch = ./pci-passthrough-nx-test.patch;
+      # Multiple device passing option
+      #      vfio-pci = "vfio-pci.ids=10de:229c,10ec:8168";
       vfio-pci = "vfio-pci.ids=10ec:8168";
       deviceTree = "tegra234-p3767-host-passthrough.dtb";
+      buspath = [
+        # Multiple devices and path could be passed through this option
+        #        {
+        #          bus = "pci";
+        #          path = "0008:00:00.0";
+        #        }
+        {
+          bus = "pci";
+          path = "0008:01:00.0";
+        }
+      ];
+      kernelParams = [
+        "pci=nomsi"
+        "pcie_acs_override=downstream,multifunction"
+      ];
     };
   };
+  netvmExtraModules = [
+    {
+      # This is the device dependent part of netvm configuration.
+      # This part should be conditional for AGX 01:01 for NX 08:01
+      microvm.devices = somDefinition."${cfg.somType}".buspath;
+      microvm.kernelParams = somDefinition."${cfg.somType}".kernelParams;
+    }
+  ];
 in
   with lib; {
     options.ghaf.hardware.nvidia.orin = {
@@ -65,11 +101,16 @@ in
 
       ghaf.boot.loader.systemd-boot-dtb.enable = true;
 
+      ghaf.virtualization.microvm.netvm = {
+        enable = true;
+        extraModules = netvmExtraModules;
+      };
+
       boot.loader = {
         efi.canTouchEfiVariables = true;
         systemd-boot.enable = true;
       };
-
+      boot.modprobeConfig.enable = true;
       boot.kernelPatches = [
         {
           name = "passthrough-patch";
@@ -96,7 +137,9 @@ in
         name = somDefinition."${cfg.somType}".deviceTree;
       };
 
-      # Passthrough Jetson Orin WiFi card
+      # Passthrough Jetson Orin Network cards
+      boot.kernelModules = ["vfio_pci" "vfio_iommu_type1" "vfio"];
+
       boot.kernelParams = [
         somDefinition."${cfg.somType}".vfio-pci
         "vfio_iommu_type1.allow_unsafe_interrupts=1"

--- a/modules/hardware/nvidia-jetson-orin/pci-passthrough-nx-test.patch
+++ b/modules/hardware/nvidia-jetson-orin/pci-passthrough-nx-test.patch
@@ -1,3 +1,141 @@
+diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
+index d00618967854..a7b459f69e33 100644
+--- a/Documentation/admin-guide/kernel-parameters.txt
++++ b/Documentation/admin-guide/kernel-parameters.txt
+@@ -3641,6 +3641,14 @@
+ 		nomsi		[MSI] If the PCI_MSI kernel config parameter is
+ 				enabled, this kernel boot option can be used to
+ 				disable the use of MSI interrupts system-wide.
++		pci_acs_override [PCIE] Override missing PCIe ACS support for:
++				downstream
++					All downstream ports - full ACS capabilities
++				multifunction
++					Add multifunction devices - multifunction ACS subset
++				id:nnnn:nnnn
++					Specific device - full ACS capabilities
++					Specified as vid:did (vendor/device ID) in hex
+ 		noioapicquirk	[APIC] Disable all boot interrupt quirks.
+ 				Safety option to keep boot IRQs enabled. This
+ 				should never be necessary.
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 0c4492a7a308..2fc00e4dd7ac 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -3571,6 +3571,106 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
+ 	dev->dev_flags |= PCI_DEV_FLAGS_NO_BUS_RESET;
+ }
+ 
++static bool acs_on_downstream;
++static bool acs_on_multifunction;
++
++#define NUM_ACS_IDS 16
++struct acs_on_id {
++	unsigned short vendor;
++	unsigned short device;
++};
++static struct acs_on_id acs_on_ids[NUM_ACS_IDS];
++static u8 max_acs_id;
++
++static __init int pcie_acs_override_setup(char *p)
++{
++	if (!p)
++		return -EINVAL;
++
++	while (*p) {
++		if (!strncmp(p, "downstream", 10))
++			acs_on_downstream = true;
++		if (!strncmp(p, "multifunction", 13))
++			acs_on_multifunction = true;
++		if (!strncmp(p, "id:", 3)) {
++			char opt[5];
++			int ret;
++			long val;
++
++			if (max_acs_id >= NUM_ACS_IDS - 1) {
++				pr_warn("Out of PCIe ACS override slots (%d)\n",
++						NUM_ACS_IDS);
++				goto next;
++			}
++
++			p += 3;
++			snprintf(opt, 5, "%s", p);
++			ret = kstrtol(opt, 16, &val);
++			if (ret) {
++				pr_warn("PCIe ACS ID parse error %d\n", ret);
++				goto next;
++			}
++			acs_on_ids[max_acs_id].vendor = val;
++
++			p += strcspn(p, ":");
++			if (*p != ':') {
++				pr_warn("PCIe ACS invalid ID\n");
++				goto next;
++			}
++
++			p++;
++			snprintf(opt, 5, "%s", p);
++			ret = kstrtol(opt, 16, &val);
++			if (ret) {
++				pr_warn("PCIe ACS ID parse error %d\n", ret);
++				goto next;
++			}
++			acs_on_ids[max_acs_id].device = val;
++			max_acs_id++;
++		}
++next:
++		p += strcspn(p, ",");
++		if (*p == ',')
++			p++;
++	}
++
++	if (acs_on_downstream || acs_on_multifunction || max_acs_id)
++		pr_warn("Warning: PCIe ACS overrides enabled; This may allow non-IOMMU protected peer-to-peer DMA\n");
++
++	return 0;
++}
++early_param("pcie_acs_override", pcie_acs_override_setup);
++
++static int pcie_acs_overrides(struct pci_dev *dev, u16 acs_flags)
++{
++	int i;
++
++	/* Never override ACS for legacy devices or devices with ACS caps */
++	if (!pci_is_pcie(dev) ||
++		pci_find_ext_capability(dev, PCI_EXT_CAP_ID_ACS))
++			return -ENOTTY;
++
++	for (i = 0; i < max_acs_id; i++)
++		if (acs_on_ids[i].vendor == dev->vendor &&
++			acs_on_ids[i].device == dev->device)
++				return 1;
++
++	switch (pci_pcie_type(dev)) {
++	case PCI_EXP_TYPE_DOWNSTREAM:
++	case PCI_EXP_TYPE_ROOT_PORT:
++		if (acs_on_downstream)
++			return 1;
++		break;
++	case PCI_EXP_TYPE_ENDPOINT:
++	case PCI_EXP_TYPE_UPSTREAM:
++	case PCI_EXP_TYPE_LEG_END:
++	case PCI_EXP_TYPE_RC_END:
++		if (acs_on_multifunction && dev->multifunction)
++			return 1;
++	}
++
++	return -ENOTTY;
++}
+ /*
+  * Some NVIDIA GPU devices do not work with bus reset, SBR needs to be
+  * prevented for those affected devices.
+@@ -4938,6 +5038,7 @@ static const struct pci_dev_acs_enabled {
+ 	{ PCI_VENDOR_ID_NXP, 0x8d9b, pci_quirk_nxp_rp_acs },
+ 	/* Zhaoxin Root/Downstream Ports */
+ 	{ PCI_VENDOR_ID_ZHAOXIN, PCI_ANY_ID, pci_quirk_zhaoxin_pcie_ports_acs },
++	{ PCI_ANY_ID, PCI_ANY_ID, pcie_acs_overrides },
+ 	{ 0 }
+ };
+ 
 diff --git a/nvidia/platform/t23x/p3768/kernel-dts/Makefile b/nvidia/platform/t23x/p3768/kernel-dts/Makefile
 index f306119fe8a3..3034a22ca7ed 100644
 --- a/nvidia/platform/t23x/p3768/kernel-dts/Makefile
@@ -14,10 +152,10 @@ index f306119fe8a3..3034a22ca7ed 100644
  dtbo-$(BUILD_ENABLE) += tegra234-p3767-0000-p3509-a02-csi.dtbo
 diff --git a/nvidia/platform/t23x/p3768/kernel-dts/tegra234-p3767-host-passthrough.dts b/nvidia/platform/t23x/p3768/kernel-dts/tegra234-p3767-host-passthrough.dts
 new file mode 100644
-index 000000000000..e273e4e9505f
+index 000000000000..7b1c2f6fda7d
 --- /dev/null
 +++ b/nvidia/platform/t23x/p3768/kernel-dts/tegra234-p3767-host-passthrough.dts
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,14 @@
 +/dts-v1/;
 +#include "tegra234-p3767-0000-p3509-a02.dts"
 +
@@ -28,6 +166,7 @@ index 000000000000..e273e4e9505f
 +&pcie_c8_rp {
 +   interconnect-names = "dma-mem", "write";
 +   /delete-property/ iommus;
++   /delete-property/ dma-coherent;
 +   /delete-property/ msi-parent;
 +   /delete-property/ msi-map;
 +};


### PR DESCRIPTION
The configuration of Orin devices moved to modules/hardware/nvidia-jetson-orin. Multiple devices for passthrough can be added. ACS Security override patch included for Orin Nx. 