### PR TITLE
Add NetworkManager to net-vm and nm-applet to gui-vm for Lenovo X1

### DIFF
--- a/modules/users/accounts.nix
+++ b/modules/users/accounts.nix
@@ -37,7 +37,7 @@ in
           isNormalUser = true;
           password = cfg.password;
           #TODO add "docker" use "lib.optionals"
-          extraGroups = ["wheel" "video"];
+          extraGroups = ["wheel" "video" "networkmanager"];
         };
         groups."${cfg.user}" = {
           name = cfg.user;

--- a/modules/virtualization/microvm/guivm.nix
+++ b/modules/virtualization/microvm/guivm.nix
@@ -37,6 +37,8 @@
           };
           systemPackages = [
             pkgs.waypipe
+            pkgs.networkmanagerapplet
+            pkgs.nm-launcher
           ];
         };
 

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -11,5 +11,6 @@
     (import ./weston)
     (import ./wifi-connector)
     (import ./qemu)
+    (import ./nm-launcher)
   ];
 }

--- a/overlays/custom-packages/nm-launcher/default.nix
+++ b/overlays/custom-packages/nm-launcher/default.nix
@@ -1,0 +1,5 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+(final: prev: {
+  nm-launcher = final.callPackage ../../../user-apps/nm-launcher {};
+})

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -25,12 +25,39 @@
         # For WLAN firmwares
         hardware.enableRedistributableFirmware = true;
 
-        networking.wireless = {
-          enable = true;
-
-          #networks."ssid".psk = "psk";
+        networking = {
+          # wireless is disabled because we use NetworkManager for wireless
+          wireless.enable = false;
+          networkmanager = {
+            enable = true;
+            unmanaged = ["ethint0"];
+          };
+        };
+        environment.etc."NetworkManager/system-connections/Wifi-1.nmconnection" = {
+          text = ''
+            [connection]
+            id=Wifi-1
+            uuid=33679db6-4cde-11ee-be56-0242ac120002
+            type=wifi
+            [wifi]
+            mode=infrastructure
+            ssid=SSID_OF_NETWORK
+            [wifi-security]
+            key-mgmt=wpa-psk
+            psk=WPA_PASSWORD
+            [ipv4]
+            method=auto
+            [ipv6]
+            method=disabled
+            [proxy]
+          '';
+          mode = "0600";
         };
       }
+      ({pkgs, ...}: {
+        # Waypipe-ssh key is used here to create keys for ssh tunneling to forward D-Bus sockets.
+        users.users.ghaf.openssh.authorizedKeys.keyFiles = ["${pkgs.waypipe-ssh}/keys/waypipe-ssh.pub"];
+      })
     ];
     guivmConfig = hostConfiguration.config.ghaf.virtualization.microvm.guivm;
     winConfig = hostConfiguration.config.ghaf.windows-launcher;
@@ -87,6 +114,11 @@
           {
             path = "${pkgs.virt-viewer}/bin/remote-viewer -f spice://${winConfig.spice-host}:${toString winConfig.spice-port}";
             icon = "${../assets/icons/png/windows.png}";
+          }
+
+          {
+            path = "${pkgs.nm-launcher}/bin/nm-launcher";
+            icon = "${pkgs.networkmanagerapplet}/share/icons/hicolor/22x22/apps/nm-device-wwan.png";
           }
         ];
       })

--- a/user-apps/nm-launcher/default.nix
+++ b/user-apps/nm-launcher/default.nix
@@ -1,0 +1,45 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenvNoCC,
+  pkgs,
+  lib,
+  stdenv,
+  ...
+}: let
+  nmLauncher =
+    pkgs.writeShellScript
+    "nm-launcher"
+    ''
+      export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
+      export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/ssh_system_dbus.sock
+      ${pkgs.openssh}/bin/ssh -M -S /tmp/control_socket \
+          -f -N -q ghaf@192.168.100.1 \
+          -i /etc/ssh/waypipe-ssh \
+          -o StrictHostKeyChecking=no \
+          -o StreamLocalBindUnlink=yes \
+          -o ExitOnForwardFailure=yes \
+          -L /tmp/ssh_session_dbus.sock:/run/user/1000/bus \
+          -L /tmp/ssh_system_dbus.sock:/run/dbus/system_bus_socket
+      ${pkgs.networkmanagerapplet}/bin/nm-connection-editor
+      # Use the control socket to close the ssh tunnel.
+      ${pkgs.openssh}/bin/ssh -q -S /tmp/control_socket -O exit ghaf@192.168.100.1
+    '';
+in
+  stdenvNoCC.mkDerivation {
+    name = "nm-launcher";
+
+    phases = ["installPhase"];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${nmLauncher} $out/bin/nm-launcher
+    '';
+
+    meta = with lib; {
+      description = "Script to launch nm-connection-editor to configure network of netvm using D-Bus over SSH.";
+      platforms = [
+        "x86_64-linux"
+      ];
+    };
+  }


### PR DESCRIPTION
Add NetworkManager to the net-vm of the Lenovo X1 Carbon target to manage external network interfaces of the net-vm. Also add the nm-applet package to the gui-vm.
The nm-launcher script is added to create SSH-tunnel to forward D-Bus messaging between net-vm and gui-vm so that nm-connection-editor GUI-application in gui-vm controls NetworkManager core in net-vm.

Usage:
- Click on the corresponding icon to launch the nm-connection-editor.
- Double click "Wifi-1" to edit the default WiFi connection.
- Set the SSID on the "Wi-Fi" tab and password on the "Wi-Fi Security" tab.

Note:
It is possible to set SSID and password before building the image. Just edit values at targets/lenovo-x1-carbon.nix.
