### PR TITLE
Fix deprecated warning for optee namespace

### DIFF
--- a/targets/nvidia-jetson-orin/optee.nix
+++ b/targets/nvidia-jetson-orin/optee.nix
@@ -69,7 +69,7 @@
       exec "${pkgs.opensc}/bin/pkcs11-tool" --module "${opteeClient}/lib/libckteec.so" $@
     '';
   in {
-    hardware.nvidia-jetpack.firmware.optee.trustedApplications = let
+    hardware.nvidia-jetpack.firmware.optee.supplicant.trustedApplications = let
       xTestTaDir = "${opteeXtest}/ta";
       xTestTaPaths =
         builtins.map (ta: {


### PR DESCRIPTION
## Description of changes

Depricated warnings are being shown as the upstream jetpack has changed the optee namespace for TAs. This patch uses the proposed namespace confentions as suggested in the warning message

## Checklist for things done

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
