### PR TITLE
Add withRepart=false; to systemd override

### DIFF
--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -29,19 +29,22 @@
     # TODO remove this when the minimal config is defined
     appstream.enable = false;
 
-    systemd.package = pkgs.systemd.override {
-      withCryptsetup = false;
-      withDocumentation = false;
-      withFido2 = false;
-      withHomed = false;
-      withHwdb = false;
-      withLibBPF = true;
-      withLocaled = false;
-      withPCRE2 = false;
-      withPortabled = false;
-      withTpm2Tss = false;
-      withUserDb = false;
-    };
+    systemd.package = pkgs.systemd.override ({
+        withCryptsetup = false;
+        withDocumentation = false;
+        withFido2 = false;
+        withHomed = false;
+        withHwdb = false;
+        withLibBPF = true;
+        withLocaled = false;
+        withPCRE2 = false;
+        withPortabled = false;
+        withTpm2Tss = false;
+        withUserDb = false;
+      }
+      // lib.optionalAttrs (lib.hasAttr "withRepart" (lib.functionArgs pkgs.systemd.override)) {
+        withRepart = false;
+      });
 
     boot.enableContainers = false;
     ##### Remove to here


### PR DESCRIPTION
Conditionally add withRepart=false; to systemd override. When building against nixos-unstable, fixes:
`error: assertion '(withRepart -> withCryptsetup)' failed`