### PR TITLE
Options for AGX and NX PCI Passthroughs

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/agx-netvm-wlan-pci-passthrough.nix
+++ b/modules/hardware/nvidia-jetson-orin/agx-netvm-wlan-pci-passthrough.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.ghaf.hardware.nvidia.orin.agx;
+in {
+  options.ghaf.hardware.nvidia.orin.agx.enableNetvmWlanPCIPassthrough =
+    lib.mkEnableOption
+    "WLAN card PCI passthrough to NetVM";
+  config = lib.mkIf cfg.enableNetvmWlanPCIPassthrough {
+    # Orin AGX WLAN card PCI passthrough
+    ghaf.hardware.nvidia.orin.enablePCIPassthroughCommon = true;
+
+    ghaf.virtualization.microvm.netvm.extraModules = [
+      {
+        microvm.devices = [
+          {
+            bus = "pci";
+            path = "0001:01:00.0";
+          }
+        ];
+      }
+    ];
+
+    boot.kernelPatches = [
+      {
+        name = "agx-pci-passthrough-patch";
+        patch = ./pci-passthrough-agx-test.patch;
+      }
+    ];
+
+    boot.kernelParams = [
+      "vfio-pci.ids=10ec:c82f"
+      "vfio_iommu_type1.allow_unsafe_interrupts=1"
+    ];
+
+    hardware.deviceTree = {
+      enable = true;
+      name = "tegra234-p3701-host-passthrough.dtb";
+    };
+  };
+}

--- a/modules/hardware/nvidia-jetson-orin/default.nix
+++ b/modules/hardware/nvidia-jetson-orin/default.nix
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Top-level module entry point for the Orin family of chips
-{lib, ...}:
-with lib; {
+{
   imports = [
     ./partition-template.nix
     ../../boot/systemd-boot-dtb.nix
     ./jetson-orin.nix
+
+    ./pci-passthrough-common.nix
+    ./agx-netvm-wlan-pci-passthrough.nix
+    ./nx-netvm-ethernet-pci-passthrough.nix
   ];
 }

--- a/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/hardware/nvidia-jetson-orin/jetson-orin.nix
@@ -6,58 +6,9 @@
   lib,
   pkgs,
   config,
-  nixpkgs,
   ...
 }: let
   cfg = config.ghaf.hardware.nvidia.orin;
-  somDefinition = {
-    "agx" = {
-      flashArgs = ["-r" config.hardware.nvidia-jetpack.flashScriptOverrides.targetBoard "mmcblk0p1"];
-      passthrough-patch = ./pci-passthrough-agx-test.patch;
-      vfio-pci = "vfio-pci.ids=10ec:c82f";
-      deviceTree = "tegra234-p3701-host-passthrough.dtb";
-      buspath = [
-        {
-          bus = "pci";
-          path = "0001:01:00.0";
-        }
-      ];
-      kernelParams = [];
-    };
-    "nx" = {
-      flashArgs = ["-r" config.hardware.nvidia-jetpack.flashScriptOverrides.targetBoard "nvme0n1p1"];
-      # This patch uses Alex Williamson's patch for enabling overrides for missing ACS capabilities on pci
-      # bus which could be accessed from following link: https://lkml.org/lkml/2013/5/30/513
-      passthrough-patch = ./pci-passthrough-nx-test.patch;
-      # Multiple device passing option
-      #      vfio-pci = "vfio-pci.ids=10de:229c,10ec:8168";
-      vfio-pci = "vfio-pci.ids=10ec:8168";
-      deviceTree = "tegra234-p3767-host-passthrough.dtb";
-      buspath = [
-        # Multiple devices and path could be passed through this option
-        #        {
-        #          bus = "pci";
-        #          path = "0008:00:00.0";
-        #        }
-        {
-          bus = "pci";
-          path = "0008:01:00.0";
-        }
-      ];
-      kernelParams = [
-        "pci=nomsi"
-        "pcie_acs_override=downstream,multifunction"
-      ];
-    };
-  };
-  netvmExtraModules = [
-    {
-      # This is the device dependent part of netvm configuration.
-      # This part should be conditional for AGX 01:01 for NX 08:01
-      microvm.devices = somDefinition."${cfg.somType}".buspath;
-      microvm.kernelParams = somDefinition."${cfg.somType}".kernelParams;
-    }
-  ];
 in
   with lib; {
     options.ghaf.hardware.nvidia.orin = {
@@ -94,8 +45,8 @@ in
         carrierBoard = "${cfg.carrierBoard}";
         modesetting.enable = true;
 
-        flashScriptOverrides = {
-          flashArgs = lib.mkForce somDefinition."${cfg.somType}".flashArgs;
+        flashScriptOverrides = lib.optionalAttrs (cfg.somType == "agx") {
+          flashArgs = lib.mkForce ["-r" config.hardware.nvidia-jetpack.flashScriptOverrides.targetBoard "mmcblk0p1"];
         };
 
         firmware.uefi.logo = ../../../docs/src/img/1600px-Ghaf_logo.svg;
@@ -105,20 +56,12 @@ in
 
       ghaf.boot.loader.systemd-boot-dtb.enable = true;
 
-      ghaf.virtualization.microvm.netvm = {
-        extraModules = netvmExtraModules;
-      };
-
       boot.loader = {
         efi.canTouchEfiVariables = true;
         systemd-boot.enable = true;
       };
       boot.modprobeConfig.enable = true;
       boot.kernelPatches = [
-        {
-          name = "passthrough-patch";
-          patch = somDefinition."${cfg.somType}".passthrough-patch;
-        }
         {
           name = "vsock-config";
           patch = null;
@@ -135,23 +78,22 @@ in
         }
       ];
 
-      hardware.deviceTree = {
-        enable = true;
-        name = somDefinition."${cfg.somType}".deviceTree;
-      };
-
-      # Passthrough Jetson Orin Network cards
-      boot.kernelModules = ["vfio_pci" "vfio_iommu_type1" "vfio"];
-
-      boot.kernelParams = [
-        somDefinition."${cfg.somType}".vfio-pci
-        "vfio_iommu_type1.allow_unsafe_interrupts=1"
-      ];
-
       services.nvpmodel = {
         enable = lib.mkDefault true;
         # Enable all CPU cores, full power consumption (50W on AGX, 25W on NX)
         profileNumber = lib.mkDefault 3;
       };
+      hardware.deviceTree =
+        {
+          enable = lib.mkDefault true;
+        }
+        # Versions of the device tree without PCI passthrough related
+        # modifications.
+        // lib.optionalAttrs (cfg.somType == "agx") {
+          name = lib.mkDefault "tegra234-p3701-0000-p3737-0000.dtb";
+        }
+        // lib.optionalAttrs (cfg.somType == "nx") {
+          name = lib.mkDefault "tegra234-p3767-0000-p3509-a02.dtb";
+        };
     };
   }

