### PR TITLE
Ghaf nix build GitHub actions

### DIFF
--- a/.github/workflows/nix-build-matrix.yml
+++ b/.github/workflows/nix-build-matrix.yml
@@ -1,0 +1,113 @@
+name: nix 
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build_matrix:
+    name: "build"
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64-linux
+            target: generic-x86_64-debug
+          - arch: x86_64-linux
+            target: lenovo-x1-carbon-gen11-debug
+          - arch: x86_64-linux
+            target: nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64
+          - arch: x86_64-linux
+            target: nvidia-jetson-orin-nx-debug-nodemoapps-from-x86_64
+          - arch: riscv64-linux
+            target: microchip-icicle-kit-debug
+    steps:
+      - name: Maximize space available on rootfs
+        # Why not use https://github.com/easimon/maximize-build-space directly?
+        # The reason is: we want to maximize the space on rootfs, since that's
+        # where the nix store (`/nix/store`) is located. Github action
+        # https://github.com/easimon/maximize-build-space maximizes
+        # the builder space on ${GITHUB_WORKSPACE}, which is not what we need.
+        # Alternatively, we could move the nix store to ${GITHUB_WORKSPACE}
+        # and use https://github.com/easimon/maximize-build-space as such, but
+        # we suspect other tooling (e.g. cachix) would not work well with such
+        # configuration.
+        run: |
+          echo "Available storage before cleanup:"
+          df -h
+          echo
+          echo "Removing unwanted software... "
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "... done"
+          echo
+          echo "Available storage after cleanup:"
+          df -h
+      - name: Checkout Ghaf
+        uses: actions/checkout@v3
+      - name: Set NIX_SYSTEM variable (emulated builds)
+        run: |
+          if [ "${{ matrix.arch }}" = "aarch64-linux" ]; then
+            echo "NIX_SYSTEM=aarch64-linux" >> "$GITHUB_ENV"
+          else
+            echo "NIX_SYSTEM=x86_64-linux" >> "$GITHUB_ENV"
+          fi
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            trusted-public-keys = ghaf-dev.cachix.org-1:IxMRy9D4TCXA/57XvtU0xrcEC0ErsnLvxJfPQe8O9pc= cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://ghaf-dev.cachix.org?priority=20 https://cache.vedenemo.dev https://cache.nixos.org
+            system-features = nixos-test benchmark big-parallel kvm
+            system = ${{ env.NIX_SYSTEM }}
+      - name: Print nix.conf
+        run: |
+          echo "/etc/nix/nix.conf:"
+          cat /etc/nix/nix.conf
+      - name: Install requirements
+        run: sudo apt-get install -y qemu-user-static
+      - name: Install cachix
+        run: |
+          nix-env -iA cachix -f https://cachix.org/api/v1/install
+          echo "Using cachix version:"
+          cachix --version
+      - name: Build ${{ matrix.arch }}.${{ matrix.target }}
+        run: |
+          echo "Snapshot nix store files before build"
+          nix-collect-garbage
+          store_pre_build=$(mktemp)
+          find /nix/store -type f > "$store_pre_build"
+
+          echo "nix build"
+          time nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
+
+          echo "Snapshot nix store files after build"
+          store_post_build=$(mktemp)
+          find /nix/store -type f > "$store_post_build"
+
+          echo "Finding new nix store files"
+          store_new_unfiltered=$(mktemp)
+          for f in $(diff "$store_pre_build" "$store_post_build" | cut -d" " -f2)
+          do
+            if [ -e $f ]; then
+              echo "$f" >> "$store_new_unfiltered"
+            fi
+          done
+          rm -f "$store_pre_build" "$store_post_build"
+
+          if [ "${{ secrets.CACHIX_AUTH_GHAF_DEV }}" = "" ]; then
+            echo "Skipping cachix push"
+          else
+            echo "Running cachix push"
+            filter='(\.drv$|\.drv.chroot$|\.check$|\.lock$|-source$|/\.links/|nixos\.img$|store-disk\.squashfs$)'
+            store_new_filtered=$(mktemp)
+            grep -vP "$filter" "$store_new_unfiltered" > "$store_new_filtered"
+            cachix authtoken ${{ secrets.CACHIX_AUTH_GHAF_DEV }}
+            time cachix push -j8 -c16 ghaf-dev < "$store_new_filtered"
+          fi

--- a/.github/workflows/nix-build-matrix.yml
+++ b/.github/workflows/nix-build-matrix.yml
@@ -79,35 +79,13 @@ jobs:
           cachix --version
       - name: Build ${{ matrix.arch }}.${{ matrix.target }}
         run: |
