### PR TITLE
systemd-boot-dtb: Fix 23.11 remote nixos-rebuild

### DIFF
--- a/modules/boot/systemd-boot-dtb.nix
+++ b/modules/boot/systemd-boot-dtb.nix
@@ -9,6 +9,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: let
   cfg = config.ghaf.boot.loader.systemd-boot-dtb;
@@ -23,10 +24,10 @@ in
         extraFiles."dtbs/${config.hardware.deviceTree.name}" = "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
         extraInstallCommands = ''
           # Find out the latest generation from loader.conf
-          default_cfg=$(cat /boot/loader/loader.conf | grep default | awk '{print $2}')
-          FILEHASH=$(sha256sum "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}" | cut -d ' ' -f 1)
+          default_cfg=$(${pkgs.coreutils}/bin/cat /boot/loader/loader.conf | ${pkgs.gnugrep}/bin/grep default | ${pkgs.gawk}/bin/awk '{print $2}')
+          FILEHASH=$(${pkgs.coreutils}/bin/sha256sum "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}" | ${pkgs.coreutils}/bin/cut -d ' ' -f 1)
           FILENAME="/dtbs/$FILEHASH.dtb"
-          cp -fv "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}" "/boot$FILENAME"
+          ${pkgs.coreutils}/bin/cp -fv "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}" "/boot$FILENAME"
           echo "devicetree $FILENAME" >> /boot/loader/entries/$default_cfg
         '';
       };


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Use full paths inside script generated by systemd-boot-dtb module.

This commit broke our script, so now using full paths to commands instead: https://github.com/NixOS/nixpkgs/commit/ecd89093e178e50ead57e3338f25e637dd29310b

## Checklist for things done

<!-- Please check, [X], to all that applies. Add [-] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [-] items if not obvious. -->

## Testing

Test by running `nixos-rebuild --flake .#nvidia-jetson-orin-nx-debug --target-host root@nx --fast boot` OR `nixos-rebuild --flake .#nvidia-jetson-orin-agx-debug --target-host root@agx --fast boot`