### PR TITLE
Remove requirement of aarch64-linux builder for EFI stuff

### DIFF
--- a/lib/mk-flash-script.nix
+++ b/lib/mk-flash-script.nix
@@ -10,7 +10,7 @@
 }: let
   cfg = hostConfiguration.config.hardware.nvidia-jetpack;
   inherit (jetpack-nixos.legacyPackages.${flash-tools-system}) flash-tools;
-  devicePkgs = jetpack-nixos.legacyPackages.aarch64-linux.devicePkgsFromNixosConfig hostConfiguration.config;
+  devicePkgs = jetpack-nixos.legacyPackages.${flash-tools-system}.devicePkgsFromNixosConfig hostConfiguration.config;
   flashScript = devicePkgs.mkFlashScript {
     flash-tools = flash-tools.overrideAttrs ({postPatch ? "", ...}: {
       postPatch = postPatch + cfg.flashScriptOverrides.postPatch;


### PR DESCRIPTION
It have proper selection of architecture inside jetpack guts, so no need to force system selection here