### PR TITLE
Instructions on how to use a Linux computer as a router for NVIDIA Je…

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -30,6 +30,7 @@
     - [Cross-Compilation](ref_impl/cross_compilation.md)
     - [Creating Application VM](ref_impl/creating_appvm.md)
     - [LabWC Desktop Environment](ref_impl/labwc.md)
+    - [Using a Laptop as a Router](ref_impl/linux-router.md)
   - [Ghaf as Library: Templates](ref_impl/ghaf-based-project.md)
     - [Example Project](ref_impl/example_project.md)
     - [Modules Options](ref_impl/modules_options.md)

--- a/docs/src/ref_impl/development.md
+++ b/docs/src/ref_impl/development.md
@@ -15,6 +15,7 @@ The scope of target support is updated with development progress:
 * [Cross-Compilation](./cross_compilation.md)
 * [Creating Application VM](./creating_appvm.md)
 * [labwc Desktop Environment](./labwc.md)
+* [Using a Laptop as a Router](./linux-router.md)
 
 Once you are up and running, you can participate in the collaborative development process by building a development build with additional options. For example, with the development username and password that are defined in [accounts.nix](https://github.com/tiiuae/ghaf/blob/main/modules/users/accounts.nix).
 

--- a/docs/src/ref_impl/linux-router.md
+++ b/docs/src/ref_impl/linux-router.md
@@ -1,0 +1,102 @@
+<!--
+	Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+	SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# How to Use a Linux Laptop or Computer as a Router for Ghaf.
+
+Because Ghaf’s Wifi is reserved by NetVM an additional network is needed for a debugging
+setup. A Linux computer can be used to provide internet accces to Ghaf. The Linux computer,
+for instance a laptop with a mainstream Linux distro can act as a router.
+
+The role of the Linux computer is to forward its access to internet via a shared Ethernet
+connection to Ghaf on Jetson.
+
+---
+
+## Preparations
+
+1. Make sure the Linux computer is *fully connected* to the internet and that an Ethernet
+   device *is free* to be configured for sharing. Typically the computer would have internet 
+   over its Wifi device leaving the Ethernet device unused. These instructions do not 
+   describe how to provide internet access to the router/laptop using Wifi.
+
+1. Connect the Linux computer using an Ethernet cable to Jetson in a peer-to-peer fashion.
+
+1. The Ethernet device in Jetson is called eth0 but in Linux it probably has another name.
+	Note that most Linux distributions use NetworkManager (providing for instance the nmcli
+	tool) and Ghaf uses networkd (providing networkctl).
+
+	You can inspect the devices and IP adresses in a NetworkManager system using `nmcli c s`
+	and `ifconfig`. In a networkd system like Ghaf you can use `ip address show eth0` and `ifconfig`
+	( the `ip` command is usually also available on NetworkManager systems)
+
+##  On the Linux computer
+
+1.	Find out the name of the Ethernet device using nmcli. Typically the connection is named 
+    *'Wired Connection 1'* or something similar. NetworkManager and nmcli declares its 
+    type as Ethernet.
+
+	Take note of the connection name and the Ethernet device name.
+
+    ```
+	nmcli connection show
+
+    ```
+
+1. Clone the Ethernet device with:
+
+    ```
+	sudo nmcli connection clone Wired\ Connection\ 1 Shared\ Connection
+
+1.	Set ipv4 mode to shared and disable ipv6
+
+    ```
+	sudo nmcli connection modify Shared\ Connection ipv4.method shared
+	sudo nmcli connection modify Shared\ Connection ipv6.method disabled
+    ```
+
+1.	Make sure the new configuration is active
+
+    ```
+	sudo nmcli connection down Wired\ Connection\ 1
+	sudo nmcli connection down Shared\ Connection
+	sudo nmcli connection reload Shared\ Connection
+	sudo nmcli connection up Shared\ Connection
+    ```
+
+1.	Note the IP address and Ethernet device name of Shared Connection using.
+
+    ```
+    nmcli connection show
+	if config <ethernet device name>
+    ```
+
+	The IP could be something like '10.42.0.1'. Note the addresspace or the netmask, typically 255.255.255.0 or /24.
+
+## On Ghaf
+
+1.	Log in to Ghaf using the serial console and for instance picocom
+
+    ```
+	sudo picocom -b 115200 /dev/ttyACM0
+    ```
+
+1.	Set the IP address of Ethernet on Ghaf within the namespace of the Shared Connection.
+	Do not use exactly the same IP address as the router, but use the same netmask.
+
+    ```
+	sudo ip address add 10.42.0.2/24 dev eth0
+	sudo ifconfig eth0 down
+	sudo ifconfig eth0 up
+    ```
+
+1. You can verify the result from Ghaf with
+
+    ```
+	ip address show eth0
+	ifconfig
+	ping 10.42.0.1
+	host elisa.fi
+	ping -c2 elisa.fi
+    ```


### PR DESCRIPTION
…tson

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Documentation Describing How to Make a Linux Router for NVIDIA Jetson

Because Ghaf’s Wifi is reserved by NetVM an additional network is needed for a debugging
setup. A Linux computer can be used to provide internet accces to Ghaf. The Linux computer,
for instance a laptop with a mainstream Linux distro can act as a router.

## Checklist for things done

Added files:
docs/src/SUMMARY.md
docs/src/ref_impl/development.md
docs/src/ref_impl/linux-router.md

Signature added
old PR deleted


