### PR TITLE
DRAFT development: sshd hardening

### DIFF
--- a/modules/development/ssh.nix
+++ b/modules/development/ssh.nix
@@ -20,6 +20,7 @@
     "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIA/pwHnzGNM+ZU4lANGROTRe2ZHbes7cnZn72Oeun/MCAAAABHNzaDo= brian@arcadia"
     "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIEJ9ewKwo5FLj6zE30KnTn8+nw7aKdei9SeTwaAeRdJDAAAABHNzaDo= brian@minerva"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDdNDuKwAsAff4iFRfujo77W4cyAbfQHjHP57h/7tJde ville.ilvonen@unikie.com"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFscDgRN+VWQVkI/dEpUkZjubp7sQkf0qpgqeiSw04pE vilvo@blop"
   ];
 in
   with lib; {

--- a/modules/development/sshd-hardening.nix
+++ b/modules/development/sshd-hardening.nix
@@ -1,0 +1,34 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}:
+{
+  # Enable ssh hardening optionally only when development profile
+  # is in use. This separate hardening module enables external
+  # networks facing debug SSH access hardening
+  config = lib.mkIf config.ghaf.profiles.debug.enable {
+    services.openssh = {
+      settings = {
+        PasswordAuthentication = false;
+        Ciphers = [
+          "aes256-gcm@openssh.com"
+          "aes128-gcm@openssh.com"
+          "aes256-ctr"
+          "aes192-ctr"
+          "aes128-ctr"
+        ];
+      };
+      # allow password auth in debug mode
+      # from ghaf via internal network only
+      extraConfig = ''
+      Match Address !192.168.101.0/24
+            PasswordAuthentication no
+      Match Address 192.168.101.0/24
+            PasswordAuthentication yes
+      '';
+    };
+  };
+}

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -169,6 +169,9 @@
           lanzaboote.nixosModules.lanzaboote
           microvm.nixosModules.host
           ../modules/host
+          # imported for host only, not all guests
+          # enabled with debug profile only
+          ../modules/development/sshd-hardening.nix
           ../modules/virtualization/microvm/microvm-host.nix
           ../modules/virtualization/microvm/netvm.nix
           ../modules/virtualization/microvm/guivm.nix


### PR DESCRIPTION
* mitigates terrapin attack with limiting sshd ciphers
* In addition - this is an attempt to harden ghaf debug mode external facing sshds (ghaf-host and net-vm) by allowing key authentication only while allowing password authentication from ghaf internal network. Presumably the nix generated sshd_config and Match rules conflict with PAM somehow

  As of now, the password auth attempt from gui-vm fails with:
```
  Dec 20 18:58:22 ghaf-host sshd[2602]: error: PAM: Authentication failure for ghaf from 192.168.101.3
  Dec 20 18:58:23 ghaf-host sshd[2602]: Failed password for ghaf from 192.168.101.3 port 40754 ssh2
```
As of now, the nix generated /etc/sshd/sshd_config is:
```
AuthorizedPrincipalsFile none
Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr GatewayPorts no
KbdInteractiveAuthentication yes
KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256 LogLevel INFO
Macs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com PasswordAuthentication no
PermitRootLogin prohibit-password
StrictModes yes
UseDns no
X11Forwarding no
UsePAM yes

Banner none

AddressFamily inet
Port 22

Subsystem sftp /nix/store/pfyxzy3ldjqhvi04hmwz7wbc355sw4a2-openssh-9.5p1/libexec/sftp-server

PrintMotd no # handled by pam_motd
AuthorizedKeysFile %h/.ssh/authorized_keys /etc/ssh/authorized_keys.d/%u

HostKey /etc/ssh/ssh_host_rsa_key
HostKey /etc/ssh/ssh_host_ed25519_key

Match Address !192.168.101.0/24
      PasswordAuthentication no
Match Address 192.168.101.0/24
      PasswordAuthentication yes
```

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
