### PR TITLE
Update nixpkgs in flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695825837,
-        "narHash": "sha256-4Ne11kNRnQsmSJCRSSNkFRSnHC4Y5gPDBIQGjjPfJiU=",
+        "lastModified": 1699169573,
+        "narHash": "sha256-cvUb1xZkvOp3W2SzylStrTirhVd9zCeo5utJl9nSIhw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5cfafa12d57374f48bcc36fda3274ada276cf69e",
+        "rev": "aeefe2054617cae501809b82b44a8e8f7be7cc4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5cfafa12d57374f48bcc36fda3274ada276cf69e' (2023-09-27)
  → 'github:NixOS/nixpkgs/aeefe2054617cae501809b82b44a8e8f7be7cc4b' (2023-11-05)