### PR TITLE
Pulseaudio remote

### DIFF
--- a/docs/src/architecture/adr.md
+++ b/docs/src/architecture/adr.md
@@ -14,6 +14,7 @@ The Ghaf platform decision log:
 | [Minimal Host](../architecture/adr/minimal-host.md) | Proposed. |
 | [netvm—Networking Virtual Machine](../architecture/adr/netvm.md) | Proposed, partially implemented for development and testing. |
 | [Platform Bus for RustVMM](../architecture/adr/platform-bus-passthrough-support.md) | Proposed, WIP. |
+| [audiovm—Audio Virtual Machine ](../architecture/adr/audiovm.md) | Proposed, WIP. |
 
 
 To create an architectural decision proposal, open [a pull request](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md#contributing-documentation) and use the [decision record template](https://github.com/tiiuae/ghaf/blob/main/docs/src/architecture/adr/template.md). Contributions to the Ghaf architecture decisions are welcome.

--- a/docs/src/architecture/adr/audiovm.md
+++ b/docs/src/architecture/adr/audiovm.md
@@ -1,0 +1,94 @@
+<!--
+    Copyright 2023 TII (SSRC) and the Ghaf contributors
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# audiovm-Audio support Virtual Machine
+
+## Status
+
+Proposed, partially implemented for development and testing.
+
+*audiovm* reference declaration will be available at [microvm/audiovm.nix]
+(https://github.com/tiiuae/ghaf/blob/main/modules/virtualization/microvm/audiovm.nix)
+
+## Context
+
+Ghaf high-level design target is to secure a monolithic OS by modularizing
+the OS. The key security target is to limit user data leakage between OS,
+applications and components. This isolates audio data between virtual
+machines and allows better control over which virtual machine gets access
+to audio peripherals.
+
+## Decision
+
+The two main goals are to isolate the virtual machine audio streams to prevent
+audio data leakage between virtual machines and allow separate control over
+which virtual machine is allowed to use audio peripherals at given time. The
+other goal is to isolate the audio stream processing to a separate virtual
+machine from the host to reduce size of trusted computing base in the host.
+
+Separating the audio processing away from the host is needed because some
+guest virtual machines need direct access to the main audio stream controls
+and allowing a direct connection from guests to host services would not be
+ideal for security perspective.
+
+On the host, the audio device is passed through to a dedicated Audio virtual
+machine (VM). AudioVM provides a service to let other virtual machines to use
+the audio peripherals. Letting the application virtual machines to connect to
+the audioVM backend directly could allow the application virtual machies to
+have full controll of all audio data including audio of other virtual
+machines. For this reason the application virtual machine audio is routed
+through the virtual machine manager. Each application virtual machine gets
+its own virtualized sound card device from the virtual machine manager.
+The virtual machine manager routes the Application virtual machines virtual
+sound card data to actual sound service on AudioVM.
+
+                      ┌─────────────────┐                 ┌──────────────────┐
+                      │                 │                 │                  │
+                      │                 │                 │                  │
+        Direct Audio  │     GuiVM       │                 │      AppVM2      │
+           ┌──────────┤                 │                 │                  │
+           │          │                 │         ┌──────►│                  │
+           │          └─────────────────┘         │       └──────────────────┘
+           │                                      │     Virtual Audio Device
+           │                                      │
+           │                                      │
+    ┌──────▼──────────┐                           │       ┌──────────────────┐
+    │                 │                           │       │                  │
+    │                 │    VM Audio               │       │                  │
+    │     AudioVM     ◄─────────────┐             │       │      AppVM1      │
+    │                 │             │             │       │                  │
+    │                 │             │             │       │                  │
+    └──────────────▲──┘             │             │       └─────────▲────────┘
+                   │            ┌───┴─────────────┴─┐               │
+                   │            │                   │               │
+      Audio device │            │    VM Manager     ├───────────────┘
+       passthrough │            │                   │   Virtual Audio Device
+                  ┌┴────────────┼───────────────────┤
+                  │             └───────────────────┤
+                  │                                 │
+                  │               Host              │
+                  │                                 │
+                  │                                 │
+                  └─────────────────────────────────┘
+
+
+## Consequences
+
+As with most passthroughs there may be some hardware dependencies which need
+to be handeled case by case. With our reference device Lenovo X1 laptop the
+integrated sound card is set in the same VFIO group with the ISA controller,
+SMBus controller and a Serial bus controller. Passing through a single device
+practically forces passing through all the devices in the same VFIO group to
+the same virtual machine. In some scenarios that can make some of the critical
+system components less isolated and allow one incident to spread to other
+components more easily. However, this is the reference hardware design related
+consequence. Hardware designs with device and device group connections that
+support device isolation - either pass through or paravirtualized - do not
+require sharing in the same virtual machine.
+
+The GUI virtual machine needs the ability to control over all the separate
+virtual machine sound channels. This may pose a threat for the Gand possibly
+also over the sound data. The level of control over the sound data should be
+reviewed as that depends on which sound subsystem is being used on AudioVM.

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -82,9 +82,9 @@
     };
 
     audio = {
-      # TODO? Should add AudioVM enabler here?
-      # audiovm.enable = mkEnableOption = "AudioVM";
-
+      # With the current implementation, the whole PCI IOMMU group 14:
+      #   00:1f.x in the example from Lenovo X1 Carbon
+      #   must be defined for passthrough to AudioVM
       pciDevices = mkOption {
         description = "PCI Devices to passthrough to AudioVM";
         type = types.listOf pciDevSubmodule;

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -81,6 +81,41 @@
       };
     };
 
+    audio = {
+      # TODO? Should add AudioVM enabler here?
+      # audiovm.enable = mkEnableOption = "AudioVM";
+
+      pciDevices = mkOption {
+        description = "PCI Devices to passthrough to AudioVM";
+        type = types.listOf pciDevSubmodule;
+        default = [];
+        example = literalExpression ''
+          [
+            {
+              path = "0000:00:1f.0";
+              vendorId = "8086";
+              productId = "5194";
+            }
+            {
+              path = "0000:00:1f.3";
+              vendorId = "8086";
+              productId = "51ca";
+            }
+            {
+              path = "0000:00:1f.4";
+              vendorId = "8086";
+              productId = "51a3";
+            }
+            {
+              path = "0000:00:1f.5";
+              vendorId = "8086";
+              productId = "51a4";
+            }
+          ]
+        '';
+      };
+    };
+
     virtioInputHostEvdevs = mkOption {
       description = ''
         List of input device files to passthrough to GuiVM using

--- a/modules/host/networking.nix
+++ b/modules/host/networking.nix
@@ -18,6 +18,9 @@ in
         enableIPv6 = false;
         useNetworkd = true;
         interfaces.virbr0.useDHCP = false;
+        extraHosts = ''
+          192.168.101.4 audio-vm.lan
+        '';
       };
 
       systemd.network = {

--- a/modules/virtualization/microvm/audiovm.nix
+++ b/modules/virtualization/microvm/audiovm.nix
@@ -1,0 +1,121 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  configHost = config;
+  vmName = "audio-vm";
+  macAddress = "02:00:00:02:03:04";
+  audiovmBaseConfiguration = {
+    imports = [
+      (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      ({
+        lib,
+        pkgs,
+        ...
+      }: {
+        ghaf = {
+          users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
+          profiles.graphics.enable = false;
+          development = {
+            ssh.daemon.enable = lib.mkDefault configHost.ghaf.development.ssh.daemon.enable;
+            debug.tools.enable = lib.mkDefault configHost.ghaf.development.debug.tools.enable;
+          };
+        };
+
+        environment = {
+          systemPackages = [
+            pkgs.pamixer
+          ];
+        };
+
+        system.stateVersion = lib.trivial.release;
+
+        nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
+        nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
+
+        time.timeZone = "Asia/Dubai";
+
+        # Enable pulseaudio support for host as a service
+        sound.enable = true;
+        hardware.pulseaudio.enable = true;
+        hardware.pulseaudio.systemWide = true;
+#        networking.firewall.interfaces.virbr0.allowedTCPPorts = [4713];
+        networking.firewall.allowedTCPPorts = [4713];
+
+        # Allow microvm user to access pulseaudio
+        users.extraUsers.ghaf.extraGroups = ["audio" "pulse-access"];
+        # Enable and allow TCP connection from localhost only
+        hardware.pulseaudio.tcp.enable = true;
+        hardware.pulseaudio.tcp.anonymousClients.allowedIpRanges = ["127.0.0.1" "192.168.101.2" "192.168.101.3"];
+        hardware.pulseaudio.extraConfig = ''
+            load-module module-native-protocol-unix
+            load-module module-native-protocol-tcp auth-ip-acl=127.0.0.1;192.168.101.2;192.168.101.3
+            set-sink-volume @DEFAULT_SINK@ 60000
+        '';
+
+        microvm = {
+          optimize.enable = false;
+          vcpu = 1;
+          mem = 1024;
+          hypervisor = "qemu";
+          shares = [
+            {
+              tag = "rw-waypipe-ssh-public-key";
+              source = "/run/waypipe-ssh-public-key";
+              mountPoint = "/run/waypipe-ssh-public-key";
+            }
+            {
+              tag = "ro-store";
+              source = "/nix/store";
+              mountPoint = "/nix/.ro-store";
+            }
+          ];
+          writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
+
+          qemu.extraArgs = [
+          ];
+        };
+
+        imports = import ../../module-list.nix;
+
+        # Fixed IP-address for debugging subnet
+        systemd.network.networks."10-ethint0".addresses = [
+          {
+            addressConfig.Address = "192.168.101.4/24";
+          }
+        ];
+      })
+    ];
+  };
+  cfg = config.ghaf.virtualization.microvm.audiovm;
+in {
+  options.ghaf.virtualization.microvm.audiovm = {
+    enable = lib.mkEnableOption "AudioVM";
+
+    extraModules = lib.mkOption {
+      description = ''
+        List of additional modules to be imported and evaluated as part of
+        AudioVM's NixOS configuration.
+      '';
+      default = [];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    microvm.vms."${vmName}" = {
+      autostart = true;
+      config =
+        audiovmBaseConfiguration
+        // {
+          imports =
+            audiovmBaseConfiguration.imports
+            ++ cfg.extraModules;
+        };
+      specialArgs = {inherit lib;};
+    };
+  };
+}

--- a/modules/virtualization/microvm/guivm.nix
+++ b/modules/virtualization/microvm/guivm.nix
@@ -57,6 +57,8 @@
             pkgs.waypipe
             pkgs.networkmanagerapplet
             pkgs.nm-launcher
+            pkgs.pamixer
+            (pkgs.callPackage ../../../packages/tcp-ssh {})
           ];
         };
 

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -13,5 +13,6 @@ _: {
     (import ./qemu)
     (import ./nm-launcher)
     (import ./labwc)
+    (import ./tcp-ssh)
   ];
 }