--- a/modules/hardware/nvidia-jetson-orin/nx-netvm-ethernet-pci-passthrough.nix
+++ b/modules/hardware/nvidia-jetson-orin/nx-netvm-ethernet-pci-passthrough.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.ghaf.hardware.nvidia.orin.nx;
+in {
+  options.ghaf.hardware.nvidia.orin.nx.enableNetvmEthernetPCIPassthrough =
+    lib.mkEnableOption
+    "Ethernet card PCI passthrough to NetVM";
+  config = lib.mkIf cfg.enableNetvmEthernetPCIPassthrough {
+    # Orin NX Ethernet card PCI Passthrough
+    ghaf.hardware.nvidia.orin.enablePCIPassthroughCommon = true;
+
+    ghaf.virtualization.microvm.netvm.extraModules = [
+      {
+        microvm.devices = [
+          {
+            bus = "pci";
+            path = "0008:01:00.0";
+          }
+        ];
+        microvm.kernelParams = [
+          "pci=nomsi"
+          "pcie_acs_override=downstream,multifunction"
+        ];
+      }
+    ];
+
+    boot.kernelPatches = [
+      {
+        name = "nx-pci-passthrough-patch";
+        # This patch uses Alex Williamson's patch for enabling overrides for missing ACS capabilities on pci
+        # bus which could be accessed from following link: https://lkml.org/lkml/2013/5/30/513
+        patch = ./pci-passthrough-nx-test.patch;
+      }
+    ];
+
+    boot.kernelParams = [
+      "vfio-pci.ids=10ec:8168"
+      "vfio_iommu_type1.allow_unsafe_interrupts=1"
+    ];
+
+    hardware.deviceTree = {
+      enable = true;
+      name = "tegra234-p3767-host-passthrough.dtb";
+    };
+  };
+}

--- a/modules/hardware/nvidia-jetson-orin/pci-passthrough-common.nix
+++ b/modules/hardware/nvidia-jetson-orin/pci-passthrough-common.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.ghaf.hardware.nvidia.orin;
+in {
+  options.ghaf.hardware.nvidia.orin.enablePCIPassthroughCommon =
+    lib.mkEnableOption
+    "Enable common options related to PCI passthrough on Orin AGX and NX";
+  config = lib.mkIf cfg.enablePCIPassthroughCommon {
+    boot.kernelModules = [
+      "vfio_pci"
+      "vfio_iommu_type1"
+      "vfio"
+    ];
+  };
+}

--- a/targets/nvidia-jetson-orin/default.nix
+++ b/targets/nvidia-jetson-orin/default.nix
@@ -51,8 +51,12 @@
           ../../modules/virtualization/microvm/netvm.nix
           {
             ghaf = {
-              hardware.nvidia.orin.enable = true;
-              hardware.nvidia.orin.somType = som;
+              hardware.nvidia.orin = {
+                enable = true;
+                somType = som;
+                agx.enableNetvmWlanPCIPassthrough = som == "agx";
+                nx.enableNetvmEthernetPCIPassthrough = som == "nx";
+              };
 
               virtualization.microvm-host.enable = true;
               host.networking.enable = true;


### PR DESCRIPTION
Instead of enabling WLAN PCI Passthrough for Orin AGX or Ethernet PCI Passthrough always in the jetson-orin.nix module, refactor options for AGX and NX PCI Passthroughs, which will enable or disable PCI Passthrough related functionality and patches from the NVIDIA Jetson Orin modules.