### PR TITLE
Docker fix

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
@@ -102,7 +102,6 @@ in
       ghaf.boot.loader.systemd-boot-dtb.enable = true;
 
       ghaf.virtualization.microvm.netvm = {
-        enable = true;
         extraModules = netvmExtraModules;
       };
 

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -19,6 +19,20 @@
 {lib, ...}: {
   nixpkgs.overlays = [
     (_final: prev: {
+      # This is added to resolve the issue https://ssrc.atlassian.net/browse/SP-2697
+      # where originated from https://github.com/NixOS/nixpkgs/issues/244159
+      # as a summary while running docker containers got a `http: invalid Host header`
+      # response failing to run.
+      # This is due to a bug in Go package in NixOS where the previous package solves
+      # this issue. Same solution will be applied GO compiler related net access bugs
+      # till next release.
+      # TODO: When moving to NixOS 23.11, this fix will be removed as it is already
+      #       fixed in the unstable channel.
+      docker = (
+        prev.docker.override {
+          buildGoPackage = _final.buildGo118Package;
+        }
+      );
       gala-app = _final.callPackage ../user-apps/gala {};
       waypipe-ssh = _final.callPackage ../user-apps/waypipe-ssh {};
       # TODO: Remove this override if/when the fix is upstreamed.

--- a/targets/nvidia-jetson-orin.nix
+++ b/targets/nvidia-jetson-orin.nix
@@ -18,22 +18,13 @@
         # The Nvidia Orin hardware dependent configuration is in
         # modules/hardware/nvidia-jetson-orin/jetson-orin.nx
         # Please refer to that section for hardware dependent netvm configuration.
-
         # To enable or disable wireless
-        networking.wireless = {
-          # Wireless Configuration
-          # Orin AGX has WiFi enabled where Orin Nx does not
-          enable =
-            if som == "agx"
-            then nixpkgs.lib.mkForce true
-            else nixpkgs.lib.mkForce false;
-        };
+        networking.wireless.enable = som == "agx";
+        # Wireless Configuration
+        # Orin AGX has WiFi enabled where Orin Nx does not
 
         # For WLAN firmwares
-        hardware.enableRedistributableFirmware =
-          if som == "agx"
-          then nixpkgs.lib.mkForce true
-          else nixpkgs.lib.mkForce false;
+        hardware.enableRedistributableFirmware = som == "agx";
         # Note: When 21.11 arrives replace the below statement with
         # wirelessRegulatoryDatabase = true;
       }
@@ -57,6 +48,9 @@
 
               virtualization.microvm-host.enable = true;
               host.networking.enable = true;
+
+              virtualization.microvm.netvm.enable = true;
+              virtualization.microvm.netvm.extraModules = netvmExtraModules;
 
               # Enable all the default UI applications
               profiles = {


### PR DESCRIPTION
This is added to resolve the issue https://ssrc.atlassian.net/browse/SP-2697 where originated from https://github.com/NixOS/nixpkgs/issues/244159. We can describe this bug  as while running docker containers got a `http: invalid Host header`
response failing to run.
This is due to a bug in Go package in NixOS where the previous package solves this issue. Same solution can be applied Go compiler related net access bugs till next NixOS release.
When moving to NixOS 23.11, this fix will be removed as it is already fixed in the unstable channel.