### PR TITLE
Bump: flake.lock for nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1700501263,
-        "narHash": "sha256-M0U063Ba2DKL4lMYI7XW13Rsk5tfUXnIYiAVa39AV/0=",
+        "lastModified": 1701053011,
+        "narHash": "sha256-8QQ7rFbKFqgKgLoaXVJRh7Ik5LtI3pyBBCfOnNOGkF0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f741f8a839912e272d7e87ccf4b9dbc6012cdaf9",
+        "rev": "5b528f99f73c4fad127118a8c1126b5e003b01a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Many new vulnerabilities identified in firefox,
bumping the flake lock to address those.

https://github.com/tiiuae/ghafscan/blob/main/reports/main/packages.x86_64-linux.generic-x86_64-release.md#vulnerabilities-fixed-in-ghaf-nixpkgs-upstream

## Description of changes


nix flake lock --update-input nixpkgs

## Checklist for things done

- [X] Summary of the proposed changes in the PR description
- [X More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [-] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [-] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config --allow-import-from-derivation` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing

<How this was tested by the author? How is this supposed to be tested by people doing system testing?>
