### PR TITLE
Orin AGX/NX: Add QSPI only variant of flash script

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
@@ -64,6 +64,10 @@ in
       # Enable the Orin boards
       enable = mkEnableOption "Orin hardware";
 
+      flashScriptOverrides.onlyQSPI =
+        mkEnableOption
+        "to only flash QSPI partitions, i.e. disable flashing of boot and root partitions to eMMC";
+
       flashScriptOverrides.preFlashCommands = mkOption {
         description = "Commands to run before the actual flashing";
         type = types.str;


### PR DESCRIPTION
Add variant of flash script, which only flashes QSPI partitions, and not eMMC at all. Also does not build boot & root images so it is faster and lighter to build.