### PR TITLE
Set static IP for gui-vm

### DIFF
--- a/modules/virtualization/microvm/guivm.nix
+++ b/modules/virtualization/microvm/guivm.nix
@@ -92,6 +92,13 @@
           };
           wantedBy = ["ghaf-session.target"];
         };
+
+        # Fixed IP-address for debugging subnet
+        systemd.network.networks."10-ethint0".addresses = [
+          {
+            addressConfig.Address = "192.168.101.3/24";
+          }
+        ];
       })
     ];
   };


### PR DESCRIPTION
This patch sets static IP address (192.168.101.3) for gui-vm to debugging subnet.

Task: SP-3252

