### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697474248,
-        "narHash": "sha256-VJ/t7b3Qi2hzx+hxAIFW8z9MZcKqBl4LIAOnYlZIZGY=",
+        "lastModified": 1699910938,
+        "narHash": "sha256-4mSF3gepQgCT4FXBcQSU55I/FW69w9/BIlRT/RSeV7E=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "fc823410ed147a40b182159bd8979b8542993c21",
+        "rev": "37a84f93607f6c3fd8560a2afc2359a93648ec59",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696405736,
-        "narHash": "sha256-Wb8qSpePi/cSLOGr9YStiU4F4w6KyycDlyHXNI8U3xA=",
+        "lastModified": 1699578541,
+        "narHash": "sha256-QwO4L8EwZZhFTJic6KUq2qixnZZWZwq3Pvhj+U6SBuI=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "abd63123e2b2dbc34d1ac38a73578b27ec9ef342",
+        "rev": "fb78ecd4e5b42bb5c4f57f36a80f99bbf3e0d010",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693791338,
-        "narHash": "sha256-wHmtB5H8AJTUaeGHw+0hsQ6nU4VyvVrP2P4NeCocRzY=",
+        "lastModified": 1696058303,
+        "narHash": "sha256-eNqKWpF5zG0SrgbbtljFOrRgFgRzCc4++TMFADBMLnc=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "8ee78470029e641cddbd8721496da1316b47d3b4",
+        "rev": "150f38bd1e09e20987feacb1b0d5991357532fb5",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1695887975,
-        "narHash": "sha256-u3+5FR12dI305jCMb0fJNQx2qwoQ54lv1tPoEWp0hmg=",
+        "lastModified": 1699997707,
+        "narHash": "sha256-ugb+1TGoOqqiy3axyEZpfF6T4DQUGjfWZ3Htry1EfvI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "adcfd6aa860d1d129055039696bc457af7d50d0e",
+        "rev": "5689f3ebf899f644a1aabe8774d4f37eb2f6c2f9",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699169573,
-        "narHash": "sha256-cvUb1xZkvOp3W2SzylStrTirhVd9zCeo5utJl9nSIhw=",
+        "lastModified": 1699596684,
+        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aeefe2054617cae501809b82b44a8e8f7be7cc4b",
+        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
• Updated input 'jetpack-nixos':
    'github:anduril/jetpack-nixos/fc823410ed147a40b182159bd8979b8542993c21' (2023-10-16)
  → 'github:anduril/jetpack-nixos/37a84f93607f6c3fd8560a2afc2359a93648ec59' (2023-11-13)
• Updated input 'microvm':
    'github:astro/microvm.nix/abd63123e2b2dbc34d1ac38a73578b27ec9ef342' (2023-10-04)
  → 'github:astro/microvm.nix/fb78ecd4e5b42bb5c4f57f36a80f99bbf3e0d010' (2023-11-10)
• Updated input 'nixos-generators':
    'github:nix-community/nixos-generators/8ee78470029e641cddbd8721496da1316b47d3b4' (2023-09-04)
  → 'github:nix-community/nixos-generators/150f38bd1e09e20987feacb1b0d5991357532fb5' (2023-09-30)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/adcfd6aa860d1d129055039696bc457af7d50d0e' (2023-09-28)
  → 'github:NixOS/nixos-hardware/5689f3ebf899f644a1aabe8774d4f37eb2f6c2f9' (2023-11-14)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/aeefe2054617cae501809b82b44a8e8f7be7cc4b' (2023-11-05)
  → 'github:NixOS/nixpkgs/da4024d0ead5d7820f6bd15147d3fe2a0c0cec73' (2023-11-10)