### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694526290,
-        "narHash": "sha256-HiWr+tfJE/hcn8atRC0S5KweSUknQLEduPLTEiSr5J8=",
+        "lastModified": 1695251123,
+        "narHash": "sha256-k1+gYvB11DHqAA7SkviypQkCFYBwzAg0Ax7XWERd5vk=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "03e7f11cf915a911277c2cdea5d7da9717597aa2",
+        "rev": "2fd97e40021284ad6b2446f797229dac2698acd1",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1694591211,
-        "narHash": "sha256-NPP7XGZH+Q5ey7nE2zGLrBrzKmLYPhj8YgsTSdhH0D4=",
+        "lastModified": 1695109627,
+        "narHash": "sha256-4rpyoVzmunIG6xWA/EonnSSqC69bDBzciFi6SjBze/0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3ccd87fcdae4732fe33773cefa4375c641a057e7",
+        "rev": "cb4dc98f776ddb6af165e6f06b2902efe31ca67a",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694499547,
-        "narHash": "sha256-R7xMz1Iia6JthWRHDn36s/E248WB1/je62ovC/dUVKI=",
+        "lastModified": 1694937365,
+        "narHash": "sha256-iHZSGrb9gVpZRR4B2ishUN/1LRKWtSHZNO37C8z1SmA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5f018cf150e29aac26c61dac0790ea023c46b24",
+        "rev": "5d017a8822e0907fb96f7700a319f9fe2434de02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
• Updated input 'microvm':
    'github:astro/microvm.nix/03e7f11cf915a911277c2cdea5d7da9717597aa2' (2023-09-12)
  → 'github:astro/microvm.nix/2fd97e40021284ad6b2446f797229dac2698acd1' (2023-09-20)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/3ccd87fcdae4732fe33773cefa4375c641a057e7' (2023-09-13)
  → 'github:NixOS/nixos-hardware/cb4dc98f776ddb6af165e6f06b2902efe31ca67a' (2023-09-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e5f018cf150e29aac26c61dac0790ea023c46b24' (2023-09-12)
  → 'github:NixOS/nixpkgs/5d017a8822e0907fb96f7700a319f9fe2434de02' (2023-09-17)