### PR TITLE
Update Lenovo X1 udev rules to use evdev input devices

### DIFF
--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -92,8 +92,11 @@
               # Laptop keyboard
               SUBSYSTEM=="input",ATTRS{name}=="AT Translated Set 2 keyboard",GROUP="kvm"
               # Laptop touchpad
-              SUBSYSTEM=="input",ATTRS{name}=="SYNA8016:00 06CB:CEB3 Mouse",GROUP="kvm",SYMLINK+="mouse"
-              SUBSYSTEM=="input",ATTRS{name}=="SYNA8016:00 06CB:CEB3 Touchpad",GROUP="kvm",SYMLINK+="touchpad"
+              SUBSYSTEM=="input",ATTRS{name}=="SYNA8016:00 06CB:CEB3 Mouse",KERNEL=="event*",GROUP="kvm",SYMLINK+="mouse"
+              SUBSYSTEM=="input",ATTRS{name}=="SYNA8016:00 06CB:CEB3 Touchpad",KERNEL=="event*",GROUP="kvm",SYMLINK+="touchpad"
+              # Laptop touchpad - UAE revision
+              SUBSYSTEM=="input",ATTRS{name}=="ELAN067C:00 04F3:31F9 Mouse",KERNEL=="event*",GROUP="kvm",SYMLINK+="mouse"
+              SUBSYSTEM=="input",ATTRS{name}=="ELAN067C:00 04F3:31F9 Touchpad",KERNEL=="event*",GROUP="kvm",SYMLINK+="touchpad"
               # Laptop TrackPoint
               SUBSYSTEM=="input",ATTRS{name}=="TPPS/2 Elan TrackPoint",GROUP="kvm"
             '';


### PR DESCRIPTION
This is another fix for the Lenovo X1 touchpad passthrough.

I noticed that sometimes Lenovo X1 boots to black screen and the GUIVM fails to start. It turned out that the touchpad has two devices under the same name: PS/2-style mousedev (/dev/input/mouse*) and evdev (/dev/input/event*). When the legacy mousedev device comes first the GUIVM fails to start with the following error: "/dev/mouse: is not an evdev device".

In this patch I added an additional filter to the udev rules to make sure we always use event devices for the passthrough.