### PR TITLE
Update jetpack-nixos in flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700515170,
-        "narHash": "sha256-TfJUOBLKmlq4//kKYXXsVilceK2IRJkj9uJYWAalubc=",
+        "lastModified": 1701118984,
+        "narHash": "sha256-quhbx5aQu0RfbWnMVaicp6sHvhPHa0WE/K0QHh7MuLI=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "8bf417eb6c8ebe61de31d1c1049dd8bd03856dec",
+        "rev": "3ce210c4aee36143a4e40de66ea43cc10d314477",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

• Updated input 'jetpack-nixos':
    'github:anduril/jetpack-nixos/8bf417eb6c8ebe61de31d1c1049dd8bd03856dec' (2023-11-20)
  → 'github:anduril/jetpack-nixos/3ce210c4aee36143a4e40de66ea43cc10d314477' (2023-11-27)

Also do necessary changes so OP-TEE works again.


## Checklist for things done

<!-- Please check, [X], to all that applies. Add [-] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config --allow-import-from-derivation` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing

Run all basic orin-agx and orin-nx Robot Framework tests. Also test using optee test that is not merged but in PR draft branch ( https://github.com/tiiuae/ci-test-automation/pull/44 ), so that RSA and ECC key generation, signing and singature verification works. Also ran OP-TEE's `xtest`.