### PR TITLE
icicle-kit: Fix firewall

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -338,11 +338,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1702453208,
-        "narHash": "sha256-0wRi9SposfE2wHqjuKt8WO2izKB/ASDOV91URunIqgo=",
+        "lastModified": 1704458188,
+        "narHash": "sha256-f6BYEuIqnbrs6J/9m1/1VdkJ6d63hO9kUC09kTPuOqE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7763c6fd1f299cb9361ff2abf755ed9619ef01d6",
+        "rev": "172385318068519900a7d71c1024242fa6af75f0",
         "type": "github"
       },
       "original": {

--- a/modules/firewall/default.nix
+++ b/modules/firewall/default.nix
@@ -1,0 +1,10 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Firewall related modules
+#
+{
+  imports = [
+    ./kernel-modules.nix
+  ];
+}

--- a/modules/firewall/kernel-modules.nix
+++ b/modules/firewall/kernel-modules.nix
@@ -1,0 +1,149 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Module which adds option ghaf.firewall.kernel-modules.enable.
+#
+# Adds bunch of modules to the kernel, so firewall can start, as our custom
+# kernels don't seem to always have all necessary modules enabled.
+#
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.ghaf.firewall.kernel-modules;
+in {
+  options.ghaf.firewall.kernel-modules = {
+    enable = lib.mkEnableOption "kernel modules required for firewall";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelPatches = [
+      {
+        name = "firewall-modules-enable";
+        patch = null;
+        extraStructuredConfig = with lib.kernel; {
+          NETFILTER_NETLINK_LOG = module;
+
+          NETFILTER_XTABLES = yes;
+
+          NETFILTER_XT_MATCH_CONNTRACK = module;
+          NETFILTER_XT_MATCH_PKTTYPE = module;
+
+          NETFILTER_XT_TARGET_CHECKSUM = module;
+          NETFILTER_XT_TARGET_CLASSIFY = module;
+          NETFILTER_XT_TARGET_CONNMARK = module;
+          NETFILTER_XT_TARGET_IDLETIMER = module;
+          NETFILTER_XT_TARGET_LOG = module;
+          NETFILTER_XT_TARGET_MARK = module;
+          NETFILTER_XT_TARGET_MASQUERADE = module;
+          NETFILTER_XT_TARGET_NETMAP = module;
+          NETFILTER_XT_TARGET_NFLOG = module;
+          NETFILTER_XT_TARGET_REDIRECT = module;
+          NETFILTER_XT_TARGET_TCPMSS = module;
+          NETFILTER_XT_TARGET_TEE = module;
+          NETFILTER_XT_TARGET_TPROXY = module;
+          NETFILTER_XT_TARGET_TRACE = module;
+
+          NF_CONNTRACK = module;
+          NF_CONNTRACK_AMANDA = module;
+          NF_CONNTRACK_BROADCAST = module;
+          NF_CONNTRACK_EVENTS = yes;
+          NF_CONNTRACK_FTP = module;
+          NF_CONNTRACK_H323 = module;
+          NF_CONNTRACK_IRC = module;
+          NF_CONNTRACK_MARK = yes;
+          NF_CONNTRACK_NETBIOS_NS = module;
+          NF_CONNTRACK_PPTP = module;
+          NF_CONNTRACK_PROCFS = yes;
+          NF_CONNTRACK_SANE = module;
+          NF_CONNTRACK_SIP = module;
+          NF_CONNTRACK_TFTP = module;
+          NF_CONNTRACK_TIMEOUT = yes;
+          NF_CONNTRACK_TIMESTAMP = yes;
+          NF_CONNTRACK_ZONES = yes;
+          NF_CT_NETLINK = module;
+          NF_CT_PROTO_DCCP = yes;
+          NF_CT_PROTO_GRE = yes;
+          NF_CT_PROTO_SCTP = yes;
+          NF_CT_PROTO_UDPLITE = yes;
+          NF_DEFRAG_IPV4 = module;
+          NF_DEFRAG_IPV6 = module;
+          NF_DUP_IPV4 = module;
+          NF_DUP_IPV6 = module;
+          NF_LOG = module;
+          NF_LOG_ARP = module;
+          NF_LOG_COMMON = module;
+          NF_LOG_IPV4 = module;
+          NF_LOG_IPV6 = module;
+          NF_NAT = module;
+          NF_NAT_AMANDA = module;
+          NF_NAT_FTP = module;
+          NF_NAT_H323 = module;
+          NF_NAT_IRC = module;
+          NF_NAT_MASQUERADE = yes;
+          NF_NAT_PPTP = module;
+          NF_NAT_REDIRECT = yes;
+          NF_NAT_SIP = module;
+          NF_NAT_TFTP = module;
+          NF_REJECT_IPV4 = module;
+          NF_REJECT_IPV6 = module;
+          NF_SOCKET_IPV4 = module;
+          NF_SOCKET_IPV6 = module;
+          NF_TABLES = module;
+          NF_TABLES_ARP = yes;
+          NF_TABLES_BRIDGE = module;
+          NF_TABLES_INET = yes;
+          NF_TABLES_IPV4 = yes;
+          NF_TABLES_IPV6 = yes;
+          NF_TABLES_NETDEV = yes;
+          NF_TPROXY_IPV4 = module;
+          NF_TPROXY_IPV6 = module;
+
+          NFT_COMPAT = module;
+          NFT_COUNTER = module;
+          NFT_LOG = module;
+          NFT_MASQ = module;
+          NFT_NAT = module;
+          NFT_REJECT = module;
+
+          IP_NF_ARPFILTER = module;
+          IP_NF_ARPTABLES = module;
+          IP_NF_ARP_MANGLE = module;
+          IP_NF_FILTER = module;
+          IP_NF_IPTABLES = module;
+          IP_NF_MANGLE = module;
+          IP_NF_MATCH_AH = module;
+          IP_NF_MATCH_ECN = module;
+          IP_NF_MATCH_RPFILTER = module;
+          IP_NF_MATCH_TTL = module;
+          IP_NF_NAT = module;
+          IP_NF_RAW = module;
+          IP_NF_SECURITY = module;
+          IP_NF_TARGET_MASQUERADE = module;
+          IP_NF_TARGET_NETMAP = module;
+          IP_NF_TARGET_REDIRECT = module;
+          IP_NF_TARGET_REJECT = module;
+
+          IP6_NF_FILTER = module;
+          IP6_NF_IPTABLES = module;
+          IP6_NF_MANGLE = module;
+          IP6_NF_MATCH_AH = module;
+          IP6_NF_MATCH_EUI64 = module;
+          IP6_NF_MATCH_FRAG = module;
+          IP6_NF_MATCH_HL = module;
+          IP6_NF_MATCH_IPV6HEADER = module;
+          IP6_NF_MATCH_MH = module;
+          IP6_NF_MATCH_OPTS = module;
+          IP6_NF_MATCH_RPFILTER = module;
+          IP6_NF_MATCH_RT = module;
+          IP6_NF_MATCH_SRH = module;
+          IP6_NF_NAT = module;
+          IP6_NF_RAW = module;
+          IP6_NF_TARGET_MASQUERADE = module;
+          IP6_NF_TARGET_REJECT = module;
+        };
+      }
+    ];
+  };
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -6,6 +6,7 @@
   ./development/debug-tools.nix
   ./development/nix.nix
   ./development/ssh.nix
+  ./firewall
   ./graphics
   ./hardware/definition.nix
   ./hardware/nvidia-jetson-orin/optee.nix

--- a/targets/microchip-icicle-kit.nix
+++ b/targets/microchip-icicle-kit.nix
@@ -42,6 +42,7 @@
                 debug.tools.enable = variant == "debug";
                 ssh.daemon.enable = true;
               };
+              firewall.kernel-modules.enable = true;
               windows-launcher.enable = false;
             };
             nixpkgs = {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

**Enable bunch of firewall related kernel modules for icicle-kit.**

Add new ghaf.firewall.kernel-modules -module, which enables bunch of
netfilter/iptables modules. Update flake.lock file to nixos-hardware
version which supports patching kernel and enabling new options
through boot.kernelPatches.

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/7763c6fd1f299cb9361ff2abf755ed9619ef01d6' (2023-12-13)
  → 'github:NixOS/nixos-hardware/172385318068519900a7d71c1024242fa6af75f0' (2024-01-05)

Needs modification to nixos-hardware https://github.com/NixOS/nixos-hardware/pull/826 which allows to override kernelPatches.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [X] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Build & run on Microchip Polarfire Icicle Kit.

Run `systemclt status firewall` and expect it to see running without errors.