### PR TITLE
PowerControl over ssh

### DIFF
--- a/packages/powercontrol/default.nix
+++ b/packages/powercontrol/default.nix
@@ -1,0 +1,84 @@
+# Copyright 2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenv,
+  pkgs,
+  ...
+}: let
+  systemctl = "/run/current-system/systemd/bin/systemctl";
+  busName = "org.freedesktop.login1";
+
+  makeSystemCtlPowerActionViaSsh = {
+    hostAddress,
+    sshKeyPath,
+    method,
+  }:
+    pkgs.writeShellScript
+    "${method}-host"
+    ''      ${pkgs.openssh}/bin/ssh \
+          -i ${sshKeyPath} \
+          -o StrictHostKeyChecking=no \
+          ghaf@${hostAddress} \
+          ${systemctl} ${method}'';
+in
+  stdenv.mkDerivation {
+    name = "powercontrol";
+
+    makePowerOffCommand = {
+      hostAddress,
+      sshKeyPath,
+    }:
+      makeSystemCtlPowerActionViaSsh {
+        inherit hostAddress sshKeyPath;
+        method = "poweroff";
+      };
+
+    makeRebootCommand = {
+      hostAddress,
+      sshKeyPath,
+    }:
+      makeSystemCtlPowerActionViaSsh {
+        inherit hostAddress sshKeyPath;
+        method = "reboot";
+      };
+
+    makeSuspendCommand = {
+      hostAddress,
+      sshKeyPath,
+    }:
+      makeSystemCtlPowerActionViaSsh {
+        inherit hostAddress sshKeyPath;
+        method = "suspend";
+      };
+
+    makeHibernateCommand = {
+      hostAddress,
+      sshKeyPath,
+    }:
+      makeSystemCtlPowerActionViaSsh {
+        inherit hostAddress sshKeyPath;
+        method = "hibernate";
+      };
+
+    polkitExtraConfig = ''
+      polkit.addRule(function(action, subject) {
+          if ((subject.user == "ghaf") &&
+             (action.id == "${busName}.power-off" ||
+              action.id == "${busName}.power-off-multiple-sessions" ||
+              action.id == "${busName}.reboot" ||
+              action.id == "${busName}.reboot-multiple-sessions" ||
+              action.id == "${busName}.suspend" ||
+              action.id == "${busName}.suspend-multiple-sessions" ||
+              action.id == "${busName}.hibernate" ||
+              action.id == "${busName}.hibernate-multiple-sessions")
+          ) {
+              return polkit.Result.YES;
+          }
+      });
+    '';
+
+    meta = {
+      description = "Scripts for host power control";
+      platforms = pkgs.openssh.meta.platforms.linux;
+    };
+  }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This PR introduces:
- The package PowerControl, which provides scripts to power control the host via ssh;
- Refactored ssh keys generation and sharing on Lenovo X1 target
- Add poweroff and reboot buttons on Lenovo X1 host in GUI

Works only on debug builds so far -- we need ssh-connection in release builds as well

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Build debug target on Lenovo X1, run it, you will see two buttons in GUI VM next to applications icons: PowerOff and Reboot. They should make described actions

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->

