### PR TITLE
Add support for colored window borders

### DIFF
--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -90,15 +90,16 @@
       qemu_kvm = prev.qemu_kvm.overrideAttrs (_final: prev: {
         patches = prev.patches ++ [./acpi-devices-passthrough.patch];
       });
-      # Waypipe with vsock
+      # Waypipe with vsock and window borders
       waypipe = prev.waypipe.overrideAttrs (prevAttrs: {
         src = pkgs.fetchFromGitLab {
           domain = "gitlab.freedesktop.org";
-          owner = "nesterov";
+          owner = "mstoeckl";
           repo = "waypipe";
-          rev = "2f1ab6a8efd2c1ad0dbcc9f8482b10861743e9c3";
-          sha256 = "sha256-P4y8p4R28j4zp0OX2GspsBKqWvCHqg+nF153LIrRYs8=";
+          rev = "ca4809435e781dfc6bd3006fde605860c8dcf179";
+          sha256 = "sha256-tSLPlf7fVq8vwbr7fHotqM/sBSXYMDM1V5yth5bhi38=";
         };
+        patches = [./waypipe-window-borders.patch];
       });
     })
   ];

--- a/overlays/waypipe-window-borders.patch
+++ b/overlays/waypipe-window-borders.patch
@@ -1,0 +1,351 @@
+From 134f22a39a360ebf9cd9f118766edb7df925b732 Mon Sep 17 00:00:00 2001
+From: Yuri Nesterov <yuriy.nesterov@unikie.com>
+Date: Tue, 10 Oct 2023 14:57:03 +0300
+Subject: [PATCH] Add support for coloured window borders
+
+---
+ protocols/function_list.txt |   3 +
+ src/handlers.c              | 112 ++++++++++++++++++++++++++++++++++++
+ src/main.h                  |   3 +
+ src/parsing.h               |   4 ++
+ src/util.c                  |  14 ++++-
+ src/util.h                  |   6 ++
+ src/waypipe.c               |  68 +++++++++++++++++++++-
+ 7 files changed, 207 insertions(+), 3 deletions(-)
+
+diff --git a/protocols/function_list.txt b/protocols/function_list.txt
+index 300408d..eb2d8b5 100644
+--- a/protocols/function_list.txt
++++ b/protocols/function_list.txt
+@@ -49,3 +49,6 @@ zwp_linux_dmabuf_v1_req_get_default_feedback
+ zwp_linux_dmabuf_v1_req_get_surface_feedback
+ zwp_primary_selection_offer_v1_req_receive
+ zwp_primary_selection_source_v1_evt_send
++xdg_wm_base_req_get_xdg_surface
++xdg_surface_req_set_window_geometry
++xdg_surface_req_get_toplevel
+diff --git a/src/handlers.c b/src/handlers.c
+index db08ee5..fd4650e 100644
+--- a/src/handlers.c
++++ b/src/handlers.c
+@@ -345,6 +345,13 @@ struct wp_object *create_wp_object(uint32_t id, const struct wp_interface *type)
+ 	} else if (type == &intf_wl_surface) {
+ 		((struct obj_wl_surface *)new_obj)->scale = 1;
+ 	}
++
++	new_obj->is_window = false;
++	new_obj->xdg_surface_id = 0;
++	new_obj->window_x = 0;
++	new_obj->window_y = 0;
++	new_obj->window_width = 0;
++	new_obj->window_height = 0;
+ 	return new_obj;
+ }
+ 
+@@ -730,6 +737,87 @@ static void rotate_damage_lists(struct obj_wl_surface *surface)
+ 			(SURFACE_DAMAGE_BACKLOG - 1) * sizeof(uint64_t));
+ 	surface->attached_buffer_uids[0] = 0;
+ }
++
++void get_pixel(struct obj_wl_buffer *buf, int x, int y, struct color *c)
++{
++	struct shadow_fd *sfd = buf->shm_buffer;
++	if (x < 0 || y < 0 || x >= buf->shm_width || y >= buf->shm_height)
++		return;
++	c->b = sfd->mem_local[(y * buf->shm_width + x) * 4];
++	c->g = sfd->mem_local[(y * buf->shm_width + x) * 4 + 1];
++	c->r = sfd->mem_local[(y * buf->shm_width + x) * 4 + 2];
++	c->a = sfd->mem_local[(y * buf->shm_width + x) * 4 + 3];
++}
++
++void set_pixel(struct obj_wl_buffer *buf, int x, int y, const struct color *c)
++{
++	struct shadow_fd *sfd = buf->shm_buffer;
++	if (x < 0 || y < 0 || x >= buf->shm_width || y >= buf->shm_height)
++		return;
++	sfd->mem_local[(y * buf->shm_width + x) * 4] = c->b;
++	sfd->mem_local[(y * buf->shm_width + x) * 4 + 1] = c->g;
++	sfd->mem_local[(y * buf->shm_width + x) * 4 + 2] = c->r;
++	sfd->mem_local[(y * buf->shm_width + x) * 4 + 3] = c->a;
++}
++
++void alpha_blend(struct color *pixel1, const struct color *pixel2)
++{
++	pixel1->r = (pixel2->a * pixel2->r + (255 - pixel2->a) * pixel1->r) / 255;
++	pixel1->g = (pixel2->a * pixel2->g + (255 - pixel2->a) * pixel1->g) / 255;
++	pixel1->b = (pixel2->a * pixel2->b + (255 - pixel2->a) * pixel1->b) / 255;
++	pixel1->a = pixel2->a + ((255 - pixel2->a) * pixel1->a) / 255;
++}
++
++void draw_rect(struct obj_wl_buffer *buf, int x1, int y1, int x2, int y2, const struct color *c)
++{
++	for (int32_t x = x1; x < x2; x++) {
++		for (int32_t y = y1; y < y2; y++) {
++			if (c->a == 255) {
++				set_pixel(buf, x, y, c);
++			}
++			else {
++				struct color c1;
++				get_pixel(buf, x, y, &c1);
++				alpha_blend(&c1, c);
++				set_pixel(buf, x, y, &c1);
++			}
++		}
++	}
++}
++
++void draw_border(struct context *ctx)
++{
++	struct obj_wl_surface *surface = (struct obj_wl_surface *)ctx->obj;
++	if (!surface)
++		return;
++	struct wp_object *obj = tracker_get(ctx->tracker, surface->attached_buffer_id);
++	if (!obj)
++		return;
++	struct obj_wl_buffer *buf = (struct obj_wl_buffer *)obj;
++	if (!buf)
++		return;
++
++	if ((buf->shm_format != WL_SHM_FORMAT_ARGB8888) && (buf->shm_format != WL_SHM_FORMAT_XRGB8888)) {
++		wp_debug("Unable to draw the border, SHM format %d is not supported", buf->shm_format);
++	}
++	else {
++		if (ctx->obj->xdg_surface_id) {
++			struct wp_object *xdg_surface = tracker_get(ctx->tracker, ctx->obj->xdg_surface_id);
++			if (xdg_surface && xdg_surface->is_window) {
++				int32_t x1 = xdg_surface->window_x;
++				int32_t y1 = xdg_surface->window_y;
++				int32_t x2 = min(buf->shm_width, xdg_surface->window_x + xdg_surface->window_width);
++				int32_t y2 = min(buf->shm_height, xdg_surface->window_y + xdg_surface->window_height);
++				int32_t border_size = min(min(ctx->g->config->border_size, x2 - x1), y2 - y1);
++				draw_rect(buf, x1, y1, x2, y1 + border_size, &ctx->g->config->border_color); // top
++				draw_rect(buf, x1, y1 + border_size, x1 + border_size, y2, &ctx->g->config->border_color); // left
++				draw_rect(buf, x1 + border_size, y2 - border_size, x2, y2, &ctx->g->config->border_color); // bottom
++				draw_rect(buf, x2 - border_size, y1 + border_size, x2, y2 - border_size, &ctx->g->config->border_color); // right
++			}
++		}
++	}
++}
++
+ void do_wl_surface_req_commit(struct context *ctx)
+ {
+ 	struct obj_wl_surface *surface = (struct obj_wl_surface *)ctx->obj;
+@@ -747,6 +835,10 @@ void do_wl_surface_req_commit(struct context *ctx)
+ 		/* commit signifies a client-side update only */
+ 		return;
+ 	}
++
++	if (ctx->g->config->border)
++		draw_border(ctx);
++
+ 	struct wp_object *obj =
+ 			tracker_get(ctx->tracker, surface->attached_buffer_id);
+ 	if (!obj) {
+@@ -1976,3 +2068,23 @@ void do_zwlr_gamma_control_v1_req_set_gamma(struct context *ctx, int fd)
+ }
+ 
+ const struct wp_interface *the_display_interface = &intf_wl_display;
++
++void do_xdg_wm_base_req_get_xdg_surface(struct context *ctx, struct wp_object *id, struct wp_object *surface)
++{
++	(void)ctx;
++	surface->xdg_surface_id = id->obj_id;
++}
++
++void do_xdg_surface_req_get_toplevel(struct context *ctx, struct wp_object *id)
++{
++	(void)id;
++	ctx->obj->is_window = true;
++}
++
++void do_xdg_surface_req_set_window_geometry(struct context *ctx, int32_t x, int32_t y, int32_t width, int32_t height)
++{
++	ctx->obj->window_x = x;
++	ctx->obj->window_y = y;
++	ctx->obj->window_width = width;
++	ctx->obj->window_height = height;
++}
+diff --git a/src/main.h b/src/main.h
+index cf260b0..75e0a27 100644
+--- a/src/main.h
++++ b/src/main.h
+@@ -45,6 +45,9 @@ struct main_config {
+ 	uint32_t vsock_cid;
+ 	uint32_t vsock_port;
+ 	bool vsock_to_host;
++	bool border;
++	struct color border_color;
++	uint32_t border_size;
+ };
+ struct globals {
+ 	const struct main_config *config;
+diff --git a/src/parsing.h b/src/parsing.h
+index f3580b0..5739001 100644
+--- a/src/parsing.h
++++ b/src/parsing.h
+@@ -41,6 +41,10 @@ struct wp_object {
+ 	const struct wp_interface *type;    // Use to lookup the message handler
+ 	uint32_t obj_id;
+ 	bool is_zombie; // object deleted but not yet acknowledged remotely
++
++	bool is_window;
++	uint32_t xdg_surface_id;
++	int32_t window_x, window_y, window_width, window_height;
+ };
+ struct message_tracker {
+ 	/* Tree containing all objects that are currently alive or zombie */
+diff --git a/src/util.c b/src/util.c
+index d43aa17..6aade78 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -739,4 +739,16 @@ int listen_on_vsock(uint32_t port, int nmaxclients, int *socket_fd_out)
+ 	*socket_fd_out = sock;
+ 	return 0;
+ }
+-#endif
+\ No newline at end of file
++#endif
++
++uint8_t hex_char_to_int(uint8_t hex)
++{
++	if (hex >= '0' && hex <= '9')
++		return hex - '0';
++	else if (hex >= 'A' && hex <= 'F')
++		return hex - 'A' + 10;
++	else if (hex >= 'a' && hex <= 'f')
++		return hex - 'a' + 10;
++	else
++		return 0;
++}
+diff --git a/src/util.h b/src/util.h
+index 81cb2a8..780bff2 100644
+--- a/src/util.h
++++ b/src/util.h
+@@ -514,4 +514,10 @@ int connect_to_vsock(uint32_t port, uint32_t cid, bool to_host, int *socket_fd);
+ int listen_on_vsock(uint32_t port, int nmaxclients, int *socket_fd_out);
+ #endif
+ 
++struct color {
++	uint8_t a, r, g, b;
++};
++
++uint8_t hex_char_to_int(uint8_t hex);
++
+ #endif // WAYPIPE_UTIL_H
+diff --git a/src/waypipe.c b/src/waypipe.c
+index 1c1be71..61e2200 100644
+--- a/src/waypipe.c
++++ b/src/waypipe.c
+@@ -399,6 +399,53 @@ static int parse_vsock_addr(const char *str, struct main_config *config)
+ }
+ #endif
+ 
++static int parse_color(const char *str, struct color *c)
++{
++	size_t l = strlen(str);
++	if (l != 7 && l != 9)
++		return -1;
++
++	if (str[0] != '#')
++		return -1;
++
++	c->r = (hex_char_to_int(str[1]) << 4) + hex_char_to_int(str[2]);
++	c->g = (hex_char_to_int(str[3]) << 4) + hex_char_to_int(str[4]);
++	c->b = (hex_char_to_int(str[5]) << 4) + hex_char_to_int(str[6]);
++	if (l == 9)
++		c->a = (hex_char_to_int(str[7]) << 4) + hex_char_to_int(str[8]);
++
++	return 0;
++}
++
++static int parse_border(const char *str, struct main_config *config)
++{
++	if (str == NULL)
++		return -1;
++
++	char tmp[128];
++	size_t l = strlen(str);
++	if (l >= 127) {
++		return -1;
++	}
++	memcpy(tmp, str, l + 1);
++
++	char *color = strtok(tmp, ",");
++	if (color) {
++		if (parse_color(color, &config->border_color) == -1) {
++			return -1;
++		}
++	}
++
++	char *border_size = strtok(NULL, ",");
++	if (border_size) {
++		if (parse_uint32(border_size, &config->border_size) == -1) {
++			return -1;
++		}
++	}
++
++	return 0;
++}
++
+ static const char *feature_names[] = {
+ 		"lz4",
+ 		"zstd",
+@@ -448,6 +495,7 @@ static const bool feature_flags[] = {
+ #define ARG_WAYPIPE_BINARY 1011
+ #define ARG_BENCH_TEST_SIZE 1012
+ #define ARG_VSOCK 1013
++#define ARG_BORDER 1014
+ 
+ static const struct option options[] = {
+ 		{"compress", required_argument, NULL, 'c'},
+@@ -469,7 +517,11 @@ static const struct option options[] = {
+ 		{"display", required_argument, NULL, ARG_DISPLAY},
+ 		{"control", required_argument, NULL, ARG_CONTROL},
+ 		{"test-size", required_argument, NULL, ARG_BENCH_TEST_SIZE},
+-		{"vsock", no_argument, NULL, ARG_VSOCK}, {0, 0, NULL, 0}};
++		{"vsock", no_argument, NULL, ARG_VSOCK},
++		{"border", required_argument, NULL, ARG_BORDER},
++		{0, 0, NULL, 0}
++};
++
+ struct arg_permissions {
+ 	int val;
+ 	uint32_t mode_mask;
+@@ -497,6 +549,7 @@ static const struct arg_permissions arg_permissions[] = {
+ 		{ARG_CONTROL, MODE_SSH | MODE_SERVER},
+ 		{ARG_BENCH_TEST_SIZE, MODE_BENCH},
+ 		{ARG_VSOCK, MODE_SSH | MODE_CLIENT | MODE_SERVER},
++		{ARG_BORDER,  MODE_SERVER},
+ };
+ 
+ /* envp is nonstandard, so use environ */
+@@ -533,7 +586,12 @@ int main(int argc, char **argv)
+ 			.vsock = false,
+ 			.vsock_cid = 2,         /* VMADDR_CID_HOST */
+ 			.vsock_to_host = false, /* VMADDR_FLAG_TO_HOST */
+-			.vsock_port = 0};
++			.vsock_port = 0,
++			.border = false,
++			.border_color = {
++				.a = 255, .r = 0, .g = 0, .b = 0
++			},
++			.border_size = 5};
+ 
+ 	/* We do not parse any getopt arguments happening after the mode choice
+ 	 * string, so as not to interfere with them. */
+@@ -705,6 +763,12 @@ int main(int argc, char **argv)
+ 			fprintf(stderr, "Option --vsock not allowed: this copy of Waypipe was not built with support for Linux VM sockets.\n");
+ 			return EXIT_FAILURE;
+ #endif
++		case ARG_BORDER: {
++			config.border = true;
++			if (parse_border(optarg, &config) == -1) {
++				fail = true;
++			}
++		} break;
+ 		default:
+ 			fail = true;
+ 			break;
+-- 
+2.34.1
+

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -70,17 +70,17 @@
       ({pkgs, ...}: {
         ghaf.graphics.weston.launchers = [
           {
-            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no chromium-vm.ghaf ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no chromium-vm.ghaf ${pkgs.waypipe}/bin/waypipe --border \"#ff5733,5\" --vsock -s ${toString guivmConfig.waypipePort} server chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${../assets/icons/png/browser.png}";
           }
 
           {
-            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no gala-vm.ghaf ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no gala-vm.ghaf ${pkgs.waypipe}/bin/waypipe --border \"#33ff57,5\" --vsock -s ${toString guivmConfig.waypipePort} server gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${../assets/icons/png/app.png}";
           }
 
           {
-            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no zathura-vm.ghaf ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString guivmConfig.waypipePort} server zathura";
+            path = "${pkgs.openssh}/bin/ssh -i ${pkgs.waypipe-ssh}/keys/waypipe-ssh -o StrictHostKeyChecking=no zathura-vm.ghaf ${pkgs.waypipe}/bin/waypipe --border \"#337aff,5\" --vsock -s ${toString guivmConfig.waypipePort} server zathura";
             icon = "${../assets/icons/png/pdf.png}";
           }
 


### PR DESCRIPTION
Colored window borders currently drawn in waypipe when it runs in server mode. They are used for the information purposes. This can be considered a temporary solution until we get support for colored window borders in the compositor.