### PR TITLE
Shared /nix/store and read-write tmpfs overlay

### DIFF
--- a/modules/virtualization/microvm/appvm.nix
+++ b/modules/virtualization/microvm/appvm.nix
@@ -56,7 +56,16 @@
             mem = vm.ramMb;
             vcpu = vm.cores;
             hypervisor = "qemu";
-            storeDiskType = "squashfs";
+
+            shares = [
+              {
+                tag = "ro-store";
+                source = "/nix/store";
+                mountPoint = "/nix/.ro-store";
+              }
+            ];
+            writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
+
             interfaces = [
               {
                 type = "tap";

--- a/modules/virtualization/microvm/guivm.nix
+++ b/modules/virtualization/microvm/guivm.nix
@@ -54,7 +54,16 @@
         microvm = {
           mem = 2048;
           hypervisor = "qemu";
-          storeDiskType = "squashfs";
+
+          shares = [
+            {
+              tag = "ro-store";
+              source = "/nix/store";
+              mountPoint = "/nix/.ro-store";
+            }
+          ];
+          writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
+
           interfaces = [
             {
               type = "tap";

--- a/modules/virtualization/microvm/netvm.nix
+++ b/modules/virtualization/microvm/netvm.nix
@@ -73,7 +73,16 @@
           };
         };
 
-        microvm.storeDiskType = "squashfs";
+        microvm = {
+          shares = [
+            {
+              tag = "ro-store";
+              source = "/nix/store";
+              mountPoint = "/nix/.ro-store";
+            }
+          ];
+          writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
+        };
 
         imports = import ../../module-list.nix;
       })


### PR DESCRIPTION
/nix/store is shared read-only from the host, and in debug mode, there is read-write tmpfs overlay on top of it, which allows usage of `nix-shell -p ...` inside the virtual machine.

Great way to save space in the images.