### PR TITLE
Add GUIVM into Jetson AGX Orin

### DIFF
--- a/packages/nm-launcher/default.nix
+++ b/packages/nm-launcher/default.nix
@@ -39,6 +39,7 @@ in
       description = "Script to launch nm-connection-editor to configure network of netvm using D-Bus over SSH.";
       platforms = [
         "x86_64-linux"
+        "aarch64-linux"
       ];
     };
   }

--- a/targets/nvidia-jetson-orin/default.nix
+++ b/targets/nvidia-jetson-orin/default.nix
@@ -48,6 +48,7 @@
           ../../modules/host
           ../../modules/virtualization/microvm/microvm-host.nix
           ../../modules/virtualization/microvm/netvm.nix
+          ../../modules/virtualization/microvm/guivm.nix
           ({config, ...}: {
             ghaf = {
               hardware.nvidia.orin = {
@@ -68,6 +69,8 @@
 
               virtualization.microvm.netvm.enable = true;
               virtualization.microvm.netvm.extraModules = netvmExtraModules;
+
+              virtualization.microvm.guivm.enable = true;
 
               # Enable all the default UI applications
               profiles = {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

GUIVM is added and enabled for AGX Orin. "nm-launcher" is available to build for aarch64. It doesn't include the GPU passthrough yet.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

1. Flash the image and boot.
2. Connect to net-vm with ssh.
3. Connect to gui-vm with ssh from net-vm.
