### PR TITLE
No more need for --allow-import-from-derivation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ Summary of the proposed changes in the PR description in your own words. For dep
   - [ ] Tested on Lenovo X1 `x86_64`
   - [ ] Tested on Jetson Orin NX or AGX `aarch64`
   - [ ] Tested on Polarfire `riscv64`
-- [ ] Author has run `nix flake check --accept-flake-config --allow-import-from-derivation` and it passes
+- [ ] Author has run `nix flake check --accept-flake-config` and it passes
 - [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
 - [ ] Author has added reviewers and removed PR draft status
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

As of the recent improvements, the `--allow-import-from-derivation` argument to `nix flake check` is no longer needed.

## Checklist for things done

<!-- Please check, [X], to all that applies. Add [-] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [X] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing

Run `nix flake check` without `--allow-import-from-derivation´
