### PR TITLE
Orin: UARTI passthrough to Net-VM

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -40,6 +40,8 @@
         - [NVIDIA Jetson AGX Orin: UART Passthrough](technologies/nvidia_agx_pt_uart.md)
         - [NVIDIA Jetson AGX Orin: PCIe Passthrough](technologies/nvidia_agx_pt_pcie.md)
         - [Generic x86: PCIe Passthrough on crosvm](technologies/x86_pcie_crosvm.md)
+        - [NVIDIA Jetson: UARTI Passthrough to netvm](technologies/nvidia_uarti_net_vm.md)
+        - [Device Tree Overlays for Passthrough](technologies/device_tree_overlays_pt.md)
     - [Platform Bus Virtualization: NVIDIA BPMP](technologies/nvidia_virtualization_bpmp.md)
     - [Hypervisor Options](technologies/hypervisor_options.md)
 

--- a/docs/src/technologies/device_tree_overlays_pt.md
+++ b/docs/src/technologies/device_tree_overlays_pt.md
@@ -1,0 +1,152 @@
+<!--
+    Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Device Tree Overlays for Passthrough
+
+The device tree blob (DTB) is a data structure that describes the hardware 
+components of a particular system so that the operating system can use and manage 
+those components. For passthrough, the hardware description in the host needs
+some modifications, which include:
+
+- Removing the device's driver to passthrough by assigning a dummy string
+  to the *compatible* property.
+- Adding the *iommus* property to the device to passthrough.
+- Removing or adding other properties that cause conflicts during the passthrough.
+
+Modifying the host device tree could be done by applying patches
+to DTS files. Nevertheless, this option is not 
+scalable if we need to apply different patches to the same .dts from 
+different configurations.
+
+A better and more scalable approach for modifying a device tree is using device
+tree overlays. The device tree overlay contains information about the nodes
+to modify (in nodes called *fragment@0 ...*) and the overlay of the 
+properties that we want to affect. For more information on the overlays, 
+see [Overlay notes](https://www.kernel.org/doc/Documentation/devicetree/overlay-notes.txt).
+
+
+## Nix hardware.deviceTree Module
+
+The Nix hardware.deviceTree module helps to work with the device trees and 
+their overlays:
+
+- To define the device tree overlay file to use.
+- To use a filter to apply the overlay only to specific files.
+- To define included paths to build the device tree overlay.
+
+## Device Tree Overlay Example
+
+In this section, you can find an example of an overlay for the UARTI passthrough. 
+Suppose that we want to passthrough the UARTI to a VM. To do this, we need
+to modify and add these properties:
+
+   * **compatible:** put a dummy driver associated with this node so that 
+   the kernel will not bind any driver to this UART unit.
+   * **iommus:** add the iommus field with the test stream ID 
+   *TEGRA_SID_NISO1_SMMU_TEST* which by default is not used by any other device
+
+The original properties of the UARTI in Nvidia Jetson Orin AGX are defined in 
+*hardware/nvidia/soc/t23x/kernel-dts/tegra234-soc/tegra234-soc-uart.dtsi* 
+as follows:
+
+```cpp
+    uarti: serial@31d0000 {
+        compatible = "arm,dummy";
+        iommus = <&smmu_niso0 TEGRA_SID_NISO1_SMMU_TEST>;
+        reg = <0x0 0x31d0000 0x0 0x10000>;
+        interrupts = <0x0 TEGRA234_IRQ_UARTI 0x04>;
+        current-speed = <115200>;
+        status = "disabled";
+    };
+```
+
+We have defined an overlay as follows for the passthrough:
+
+
+```cpp
+/*
+ * Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+ * SPDX-License-Identifier: CC-BY-SA-4.0
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/memory/tegra234-smmu-streamid.h>
+
+/{
+    overlay-name = "UARTI passthrough on host";
+    compatible = "nvidia,p3737-0000+p3701-0000";
+    
+    fragment@0 {
+        target = <&uarti>;
+        __overlay__ {
+            compatible = "arm,dummy";
+            iommus = <&smmu_niso0 TEGRA_SID_NISO1_SMMU_TEST>;
+            status = "okay";
+        };
+    };
+};
+```
+
+We will describe here all the components:
+
+* **#include <dt-bindings/memory/tegra234-smmu-streamid.h>:** the 
+  included headers files for the macro definitions used in the device
+  tree overlay.
+
+* **overlay-name:** briefly describes the purpose of the device tree
+
+* **compatible:** this must be at least one of the root (/) compatibles of 
+the source device tree that we want to overlay, because the 
+*hardware.deviceTree* module will apply only to each .dtb file matching 
+"compatible" of the overlay.
+
+* **fragment@0:** node with the information of the source node to 
+  modify.
+
+* **fragment@0/target:** label to the node to modify.
+  For this case we can use the label *uarti*, but also we can use
+  the path with path: *target-path="/serial@31d0000"*
+
+* **__overlay__:** contains the properties that we want to add or modify from
+the source node.
+
+In Nix you can enable the hardware.deviceTree module and define the device
+tree path as follows:
+
+``` nix
+# Enable hardware.deviceTree for handle host dtb overlays
+hardware.deviceTree.enable = true;
+
+# Apply the device tree overlay only to tegra234-p3701-host-passthrough.dtb
+hardware.deviceTree.overlays = [
+    {
+    name = "uarti_pt_host_overlay";
+    dtsFile = ./uarti_pt_host_overlay.dts;
+
+    # Apply overlay only to host passthrough device tree
+    filter = "tegra234-p3701-host-passthrough.dtb";
+    }
+];
+```
+
+Also, in [jetson-orin.nix](../../../modules/jetpack/nvidia-jetson-orin/jetson-orin.nix) the 
+*dtboBuildExtraIncludePaths* is defined with the path needed to include 
+the *tegra234-smmu-streamid.h* header file.
+
+``` nix
+hardware.deviceTree =
+{
+    enable = lib.mkDefault true;
+    # Add the include paths to build the dtb overlays
+    dtboBuildExtraIncludePaths = [
+    "${lib.getDev config.hardware.deviceTree.kernelPackage}/lib/modules/${config.hardware.deviceTree.kernelPackage.modDirVersion}/source/nvidia/soc/t23x/kernel-include"
+    ];
+}
+```
+
+You can find this full implementation in the Nix module: 
+[uarti-net-vm](../../../modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm)

--- a/docs/src/technologies/nvidia_uarti_net_vm.md
+++ b/docs/src/technologies/nvidia_uarti_net_vm.md
@@ -1,0 +1,82 @@
+<!--
+    Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# NVIDIA Jetson Orin AGX: UARTI Passthrough to netvm
+
+This document describes the UARTI (UART port I) passthrough to the netvm in Ghaf.
+
+**NOTE**: This implementation works only with NVIDIA Jetson AGX Orin, as it is the only  NVIDIA 
+Jetson Orin with the UARTI port available.
+
+## UARTI Connection
+
+The UARTI is mapped as *serial@31d0000* in the device tree information. This UARTI is connected to 
+the NVIDIA Jetson AGX Orin Micro-USB debugging port (ttyACM1) with a default speed of 115200 bps.
+
+For more information on the UART ports connections in NVIDIA Jetson AGX Orin, 
+see: [NVIDIA Jetson AGX Orin: UART Passthrough](nvidia_agx_pt_uart.md)
+
+## UARTI Passthrough Configuration
+
+This section describes how the UARTI passthrough is configured in Ghaf for microvm. 
+We recommend to read [NVIDIA Jetson AGX Orin: UART Passthrough](nvidia_agx_pt_uart.md) before continuing.
+
+The UARTI passthrough configuration declaration 
+[UARTI to netvm](../../../modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/default.nix) 
+includes:
+
+
+- The microvm QEMU extra argument to add the 31d0000.serial to the netvm.
+- The microvm QEMU extra argument to specify a custom device tree (dtb) for the
+  netvm that includes the 31d0000.serial as a platform device.
+- The microvm disable default serial console, to add virtual PCI serial console.
+- A binding service (bindSerial31d0000) for the 31d0000.serial in order to 
+  bind this device to the VFIO driver to make it available to microvm.
+- A kernel patch to add a custom device tree (dtb) source code for the
+  netvm.
+- A device tree overlay to host device tree to assign an IOMMU to the 31d0000.serial 
+  device, and also a dummy driver
+
+Note: Due to the Linux kernel being unable to use the console in two UART ports 
+of the same kind, a virtual PCI Serial console was used as QEMU console output.
+
+
+Also, a new udev rule is defined to group all KVM devices that bind to VFIO in 
+the IOMMU group 59.
+
+
+    services.udev.extraRules = ''
+              # Make group kvm all devices that bind to vfio in iommu group 59
+              SUBSYSTEM=="vfio",KERNEL=="59",GROUP="kvm"
+            '';
+
+The *passthroughs.uarti_net_vm.enable* flag enables the UARTI passthrough to the netvm.
+Make sure to enable the flag as it allows access to netvm through the debugging USB port 
+when the SSH connection does not work.
+
+	hardware.nvidia = {
+		virtualization.enable = true;
+		virtualization.host.bpmp.enable = false;
+		passthroughs.host.uarta.enable = false;
+		passthroughs.uarti_net_vm.enable = true;
+	};
+
+Enable the *virtualization.enable* flag as well, as it is a pre-requirement 
+for *passthroughs.uarti_net_vm.enable*.
+
+## Testing the UARTI on netvm
+
+Connect the NVIDIA Jetson AGX Orin debug Micro-USB to your computer and open 
+the serial port on ttyACM1 at 115200 bps. Use Picocom with the next command:
+
+	picocom -b 115200 /dev/ttyACM1
+
+After the netvm boots, you will see the message:
+
+	<<< Welcome to NixOS 23.11pre-git (aarch64) - ttyAMA0 >>>
+
+	Run 'nixos-help' for the NixOS manual.
+
+	net-vm login: 

--- a/docs/src/technologies/passthrough.md
+++ b/docs/src/technologies/passthrough.md
@@ -15,3 +15,5 @@ Our current supported passthrough devices implementations:
 - [NVIDIA Jetson AGX Orin: UART Passthrough](nvidia_agx_pt_uart.md)
 - [NVIDIA Jetson AGX Orin: PCIe Passthrough](nvidia_agx_pt_pcie.md)
 - [Generic x86: PCIe Passthrough on crosvm](x86_pcie_crosvm.md)
+- [NVIDIA Jetson: UARTI Passthrough to netvm](nvidia_uarti_net_vm.md)
+- [Device Tree Overlays for Passthrough](device_tree_overlays_pt.md)

--- a/modules/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -97,6 +97,10 @@ in
       hardware.deviceTree =
         {
           enable = lib.mkDefault true;
+          # Add the include paths to build the dtb overlays
+          dtboBuildExtraIncludePaths = [
+            "${lib.getDev config.hardware.deviceTree.kernelPackage}/lib/modules/${config.hardware.deviceTree.kernelPackage.modDirVersion}/source/nvidia/soc/t23x/kernel-include"
+          ];
         }
         # Versions of the device tree without PCI passthrough related
         # modifications.

--- a/modules/jetpack/nvidia-jetson-orin/virtualization/default.nix
+++ b/modules/jetpack/nvidia-jetson-orin/virtualization/default.nix
@@ -1,9 +1,10 @@
-# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
   imports = [
     ./common/bpmp-virt-common
     ./host/bpmp-virt-host
     ./host/uarta-host
+    ./passthrough/uarti-net-vm
   ];
 }

