### PR TITLE
GhA: fix PR builder for lenovo-x1-carbon-gen11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,9 +116,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: cachix/install-nix-action@v22
         with:
-          extra-conf: |
+          extra_nix_config: |
             trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://ghaf-dev.cachix.org?priority=20 https://cache.vedenemo.dev https://cache.nixos.org
             system-features = nixos-test benchmark big-parallel kvm


### PR DESCRIPTION

This commit changes the PR builder action to use [cachix/install-nix-action](https://github.com/cachix/install-nix-action) instead of
[DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action) to install nix in the PR builder workflow.

This change is needed to fix the PR builder workflow build issue for lenovo-x1-carbon-gen11 targets.

It's still unclear why, but using [DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action) in the builder workflow started failing for lenovo-x1-carbon-gen11 somewhere between Monday 2.10.2023 and Friday 6.10.2023. The builder action was not merged to Ghaf yet, so we can't clearly see at which point the failure started. Example error trace from the eariler build failure is attached below.

I propose to merge this fix now and then later analyze why lenovo-x1-carbon-gen11 build fails with the DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action) nix installer.

```
error: builder for '/nix/store/29sdh85i69hng74v74jn1skib98db74p-nixos-disk-image.drv' failed with exit code 1;
       last 10 log lines:
       > copying path '/nix/store/p5f70jq64dsfy9ygc32fblqgy10h2s70-freepats-20060219' to 'local'...
       > copying path '/nix/store/nhf0q3qcs8awg0jj2y9hnfksshdhfsid-fontconfig-etc' to 'local'...
       > copying path '/nix/store/s86wnrhyzvcvwwgnbzzc6pi1hsm42dky-gawk-5.2.1-info' to 'local'...
       > copying path '/nix/store/8yil1h65napjd9z4jlz79xl2p1x644yq-gawk-5.2.1-man' to 'local'...
       > copying path '/nix/store/81d13il7plchw65gz8y9ywcxrngq149c-gcc-12.2.0-libgcc' to 'local'...
       > error: hash mismatch importing path '/nix/store/81d13il7plchw65gz8y9ywcxrngq149c-gcc-12.2.0-libgcc';
       >          specified: sha256:1bavzsfd2ip96g5m5isqacfjfza4gyv05sfc581b9nkycnll0x3j
       >          got:       sha256:01x87z55x4ndjslkavg9b7bbqi901n40diqvhc93nsiwn6l89kdl
       > copying path '/nix/store/vlgiqi255gbxa3k3i849prxy2fqa6m08-gfortran-12.2.0-libgcc' to 'local'...
       > error: build of '/nix/store/308b85v67qn5lzs5ydfaxhall7w8kkhs-nixos-system-ghaf-host-23.05.20230927.5cfafa1' failed
       For full logs, run 'nix log /nix/store/29sdh85i69hng74v74jn1skib98db74p-nixos-disk-image.drv'.
```