### PR TITLE
Update microvm in flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690637422,
-        "narHash": "sha256-hSEkpMhbQUcYLkKwOM5NiaSQ78NdPkosqcYc1TyMog8=",
+        "lastModified": 1694526290,
+        "narHash": "sha256-HiWr+tfJE/hcn8atRC0S5KweSUknQLEduPLTEiSr5J8=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "38260452faac611b03cb8a03cf4ba78999587f5e",
+        "rev": "03e7f11cf915a911277c2cdea5d7da9717597aa2",
         "type": "github"
       },
       "original": {

--- a/modules/virtualization/microvm/appvm.nix
+++ b/modules/virtualization/microvm/appvm.nix
@@ -55,7 +55,6 @@
             mem = vm.ramMb;
             vcpu = vm.cores;
             hypervisor = "qemu";
-            qemu.bios.enable = true;
             storeDiskType = "squashfs";
             interfaces = [
               {

--- a/modules/virtualization/microvm/guivm.nix
+++ b/modules/virtualization/microvm/guivm.nix
@@ -54,7 +54,6 @@
         microvm = {
           mem = 2048;
           hypervisor = "qemu";
-          qemu.bios.enable = false;
           storeDiskType = "squashfs";
           interfaces = [
             {

--- a/modules/virtualization/microvm/netvm.nix
+++ b/modules/virtualization/microvm/netvm.nix
@@ -73,7 +73,6 @@
           };
         };
 
-        microvm.qemu.bios.enable = false;
         microvm.storeDiskType = "squashfs";
 
         imports = import ../../module-list.nix;

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -18,9 +18,9 @@
 #
 {lib, ...}: {
   nixpkgs.overlays = [
-    (_final: prev: {
-      gala-app = _final.callPackage ../user-apps/gala {};
-      waypipe-ssh = _final.callPackage ../user-apps/waypipe-ssh {};
+    (final: prev: {
+      gala-app = final.callPackage ../user-apps/gala {};
+      waypipe-ssh = final.callPackage ../user-apps/waypipe-ssh {};
       # TODO: Remove this override if/when the fix is upstreamed.
       # Disabling colord dependency for weston. Colord has argyllcms as
       # a dependency, and this package is not cross-compilable.

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -117,7 +117,7 @@
                     name = "chromium";
                     packages = [pkgs.chromium];
                     ipAddress = "192.168.101.5/24";
-                    macAddress = "02:00:00:03:03:05";
+                    macAddress = "02:00:00:03:05:01";
                     ramMb = 3072;
                     cores = 4;
                   }
@@ -125,7 +125,7 @@
                     name = "gala";
                     packages = [pkgs.gala-app];
                     ipAddress = "192.168.101.6/24";
-                    macAddress = "02:00:00:03:03:06";
+                    macAddress = "02:00:00:03:06:01";
                     ramMb = 1536;
                     cores = 2;
                   }
@@ -133,12 +133,14 @@
                     name = "zathura";
                     packages = [pkgs.zathura];
                     ipAddress = "192.168.101.7/24";
-                    macAddress = "02:00:00:03:03:07";
+                    macAddress = "02:00:00:03:07:01";
                     ramMb = 512;
                     cores = 1;
                   }
                 ];
-                extraModules = [{}];
+                extraModules = [
+                  ../overlays/custom-packages.nix
+                ];
               };
 
               # Enable all the default UI applications


### PR DESCRIPTION
The behavior onwards from now, is the same as if the microvm.qemu.bios.enable is always set to false.