--- a/modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/default.nix
+++ b/modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/default.nix
@@ -1,0 +1,86 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  cfg = config.ghaf.hardware.nvidia.passthroughs.uarti_net_vm;
+in {
+  options.ghaf.hardware.nvidia.passthroughs.uarti_net_vm.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = "Enable UARTI passthrough on Nvidia Orin to the Net-VM";
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.udev.extraRules = ''
+      # Make group kvm all devices that bind to vfio in iommu group 59
+      SUBSYSTEM=="vfio",KERNEL=="59",GROUP="kvm"
+    '';
+    ghaf.hardware.nvidia.virtualization.enable = true;
+
+    ghaf.virtualization.microvm.netvm.extraModules = [
+      {
+        # Use serial passthrough (ttyAMA0) and virtual PCI serial (ttyS0)
+        # as Linux console
+        microvm.kernelParams = [
+          "console=ttyAMA0 console=ttyS0"
+        ];
+        microvm.qemu.serialConsole = false;
+        microvm.qemu.extraArgs = [
+          # Add custom dtb to Net-VM with 31d0000.serial in platform devices
+          "-dtb"
+          "${config.hardware.deviceTree.package}/tegra234-p3701-ghaf-net-vm.dtb"
+          # Add UARTI (31d0000.serial) as passtrhough device
+          "-device"
+          "vfio-platform,host=31d0000.serial"
+          # Add a virtual PCI serial device as console
+          "-device"
+          "pci-serial,chardev=stdio,id=serial0"
+        ];
+      }
+    ];
+
+    # Make sure that Net-VM runs after the binding services are enabled
+    systemd.services."microvm@net-vm".after = ["bindSerial31d0000.service"];
+
+    boot.kernelPatches = [
+      {
+        name = "Add Net-VM device tree with UARTI in platform devices";
+        patch = ./patches/net_vm_dtb_with_uarti.patch;
+      }
+    ];
+
+    systemd.services.bindSerial31d0000 = {
+      description = "Bind UARTI to the vfio-platform driver";
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = "yes";
+        ExecStartPre = ''
+          ${pkgs.bash}/bin/bash -c "echo vfio-platform > /sys/bus/platform/devices/31d0000.serial/driver_override"
+        '';
+        ExecStart = ''
+          ${pkgs.bash}/bin/bash -c "echo 31d0000.serial > /sys/bus/platform/drivers/vfio-platform/bind"
+        '';
+      };
+    };
+
+    # Enable hardware.deviceTree for handle host dtb overlays
+    hardware.deviceTree.enable = true;
+
+    # Apply the device tree overlay only to tegra234-p3701-host-passthrough.dtb
+    hardware.deviceTree.overlays = [
+      {
+        name = "uarti_pt_host_overlay";
+        dtsFile = ./uarti_pt_host_overlay.dts;
+
+        # Apply overlay only to host passthrough device tree
+        # TODO: make this avaliable if PCI passthrough is disabled
+        filter = "tegra234-p3701-host-passthrough.dtb";
+      }
+    ];
+  };
+}

