### PR TITLE
Orin AGX: Extract partitions while flashing

### DIFF
--- a/modules/hardware/nvidia-jetson-orin/partition-template.nix
+++ b/modules/hardware/nvidia-jetson-orin/partition-template.nix
@@ -123,20 +123,23 @@ in
           mkdir -pv "$WORKDIR/bootloader"
         ''
         + lib.optionalString (!cfg.flashScriptOverrides.onlyQSPI) ''
-          echo "Decompressing ${images}/esp.img.zst into $WORKDIR/bootloader/esp.img ..."
-          @pzstd@ -d "${images}/esp.img.zst" -o "$WORKDIR/bootloader/esp.img"
-          echo "Decompressing ${images}/root.img.zst into $WORKDIR/root.img ..."
-          @pzstd@ -d "${images}/root.img.zst" -o "$WORKDIR/root.img"
-
+          ESP_OFFSET=$(cat "${images}/esp.offset")
           ESP_SIZE=$(cat "${images}/esp.size")
+          ROOT_OFFSET=$(cat "${images}/root.offset")
           ROOT_SIZE=$(cat "${images}/root.size")
+
+          img="${images}/sd-image/${config.sdImage.imageName}.zst"
+          echo "Extracting ESP partition to $WORKDIR/bootloader/esp.img ..."
+          dd if=<(@pzstd@ -d "$img" -c) of="$WORKDIR/bootloader/esp.img" bs=512 iseek="$ESP_OFFSET" count="$ESP_SIZE"
+          echo "Extracting root partition to $WORKDIR/root.img ..."
+          dd if=<(@pzstd@ -d "$img" -c) of="$WORKDIR/bootloader/root.img" bs=512 iseek="$ROOT_OFFSET" count="$ROOT_SIZE"
 
           echo "Patching flash.xml with absolute paths to esp.img and root.img ..."
           @sed@ -i \
             -e "s#bootloader/esp.img#$WORKDIR/bootloader/esp.img#" \
             -e "s#root.img#$WORKDIR/root.img#" \
-            -e "s#ESP_SIZE#$ESP_SIZE#" \
-            -e "s#ROOT_SIZE#$ROOT_SIZE#" \
+            -e "s#ESP_SIZE#$((ESP_SIZE * 512))#" \
+            -e "s#ROOT_SIZE#$((ROOT_SIZE * 512))#" \
             flash.xml
 
         ''


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

On NVIDIA Jetson Orin AGX, extract ESP and root partitions while running the flashing script, instead of shipping the images twice in the store path. This should make NVIDIA build targets take half the disk space the used to.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Build and run NVIDIA Orin AGX flash scripts, both native and cross. Changes should not affect NX flash scripts.