### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,11 +171,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702070778,
-        "narHash": "sha256-Sx0rcHKE8YMbb25fH4np1tLjSuOZTCn/0uNUCK83v40=",
+        "lastModified": 1702316505,
+        "narHash": "sha256-ue7h47DG+ltIs1kfYdcvt4faqoqLYcct11I69gj3P1Y=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "6cd9cad3ce43e13fa8fde87b6880f7546fb12097",
+        "rev": "74880473fa4f9b69d97d81128de6437d6a068df2",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1701656485,
-        "narHash": "sha256-xDFormrGCKKGqngHa2Bz1GTeKlFMMjLnHhTDRdMJ1hs=",
+        "lastModified": 1702453208,
+        "narHash": "sha256-0wRi9SposfE2wHqjuKt8WO2izKB/ASDOV91URunIqgo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fa194fc484fd7270ab324bb985593f71102e84d1",
+        "rev": "7763c6fd1f299cb9361ff2abf755ed9619ef01d6",
         "type": "github"
       },
       "original": {
@@ -353,11 +353,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701802827,
-        "narHash": "sha256-wTn0lpV75Uv6tU6haEypNsmnJJPb0hpaMIy/4uf5AiQ=",
+        "lastModified": 1702233072,
+        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a804fc878d7ba1558b960b4c64b0903da426ac41",
+        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
         "type": "github"
       },
       "original": {
@@ -384,11 +384,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700922917,
-        "narHash": "sha256-ej2fch/T584b5K9sk1UhmZF7W6wEfDHuoUYpFN8dtvM=",
+        "lastModified": 1702456155,
+        "narHash": "sha256-I2XhXGAecdGlqi6hPWYT83AQtMgL+aa3ulA85RAEgOk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e5ee5c5f3844550c01d2131096c7271cec5e9b78",
+        "rev": "007a45d064c1c32d04e1b8a0de5ef00984c419bc",
         "type": "github"
       },
       "original": {
@@ -465,11 +465,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701958734,
-        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "lastModified": 1702461037,
+        "narHash": "sha256-ssyGxfGHRuuLHuMex+vV6RMOt7nAo07nwufg9L5GkLg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e8cea581dd2b7c9998c1e6662db2c1dc30e7fdb0",
+        "rev": "d06b70e5163a903f19009c3f97770014787a080f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Update flake.lock file

• Updated input 'jetpack-nixos':
    'github:anduril/jetpack-nixos/6cd9cad3ce43e13fa8fde87b6880f7546fb12097' (2023-12-08)
  → 'github:anduril/jetpack-nixos/74880473fa4f9b69d97d81128de6437d6a068df2' (2023-12-11)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/fa194fc484fd7270ab324bb985593f71102e84d1' (2023-12-04)
  → 'github:NixOS/nixos-hardware/fef05bf9c8e818f4ca1425ef4c18e6680becd072' (2023-12-11)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a804fc878d7ba1558b960b4c64b0903da426ac41' (2023-12-05)
  → 'github:NixOS/nixpkgs/781e2a9797ecf0f146e81425c822dca69fe4a348' (2023-12-10)
• Updated input 'pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/e5ee5c5f3844550c01d2131096c7271cec5e9b78' (2023-11-25)
  → 'github:cachix/pre-commit-hooks.nix/e1d203c2fa7e2593c777e490213958ef81f71977' (2023-12-11)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/e8cea581dd2b7c9998c1e6662db2c1dc30e7fdb0' (2023-12-07)
  → 'github:numtide/treefmt-nix/5ff2cdbe0db6a6f3445f7d878cb87d121d914d83' (2023-12-11)

This update was removed because it broke things:
• Updated input 'microvm':
    'github:astro/microvm.nix/89bb7a5230a4820736a43e058c8d2a2c560d672b' (2023-11-28)
  → 'github:astro/microvm.nix/252d7153e6faab321f012d9a0c6e290f888b8d0f' (2023-12-11)

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Should test first, then removing draft status.

All basic robot frame work tests and flash scripts.