--- a/modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/patches/net_vm_dtb_with_uarti.patch
+++ b/modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/patches/net_vm_dtb_with_uarti.patch
@@ -1,0 +1,421 @@
+diff --git a/nvidia/platform/t23x/concord/kernel-dts/Makefile b/nvidia/platform/t23x/concord/kernel-dts/Makefile
+index 450191e..3ea10e8 100644
+--- a/nvidia/platform/t23x/concord/kernel-dts/Makefile
++++ b/nvidia/platform/t23x/concord/kernel-dts/Makefile
+@@ -9,6 +9,7 @@ ifneq ($(filter y,$(CONFIG_ARCH_TEGRA_23x_SOC)),)
+ BUILD_ENABLE=y
+ endif
+ 
++dtb-$(BUILD_ENABLE) += tegra234-p3701-ghaf-net-vm.dtb
+ dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-p3737-0000.dtb
+ dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-as-p3701-0004-p3737-0000.dtb
+ dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-as-p3767-0004-p3737-0000.dtb
+diff --git a/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-ghaf-net-vm.dts b/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-ghaf-net-vm.dts
+new file mode 100644
+index 0000000..119a25a
+--- /dev/null
++++ b/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-ghaf-net-vm.dts
+@@ -0,0 +1,403 @@
++/dts-v1/;
++
++/ {
++	interrupt-parent = <0x8002>;
++	model = "linux,dummy-virt";
++	#size-cells = <0x02>;
++	#address-cells = <0x02>;
++	compatible = "linux,dummy-virt";
++
++	psci {
++		migrate = <0xc4000005>;
++		cpu_on = <0xc4000003>;
++		cpu_off = <0x84000002>;
++		cpu_suspend = <0xc4000001>;
++		method = "hvc";
++		compatible = "arm,psci-1.0\0arm,psci-0.2\0arm,psci";
++	};
++
++	memory@40000000 {
++		numa-node-id = <0x00>;
++		reg = <0x00 0x40000000 0x00 0x20000000>;
++		device_type = "memory";
++	};
++
++	platform-bus@c000000 {
++		interrupt-parent = <0x8002>;
++		ranges = <0x00 0x00 0xc000000 0x2000000>;
++		#address-cells = <0x01>;
++		#size-cells = <0x01>;
++		compatible = "qemu,platform\0simple-bus";
++
++        uarti: serial@c000000 {
++            compatible = "arm,sbsa-uart";
++            current-speed = <0x1c200>;
++            interrupts = <0x00 0x70 0x04>;
++            reg = <0x00000000 0x10000>;
++            status = "okay";
++        };
++	};
++
++	fw-cfg@9020000 {
++		dma-coherent;
++		reg = <0x00 0x9020000 0x00 0x18>;
++		compatible = "qemu,fw-cfg-mmio";
++	};
++
++	virtio_mmio@a000000 {
++		dma-coherent;
++		interrupts = <0x00 0x10 0x01>;
++		reg = <0x00 0xa000000 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a000200 {
++		dma-coherent;
++		interrupts = <0x00 0x11 0x01>;
++		reg = <0x00 0xa000200 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a000400 {
++		dma-coherent;
++		interrupts = <0x00 0x12 0x01>;
++		reg = <0x00 0xa000400 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a000600 {
++		dma-coherent;
++		interrupts = <0x00 0x13 0x01>;
++		reg = <0x00 0xa000600 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a000800 {
++		dma-coherent;
++		interrupts = <0x00 0x14 0x01>;
++		reg = <0x00 0xa000800 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a000a00 {
++		dma-coherent;
++		interrupts = <0x00 0x15 0x01>;
++		reg = <0x00 0xa000a00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a000c00 {
++		dma-coherent;
++		interrupts = <0x00 0x16 0x01>;
++		reg = <0x00 0xa000c00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a000e00 {
++		dma-coherent;
++		interrupts = <0x00 0x17 0x01>;
++		reg = <0x00 0xa000e00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a001000 {
++		dma-coherent;
++		interrupts = <0x00 0x18 0x01>;
++		reg = <0x00 0xa001000 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a001200 {
++		dma-coherent;
++		interrupts = <0x00 0x19 0x01>;
++		reg = <0x00 0xa001200 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a001400 {
++		dma-coherent;
++		interrupts = <0x00 0x1a 0x01>;
++		reg = <0x00 0xa001400 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a001600 {
++		dma-coherent;
++		interrupts = <0x00 0x1b 0x01>;
++		reg = <0x00 0xa001600 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a001800 {
++		dma-coherent;
++		interrupts = <0x00 0x1c 0x01>;
++		reg = <0x00 0xa001800 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a001a00 {
++		dma-coherent;
++		interrupts = <0x00 0x1d 0x01>;
++		reg = <0x00 0xa001a00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a001c00 {
++		dma-coherent;
++		interrupts = <0x00 0x1e 0x01>;
++		reg = <0x00 0xa001c00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a001e00 {
++		dma-coherent;
++		interrupts = <0x00 0x1f 0x01>;
++		reg = <0x00 0xa001e00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a002000 {
++		dma-coherent;
++		interrupts = <0x00 0x20 0x01>;
++		reg = <0x00 0xa002000 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a002200 {
++		dma-coherent;
++		interrupts = <0x00 0x21 0x01>;
++		reg = <0x00 0xa002200 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a002400 {
++		dma-coherent;
++		interrupts = <0x00 0x22 0x01>;
++		reg = <0x00 0xa002400 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a002600 {
++		dma-coherent;
++		interrupts = <0x00 0x23 0x01>;
++		reg = <0x00 0xa002600 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a002800 {
++		dma-coherent;
++		interrupts = <0x00 0x24 0x01>;
++		reg = <0x00 0xa002800 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a002a00 {
++		dma-coherent;
++		interrupts = <0x00 0x25 0x01>;
++		reg = <0x00 0xa002a00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a002c00 {
++		dma-coherent;
++		interrupts = <0x00 0x26 0x01>;
++		reg = <0x00 0xa002c00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a002e00 {
++		dma-coherent;
++		interrupts = <0x00 0x27 0x01>;
++		reg = <0x00 0xa002e00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a003000 {
++		dma-coherent;
++		interrupts = <0x00 0x28 0x01>;
++		reg = <0x00 0xa003000 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a003200 {
++		dma-coherent;
++		interrupts = <0x00 0x29 0x01>;
++		reg = <0x00 0xa003200 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a003400 {
++		dma-coherent;
++		interrupts = <0x00 0x2a 0x01>;
++		reg = <0x00 0xa003400 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a003600 {
++		dma-coherent;
++		interrupts = <0x00 0x2b 0x01>;
++		reg = <0x00 0xa003600 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a003800 {
++		dma-coherent;
++		interrupts = <0x00 0x2c 0x01>;
++		reg = <0x00 0xa003800 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a003a00 {
++		dma-coherent;
++		interrupts = <0x00 0x2d 0x01>;
++		reg = <0x00 0xa003a00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a003c00 {
++		dma-coherent;
++		interrupts = <0x00 0x2e 0x01>;
++		reg = <0x00 0xa003c00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	virtio_mmio@a003e00 {
++		dma-coherent;
++		interrupts = <0x00 0x2f 0x01>;
++		reg = <0x00 0xa003e00 0x00 0x200>;
++		compatible = "virtio,mmio";
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		poweroff {
++			gpios = <0x8004 0x03 0x00>;
++			linux,code = <0x74>;
++			label = "GPIO Key Poweroff";
++		};
++	};
++
++	pl061@9030000 {
++		phandle = <0x8004>;
++		clock-names = "apb_pclk";
++		clocks = <0x8000>;
++		interrupts = <0x00 0x07 0x04>;
++		gpio-controller;
++		#gpio-cells = <0x02>;
++		compatible = "arm,pl061\0arm,primecell";
++		reg = <0x00 0x9030000 0x00 0x1000>;
++	};
++
++	pcie@10000000 {
++		interrupt-map-mask = <0x1800 0x00 0x00 0x07>;
++		interrupt-map = <0x00 0x00 0x00 0x01 0x8002 0x00 0x00 0x00 0x03 0x04 0x00 0x00 0x00 0x02 0x8002 0x00 0x00 0x00 0x04 0x04 0x00 0x00 0x00 0x03 0x8002 0x00 0x00 0x00 0x05 0x04 0x00 0x00 0x00 0x04 0x8002 0x00 0x00 0x00 0x06 0x04 0x800 0x00 0x00 0x01 0x8002 0x00 0x00 0x00 0x04 0x04 0x800 0x00 0x00 0x02 0x8002 0x00 0x00 0x00 0x05 0x04 0x800 0x00 0x00 0x03 0x8002 0x00 0x00 0x00 0x06 0x04 0x800 0x00 0x00 0x04 0x8002 0x00 0x00 0x00 0x03 0x04 0x1000 0x00 0x00 0x01 0x8002 0x00 0x00 0x00 0x05 0x04 0x1000 0x00 0x00 0x02 0x8002 0x00 0x00 0x00 0x06 0x04 0x1000 0x00 0x00 0x03 0x8002 0x00 0x00 0x00 0x03 0x04 0x1000 0x00 0x00 0x04 0x8002 0x00 0x00 0x00 0x04 0x04 0x1800 0x00 0x00 0x01 0x8002 0x00 0x00 0x00 0x06 0x04 0x1800 0x00 0x00 0x02 0x8002 0x00 0x00 0x00 0x03 0x04 0x1800 0x00 0x00 0x03 0x8002 0x00 0x00 0x00 0x04 0x04 0x1800 0x00 0x00 0x04 0x8002 0x00 0x00 0x00 0x05 0x04>;
++		#interrupt-cells = <0x01>;
++		ranges = <0x1000000 0x00 0x00 0x00 0x3eff0000 0x00 0x10000 0x2000000 0x00 0x10000000 0x00 0x10000000 0x00 0x2eff0000 0x3000000 0x80 0x00 0x80 0x00 0x80 0x00>;
++		reg = <0x40 0x10000000 0x00 0x10000000>;
++		msi-map = <0x00 0x8003 0x00 0x10000>;
++		dma-coherent;
++		bus-range = <0x00 0xff>;
++		linux,pci-domain = <0x00>;
++		#size-cells = <0x02>;
++		#address-cells = <0x03>;
++		device_type = "pci";
++		compatible = "pci-host-ecam-generic";
++	};
++
++	pl031@9010000 {
++		clock-names = "apb_pclk";
++		clocks = <0x8000>;
++		interrupts = <0x00 0x02 0x04>;
++		reg = <0x00 0x9010000 0x00 0x1000>;
++		compatible = "arm,pl031\0arm,primecell";
++	};
++
++	pl011@9000000 {
++		clock-names = "uartclk\0apb_pclk";
++		clocks = <0x8000 0x8000>;
++		interrupts = <0x00 0x01 0x04>;
++		reg = <0x00 0x9000000 0x00 0x1000>;
++		compatible = "arm,pl011\0arm,primecell";
++	};
++
++	pmu {
++		interrupts = <0x01 0x07 0x04>;
++		compatible = "arm,armv8-pmuv3";
++	};
++
++	intc@8000000 {
++		phandle = <0x8002>;
++		reg = <0x00 0x8000000 0x00 0x10000 0x00 0x80a0000 0x00 0xf60000>;
++		#redistributor-regions = <0x01>;
++		compatible = "arm,gic-v3";
++		ranges;
++		#size-cells = <0x02>;
++		#address-cells = <0x02>;
++		interrupt-controller;
++		#interrupt-cells = <0x03>;
++
++		its@8080000 {
++			phandle = <0x8003>;
++			reg = <0x00 0x8080000 0x00 0x20000>;
++			#msi-cells = <0x01>;
++			msi-controller;
++			compatible = "arm,gic-v3-its";
++		};
++	};
++
++	flash@0 {
++		bank-width = <0x04>;
++		reg = <0x00 0x00 0x00 0x4000000 0x00 0x4000000 0x00 0x4000000>;
++		compatible = "cfi-flash";
++	};
++
++	cpus {
++		#size-cells = <0x00>;
++		#address-cells = <0x01>;
++
++		cpu-map {
++
++			socket0 {
++
++				cluster0 {
++
++					core0 {
++						cpu = <0x8001>;
++					};
++				};
++			};
++		};
++
++		cpu@0 {
++			phandle = <0x8001>;
++			numa-node-id = <0x00>;
++			reg = <0x00>;
++			compatible = "arm,arm-v8";
++			device_type = "cpu";
++		};
++	};
++
++	timer {
++		interrupts = <0x01 0x0d 0x04 0x01 0x0e 0x04 0x01 0x0b 0x04 0x01 0x0a 0x04>;
++		always-on;
++		compatible = "arm,armv8-timer\0arm,armv7-timer";
++	};
++
++	apb-pclk {
++		phandle = <0x8000>;
++		clock-output-names = "clk24mhz";
++		clock-frequency = <0x16e3600>;
++		#clock-cells = <0x00>;
++		compatible = "fixed-clock";
++	};
++
++	chosen {
++		linux,initrd-end = <0x00 0x48e68d46>;
++		linux,initrd-start = <0x00 0x48000000>;
++		bootargs = "console=ttyAMA0 reboot=t panic=-1 loglevel=4 init=/nix/store/ygzbib5kmqc4ffmmnd6lclga4fq73ngy-nixos-system-net-vm-23.11pre-git/init regInfo=/nix/store/jma8cq84vbxjzhzwcidw0lpqc3fpfw5i-closure-info/registration";
++		stdout-path = "/pl011@9000000";
++		rng-seed = <0x54924b6e 0x299b1a4d 0xf0a6795d 0xd346c073 0xe484a1ae 0x334ba8a5 0xe5e9b9f 0x856453b0>;
++		kaslr-seed = <0x981c9928 0x20d330ce>;
++	};
++};

--- a/modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/uarti_pt_host_overlay.dts
+++ b/modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/uarti_pt_host_overlay.dts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+ * SPDX-License-Identifier: CC-BY-SA-4.0
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/memory/tegra234-smmu-streamid.h>
+
+/{
+    overlay-name = "UARTI passthrough on host";
+    compatible = "nvidia,p3737-0000+p3701-0000";
+    
+    fragment@0 {
+        target = <&uarti>;
+        __overlay__ {
+            compatible = "arm,dummy";
+            iommus = <&smmu_niso0 TEGRA_SID_NISO1_SMMU_TEST>;
+            status = "okay";
+        };
+    };
+};

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -58,9 +58,10 @@
               };
 
               hardware.nvidia = {
-                virtualization.enable = false;
+                virtualization.enable = true;
                 virtualization.host.bpmp.enable = false;
                 passthroughs.host.uarta.enable = false;
+                passthroughs.uarti_net_vm.enable = som == "agx";
               };
 
               virtualization.microvm-host.enable = true;


### PR DESCRIPTION
Having a USB debug port connected to the Net-VM is useful when the SSH connection is not working or correctly configured. This implementation enables access from the Nvidia Orin AGX debug micro USB port (ttyACM1)  to the Net-VM console.

**NOTE**: this implementation only works with Nvidia Jetson Orin AGX, due is the only 
Nvidia Jetson Orin with the UARTI port available.


## Description of changes

The UARTI is mapped as *serial@31d0000* in the device tree information. This UARTI is connected to 
the Nvidia Orin micro USB debugging port (ttyACM1) with a default speed of 115000bps.

The UARTI passthrough is configured in Ghaf for Microvm. 

The UARTI passthrough configuration declaration is available in: 
[UARTI to Net-VM](https://github.com/jpruiz84/ghaf/blob/uarti/modules/hardware/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/default.nix) 

This declaration includes:

- Microvm Qemu extra argument to add the 31d0000.serial to the Net-VM.
- Microvm Qemu extra argument to specify a custom device tree (dtb) for the
  Net-VM that includes the 31d0000.serial as a platform device.
- Microvm disable default serial console, to add virtual pci-serial console.
- Binding service (bindSerial31d0000) for the 31d0000.serial in order to 
  bind this device to the VFIO driver to make it available to Microvm.
- Kernel patch to add a custom device tree (dtb) source code for the
  Net-VM.
- Device tree overlay to host device tree to assign an IOMMU to the 31d0000.serial 
  device, and also a dummy driver

Note: due the Linux kernel is not able to use the console in two UART ports
of the same kind, a virtual pci-serial console was used as qemu console output.


Also, a new udev rule was defined to make group kvm all devices that bind to vfio 
in iommu group 59.


    services.udev.extraRules = ''
              # Make group kvm all devices that bind to vfio in iommu group 59
              SUBSYSTEM=="vfio",KERNEL=="59",GROUP="kvm"
            '';

Also, here the *passthroughs.uarti_net_vm.enable* is enabled by default. This flag
enables the UARTI passthrough to he Net-VM. We recommend to have this enabled by 
default, because it is useful to have access to the Net-VM through the debugging
USB port when the ssh connection does not work.

	hardware.nvidia = {
		virtualization.enable = true;
		virtualization.host.bpmp.enable = false;
		passthroughs.host.uarta.enable = false;
		passthroughs.uarti_net_vm.enable = true;
	};

The flag *virtualization.enable* should be enabled, because it is a 
pre-requirement for *passthroughs.uarti_net_vm.enable*.


Jira task: https://ssrc.atlassian.net/browse/SP-3722

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [] Author has run `nix flake check --accept-flake-config` and it passes
- [] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Connect the NVIDIA Jetson Orin AGX debug micro USB to your PC 
and open the serial port on ttyACM1 at 115200 bps. 
You can use picocom with the next command:

	picocom -b 115200 /dev/ttyACM1

Press enter and you will see the Net-VM logging

	net-vm login: 

Also, you can reboot your board and see the full Net-VM boot up logs.
