### PR TITLE
refactor: dns+dhcp to a module, support short host queries

### DIFF
--- a/modules/virtualization/microvm/common/dns-dhcp.nix
+++ b/modules/virtualization/microvm/common/dns-dhcp.nix
@@ -1,0 +1,60 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+_: let
+  domain = "ghaf";
+in {
+  # Disable resolved since we are using dnsmasq
+  # This options defaults to false but has been
+  # tested not to work with dnsmasq if not set
+  # explicitly to false
+  services.resolved.enable = false;
+  # do not really use resolvconf for anything
+  networking.resolvconf.enable = false;
+
+  # dnsmasq prioritises /etc/hosts to which NixOS
+  # generates hostname entry. Here we generate
+  # additional hosts that is used to replace
+  # /etc/hosts
+  environment.etc."additional-hosts" = {
+    text = ''
+      127.0.0.1 localhost
+      192.168.100.1 net-vm
+    '';
+    mode = "0444";
+  };
+
+  # Dnsmasq is used as a DHCP/DNS server inside the NetVM
+  services.dnsmasq = {
+    enable = true;
+    settings = {
+      # keep local queries within domain by
+      # caching them within dnsmasq. query outside
+      # only if name is not available locally
+      local = ["/{domain}/192.168.100.1"];
+      server = ["8.8.8.8"];
+      dhcp-range = ["192.168.100.2,192.168.100.254"];
+      dhcp-sequential-ip = true;
+      dhcp-authoritative = true;
+      domain = "${domain}";
+      listen-address = ["127.0.0.1,192.168.100.1"];
+      dhcp-option = [
+        "option:router,192.168.100.1"
+        "option:dns-server,192.168.100.1"
+      ];
+      expand-hosts = true;
+
+      # see comment above with additional-hosts generation
+      no-hosts = true;
+      addn-hosts = "/etc/additional-hosts";
+
+      domain-needed = true;
+      bogus-priv = true;
+
+      # local host names and static IP addresses
+      dhcp-host = [
+        "02:00:00:01:01:01,192.168.100.1,net-vm"
+        "02:00:00:02:02:02,192.168.100.3,gui-vm"
+      ];
+    };
+  };
+}

--- a/modules/virtualization/microvm/common/vm-networking.nix
+++ b/modules/virtualization/microvm/common/vm-networking.nix
@@ -38,15 +38,22 @@ in {
     networks."10-${networkName}" = {
       matchConfig.MACAddress = macAddress;
       DHCP = "yes";
+      dhcpV4Config.UseDomains = "yes";
       linkConfig.RequiredForOnline = "routable";
       linkConfig.ActivationPolicy = "always-up";
     };
   };
 
-  # systemd-resolved does not support local names resolution
-  # without configuring a local domain. With the local domain,
-  # one would need also to disable DNSSEC for the clients.
-  # Disabling DNSSEC for other VM then NetVM is
-  # completely safe since they use NetVM as DNS proxy.
-  services.resolved.dnssec = "false";
+  services.resolved = {
+    # systemd-resolved does not support local names resolution
+    # without configuring a local domain. With the local domain,
+    # one would need also to disable DNSSEC for the clients.
+    # Disabling DNSSEC for other VM then NetVM is
+    # completely safe since they use NetVM as DNS proxy.
+    dnssec = "false";
+    # Disable local DNS stub listener on 127.0.0.53
+    extraConfig = ''
+      DNSStubListener=no
+    '';
+  };
 }

--- a/modules/virtualization/microvm/netvm.nix
+++ b/modules/virtualization/microvm/netvm.nix
@@ -12,6 +12,7 @@
   netvmBaseConfiguration = {
     imports = [
       (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      (import ./common/dns-dhcp.nix {})
       ({lib, ...}: {
         ghaf = {
           users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
@@ -35,32 +36,8 @@
           firewall.allowedUDPPorts = [53];
         };
 
-        # Add simple wi-fi connection helper
-        environment.systemPackages = lib.mkIf config.ghaf.profiles.debug.enable [pkgs.wifi-connector];
-
-        # Dnsmasq is used as a DHCP/DNS server inside the NetVM
-        services.dnsmasq = {
-          enable = true;
-          resolveLocalQueries = true;
-          settings = {
-            server = ["8.8.8.8"];
-            dhcp-range = ["192.168.100.2,192.168.100.254"];
-            dhcp-sequential-ip = true;
-            dhcp-authoritative = true;
-            domain = "ghaf";
-            listen-address = ["127.0.0.1,192.168.100.1"];
-            dhcp-option = [
-              "option:router,192.168.100.1"
-              "6,192.168.100.1"
-            ];
-            expand-hosts = true;
-            domain-needed = true;
-            bogus-priv = true;
-          };
-        };
-
-        # Disable resolved since we are using Dnsmasq
-        services.resolved.enable = false;
+        # support net-vm debug with simple wi-fi connection helper and tshark analyzer
+        environment.systemPackages = with pkgs; lib.mkIf config.ghaf.profiles.debug.enable [wifi-connector tshark];
 
         systemd.network = {
           enable = true;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

* Renaming module to dns-dhcp allows us to change the internal implementation
  of DNS and DHCP services from dnsmasq to something else, like rust-based,
  later
* Current implementation stays dnsmasq-based but is only refactored into a
  module
* Disable systemd resolved on client side VMs completely, including DNS stub
  listener on 127.0.0.53 which made the name queries time out before going
  to primary nameserver 192.168.100.1 in the net-vm. Also note that it is
  required to set resolve.enable to false - even when NixOS options document
  the default as false.
* Give static IPs to guests based on their mimicked synthetic MAC
* dhcp-option '6' equals 'option:dns-server'. More descriptive this way.
* Client side queries are configured to use .ghaf domain for local name queries
* Better not set debug subnet ip addresses in dnsmasq, because sometimes we are
  debugging the dnsmasq itself.
* Add tshark network packet capturing tool for builds that include
  the ghaf debug profile

Considerations:

* ghaf-host uses resolv.conf via DNS stub resolver. It does not use
  net-vm (192.168.100.1) as default nameserver. This is considered
  more secure than using net-vm. Future development could be
  debug optional that allows ghaf-host access to local network host
  names. This has risks related to development and testing time
  assumptions on ghaf-host access to names with release builds.
* net-vm does not serve IP address for ghaf-host queries - even
  for debug builds. See rationale above.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

```
[ghaf@gui-vm:~]$ time for host in net-vm chromium-vm gala-vm gui-vm \
> zathura-vm; do dig +short $host; done;
192.168.100.1
192.168.100.6
192.168.100.4
192.168.100.3
192.168.100.5

real	0m0.151s
user	0m0.029s
sys	0m0.031s
```

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