-          echo "Snapshot nix store files before build"
-          nix-collect-garbage
-          store_pre_build=$(mktemp)
-          find /nix/store -type f > "$store_pre_build"
-
-          echo "nix build"
-          time nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
-
-          echo "Snapshot nix store files after build"
-          store_post_build=$(mktemp)
-          find /nix/store -type f > "$store_post_build"
-
-          echo "Finding new nix store files"
-          store_new_unfiltered=$(mktemp)
-          for f in $(diff "$store_pre_build" "$store_post_build" | cut -d" " -f2)
-          do
-            if [ -e $f ]; then
-              echo "$f" >> "$store_new_unfiltered"
-            fi
-          done
-          rm -f "$store_pre_build" "$store_post_build"
-
           if [ "${{ secrets.CACHIX_AUTH_GHAF_DEV }}" = "" ]; then
-            echo "Skipping cachix push"
+            echo "Running nix build, no cachix push"
+            time nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
+            echo "Skipping cachix push, no token"
           else
-            echo "Running cachix push"
-            filter='(\.drv$|\.drv.chroot$|\.check$|\.lock$|-source$|/\.links/|nixos\.img$|store-disk\.squashfs$)'
-            store_new_filtered=$(mktemp)
-            grep -vP "$filter" "$store_new_unfiltered" > "$store_new_filtered"
             cachix authtoken ${{ secrets.CACHIX_AUTH_GHAF_DEV }}
-            time cachix push -j8 -c16 ghaf-dev < "$store_new_filtered"
+            echo "Running nix build, with cachix watch-exec"
+            cachix watch-exec ghaf-dev -- \
+              time nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
           fi

--- a/.github/workflows/nix-build-matrix.yml
+++ b/.github/workflows/nix-build-matrix.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   build_matrix:
@@ -15,15 +14,9 @@ jobs:
       matrix:
         include:
           - arch: x86_64-linux
-            target: generic-x86_64-debug
-          - arch: x86_64-linux
             target: lenovo-x1-carbon-gen11-debug
           - arch: x86_64-linux
             target: nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64
-          - arch: x86_64-linux
-            target: nvidia-jetson-orin-nx-debug-nodemoapps-from-x86_64
-          - arch: riscv64-linux
-            target: microchip-icicle-kit-debug
     steps:
       - name: Maximize space available on rootfs
         # Why not use https://github.com/easimon/maximize-build-space directly?
@@ -62,14 +55,10 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
-            trusted-public-keys = ghaf-dev.cachix.org-1:IxMRy9D4TCXA/57XvtU0xrcEC0ErsnLvxJfPQe8O9pc= cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://ghaf-dev.cachix.org?priority=20 https://cache.vedenemo.dev https://cache.nixos.org
             system-features = nixos-test benchmark big-parallel kvm
             system = ${{ env.NIX_SYSTEM }}
-      - name: Print nix.conf
-        run: |
-          echo "/etc/nix/nix.conf:"
-          cat /etc/nix/nix.conf
       - name: Install requirements
         run: sudo apt-get install -y qemu-user-static
       - name: Install cachix
@@ -79,13 +68,13 @@ jobs:
           cachix --version
       - name: Build ${{ matrix.arch }}.${{ matrix.target }}
         run: |
-          if [ "${{ secrets.CACHIX_AUTH_GHAF_DEV }}" = "" ]; then
+          if [ "${{ secrets.CACHIX_AUTH_TOKEN }}" = "" ]; then
             echo "Running nix build, no cachix push"
-            time nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
+            nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
             echo "Skipping cachix push, no token"
           else
-            cachix authtoken ${{ secrets.CACHIX_AUTH_GHAF_DEV }}
+            cachix authtoken ${{ secrets.CACHIX_AUTH_TOKEN }}
             echo "Running nix build, with cachix watch-exec"
             cachix watch-exec ghaf-dev -- \
-              time nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
+              nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
           fi


### PR DESCRIPTION
Run nix build in Github Actions:

- Uses cross-compile targets, but also allows emulated builds.
- Builds are run on GitHub-hosted runners.  
- Makes use of Cachix to push the build artifacts for later re-use. Using Cachix cache isn't strictly required, but might be useful for many reasons e.g.: to speed-up the PR builds, to allow faster local builds, and to offload the bursts of concurrent builds away from the main cache (vedenemo). See: https://app.cachix.org/cache/ghaf-dev.
- All builds are run concurrently, see the build matrix configuration for more details. From the current targets, 'lenovo-x1-carbon-gen11-debug' seems to take longest. Execution time obviously depends on how much needs to be re-built, currently the best case for the whole build matrix to finish is around 40 minutes. We start-off with limited amount of targets, to limit the github action minutes used by this new workflow.
- Some (not fully developed) ideas to improve the execution time:
  - Would it be possible to have this CI build output (subsets) that would not change unless the relevant inputs changed, meaning all build results would be read from the cache if the target had been built earlier with the same inputs. Currently, the main build results (store-disk.squashf, nixos.img) are re-build every time a new commit is pushed, even if the commit didn't introduce any changes to the inputs - [reference](https://github.com/tiiuae/ghaf/blob/5dd5711ff984df60f2d0e099d40a903577b42566/lib/default.nix#L6).
  
For more information, see: https://ssrc.atlassian.net/wiki/spaces/SP/pages/837648757/Running+nix+build+in+github+actions.