### PR TITLE
Labwc fonts

### DIFF
--- a/modules/graphics/fonts.nix
+++ b/modules/graphics/fonts.nix
@@ -18,6 +18,7 @@ in {
     // lib.mkIf labwc.enable {
       fonts.packages = with pkgs; [
         (nerdfonts.override {fonts = ["FiraCode"];})
+        hack-font
       ];
     };
 }

--- a/modules/graphics/waybar.config.nix
+++ b/modules/graphics/waybar.config.nix
@@ -54,7 +54,7 @@
     # a launcher on the panel, the launcher will replace weston-terminal launcher.
     {
       name = "terminal";
-      path = "${pkgs.weston}/bin/weston-terminal";
+      path = "${pkgs.weston}/bin/weston-terminal --font=${pkgs.hack-font}/share/fonts/truetype/Hack-Regular.ttf";
       icon = "${pkgs.weston}/share/weston/icon_terminal.png";
     }
   ];


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Hack font is integrated to labwc for weston-terminal application.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
