### PR TITLE
AGX Wireless bug fix

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
@@ -102,7 +102,6 @@ in
       ghaf.boot.loader.systemd-boot-dtb.enable = true;
 
       ghaf.virtualization.microvm.netvm = {
-        enable = true;
         extraModules = netvmExtraModules;
       };
 

--- a/targets/nvidia-jetson-orin.nix
+++ b/targets/nvidia-jetson-orin.nix
@@ -18,22 +18,13 @@
         # The Nvidia Orin hardware dependent configuration is in
         # modules/hardware/nvidia-jetson-orin/jetson-orin.nx
         # Please refer to that section for hardware dependent netvm configuration.
-
         # To enable or disable wireless
-        networking.wireless = {
-          # Wireless Configuration
-          # Orin AGX has WiFi enabled where Orin Nx does not
-          enable =
-            if som == "agx"
-            then nixpkgs.lib.mkForce true
-            else nixpkgs.lib.mkForce false;
-        };
+        networking.wireless.enable = som == "agx";
+        # Wireless Configuration
+        # Orin AGX has WiFi enabled where Orin Nx does not
 
         # For WLAN firmwares
-        hardware.enableRedistributableFirmware =
-          if som == "agx"
-          then nixpkgs.lib.mkForce true
-          else nixpkgs.lib.mkForce false;
+        hardware.enableRedistributableFirmware = som == "agx";
         # Note: When 21.11 arrives replace the below statement with
         # wirelessRegulatoryDatabase = true;
       }
@@ -57,6 +48,9 @@
 
               virtualization.microvm-host.enable = true;
               host.networking.enable = true;
+
+              virtualization.microvm.netvm.enable = true;
+              virtualization.microvm.netvm.extraModules = netvmExtraModules;
 
               # Enable all the default UI applications
               profiles = {


### PR DESCRIPTION
Separation of netvmExtraModules caused a bug in agx wireless, where this was fixed by adding appropriate corrections. Wireless condition for agx is improved. A small fix was added for docker (where it is not included if it is not enabled) in case it is planned to add for support.