### PR TITLE
checks: Improve nix flake check performance

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,32 +1,22 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{inputs, ...}: {
-  perSystem = {pkgs, ...}: {
-    checks = {
-      reuse =
-        pkgs.runCommandLocal "reuse-lint" {
-          buildInputs = [pkgs.reuse];
-        } ''
-          cd ${../.}
-          reuse lint
-          touch $out
-        '';
-      nix-build-all = pkgs.writeShellApplication {
-        name = "nix-build-all";
-        runtimeInputs = let
-          devour-flake = pkgs.callPackage inputs.devour-flake {};
-        in [
-          pkgs.nix
-          devour-flake
-        ];
-        text = ''
-          # Make sure that flake.lock is sync
-          nix flake lock --no-update-lock-file
-
-          # Do a full nix build (all outputs)
-          devour-flake . "$@"
-        '';
-      };
-    };
+{lib, ...}: {
+  perSystem = {
+    pkgs,
+    self',
+    ...
+  }: {
+    checks =
+      {
+        reuse =
+          pkgs.runCommandLocal "reuse-lint" {
+            buildInputs = [pkgs.reuse];
+          } ''
+            cd ${../.}
+            reuse lint
+            touch $out
+          '';
+      }
+      // (lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages);
   };
 }


### PR DESCRIPTION
This reduces the memory load of `nix flake check` to ~15GB by making it more sequential.

## Description of changes

Changes the scope of nix-flake check to being more streamlined, to reduce memory consumption runaway.

## Checklist for things done


- [X] Summary of the proposed changes in the PR description
- [-] More detailed description in the commit message(s)
- [-] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [-] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [-] PR linked to architecture documentation and requirement(s) (ticket id)
- [-] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [X] Author has run `nix flake check --accept-flake-config --allow-import-from-derivation` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing

<How this was tested by the author? How is this supposed to be tested by people doing system testing?>