### PR TITLE
Fix formatting again by running `nix fmt`

### DIFF
--- a/packages/wifi-connector/default.nix
+++ b/packages/wifi-connector/default.nix
@@ -23,16 +23,16 @@
               echo "Disconnecting..."
       ''
       + lib.optionalString useNmcli ''
-              CONNECTION=$(nmcli d | grep -w wifi | grep -w connected |  awk '{print $4}')
-              if [ -z "$CONNECTION" ]; then
-                echo "No active Wi-Fi connection found";
-                exit 0;
-              fi
-              nmcli con down id $CONNECTION
+        CONNECTION=$(nmcli d | grep -w wifi | grep -w connected |  awk '{print $4}')
+        if [ -z "$CONNECTION" ]; then
+          echo "No active Wi-Fi connection found";
+          exit 0;
+        fi
+        nmcli con down id $CONNECTION
       ''
       + lib.optionalString (!useNmcli) ''
-              #Stop any running wpa_supplicant instances
-              pkill wpa_supplicant
+        #Stop any running wpa_supplicant instances
+        pkill wpa_supplicant
       ''
       + ''
               exit 0


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Fix formatting again

## Checklist for things done

<!-- Please check, [X], to all that applies. Add [-] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing

Run `nix fmt` and see that there are not any changes