### PR TITLE
Re-enable qboot on AppVMs

### DIFF
--- a/modules/virtualization/microvm/appvm.nix
+++ b/modules/virtualization/microvm/appvm.nix
@@ -17,6 +17,7 @@
         ({
           lib,
           config,
+          pkgs,
           ...
         }: {
           ghaf = {
@@ -62,6 +63,11 @@
                 id = hostname;
                 mac = vm.macAddress;
               }
+            ];
+            # Use qboot BIOS on x86_64-linux as workaround
+            qemu.extraArgs = lib.optionals (config.nixpkgs.hostPlatform.system == "x86_64-linux") [
+              "-bios"
+              "${pkgs.qboot}/bios.bin"
             ];
           };
 


### PR DESCRIPTION
Workaround the issue where vm's somewhat randomly hang at the last kernel output line being "ACPI: Core revision 20220331"