### PR TITLE
Configure nvpmodel to use profile number 3

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
@@ -143,5 +143,11 @@ in
         somDefinition."${cfg.somType}".vfio-pci
         "vfio_iommu_type1.allow_unsafe_interrupts=1"
       ];
+
+      services.nvpmodel = {
+        enable = lib.mkDefault true;
+        # Enable all CPU cores, full power consumption (50W on AGX, 25W on NX)
+        profileNumber = lib.mkDefault 3;
+      };
     };
   }


### PR DESCRIPTION
Configure nvpmodel to use profile number 3 by default, which enables all CPU cores on Orin AGX and NX devices. This causes AGX to use 50W and NX to use 25W of power.

This also probably fixes random boot time failures of nvpmodel.service