### PR TITLE
Refactor demo apps inclusion

### DIFF
--- a/modules/graphics/default.nix
+++ b/modules/graphics/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./weston.nix
     ./weston.ini.nix
+    ./demo-apps.nix
     ./fonts.nix
   ];
 }

--- a/modules/graphics/demo-apps.nix
+++ b/modules/graphics/demo-apps.nix
@@ -1,0 +1,57 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.ghaf.graphics.demo-apps;
+  weston = config.ghaf.graphics.weston;
+
+  /*
+  Generate launchers to be used in weston.ini
+
+  Type: mkProgramOption ::  string -> bool -> option
+
+  */
+  mkProgramOption = name: default:
+    with lib;
+      mkOption {
+        inherit default;
+        type = types.bool;
+        description = "Include package ${name} to menu and system environment";
+      };
+in {
+  options.ghaf.graphics.demo-apps = with lib; {
+    chromium = mkProgramOption "Chromium browser" false;
+    gala-app = mkProgramOption "Gala App" false;
+    element-desktop = mkProgramOption "Element desktop" weston.enableDemoApplications;
+    zathura = mkProgramOption "zathura" weston.enableDemoApplications;
+  };
+
+  config = lib.mkIf weston.enable {
+    ghaf.graphics.weston.launchers =
+      lib.optional cfg.chromium {
+        path = "${pkgs.chromium}/bin/chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
+        icon = "${pkgs.chromium}/share/icons/hicolor/24x24/apps/chromium.png";
+      }
+      ++ lib.optional cfg.element-desktop {
+        path = "${pkgs.element-desktop}/bin/element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland";
+        icon = "${pkgs.element-desktop}/share/icons/hicolor/24x24/apps/element.png";
+      }
+      ++ lib.optional cfg.gala-app {
+        path = "${pkgs.gala-app}/bin/gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
+        icon = "${pkgs.gala-app}/gala/resources/icon-24x24.png";
+      }
+      ++ lib.optional cfg.zathura {
+        path = "${pkgs.zathura}/bin/zathura";
+        icon = "${pkgs.zathura}/share/icons/hicolor/32x32/apps/org.pwmt.zathura.png";
+      };
+    environment.systemPackages =
+      lib.optional cfg.chromium pkgs.chromium
+      ++ lib.optional cfg.element-desktop pkgs.element-desktop
+      ++ lib.optional cfg.gala-app pkgs.gala-app
+      ++ lib.optional cfg.zathura pkgs.zathura;
+  };
+}

--- a/modules/graphics/demo-apps.nix
+++ b/modules/graphics/demo-apps.nix
@@ -25,6 +25,7 @@
 in {
   options.ghaf.graphics.demo-apps = with lib; {
     chromium = mkProgramOption "Chromium browser" false;
+    firefox = mkProgramOption "Firefox browser" weston.enableDemoApplications;
     gala-app = mkProgramOption "Gala App" false;
     element-desktop = mkProgramOption "Element desktop" weston.enableDemoApplications;
     zathura = mkProgramOption "zathura" weston.enableDemoApplications;
@@ -35,6 +36,10 @@ in {
       lib.optional cfg.chromium {
         path = "${pkgs.chromium}/bin/chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
         icon = "${pkgs.chromium}/share/icons/hicolor/24x24/apps/chromium.png";
+      }
+      ++ lib.optional cfg.firefox {
+        path = "${pkgs.firefox}/bin/firefox";
+        icon = "${pkgs.firefox}/share/icons/hicolor/32x32/apps/firefox.png"; # FIXME: no 24x24 icon in FF
       }
       ++ lib.optional cfg.element-desktop {
         path = "${pkgs.element-desktop}/bin/element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland";
@@ -51,6 +56,7 @@ in {
     environment.systemPackages =
       lib.optional cfg.chromium pkgs.chromium
       ++ lib.optional cfg.element-desktop pkgs.element-desktop
+      ++ lib.optional cfg.firefox pkgs.firefox
       ++ lib.optional cfg.gala-app pkgs.gala-app
       ++ lib.optional cfg.zathura pkgs.zathura;
   };

--- a/modules/graphics/demo-apps.nix
+++ b/modules/graphics/demo-apps.nix
@@ -10,6 +10,17 @@
   weston = config.ghaf.graphics.weston;
 
   /*
+  Scaled down firefox icon
+  */
+  firefox-icon = pkgs.runCommand "firefox-icon-24x24" {} ''
+    mkdir -p $out/share/icons/hicolor/24x24/apps
+    ${pkgs.buildPackages.imagemagick}/bin/convert \
+      ${pkgs.firefox}/share/icons/hicolor/128x128/apps/firefox.png \
+      -resize 24x24 \
+      $out/share/icons/hicolor/24x24/apps/firefox.png
+  '';
+
+  /*
   Generate launchers to be used in weston.ini
 
   Type: mkProgramOption ::  string -> bool -> option
@@ -39,7 +50,7 @@ in {
       }
       ++ lib.optional cfg.firefox {
         path = "${pkgs.firefox}/bin/firefox";
-        icon = "${pkgs.firefox}/share/icons/hicolor/32x32/apps/firefox.png"; # FIXME: no 24x24 icon in FF
+        icon = "${firefox-icon}/share/icons/hicolor/24x24/apps/firefox.png";
       }
       ++ lib.optional cfg.element-desktop {
         path = "${pkgs.element-desktop}/bin/element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland";

--- a/modules/graphics/weston.ini.nix
+++ b/modules/graphics/weston.ini.nix
@@ -33,28 +33,6 @@
       icon = "${pkgs.weston}/share/weston/icon_terminal.png";
     }
   ];
-  demoLaunchers = [
-    # Add application launchers
-    {
-      path = "${pkgs.chromium}/bin/chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
-      icon = "${pkgs.chromium}/share/icons/hicolor/24x24/apps/chromium.png";
-    }
-
-    {
-      path = "${pkgs.element-desktop}/bin/element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland";
-      icon = "${pkgs.element-desktop}/share/icons/hicolor/24x24/apps/element.png";
-    }
-
-    {
-      path = "${pkgs.gala-app}/bin/gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
-      icon = "${pkgs.gala-app}/gala/resources/icon-24x24.png";
-    }
-
-    {
-      path = "${pkgs.zathura}/bin/zathura";
-      icon = "${pkgs.zathura}/share/icons/hicolor/32x32/apps/org.pwmt.zathura.png";
-    }
-  ];
 in {
   options.ghaf.graphics.weston = with lib; {
     launchers = mkOption {
@@ -77,16 +55,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    ghaf.graphics.weston.launchers = defaultLauncher ++ lib.optionals cfg.enableDemoApplications demoLaunchers;
-    environment.systemPackages = with pkgs;
-      lib.optionals cfg.enableDemoApplications [
-        # Graphical applications
-        # Probably, we'll want to re/move it from here later
-        chromium
-        element-desktop
-        gala-app
-        zathura
-      ];
+    ghaf.graphics.weston.launchers = defaultLauncher;
     environment.etc."xdg/weston/weston.ini" = {
       text =
         ''


### PR DESCRIPTION
Allow precise control to include/exclude GUI demo application, as well as add firefox as second browser.