### PR TITLE
Deploy github-pages with github token

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
 
 jobs:
   deploy:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,13 +9,15 @@ jobs:
   deploy:
     name: build doc and deploy to gh pages
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v22
       - name: build
         run: nix build .#doc
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.KTUSAWRK_GHAF_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./result


### PR DESCRIPTION
This PR makes the following changes to the github workflow that builds and deploys github pages:
- Use GITHUB_TOKEN to deploy github pages
- Only deploy github pages if the push to main branch changes the content under `docs/`