### PR TITLE
GhA: Cancel in-progress builds on new trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,11 @@ jobs:
       always() &&
       needs.authorize.result == 'success' &&
       needs.build-yml-check.outputs.result == 'not-changed'
+    concurrency:
+      # Cancel any in-progress workflow runs from the same PR or branch,
+      # allowing matrix jobs to run concurrently:
+      group: ${{ github.workflow }}.${{ github.event.pull_request.number || github.ref }}.${{ matrix.arch }}.${{ matrix.target }}
+      cancel-in-progress: true
     steps:
       - name: Maximize space available on rootfs
         # Why not use https://github.com/easimon/maximize-build-space directly?


### PR DESCRIPTION
Cancel any in-progress build workflow runs from the same PR when a new version of the PR is pushed.
Before this change, pre-merge build workflows would continue to run even if a new version of the PR was pushed.

This change was tested in a forked repository. As an example, the following workflow run in the forked repo was canceled due to new changes pushed to PR while an earlier build was still in-progress: https://github.com/henrirosten/ghaf/actions/runs/6470895940