### PR TITLE
Use more compact notation in .reuse/dep5

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,8 +5,7 @@ Source: https://github.com/tiiuae/ghaf
 
 Copyright: 2022-2024 Technology Innovation Institute (TII) <https://github.com/tiiuae/ghaf>
 License: Apache-2.0
-Files: *.lock *.png *.svg *.patch *.db *.key *.pem *.cer *.p12
-
-Copyright: 2022-2024 Technology Innovation Institute (TII) <https://github.com/tiiuae/ghaf>
-License: Apache-2.0
-Files: modules/host/ghaf_host_hardened_baseline-x86 modules/host/ghaf_host_hardened_baseline-jetson-orin
+Files: 
+  *.lock *.png *.svg *.patch *.db *.key *.pem *.cer *.p12
+  modules/host/ghaf_host_hardened_baseline-x86
+  modules/host/ghaf_host_hardened_baseline-jetson-orin


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Minor fixup of `.reuse/dep5` formatting

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Should pass reuse check on CI
