### PR TITLE
Change cache.vedenemo.dev public key to new key

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       "https://cache.ssrcdevops.tii.ae"
     ];
     extra-trusted-public-keys = [
-      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
       "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
     ];
   };

--- a/templates/targets/aarch64/nvidia/orin-agx/flake.nix
+++ b/templates/targets/aarch64/nvidia/orin-agx/flake.nix
@@ -9,7 +9,7 @@
       "https://cache.ssrcdevops.tii.ae"
     ];
     extra-trusted-public-keys = [
-      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
       "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
     ];
   };

--- a/templates/targets/aarch64/nvidia/orin-nx/flake.nix
+++ b/templates/targets/aarch64/nvidia/orin-nx/flake.nix
@@ -9,7 +9,7 @@
       "https://cache.ssrcdevops.tii.ae"
     ];
     extra-trusted-public-keys = [
-      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
       "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
     ];
   };

--- a/templates/targets/aarch64/nxp/imx8/flake.nix
+++ b/templates/targets/aarch64/nxp/imx8/flake.nix
@@ -9,7 +9,7 @@
       "https://cache.ssrcdevops.tii.ae"
     ];
     extra-trusted-public-keys = [
-      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
       "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
     ];
   };

--- a/templates/targets/riscv64/microchip/polarfire/flake.nix
+++ b/templates/targets/riscv64/microchip/polarfire/flake.nix
@@ -9,7 +9,7 @@
       "https://cache.ssrcdevops.tii.ae"
     ];
     extra-trusted-public-keys = [
-      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
       "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
     ];
   };

--- a/templates/targets/x86_64/generic/flake.nix
+++ b/templates/targets/x86_64/generic/flake.nix
@@ -9,7 +9,7 @@
       "https://cache.ssrcdevops.tii.ae"
     ];
     extra-trusted-public-keys = [
-      "cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg="
+      "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
       "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
     ];
   };


### PR DESCRIPTION
We will be changing to a new cache server soon and this is the new public key. Not to be merged yet, but reviewed and approved so it's ready to go.