### PR TITLE
Add warning about aarch64-linux flash-script

### DIFF
--- a/lib/mk-flash-script/default.nix
+++ b/lib/mk-flash-script/default.nix
@@ -31,7 +31,16 @@
     flash-tools = flash-tools.overrideAttrs ({postPatch ? "", ...}: {
       postPatch = postPatch + cfg.flashScriptOverrides.postPatch;
     });
-    inherit (hostConfiguration.config.ghaf.hardware.nvidia.orin.flashScriptOverrides) preFlashCommands;
+    preFlashCommands =
+      nixpkgs.lib.optionalString (flash-tools-system == "aarch64-linux") ''
+        echo "WARNING! WARNING! WARNING!"
+        echo "You are trying to run aarch64-linux hosted version of the flash-script."
+        echo "It runs flashing tools with QEMU using user-mode emulation of x86 cpu."
+        echo "There are no known reports from anyone who would have gotten this working ever."
+        echo "If this fails, YOU HAVE BEEN WARNED, and don't open a bug report!"
+        echo ""
+      ''
+      + hostConfiguration.config.ghaf.hardware.nvidia.orin.flashScriptOverrides.preFlashCommands;
   };
 
   patchFlashScript =


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Add warning about aarch64-linux flash-script
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

This just adds a warning message to aarch64-linux flash script. Checked that x86 and aarch64 versions of the flash script build.