### PR TITLE
Add OP-TEE's xtest (orin nx)

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/optee.nix
+++ b/modules/hardware/nvidia-jetson-orin/optee.nix
@@ -1,0 +1,66 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  options.ghaf.hardware.nvidia.orin.optee = {
+    xtest = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Adds OP-TEE's xtest and related TA/Plugins
+      '';
+    };
+
+    pkcs11-tool = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        OpenSC pkcs11-tool, but for a convenience reasons \"pkcs11-tool-optee\" shell
+        script is created. It calls pkcs11-tool with "--module"-option set to
+        OP-TEE's PKCS#11 library.
+
+        Example usage: same as pkcs11-tool, but ommit "--module"-option
+
+        pkcs11-tool-optee --help
+        pkcs11-tool-optee --show-info -L
+      '';
+    };
+
+    pkcs11 = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Adds OP-TEE's PKCS#11 TA.
+        '';
+      };
+
+      heapSize = lib.mkOption {
+        type = lib.types.int;
+        default = 32768;
+        description = lib.mdDoc ''
+          Defines PKCS11 TA heap size. Heap size has a direct
+          correlation to its secure storage size. Heap == Storage.
+
+          NOTE: Redefining secure storage size once it has been created
+          might corrupt existing storage. Default storage path /data/tee.
+          Remove existing storage when redefined.
+        '';
+      };
+
+      tokenCount = lib.mkOption {
+        type = lib.types.int;
+        default = 3;
+        description = lib.mdDoc ''
+          PKCS#11 token count.
+
+          NOTE: Redefining token count might corrupt secure storage,
+          if it exist. Default storage path /data/tee.
+          Remove existing storage when redefined.
+        '';
+      };
+    };
+  };
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -8,6 +8,7 @@
   ./development/ssh.nix
   ./graphics
   ./hardware/x86_64-linux.nix
+  ./hardware/nvidia-jetson-orin/optee.nix
   ./installer
   ./profiles/applications.nix
   ./profiles/debug.nix

--- a/modules/profiles/debug.nix
+++ b/modules/profiles/debug.nix
@@ -25,6 +25,11 @@ in
           # Let us in.
           ssh.daemon.enable = true;
         };
+
+        hardware.nvidia.orin.optee = {
+          xtest = true;
+          pkcs11-tool = true;
+        };
       };
     };
   }

--- a/targets/nvidia-jetson-orin/optee.nix
+++ b/targets/nvidia-jetson-orin/optee.nix
@@ -2,6 +2,7 @@
   {
     pkgs,
     config,
+    lib,
     ...
   }: let
     # TODO: Refactor this later, if this gets proper implementation on the
@@ -15,21 +16,47 @@
       opteeClient
       ;
     inherit (config.hardware.nvidia-jetpack.devicePkgs) taDevKit teeSupplicant;
