### PR TITLE
Ensure string in systemd override check

### DIFF
--- a/overlays/custom-packages/systemd/default.nix
+++ b/overlays/custom-packages/systemd/default.nix
@@ -6,7 +6,7 @@
     # the patch is already present.
     #
     # https://github.com/NixOS/nixpkgs/pull/239201
-    shouldOverride = !(final.lib.lists.any (p: final.lib.strings.hasSuffix "0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch" p) prev.systemd.patches);
+    shouldOverride = !(final.lib.lists.any (p: final.lib.strings.hasSuffix "0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch" (toString p)) prev.systemd.patches);
   in
     prev.systemd.overrideAttrs (prevAttrs:
       final.lib.optionalAttrs shouldOverride {


### PR DESCRIPTION
Ensure the conditional systemd timesyncd patch inclusion uses strings in checking the list of nixpkgs upstream patches.

We notice ghafscan [fails to evaluate](https://github.com/tiiuae/ghafscan/blob/ce517a0e91bb9cb6928224abff8598fe3c2de203/reports/main/packages.x86_64-linux.generic-x86_64-release.md?plain=1#L85) generic-x86_64 when pinned to nixos-unstable. It seems the issue is caused by the check which was added in https://github.com/tiiuae/ghaf/pull/449 and the fact that the upstreamed systemd patch is [now available](https://nixpk.gs/pr-tracker.html?pr=239201) in nixos-unstable.

Before the fix attempt in this PR, the evaluation would fail as follows:

```
       … while calling anonymous lambda

         at /nix/store/f8r5v40y82j97i9c8gq7l9my5r3x83yh-source/overlays/custom-packages/systemd/default.nix:9:45:

            8|     # https://github.com/NixOS/nixpkgs/pull/239201
            9|     shouldOverride = !(final.lib.lists.any (p: final.lib.strings.hasSuffix "0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch" p) prev.systemd.patches);
             |                                             ^
           10|   in

       … from call site

         at /nix/store/f8r5v40y82j97i9c8gq7l9my5r3x83yh-source/overlays/custom-packages/systemd/default.nix:9:48:

            8|     # https://github.com/NixOS/nixpkgs/pull/239201
            9|     shouldOverride = !(final.lib.lists.any (p: final.lib.strings.hasSuffix "0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch" p) prev.systemd.patches);
             |                                                ^
           10|   in

       … while calling 'hasSuffix'

         at /nix/store/rqdf3gfjq8zh488msnv62h03kkzr308q-source/lib/strings.nix:300:5:

          299|     # Input string
          300|     content:
             |     ^
          301|     let

       … from call site

         at /nix/store/rqdf3gfjq8zh488msnv62h03kkzr308q-source/lib/strings.nix:307:5:

          306|     # to strings and comparing. This was surprising and confusing.
          307|     warnIf
             |     ^
          308|       (isPath suffix)

       … while calling anonymous lambda

         at /nix/store/rqdf3gfjq8zh488msnv62h03kkzr308q-source/lib/trivial.nix:367:50:

          366|   */
          367|   warnIf = cond: msg: if cond then warn msg else x: x;
             |                                                  ^
          368|

       error: cannot coerce a list to a string
```
It seems the upstream patch is evaluated as list:
```
[ /nix/store/rqdf3gfjq8zh488msnv62h03kkzr308q-source/pkgs/os-specific/linux/systemd/0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch ]
```
Explicitly converting it to string fixes the issue, although, it's unclear why it is originally evaluated as list.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
Tested by changing the nixpkgs flake input to nixos-unstable and verifying the following:
- `nix build .#packages.x86_64-linux.generic-x86_64-debug` fails to evaluate without the changes from this PR
- `nix build .#packages.x86_64-linux.generic-x86_64-debug` passes evaluation with the changes from this PR

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
