### PR TITLE
github workflows: Don't use nodemoapps versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,9 +88,9 @@ jobs:
           - arch: x86_64-linux
             target: lenovo-x1-carbon-gen11-debug
           - arch: x86_64-linux
-            target: nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64
+            target: nvidia-jetson-orin-agx-debug-from-x86_64
           - arch: x86_64-linux
-            target: nvidia-jetson-orin-nx-debug-nodemoapps-from-x86_64
+            target: nvidia-jetson-orin-nx-debug-from-x86_64
           - arch: riscv64-linux
             target: microchip-icicle-kit-debug
           - arch: x86_64-linux


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Don't use nodemoapps versions of NVIDIA Jetson Orin AGX and NX targets, but build full versions instead.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Tested that it is possible to build the full cross-compiled targets:
`nix build .#nvidia-jetson-orin-agx-debug-from-x86_64-flash-script`
`nix build .#nvidia-jetson-orin-nx-debug-from-x86_64-flash-script`