### PR TITLE
jetpack-nixos: Fix otaUtils cross-compilation

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/default.nix
+++ b/modules/hardware/nvidia-jetson-orin/default.nix
@@ -11,5 +11,7 @@
     ./pci-passthrough-common.nix
     ./agx-netvm-wlan-pci-passthrough.nix
     ./nx-netvm-ethernet-pci-passthrough.nix
+
+    ./ota-utils-fix.nix
   ];
 }

--- a/modules/hardware/nvidia-jetson-orin/ota-utils-fix.nix
+++ b/modules/hardware/nvidia-jetson-orin/ota-utils-fix.nix
@@ -1,0 +1,33 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This overlay is for fixing ota-utils.
+#
+# There is upstream PR waiting for review:
+# https://github.com/anduril/jetpack-nixos/pull/162
+#
+{
+  pkgs,
+  lib,
+  ...
+}: {
+  # mkAfter needed here so that we can be sure the overlay is after the overlay
+  # included from jetpack-nixos. Otherwise it will just override the whole
+  # nvidia-jetpack set.
+  nixpkgs.overlays = lib.mkAfter [
+    (_final: prev: {
+      nvidia-jetpack =
+        prev.nvidia-jetpack
+        // {
+          otaUtils = prev.nvidia-jetpack.otaUtils.overrideAttrs (_finalAttrs: prevAttrs: {
+            depsBuildHost = [pkgs.bash];
+            installPhase =
+              prevAttrs.installPhase
+              + ''
+                substituteInPlace $out/bin/* --replace '#!/usr/bin/env bash' '#!${pkgs.bash}/bin/bash'
+              '';
+          });
+        };
+    })
+  ];
+}


### PR DESCRIPTION
## Description of changes

setup-jetson-efi-variables.service failed to start on cross-compiled builds, this seems to be caused by non-working patchShebangs. Adding an overlay which fixes the shebang lines of the scripts in the end of the installPhase.

## Checklist for things done

<!-- Please check, [X], to all that applies. Add [-] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [-] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [- Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [-] Author has run `nix flake check --accept-flake-config --allow-import-from-derivation` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing

This is a rather small change, and it is clear that it only affects Orin AGX and Orin NX targets.

Tested on both Orin AGX and Orin NX. Tested also that non-cross-compiled builds do not break.

How to test:

Simply run `systemctl status setup-jetson-efi-variables.service`, and see that service has not failed to start