### PR TITLE
Add an XDG handler for PDF files to the chromium-vm

### DIFF
--- a/modules/virtualization/microvm/appvm.nix
+++ b/modules/virtualization/microvm/appvm.nix
@@ -27,7 +27,17 @@
           config,
           pkgs,
           ...
-        }: {
+        }: let
+          waypipeBorder =
+            if vm.borderColor != null
+            then "--border \"${vm.borderColor}\""
+            else "";
+          runWaypipe = with pkgs;
+            writeScriptBin "run-waypipe" ''
+              #!${runtimeShell} -e
+              ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString configHost.ghaf.virtualization.microvm.guivm.waypipePort} ${waypipeBorder} server $@
+            '';
+        in {
           ghaf = {
             users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
 
@@ -65,6 +75,7 @@
 
           environment.systemPackages = [
             pkgs.waypipe
+            runWaypipe
           ];
 
           microvm = {
@@ -159,6 +170,13 @@ in {
               '';
               type = int;
               default = 0;
+            };
+            borderColor = mkOption {
+              description = ''
+                Border color of the AppVM window
+              '';
+              type = nullOr str;
+              default = null;
             };
           };
         });


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This is a proof of concept XDG handler for PDF files. 

When a user attempts to open a PDF file from Chromium, it executes the openpdf script. The script sends the PDF file path to the GUIVM over a TCP connection. The GUIVM copies the file from chromium-vm to a temporary location in the zathura-vm and opens it there. Once the viewer is closed, the file is deleted from the zathura-vm.

Sending the file path over a TCP connection with the netcat is obviously not ideal. It should be updated once we have some inter-vm communication mechanism developed. Also, using the scp command might not be needed once we have support for permanent file storage.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

1. Connect to the internet.
2. Open Chromium browser and download any PDF file.
3. Click on the downloaded PDF and make sure it opens in zathura-vm.
4. Try to open multiple PDF files simultaneously.