### PR TITLE
GhA: add CI step to check template integrity

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,3 +23,16 @@ jobs:
         run: nix develop --command reuse lint
       - name: Check nix flake show runs successfully
         run: nix flake show
+      - name: Check that template is in tact
+        run: |
+          export GHAF_PATH=$(pwd)
+          export TMP_DIR=${{ runner.temp }}/$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13)-ghaf-template-test
+
+          mkdir -p $TMP_DIR && cd $TMP_DIR
+
+          # # FIXME: Flake initialization command stuck, so we just copy template
+          # nix flake init -t $GHAF_PATH#target-x86_64-generic
+          cp -r $GHAF_PATH/templates/targets/x86_64/generic/* .
+          sed "s|github:tiiuae/ghaf|path:${GHAF_PATH}|g" -i flake.nix
+
+          nix flake show .

--- a/templates/targets/x86_64/generic/flake.nix
+++ b/templates/targets/x86_64/generic/flake.nix
@@ -42,6 +42,8 @@
     self,
     ghaf,
     nixpkgs,
+    # deadnix: skip
+    nixos-hardware,
     flake-utils,
   }: let
     systems = with flake-utils.lib.system; [


### PR DESCRIPTION
Make sure that potential API breaking change will not break `x86_64-target` template.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Could happen that accidentally, after refactoring some breaking changes introduced, because of lack of tests for templates they may break. This PR fixes this issue by introducing a trivial integration check for `x86_64-target` template. 

We could also expand these checks to other templates. For now, we will focus only on one template, as it is the most common one. 

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

I've used [act](https://github.com/nektos/act) to run Github Action locally with #340. And this PR planned to be ready to merge after #340.