--- a/overlays/custom-packages/tcp-ssh/default.nix
+++ b/overlays/custom-packages/tcp-ssh/default.nix
@@ -1,0 +1,5 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+(final: prev: {
+  tcp-ssh = final.callPackage ../../../user-apps/tcp-ssh {};
+})

--- a/overlays/custom-packages/tcp-ssh/default.nix
+++ b/overlays/custom-packages/tcp-ssh/default.nix
@@ -1,5 +1,5 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-(final: prev: {
-  tcp-ssh = final.callPackage ../../../user-apps/tcp-ssh {};
+(final: _prev: {
+  tcp-ssh = final.callPackage ../../../packages/tcp-ssh {};
 })

--- a/packages/tcp-ssh/default.nix
+++ b/packages/tcp-ssh/default.nix
@@ -4,14 +4,12 @@
   stdenvNoCC,
   pkgs,
   lib,
-  stdenv,
   ...
 }: let
   tcp-ssh =
     pkgs.writeShellScript
     "tcp-ssh"
     ''
-      #!/bin/bash
 
       # Check if two arguments (HOST and PORT) are provided
       if [ $# -ne 2 ]; then
@@ -21,9 +19,9 @@
 
       HOST="$1"
       PORT="$2"
-      PID_FILE="/tmp/tcp-ssh-$PORT.pid"
+      PID_FILE="''${PID_PATH:-./}tcp-ssh-$PORT.pid"
 
-      # Stop any running tcp-ssh tunnel instances
+      # Stop any running tcp-ssh tunnel instances for the same tcp port
       if [ -f "$PID_FILE" ]; then
           # TODO Killing PID(s) in a file, potential for misuse
           ${pkgs.procps}/bin/pkill -F "$PID_FILE"
@@ -38,7 +36,7 @@
            -o StrictHostKeyChecking=no \
            -o ExitOnForwardFailure=yes \
            -L $PORT:127.0.0.1:$PORT $HOST &
-      # Chatch the last command process (ssh) PID
+      # Catch the last command process (ssh) PID
       PID="$!"
 
       # Sleep for a second to verify connection does not die immediately

--- a/user-apps/tcp-ssh/default.nix
+++ b/user-apps/tcp-ssh/default.nix
@@ -1,0 +1,75 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenvNoCC,
+  pkgs,
+  lib,
+  stdenv,
+  ...
+}: let
+  tcp-ssh =
+    pkgs.writeShellScript
+    "tcp-ssh"
+    ''
+      #!/bin/bash
+
+      # Check if two arguments (HOST and PORT) are provided
+      if [ $# -ne 2 ]; then
+        echo "Usage: $0 <HOST> <PORT>"
+        exit 1
+      fi
+
+      HOST="$1"
+      PORT="$2"
+      PID_FILE="/tmp/tcp-ssh-$PORT.pid"
+
+      # Stop any running tcp-ssh tunnel instances
+      if [ -f "$PID_FILE" ]; then
+          # TODO Killing PID(s) in a file, potential for misuse
+          ${pkgs.procps}/bin/pkill -F "$PID_FILE"
+          rm "$PID_FILE"
+      fi
+
+      # Start tcp tunnel without shell in background mode
+      # Opens a TCP tunnel from localhost to HOST:PORT
+      # TODO Using ghaf waypipe-ssh default ssh key which is public and not secure
+      ${pkgs.openssh}/bin/ssh -N \
+           -i /run/waypipe-ssh/id_ed25519 \
+           -o StrictHostKeyChecking=no \
+           -o ExitOnForwardFailure=yes \
+           -L $PORT:127.0.0.1:$PORT $HOST &
+      # Chatch the last command process (ssh) PID
+      PID="$!"
+
+      # Sleep for a second to verify connection does not die immediately
+      sleep 1
+
+      # Check if the connection ssh process with PID is still up
+      if [ -n "$(${pkgs.procps}/bin/ps -p $PID -o pid=)" ]
+      then
+        echo "TCP tunnel over ssh to $HOST:$PORT established."
+        # Save the PID to a file
+        echo $PID > $PID_FILE
+      else
+        echo "Failed to connect to $HOST:$PORT."
+      fi
+    '';
+in
+  stdenvNoCC.mkDerivation {
+    name = "tcp-ssh";
+
+    phases = ["installPhase"];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${tcp-ssh} $out/bin/tcp-ssh
+    '';
+
+    meta = with lib; {
+      description = "Helper script making tcp pipes over ssh";
+      platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    };
+  }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Initial Passthrough of Sound card for Lenovo X1 with pulseaudio backend for chromium
ADR documentation for the current implementation

## Checklist for things done

<!-- Please check, [X], to all that applies. Add [-] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] PR linked to architecture documentation and requirement(s) (ticket id)
- [ X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [-] Tested on Jetson Orin NX or AGX `aarch64`
  - [-] Tested on Polarfire `riscv64`
- [-] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing
Chromium VM sound playback works on Lenovo X1
GuiVM can control pulseaudio with pamixer (or similar tool)
For GuiVM audio control:
```
# Open tcp-ssh tunnel to audioVM port 4713 in shell:
tcp-ssh audio-vm.ghaf 4713
# With the ssh tunnel AudioVM Pulseaudio server can be accessed from localhost:4713
export PULSE_SERVER=localhost
# use pamixer (for example to toggle mute with "-t")
pamixer -t
```
