### PR TITLE
GhA: Add more pre-merge build targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,12 @@ jobs:
             target: lenovo-x1-carbon-gen11-debug
           - arch: x86_64-linux
             target: nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64
+          - arch: x86_64-linux
+            target: nvidia-jetson-orin-nx-debug-nodemoapps-from-x86_64
+          - arch: riscv64-linux
+            target: microchip-icicle-kit-debug
+          - arch: x86_64-linux
+            target: doc
     if: |
       always() &&
       needs.authorize.result == 'success' &&


### PR DESCRIPTION
Add following new pre-merge build targets:
- x86_64-linux.nvidia-jetson-orin-nx-debug-nodemoapps-from-x86_64
- riscv64-linux.microchip-icicle-kit-debug
- x86_64-linux.doc

This change was tested in a forked repo: https://github.com/henrirosten/ghaf/actions/runs/6654144039