+
+    opteeSource = pkgs.fetchgit {
+      url = "https://nv-tegra.nvidia.com/r/tegra/optee-src/nv-optee";
+      rev = "jetson_${l4tVersion}";
+      sha256 = "sha256-44RBXFNUlqZoq3OY/OFwhiU4Qxi4xQNmetFmlrr6jzY=";
+    };
+
+    opteeXtest = stdenv.mkDerivation {
+      pname = "optee_xtest";
+      version = l4tVersion;
+      src = opteeSource;
+      nativeBuildInputs = [(pkgs.buildPackages.python3.withPackages (p: [p.cryptography]))];
+      postPatch = ''
+        patchShebangs --build $(find optee/optee_test -type d -name scripts -printf '%p ')
+      '';
+      makeFlags = [
+        "-C optee/optee_test"
+        "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        "OPTEE_CLIENT_EXPORT=${opteeClient}"
+        "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
+        "O=$(PWD)/out"
+      ];
+      installPhase = ''
+        runHook preInstall
+        install -Dm 755 ./out/xtest/xtest $out/bin/xtest
+        mkdir $out/ta
+        find ./out -name "*.ta" -exec cp {} $out/ta/ \;
+        runHook postInstall
+      '';
+    };
     pcks11Ta = stdenv.mkDerivation {
       pname = "pkcs11";
       version = l4tVersion;
-      src = pkgs.fetchgit {
-        url = "https://nv-tegra.nvidia.com/r/tegra/optee-src/nv-optee";
-        rev = "jetson_${l4tVersion}";
-        sha256 = "sha256-44RBXFNUlqZoq3OY/OFwhiU4Qxi4xQNmetFmlrr6jzY=";
-      };
+      src = opteeSource;
       nativeBuildInputs = [(pkgs.buildPackages.python3.withPackages (p: [p.cryptography]))];
       makeFlags = [
         "-C optee/optee_os/ta/pkcs11"
         "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
         "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
-        "CFG_PKCS11_TA_TOKEN_COUNT=3"
-        "CFG_PKCS11_TA_HEAP_SIZE=32768"
+        "CFG_PKCS11_TA_TOKEN_COUNT=${builtins.toString config.ghaf.hardware.nvidia.orin.optee.pkcs11.tokenCount}"
+        "CFG_PKCS11_TA_HEAP_SIZE=${builtins.toString config.ghaf.hardware.nvidia.orin.optee.pkcs11.heapSize}"
         "CFG_PKCS11_TA_AUTH_TEE_IDENTITY=y"
         "CFG_PKCS11_TA_ALLOW_DIGEST_KEY=y"
         "OPTEE_CLIENT_EXPORT=${opteeClient}"
@@ -45,16 +72,40 @@
       exec "${pkgs.opensc}/bin/pkcs11-tool" --module "${teeSupplicant}/lib/libckteec.so" $@
     '';
   in {
-    hardware.nvidia-jetpack.firmware.optee.clientLoadPath = pkgs.linkFarm "optee-load-path" [
-      {
-        # By default, tee_supplicant expects to find the TAs under
-        # optee_armtz
-        name = "optee_armtz/fd02c9da-306c-48c7-a49c-bbd827ae86ee.ta";
-        path = "${pcks11Ta}/fd02c9da-306c-48c7-a49c-bbd827ae86ee.ta";
-      }
-    ];
-    environment.systemPackages = [
-      pkcs11-tool-optee
-    ];
+    hardware.nvidia-jetpack.firmware.optee.clientLoadPath =
+      pkgs.linkFarm "optee-load-path"
+      (
+        (
+          if config.ghaf.hardware.nvidia.orin.optee.xtest
+          then
+            (
+              let
+                xTestTaDir = "${opteeXtest}/ta";
+              in
+                builtins.map (
+                  ta: {
+                    name = "optee_armtz" + "/" + ta;
+                    path = xTestTaDir + "/" + ta;
+                  }
+                ) (builtins.attrNames (builtins.readDir xTestTaDir))
+            )
+          else []
+        )
+        ++ (
+          if config.ghaf.hardware.nvidia.orin.optee.pkcs11.enable
+          then [
+            {
+              name = "optee_armtz/fd02c9da-306c-48c7-a49c-bbd827ae86ee.ta";
+              path = "${pcks11Ta}/fd02c9da-306c-48c7-a49c-bbd827ae86ee.ta";
+            }
+          ]
+          else []
+        )
+      );
+
+    environment.systemPackages =
+      []
+      ++ (lib.optional config.ghaf.hardware.nvidia.orin.optee.pkcs11-tool pkcs11-tool-optee)
+      ++ (lib.optional config.ghaf.hardware.nvidia.orin.optee.xtest opteeXtest);
   }
 )


### PR DESCRIPTION
Commits adds OP-TEE's xtest. Xtest is added only for Orin NX. 

Xtest ran on Orin NX and following tests fails:
  - 1008: Loads corrupt TA. Test requires TA directory path at the compile time, but currently it would end up with infinite recursion.
  - 1033: Plugin test case. Plugin support can be disabled or passing an extra argument to tee-supplicant
  - 4016_ed25519: One of the function uses uninitialized parameter. Fix requires OP-TEE [patch.](https://github.com/OP-TEE/optee_os/commit/e4c24b7f9f1afbdd7a48766007cf0055b4b8df6b)