### PR TITLE
Fix waypipe in labwc

### DIFF
--- a/modules/graphics/labwc.nix
+++ b/modules/graphics/labwc.nix
@@ -22,26 +22,21 @@ in {
     # Next 2 services/targets are taken from official weston documentation
     # and adjusted for labwc
     # https://wayland.pages.freedesktop.org/weston/toc/running-weston.html
-
-    # labwc socket
-    systemd.user.sockets."labwc" = {
-      unitConfig = {
-        Description = "labwc, a Wayland compositor";
-        Documentation = "man:labwc(1)";
-      };
-      socketConfig = {
-        ListenStream = "%t/wayland-1";
-      };
-      wantedBy = ["labwc.service"];
-    };
-
-    # labwc service
-    systemd.user.services."labwc" = {
+    systemd.user.services."labwc" = let
+      autostart =
+        pkgs.concatScript "labwc-autostart"
+        [
+          "${pkgs.labwc}/share/doc/labwc/autostart"
+          (pkgs.writeText "autostart-extra" ''
+            # Import WAYLAND_DISPLAY variable to make it available to waypipe and other systemd services
+            ${pkgs.systemd}/bin/systemctl --user import-environment WAYLAND_DISPLAY 2>&1 &
+          '')
+        ];
+    in {
       enable = true;
       description = "labwc, a Wayland compositor, as a user service TEST";
       documentation = ["man:labwc(1)"];
-      requires = ["labwc.socket"];
-      after = ["labwc.socket" "ghaf-session.service"];
+      after = ["ghaf-session.service"];
       serviceConfig = {
         # Previously there was "notify" type, but for some reason
         # systemd kills labwc.service because of timeout (even if it is disabled).
@@ -52,7 +47,7 @@ in {
         # Defaults to journal
         StandardOutput = "journal";
         StandardError = "journal";
-        ExecStart = "${pkgs.labwc}/bin/labwc -C ${pkgs.labwc}/share/doc/labwc -s ${pkgs.labwc}/share/doc/labwc/autostart";
+        ExecStart = "${pkgs.labwc}/bin/labwc -C ${pkgs.labwc}/share/doc/labwc -s ${autostart}";
         #GPU pt needs some time to start - labwc fails to restart 3 times in avg.
         ExecStartPre = "${pkgs.coreutils}/bin/sleep 3";
         Restart = "on-failure";

--- a/modules/virtualization/microvm/guivm.nix
+++ b/modules/virtualization/microvm/guivm.nix
@@ -96,23 +96,14 @@
         systemd.user.services.waypipe = {
           enable = true;
           description = "waypipe";
-          after = ["weston.service"];
+          after = ["weston.service" "labwc.service"];
           serviceConfig = {
             Type = "simple";
-            Environment = [
-              "WAYLAND_DISPLAY=\"wayland-1\""
-              "DISPLAY=\":0\""
-              "XDG_SESSION_TYPE=wayland"
-              "QT_QPA_PLATFORM=\"wayland\"" # Qt Applications
-              "GDK_BACKEND=\"wayland\"" # GTK Applications
-              "XDG_SESSION_TYPE=\"wayland\"" # Electron Applications
-              "SDL_VIDEODRIVER=\"wayland\""
-              "CLUTTER_BACKEND=\"wayland\""
-            ];
             ExecStart = "${pkgs.waypipe}/bin/waypipe --vsock -s ${toString cfg.waypipePort} client";
             Restart = "always";
             RestartSec = "1";
           };
+          startLimitIntervalSec = 0;
           wantedBy = ["ghaf-session.target"];
         };
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Running applications from appvms with waypipe doesn't work when labwc is enabled. The reason is the waypipe service configured to use the wayland-1 socket which is created by systemd for weston and labwc. However, labwc doesn't have systemd integration and instead of using wayland-1 it creates its own socket which is wayland-0 by default.

This PR makes waypipe use the correct socket from the WAYLAND_DISPLAY environmental variable both for weston and labwc. It also removes the unused wayland-1 socket in labwc module and improves weston startup sequence to leverage systemd integration.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
- Enable labwc by uncommenting `profiles.graphics.compositor = "labwc";` in the guivm.nix.
- Build an image for lenovo x1, boot and ssh to zathura-vm.ghaf.
- Run `waypipe --vsock -s 1100 server zathura`.

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
