### PR TITLE
[Lenovo X1]: Enable secure boot for Ghaf Host

### DIFF
--- a/modules/reference/hardened/default.nix
+++ b/modules/reference/hardened/default.nix
@@ -1,0 +1,3 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ imports = [ ./host-hardened.nix ]; }

--- a/modules/reference/hardened/host-hardened.nix
+++ b/modules/reference/hardened/host-hardened.nix
@@ -1,0 +1,16 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.reference.hardened.host-hardened;
+  inherit (lib) mkEnableOption mkIf;
+in
+{
+  options.ghaf.reference.hardened.host-hardened = {
+    enable = mkEnableOption "Host hardened configuration";
+  };
+
+  # Enable secure boot in the host configuration
+  config = mkIf cfg.enable { ghaf.host.secureboot.enable = true; };
+}

--- a/modules/reference/profiles/default.nix
+++ b/modules/reference/profiles/default.nix
@@ -7,5 +7,6 @@
   imports = [
     ./laptop-x86.nix
     ./mvp-user-trial.nix
+    ./mvp-hardened.nix
   ];
 }

--- a/modules/reference/profiles/mvp-hardened.nix
+++ b/modules/reference/profiles/mvp-hardened.nix
@@ -1,0 +1,17 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.reference.profiles.mvp-hardened;
+  inherit (lib) mkEnableOption mkIf;
+in
+{
+  imports = [ ../hardened ];
+
+  options.ghaf.reference.profiles.mvp-hardened = {
+    enable = mkEnableOption "Enable the mvp hardened configuration";
+  };
+
+  # Enable secure boot in the host configuration
+  config = mkIf cfg.enable { ghaf.reference.hardened.host-hardened.enable = true; };
+}

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -21,6 +21,7 @@ let
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen10.nix";
           reference.profiles.mvp-user-trial.enable = true;
+          reference.profiles.mvp-hardened.enable = false;
         };
       }
     ])
@@ -30,6 +31,7 @@ let
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen11.nix";
           reference.profiles.mvp-user-trial.enable = true;
+          reference.profiles.mvp-hardened.enable = false;
         };
       }
     ])
@@ -59,6 +61,7 @@ let
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen10.nix";
           reference.profiles.mvp-user-trial.enable = true;
+          reference.profiles.mvp-hardened.enable = false;
         };
       }
     ])
@@ -68,6 +71,7 @@ let
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen11.nix";
           reference.profiles.mvp-user-trial.enable = true;
+          reference.profiles.mvp-hardened.enable = false;
         };
       }
     ])


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This patch will enable secure boot feature on Lenovo X1 Carbon for Ghaf Host for debug builds.


## Checklist for things done

<!-- Please check, [X], to all that applies. Add [-] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing

1) Enable secure boot from BIOS.
2) Enroll keys `sudo sbctl enroll-keys --microsoft` and reboot
3) Run below command to verify functionality  
```
[ghaf@ghaf-host:~]$ sbctl status | grep Secure
Secure Boot:    ✓ Enabled
```
4) Also can verify lanzaboote version 
```
[ghaf@ghaf-host:~]$ sudo bootctl status | grep lanza
         Stub: lanzastub 0.4.1
```
5) By default following files will signed
```
[ghaf@ghaf-host:~]$ sudo sbctl verify 
Verifying file database and EFI images in /boot...
✓ /boot/EFI/BOOT/BOOTX64.EFI is signed
✓ /boot/EFI/systemd/systemd-bootx64.efi is signed
✓ /boot/EFI/Linux/nixos-generation-1-wbr7t62iuwsgggvvhowsleqqfpruht22kj5jc6hyafmn72ofevza.efi is signed
✗ /boot/EFI/nixos/kernel-6.8.12-ssnfqvg7y2ximh6dtgs2kxmeh6u5oafc6kcsddoya7xkj7nkxpaa.efi is not signed
```

**Note:** You may need to flash image as some of lanzaboote file may not install with `nixos-rebuild ... switch`

**More Details:** https://github.com/tiiuae/ghaf/blob/main/docs/src/architecture/secureboot.md
