### PR TITLE
Fix sysbench cross-compiling

### DIFF
--- a/modules/development/debug-tools.nix
+++ b/modules/development/debug-tools.nix
@@ -38,12 +38,7 @@ in
           speedtest-cli
         ]
         ++
-        # LuaJIT (which is sysbench dependency) not available on RISC-V.
-        # Sysbench also does not cross-compile.
-        lib.optional (
-          (config.nixpkgs.hostPlatform.system != "riscv64-linux")
-          && (config.nixpkgs.buildPlatform.system == config.nixpkgs.hostPlatform.system)
-        )
-        sysbench;
+        # LuaJIT (which is sysbench dependency) not available on RISC-V
+        lib.optional (config.nixpkgs.hostPlatform.system != "riscv64-linux") sysbench;
     };
   }


### PR DESCRIPTION
This also reverts commit eaa960c84516f4887fea50e29f4b0bee529980f0.

It now builds, although require more work on it.
I don't like extra patch file too much, it does too much unrelated changes (patch borrowed from https://lore.kernel.org/buildroot/20230525215103.37218-3-svromanov@sberdevices.ru/T/ ).