### PR TITLE
Fix Lenovo X1 touchpad passthrough

### DIFF
--- a/modules/development/debug-tools.nix
+++ b/modules/development/debug-tools.nix
@@ -31,6 +31,7 @@ in
 
         traceroute
         dig
+        evtest
       ];
     };
   }

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -39,7 +39,9 @@
           "-device"
           "virtio-input-host-pci,evdev=/dev/input/by-path/platform-i8042-serio-0-event-kbd"
           "-device"
-          "virtio-input-host-pci,evdev=/dev/input/by-path/pci-0000:00:15.0-platform-i2c_designware.0-event-mouse"
+          "virtio-input-host-pci,evdev=/dev/mouse"
+          "-device"
+          "virtio-input-host-pci,evdev=/dev/touchpad"
           # Lenovo X1 trackpoint (red button/joystick)
           "-device"
           "virtio-input-host-pci,evdev=/dev/input/by-path/platform-i8042-serio-1-event-mouse"
@@ -90,8 +92,8 @@
               # Laptop keyboard
               SUBSYSTEM=="input",ATTRS{name}=="AT Translated Set 2 keyboard",GROUP="kvm"
               # Laptop touchpad
-              SUBSYSTEM=="input",ATTRS{name}=="SYNA8016:00",GROUP="kvm"
-              SUBSYSTEM=="input",ATTRS{name}=="SYNA8016:00 06CB:CEB3 Mouse",GROUP="kvm"
+              SUBSYSTEM=="input",ATTRS{name}=="SYNA8016:00 06CB:CEB3 Mouse",GROUP="kvm",SYMLINK+="mouse"
+              SUBSYSTEM=="input",ATTRS{name}=="SYNA8016:00 06CB:CEB3 Touchpad",GROUP="kvm",SYMLINK+="touchpad"
               # Laptop TrackPoint
               SUBSYSTEM=="input",ATTRS{name}=="TPPS/2 Elan TrackPoint",GROUP="kvm"
             '';


### PR DESCRIPTION
Lenovo X1 touchpad doesn't work on every boot. The reason for that is that the touchpad has two input devices with the same dev link. In this PR I updated udev rules to create separate links and pass them both to the GUIVM. I also added evtest to debug-tools which is really useful for debugging input devices.

Fixes SP-2889