### PR TITLE
wifi-connector: Support nmcli interface

### DIFF
--- a/overlays/custom-packages/wifi-connector/default.nix
+++ b/overlays/custom-packages/wifi-connector/default.nix
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 (final: _prev: {
   wifi-connector = final.callPackage ../../../packages/wifi-connector {};
+  wifi-connector-nmcli = final.callPackage ../../../packages/wifi-connector {useNmcli = true;};
 })

--- a/packages/wifi-connector/default.nix
+++ b/packages/wifi-connector/default.nix
@@ -4,51 +4,95 @@
   stdenvNoCC,
   pkgs,
   lib,
+  useNmcli ? false,
   ...
 }: let
   wifiConnector =
     pkgs.writeShellScript
     "wifi-connector"
-    ''
-      # Check if the script is run as root
-      if [ "$EUID" -ne 0 ]; then
-        echo "Please run this script as root or with sudo."
-        exit 1
-      fi
+    (''
+        # Check if the script is run as root
+        if [ "$EUID" -ne 0 ]; then
+          echo "Please run this script as root or with sudo."
+          exit 1
+        fi
 
-      # Check if two arguments (SSID and PSK) are provided
-      if [ $# -ne 2 ]; then
-        echo "Usage: $0 <SSID> <PSK>"
-        exit 1
-      fi
+        while getopts ":ds:p:" opt; do
+          case $opt in
+            d)
+              echo "Disconnecting..."
+      ''
+      + lib.optionalString useNmcli ''
+              CONNECTION=$(nmcli d | grep -w wifi | grep -w connected |  awk '{print $4}')
+              if [ -z "$CONNECTION" ]; then
+                echo "No active Wi-Fi connection found";
+                exit 0;
+              fi
+              nmcli con down id $CONNECTION
+      ''
+      + lib.optionalString (!useNmcli) ''
+              #Stop any running wpa_supplicant instances
+              pkill wpa_supplicant
+      ''
+      + ''
+              exit 0
+              ;;
+            s)
+              SSID=$OPTARG
+              ;;
+            p)
+              PSK=$OPTARG
+              ;;
+            \?)
+               echo "Invalid option: -$OPTARG" >&2
+               exit 1
+               ;;
+            :)
+               echo "Option -$OPTARG does not take an argument." >&2
+               exit 1
+               ;;
+          esac
+        done
 
-      SSID="$1"
-      PSK="$2"
+        if [ -z "$SSID" ] || [ -z "$PSK" ]; then
+          echo "Usage: $0 -s <SSID> -p <PSK> OR -d to disconnect"
+          exit 1
+        fi
 
-      # Stop any running wpa_supplicant instances
-      pkill wpa_supplicant
+      ''
+      + lib.optionalString useNmcli ''
+        #Run nmcli command, get its output;
+        #split above result with ' as a delimiter and take the second part (devicename)
+        DEVICE=$(nmcli device wifi connect $SSID password $PSK | cut -d"'" -f2)
+      ''
+      + lib.optionalString (!useNmcli) ''
+        #Stop any running wpa_supplicant instances
+        pkill wpa_supplicant
 
-      # Create a wpa_supplicant configuration file
-      cat > ./wpa_supplicant.conf <<EOL
-      network={
-          ssid="$SSID"
-          psk="$PSK"
-      }
-      EOL
+        DEVICE=$(ifconfig | grep wlp | cut -d":" -f1)
 
-      # Start wpa_supplicant with the specified configuration
-      wpa_supplicant -B -i wlp0s4f0 -c ./wpa_supplicant.conf
+        # Create a wpa_supplicant configuration file
+        cat > ./wpa_supplicant.conf <<EOL
+        network={
+            ssid="$SSID"
+            psk="$PSK"
+        }
+        EOL
 
-      # Wait for a few seconds to allow the connection to establish
-      sleep 5
+        # Start wpa_supplicant with the specified configuration
+        wpa_supplicant -B -i $DEVICE -c ./wpa_supplicant.conf
+      ''
+      + ''
+        # Wait for a few seconds to allow the connection to establish
+        sleep 5
 
-      # Check if the connection was successful
-      if ifconfig wlp0s4f0 | grep -q "inet"; then
-        echo "Connected to $SSID successfully."
-      else
-        echo "Failed to connect to $SSID."
-      fi
-    '';
+        # Check if the connection was successful
+        if ifconfig $DEVICE | grep -q "inet"; then
+          echo "Connected to $SSID successfully."
+        else
+          echo "Failed to connect to $SSID."
+        fi
+      '');
 in
   stdenvNoCC.mkDerivation {
     name = "wifi-connector";

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -80,6 +80,8 @@
           in "${script}/bin/get-auth-keys";
           mode = "0555";
         };
+        # Add simple wi-fi connection helper
+        environment.systemPackages = lib.mkIf hostConfiguration.config.ghaf.profiles.debug.enable [pkgs.wifi-connector-nmcli];
         services.openssh = {
           authorizedKeysCommand = "/etc/ssh/get-auth-keys";
           authorizedKeysCommandUser = "nobody";


### PR DESCRIPTION
Now when NetworkManager is in use for NetVM, edit the script to use nmcli to avoid any conflicts.