### PR TITLE
Setup vsock devices for APPVMs and use it for Waypipe

### DIFF
--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -16,7 +16,11 @@
 # nativeBuildInputs and buildInputs where possible.
 # It makes things clear and robust.
 #
-{lib, ...}: {
+{
+  lib,
+  pkgs,
+  ...
+}: {
   nixpkgs.overlays = [
     (final: prev: {
       gala-app = final.callPackage ../user-apps/gala {};
@@ -80,6 +84,16 @@
       });
       qemu_kvm = prev.qemu_kvm.overrideAttrs (_final: prev: {
         patches = prev.patches ++ [./acpi-devices-passthrough.patch];
+      });
+      # Waypipe with vsock
+      waypipe = prev.waypipe.overrideAttrs (prevAttrs: {
+        src = pkgs.fetchFromGitLab {
+          domain = "gitlab.freedesktop.org";
+          owner = "nesterov";
+          repo = "waypipe";
+          rev = "2f1ab6a8efd2c1ad0dbcc9f8482b10861743e9c3";
+          sha256 = "sha256-P4y8p4R28j4zp0OX2GspsBKqWvCHqg+nF153LIrRYs8=";
+        };
       });
     })
   ];

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -32,6 +32,7 @@
         };
       }
     ];
+    guivmConfig = hostConfiguration.config.ghaf.virtualization.microvm.guivm;
     guivmExtraModules = [
       {
         # Early KMS needed for GNOME to work inside GuiVM
@@ -68,17 +69,17 @@
       ({pkgs, ...}: {
         ghaf.graphics.weston.launchers = [
           {
-            path = "${pkgs.waypipe}/bin/waypipe ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.5 chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.5 ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${pkgs.weston}/share/weston/icon_editor.png";
           }
 
           {
-            path = "${pkgs.waypipe}/bin/waypipe ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.6 gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.6 ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${pkgs.weston}/share/weston/icon_editor.png";
           }
 
           {
-            path = "${pkgs.waypipe}/bin/waypipe ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.7 zathura";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.7 ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server zathura";
             icon = "${pkgs.weston}/share/weston/icon_editor.png";
           }
         ];
@@ -157,11 +158,6 @@
                         nixpkgs.config.pulseaudio = true;
 
                         microvm.qemu.extraArgs = [
-                          # APPVMs use microvm qemu machine which has pcie
-                          # disabled by default, and it also causes other
-                          # problems.
-                          "-M"
-                          "q35,accel=kvm:tcg,mem-merge=on,sata=off"
                           # Lenovo X1 integrated usb webcam
                           "-device"
                           "qemu-xhci"

--- a/user-apps/vsockproxy/default.nix
+++ b/user-apps/vsockproxy/default.nix
@@ -1,0 +1,33 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenv,
+  pkgs,
+  lib,
+  ...
+}:
+stdenv.mkDerivation {
+  name = "vsockproxy";
+
+  nativeBuildInputs = with pkgs; [meson ninja];
+
+  src = pkgs.fetchFromGitHub {
+    owner = "tiiuae";
+    repo = "vsockproxy";
+    rev = "aad625f9a27ce4c68d9996c65ece8477ace37534";
+    sha256 = "sha256-3WgpDlF8oIdlgwkvl7TPR6WAh+qk0mowzuYiPY0rwaU=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install ./vsockproxy $out/bin/vsockproxy
+  '';
+
+  meta = with lib; {
+    description = "vsockproxy";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
This PR makes Waypipe work over VSOCK instead of UNIX domain sockets. It increases performance by getting rid of the unnecessary overhead caused by forwarding UNIX sockets over SSH. Testing with iperf show that UNIX sockets over SSH can transfer about 4 Gbits/sec on Lenovo X1 Carbon but with VSOCK it can handle about 15 Gbits/sec between GUIVM and APPVMs.