### PR TITLE
windows-launcher: Change spice to enableSpice

### DIFF
--- a/modules/windows-launcher/default.nix
+++ b/modules/windows-launcher/default.nix
@@ -7,16 +7,14 @@
   ...
 }: let
   cfg = config.ghaf.windows-launcher;
-  windows-launcher = pkgs.callPackage ../../user-apps/windows-launcher {spice = cfg.spice;};
+  windows-launcher = pkgs.callPackage ../../user-apps/windows-launcher {enableSpice = cfg.spice;};
 in {
   options.ghaf.windows-launcher = {
     enable = lib.mkEnableOption "Windows launcher";
   };
 
-  options.ghaf.windows-launcher.spice = lib.mkOption {
-    description = "Enable remote access to the virtual machine using spice";
-    type = lib.types.bool;
-    default = false;
+  options.ghaf.windows-launcher.spice = lib.mkEnableOption {
+    description = "remote access to the virtual machine using spice";
   };
 
   options.ghaf.windows-launcher.spice-port = lib.mkOption {

--- a/user-apps/default.nix
+++ b/user-apps/default.nix
@@ -17,7 +17,8 @@ in
         pkgs = nixpkgs.legacyPackages.${system};
       in {
         gala-app = pkgs.callPackage ./gala {};
-        windows-launcher = pkgs.callPackage ./windows-launcher {};
+        windows-launcher = pkgs.callPackage ./windows-launcher {enableSpice = false;};
+        windows-launcher-spice = pkgs.callPackage ./windows-launcher {enableSpice = true;};
       };
     }))
   ]

--- a/user-apps/windows-launcher/default.nix
+++ b/user-apps/windows-launcher/default.nix
@@ -5,7 +5,7 @@
   pkgs,
   lib,
   stdenv,
-  spice ? false,
+  enableSpice ? false,
   ...
 }: let
   ovmfPrefix =
@@ -32,7 +32,7 @@
           exit
         fi
       ''
-      + lib.optionalString (!spice) ''
+      + lib.optionalString (!enableSpice) ''
         if [[ -z "''${WAYLAND_DISPLAY}" ]]; then
           echo "Wayland display not found"
           exit
@@ -68,13 +68,13 @@
           "-drive file=$OVMF_CODE,format=raw,if=pflash,readonly=on"
           "-drive file=$OVMF_VARS,format=raw,if=pflash"
       ''
-      + lib.optionalString (!spice) ''
+      + lib.optionalString (!enableSpice) ''
         "-vga none"
         "-device ramfb"
         "-device virtio-gpu-pci"
         "-nic user,model=virtio"
       ''
-      + lib.optionalString spice ''
+      + lib.optionalString enableSpice ''
         "-vga qxl"
         "-device virtio-serial-pci"
         "-spice port=5900,addr=0.0.0.0,disable-ticketing=on"


### PR DESCRIPTION
Change spice to enableSpice in package arguments. This is because there exists a package called spice, so when called through callPackage the spice argument gets filled with that package, instead of defaulting to false.