### PR TITLE
Conditionally enable systemd timesyncd patch

### DIFF
--- a/overlays/custom-packages/systemd/default.nix
+++ b/overlays/custom-packages/systemd/default.nix
@@ -1,18 +1,26 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 (final: prev: {
-  systemd = prev.systemd.overrideAttrs (prevAttrs: {
-    patches = prevAttrs.patches ++ [./systemd-timesyncd-disable-nscd.patch];
-    postPatch =
-      prevAttrs.postPatch
-      + ''
-        substituteInPlace units/systemd-timesyncd.service.in \
-          --replace \
-          "Environment=SYSTEMD_NSS_RESOLVE_VALIDATE=0" \
-          "${final.lib.concatStringsSep "\n" [
-          "Environment=LD_LIBRARY_PATH=$out/lib"
-          "Environment=SYSTEMD_NSS_RESOLVE_VALIDATE=0"
-        ]}"
-      '';
-  });
+  systemd = let
+    # The patch has been added nixpkgs upstream, don't override attributes if
+    # the patch is already present.
+    #
+    # https://github.com/NixOS/nixpkgs/pull/239201
+    shouldOverride = !(final.lib.lists.any (p: final.lib.strings.hasSuffix "0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch" p) prev.systemd.patches);
+  in
+    prev.systemd.overrideAttrs (prevAttrs:
+      final.lib.optionalAttrs shouldOverride {
+        patches = prevAttrs.patches ++ [./systemd-timesyncd-disable-nscd.patch];
+        postPatch =
+          prevAttrs.postPatch
+          + ''
+            substituteInPlace units/systemd-timesyncd.service.in \
+              --replace \
+              "Environment=SYSTEMD_NSS_RESOLVE_VALIDATE=0" \
+              "${final.lib.concatStringsSep "\n" [
+              "Environment=LD_LIBRARY_PATH=$out/lib"
+              "Environment=SYSTEMD_NSS_RESOLVE_VALIDATE=0"
+            ]}"
+          '';
+      });
 })


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

The systemd package was patched nixpkgs upstream, causing the build against nixos-unstable to break, because same patch is about to be applied twice. Check if the patch is already present, and don't do timesync related overrides if it is.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Test by changing `nixpkgs` flake input to `nixos-unstable`. Try to build things