### PR TITLE
fix cross-build for vsock and pipewire

### DIFF
--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -8,6 +8,7 @@ _: {
     (import ./edk2.nix)
     (import ./element-desktop.nix)
     (import ./jbig2dec.nix)
+    (import ./pipewire.nix)
     (import ./sysbench.nix)
   ];
 }

--- a/overlays/cross-compilation/pipewire.nix
+++ b/overlays/cross-compilation/pipewire.nix
@@ -1,0 +1,11 @@
+# Copyright 2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+(_final: prev: {
+  # It defaulted to
+  # { ...
+  # , x11Support ? true
+  # , ffadoSupport ? x11Support && stdenv.buildPlatform.canExecute stdenv.hostPlatform
+  # }
+  # It should evaluate to `false` in case of cross-compilation, but it doesn't happens for unknown reasons.
+  pipewire = prev.pipewire.override {ffadoSupport = false;};
+})

--- a/packages/vsockproxy/default.nix
+++ b/packages/vsockproxy/default.nix
@@ -9,7 +9,11 @@
 stdenv.mkDerivation {
   name = "vsockproxy";
 
-  nativeBuildInputs = with pkgs; [meson ninja];
+  # FIXME: Kludge `pkgs.buildPackages`, to fix cross build.
+  # Normally `nativeBuildInputs` doesn't require explicit mention of `buildPackages`
+  # but it doesn't works in this particular case for unknown reasons.
+  # FIXME: need to investigate source of this issue.
+  nativeBuildInputs = with pkgs.buildPackages; [meson ninja];
 
   src = pkgs.fetchFromGitHub {
     owner = "tiiuae";


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Fix crosscompilation of broken chain `pipewire -> ffado -> pyqt -> qt*` by disabling `ffado`.
I believe we never would use firewire for audio source/sink on our cross-compiled devices.
(probably refactor upstream ffado to split to ffado and ffado-gui would be proper solution, I even tried to do it couple years ago)

Also this PR contain quickfix for vsockproxy cross-compilation, which is pretty hacky and would need revisit in future.
(see code comment for details)

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

These fixes unblock building, build proceeds to big packages such as electron
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
