### PR TITLE
Refactor VM networking

### DIFF
--- a/docs/src/ref_impl/creating_appvm.md
+++ b/docs/src/ref_impl/creating_appvm.md
@@ -28,7 +28,6 @@ vms = with pkgs; [
   {
     name = "chromium";
     packages = [chromium];
-    ipAddress = "192.168.101.5/24";
     macAddress = "02:00:00:03:03:05";
     ramMb = 3072;
     cores = 4;
@@ -36,7 +35,6 @@ vms = with pkgs; [
   {
     name = "gala";
     packages = [(pkgs.callPackage ../user-apps/gala {})];
-    ipAddress = "192.168.101.6/24";
     macAddress = "02:00:00:03:03:06";
     ramMb = 1536;
     cores = 2;
@@ -44,7 +42,6 @@ vms = with pkgs; [
   {
     name = "zathura";
     packages = [zathura];
-    ipAddress = "192.168.101.7/24";
     macAddress = "02:00:00:03:03:07";
     ramMb = 512;
     cores = 1;
@@ -57,9 +54,8 @@ Each VM has the following properties:
 
 | **Property** | **Type**                  | **Unique** | **Description**                                                                                               | **Example**         |
 | -------------- | --------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------- | --------------------- |
-| name         | str                       | yes        | This name is prefixed with `vm-` and will be shown in microvm list. The prefixed name - e.g. `vm-chromium` will be also the VM hostname.                                     | “chromium”        |
+| name         | str                       | yes        | This name is postfixed with `-vm` and will be shown in microvm list. The name - e.g. `chromium-vm` will be also the VM hostname. The lenght of the name must be 8 characters or less.                                     | “chromium”        |
 | packages     | list of types.package     | no         | Packages to include in a VM. It is possible to make it empty or add several packages.                          | [chromium top]    |
-| ipAddress    | str                       | yes        | This IP will be used to access a VM from the host. Should has the same subnetwork, as other VMs: Net, GUI VMs. | "192.168.101.5/24"  |
 | macAddress   | str                       | yes        | Needed for network configuration.                                                                              | "02:00:00:03:03:05" |
 | ramMb        | int, [1, …, host memory] | no         | Memory in MB.                                                                                                  | 3072                |
 | cores        | int,  [1, …, host cores] | no         | Virtual CPU cores.                                                                                             | 4                   |

--- a/modules/host/networking.nix
+++ b/modules/host/networking.nix
@@ -38,7 +38,7 @@ in
         # Connect VM tun/tap device to the bridge
         # TODO configure this based on IF the netvm is enabled
         networks."11-netvm" = {
-          matchConfig.Name = "vm-*";
+          matchConfig.Name = "tap-*";
           networkConfig.Bridge = "virbr0";
         };
       };

--- a/modules/virtualization/microvm/common/vm-networking.nix
+++ b/modules/virtualization/microvm/common/vm-networking.nix
@@ -1,0 +1,52 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  vmName,
+  macAddress,
+  ...
+}: let
+  networkName = "ethint0";
+in {
+  networking = {
+    hostName = vmName;
+    enableIPv6 = false;
+    firewall.allowedTCPPorts = [22];
+    firewall.allowedUDPPorts = [67];
+    useNetworkd = true;
+    nat = {
+      enable = true;
+      internalInterfaces = [networkName];
+    };
+  };
+
+  microvm.interfaces = [
+    {
+      type = "tap";
+      # The interface names must have maximum length of 15 characters
+      id = "tap-${vmName}";
+      mac = macAddress;
+    }
+  ];
+
+  systemd.network = {
+    enable = true;
+    # Set internal network's interface name to networkName
+    links."10-${networkName}" = {
+      matchConfig.PermanentMACAddress = macAddress;
+      linkConfig.Name = networkName;
+    };
+    networks."10-${networkName}" = {
+      matchConfig.MACAddress = macAddress;
+      DHCP = "yes";
+      linkConfig.RequiredForOnline = "routable";
+      linkConfig.ActivationPolicy = "always-up";
+    };
+  };
+
+  # systemd-resolved does not support local names resolution
+  # without configuring a local domain. With the local domain,
+  # one would need also to disable DNSSEC for the clients.
+  # Disabling DNSSEC for other VM then NetVM is
+  # completely safe since they use NetVM as DNS proxy.
+  services.resolved.dnssec = "false";
+}

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -69,17 +69,17 @@
       ({pkgs, ...}: {
         ghaf.graphics.weston.launchers = [
           {
-            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.5 ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no chromium-vm.ghaf ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${../assets/icons/png/browser.png}";
           }
 
           {
-            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.6 ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no gala-vm.ghaf ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${../assets/icons/png/app.png}";
           }
 
           {
-            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no 192.168.101.7 ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server zathura";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no zathura-vm.ghaf ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server zathura";
             icon = "${../assets/icons/png/pdf.png}";
           }
         ];
@@ -145,7 +145,6 @@
                   {
                     name = "chromium";
                     packages = [pkgs.chromium pkgs.pamixer];
-                    ipAddress = "192.168.101.5/24";
                     macAddress = "02:00:00:03:05:01";
                     ramMb = 3072;
                     cores = 4;
@@ -179,7 +178,6 @@
                   {
                     name = "gala";
                     packages = [pkgs.gala-app];
-                    ipAddress = "192.168.101.6/24";
                     macAddress = "02:00:00:03:06:01";
                     ramMb = 1536;
                     cores = 2;
@@ -187,7 +185,6 @@
                   {
                     name = "zathura";
                     packages = [pkgs.zathura];
-                    ipAddress = "192.168.101.7/24";
                     macAddress = "02:00:00:03:07:01";
                     ramMb = 512;
                     cores = 1;


### PR DESCRIPTION
*Introduce new naming pattern for VMs
All VMs' names/hostnames are created using '<vmname>-vm' pattern. All VMs' network interfaces named using
'tap-<hostname>' pattern. NetVM's bridge is configured to include all 'tap-*' interfaces.
This approach makes no distinction between service VMs and application VMs, but it allows to easily guess the hostname without using a network toolkit.

*Introduce .ghaf local domain.
All VMs except of NetVM now get their IPs from NetVM's DHCP server. The VMs are accessible by their hostnames with .ghaf postfix added, for instance, 'ssh gui-vm.ghaf'.

*All VMs use separate subnet from now on, which is different from the debug-subnet.

*The network configuration which is common for every VM is now extracted into the separate 'vm-networking.nix' file.