### PR TITLE
Wayland displaying using shared memory between virtual machines

### DIFF
--- a/modules/common/systemd/hardened-configs/common/microvm@.nix
+++ b/modules/common/systemd/hardened-configs/common/microvm@.nix
@@ -25,7 +25,7 @@
   ProtectSystem = "full";
   ProtectProc = "noaccess";
   # ReadWritePaths=[ "/etc"];
-  PrivateTmp = true;
+  PrivateTmp = false;
 
   # Not applicable for the service runs as root
   # PrivateMounts=true;

--- a/modules/common/users/accounts.nix
+++ b/modules/common/users/accounts.nix
@@ -23,6 +23,13 @@ in
         A default user to create in the system.
       '';
     };
+    uid = mkOption {
+      default = 1000;
+      type = with types; int;
+      description = ''
+        A default user id for the user.
+      '';
+    };
     password = mkOption {
       default = "ghaf";
       type = with types; str;
@@ -38,6 +45,7 @@ in
       users."${cfg.user}" = {
         isNormalUser = true;
         inherit (cfg) password;
+        inherit (cfg) uid;
         #TODO add "docker" use "lib.optionals"
         extraGroups = [
           "wheel"

--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -431,13 +431,13 @@ let
           ${pkgs.systemd}/bin/loginctl lock-session
 
           # Switch off display before suspension
-          WAYLAND_DISPLAY=/run/user/1000/wayland-0 ${pkgs.wlopm}/bin/wlopm --off '*'
+          WAYLAND_DISPLAY=/run/user/${builtins.toString config.ghaf.users.accounts.uid}/wayland-0 ${pkgs.wlopm}/bin/wlopm --off '*'
 
           # Send suspend command to host
           ${if useGivc then "${pkgs.givc-cli}/bin/givc-cli ${cliArgs}" else "systemctl"} suspend
 
           # Switch on display on wakeup
-          WAYLAND_DISPLAY=/run/user/1000/wayland-0 ${pkgs.wlopm}/bin/wlopm --on '*'
+          WAYLAND_DISPLAY=/run/user/${builtins.toString config.ghaf.users.accounts.uid}/wayland-0 ${pkgs.wlopm}/bin/wlopm --on '*'
           ;;
       *)
           echo "Invalid argument: $1"

--- a/modules/hardware/common/default.nix
+++ b/modules/hardware/common/default.nix
@@ -8,5 +8,6 @@
     ./devices.nix
     ./kernel.nix
     ./qemu.nix
+    ./shared-mem.nix
   ];
 }

--- a/modules/hardware/common/shared-mem.nix
+++ b/modules/hardware/common/shared-mem.nix
@@ -1,0 +1,259 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Module for Shared Memory Definitions
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.shm;
+  inherit (lib)
+    foldl'
+    lists
+    mkMerge
+    mkIf
+    mkOption
+    mdDoc
+    types
+    ;
+in
+{
+  options.ghaf.shm = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = mdDoc ''
+        Enables shared memory communication between virtual machines (VMs)
+      '';
+    };
+    memSize = mkOption {
+      type = types.int;
+      default = 16;
+      description = mdDoc ''
+        Specifies the size of the shared memory region, measured in 
+        megabytes (MB)
+      '';
+    };
+    hugePageSz = mkOption {
+      type = types.str;
+      default = "2M";
+      description = mdDoc ''
+        Specifies the size of the large memory page area. Supported kernel 
+        values are 2 MB and 1 GB
+      '';
+      apply =
+        value:
+        if value != "2M" && value != "1G" then
+          builtins.throw "Invalid huge memory area page size"
+        else
+          value;
+    };
+    hostSocketPath = mkOption {
+      type = types.path;
+      default = "/tmp/ivshmem_socket"; # The value is hardcoded in the application
+      description = mdDoc ''
+        Specifies the path to the shared memory socket, used by QEMU 
+        instances for inter-VM memory sharing and interrupt signaling
+      '';
+    };
+    flataddr = mkOption {
+      type = types.str;
+      default = "0x920000000";
+      description = mdDoc ''
+        Maps the shared memory to a physical address if set to a non-zero value.
+        The address must be platform-specific and arbitrarily chosen to avoid 
+        conflicts with other memory areas, such as PCI regions.
+      '';
+    };
+    vms_enabled = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = mdDoc ''
+        List of vms having access to shared memory
+      '';
+    };
+    enable_host = mkOption {
+      type = types.bool;
+      default = false;
+      description = mdDoc ''
+        Enables the memsocket functionality on the host system
+      '';
+    };
+    instancesCount = mkOption {
+      type = types.int;
+      default =
+        if cfg.enable_host then (builtins.length cfg.vms_enabled) + 1 else builtins.length cfg.vms_enabled;
+      description = mdDoc ''
+        Number of memory slots allocated in the shared memory region
+      '';
+    };
+    serverSocketPath = mkOption {
+      type = types.path;
+      default = "/run/user/${builtins.toString config.ghaf.users.accounts.uid}/memsocket-server.sock";
+      description = mdDoc ''
+        Specifies the path of the listening socket, which is used by Waypipe 
+        or other server applications as the output socket in server mode for 
+        data transmission
+      '';
+    };
+    clientSocketPath = mkOption {
+      type = types.path;
+      default = "/run/user/${builtins.toString config.ghaf.users.accounts.uid}/memsocket-client.sock";
+      description = mdDoc ''
+        Specifies the location of the output socket, which will connected to 
+        in order to receive data from AppVMs. This socket must be created by 
+        another application, such as Waypipe, when operating in client mode
+      '';
+    };
+    display = mkOption {
+      type = types.bool;
+      default = false;
+      description = mdDoc ''
+        Enables the use of shared memory with Waypipe for Wayland-enabled 
+        applications running on virtual machines (VMs), facilitating 
+        efficient inter-VM communication
+      '';
+    };
+  };
+  config =
+    let
+      user = "microvm";
+      group = "kvm";
+    in
+    mkIf cfg.enable (mkMerge [
+      {
+        boot.kernelParams =
+          let
+            hugepages = if cfg.hugePageSz == "2M" then cfg.memSize / 2 else cfg.memSize / 1024;
+          in
+          [
+            "hugepagesz=${cfg.hugePageSz}"
+            "hugepages=${toString hugepages}"
+          ];
+      }
+      {
+        systemd.tmpfiles.rules = [
+          "d /dev/hugepages 0755 ${user} ${group} - -"
+        ];
+      }
+      (mkIf cfg.enable_host {
+        environment.systemPackages = [
+          (pkgs.callPackage ../../../packages/memsocket { vms = cfg.instancesCount; })
+        ];
+      })
+      {
+        systemd.services.ivshmemsrv =
+          let
+            pidFilePath = "/tmp/ivshmem-server.pid";
+            ivShMemSrv =
+              let
+                vectors = toString (2 * cfg.instancesCount);
+              in
+              pkgs.writeShellScriptBin "ivshmemsrv" ''
+                if [ -S ${cfg.hostSocketPath} ]; then
+                  echo Erasing ${cfg.hostSocketPath} ${pidFilePath}
+                  rm -f ${cfg.hostSocketPath}
+                fi
+                ${pkgs.qemu_kvm}/bin/ivshmem-server -p ${pidFilePath} -n ${vectors} -m /dev/hugepages/ -l ${(toString cfg.memSize) + "M"}
+              '';
+          in
+          {
+            enable = true;
+            description = "Start qemu ivshmem memory server";
+            path = [ ivShMemSrv ];
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              StandardOutput = "journal";
+              StandardError = "journal";
+              ExecStart = "${ivShMemSrv}/bin/ivshmemsrv";
+              User = user;
+              Group = group;
+            };
+          };
+      }
+      {
+        microvm.vms =
+          let
+            memsocket = pkgs.callPackage ../../../packages/memsocket { vms = cfg.instancesCount; };
+            vectors = toString (2 * cfg.instancesCount);
+            makeAssignment = vmName: {
+              ${vmName} = {
+                config = {
+                  config = {
+                    microvm = {
+                      qemu = {
+                        extraArgs = [
+                          "-device"
+                          "ivshmem-doorbell,vectors=${vectors},chardev=ivs_socket,flataddr=${cfg.flataddr}"
+                          "-chardev"
+                          "socket,path=${cfg.hostSocketPath},id=ivs_socket"
+                        ];
+                      };
+                      kernelParams = [ "kvm_ivshmem.flataddr=${cfg.flataddr}" ];
+                    };
+                    boot.extraModulePackages = [
+                      (pkgs.linuxPackages.callPackage ../../../packages/memsocket/module.nix {
+                        inherit (config.microvm.vms.${vmName}.config.config.boot.kernelPackages) kernel;
+                        vmCount = cfg.instancesCount;
+                      })
+                    ];
+                    services = {
+                      udev = {
+                        extraRules = ''
+                          SUBSYSTEM=="misc",KERNEL=="ivshmem",GROUP="kvm",MODE="0666"
+                        '';
+                      };
+                    };
+                    environment.systemPackages = [
+                      memsocket
+                    ];
+                    systemd.user.services.memsocket =
+                      if vmName == "gui-vm" then
+                        {
+                          enable = true;
+                          description = "memsocket";
+                          after = [ "labwc.service" ];
+                          serviceConfig = {
+                            Type = "simple";
+                            ExecStart = "${memsocket}/bin/memsocket -c ${cfg.clientSocketPath}";
+                            Restart = "always";
+                            RestartSec = "1";
+                          };
+                          wantedBy = [ "ghaf-session.target" ];
+                        }
+                      else
+                        # machines connecting to gui-vm
+                        let
+                          vmIndex = lists.findFirstIndex (vm: vm == vmName) null cfg.vms_enabled;
+                        in
+                        {
+                          enable = true;
+                          description = "memsocket";
+                          serviceConfig = {
+                            Type = "simple";
+                            ExecStart = "${memsocket}/bin/memsocket -s ${cfg.serverSocketPath} ${builtins.toString vmIndex}";
+                            Restart = "always";
+                            RestartSec = "1";
+                          };
+                          wantedBy = [ "default.target" ];
+                        };
+                  };
+                };
+              };
+            };
+          in
+          foldl' lib.attrsets.recursiveUpdate { } (map makeAssignment cfg.vms_enabled);
+      }
+      {
+        microvm.vms.gui-vm.config.config.boot.kernelParams = [
+          "kvm_ivshmem.flataddr=${cfg.flataddr}"
+        ];
+      }
+    ]);
+}

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -16,6 +16,7 @@
       ./virtualization/microvm/modules.nix
       ./networking.nix
       ./power-control.nix
+      ../hardware/common/shared-mem.nix
     ];
   };
 }

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -117,7 +117,7 @@ let
                   # Switch off display, if wayland is running
                   if ${pkgs.procps}/bin/pgrep -fl "wayland" > /dev/null; then
                     wl_running=1
-                    WAYLAND_DISPLAY=/run/user/1000/wayland-0 ${pkgs.wlopm}/bin/wlopm --off '*'
+                    WAYLAND_DISPLAY=/run/user/${builtins.toString config.ghaf.users.accounts.uid}/wayland-0 ${pkgs.wlopm}/bin/wlopm --off '*'
                   else
                     wl_running=0
                   fi
@@ -127,7 +127,7 @@ let
 
                   # Enable display
                   if [ "$wl_running" -eq 1 ]; then
-                    WAYLAND_DISPLAY=/run/user/1000/wayland-0 ${pkgs.wlopm}/bin/wlopm --on '*'
+                    WAYLAND_DISPLAY=/run/user/${builtins.toString config.ghaf.users.accounts.uid}/wayland-0 ${pkgs.wlopm}/bin/wlopm --on '*'
                   fi
                   ;;
                 "button/lid LID open")

--- a/overlays/custom-packages/qemu/0001-ivshmem-flat-memory-support.patch
+++ b/overlays/custom-packages/qemu/0001-ivshmem-flat-memory-support.patch
@@ -1,0 +1,258 @@
+From 13229d9e11eaf15eb6679be036364b9d0256f1c1 Mon Sep 17 00:00:00 2001
+From: Jaroslaw Kurowski <jaroslaw.kurowski@tii.ae>
+Date: Wed, 10 Jul 2024 15:21:07 +0400
+Subject: ivshmem flat memory support
+
+---
+ contrib/ivshmem-server/ivshmem-server.c |  6 +-
+ hw/i386/pc_q35.c                        |  2 +
+ hw/misc/ivshmem.c                       | 74 ++++++++++++++++++++++---
+ include/hw/misc/ivshmem.h               |  1 +
+ 4 files changed, 71 insertions(+), 12 deletions(-)
+
+diff --git a/contrib/ivshmem-server/ivshmem-server.c b/contrib/ivshmem-server/ivshmem-server.c
+index 2f3c732..906c5d0 100644
+--- a/contrib/ivshmem-server/ivshmem-server.c
++++ b/contrib/ivshmem-server/ivshmem-server.c
+@@ -11,6 +11,7 @@
+ 
+ #include <sys/socket.h>
+ #include <sys/un.h>
++#include <sys/mman.h>
+ 
+ #include "ivshmem-server.h"
+ 
+@@ -297,11 +298,10 @@ ivshmem_server_start(IvshmemServer *server)
+                              server->shm_path);
+         shm_fd = shm_open(server->shm_path, O_CREAT | O_RDWR, S_IRWXU);
+     } else {
+-        gchar *filename = g_strdup_printf("%s/ivshmem.XXXXXX", server->shm_path);
++        gchar *filename = g_strdup_printf("%s/ivshmem", server->shm_path);
+         IVSHMEM_SERVER_DEBUG(server, "Using file-backed shared memory: %s\n",
+                              server->shm_path);
+-        shm_fd = mkstemp(filename);
+-        unlink(filename);
++        shm_fd = open(filename, O_RDWR | O_CREAT, 0666);
+         g_free(filename);
+     }
+ 
+diff --git a/hw/i386/pc_q35.c b/hw/i386/pc_q35.c
+index c7bc8a2..d76939e 100644
+--- a/hw/i386/pc_q35.c
++++ b/hw/i386/pc_q35.c
+@@ -28,6 +28,7 @@
+  * THE SOFTWARE.
+  */
+ 
++#include "hw/misc/ivshmem.h"
+ #include "qemu/osdep.h"
+ #include "qemu/units.h"
+ #include "hw/acpi/acpi.h"
+@@ -361,6 +362,7 @@ static void pc_q35_machine_options(MachineClass *m)
+     machine_class_allow_dynamic_sysbus_dev(m, TYPE_INTEL_IOMMU_DEVICE);
+     machine_class_allow_dynamic_sysbus_dev(m, TYPE_RAMFB_DEVICE);
+     machine_class_allow_dynamic_sysbus_dev(m, TYPE_VMBUS_BRIDGE);
++    machine_class_allow_dynamic_sysbus_dev(m, TYPE_IVSHMEM_FLAT);
+     compat_props_add(m->compat_props,
+                      pc_q35_compat_defaults, pc_q35_compat_defaults_len);
+ }
+diff --git a/hw/misc/ivshmem.c b/hw/misc/ivshmem.c
+index de49d1b..b1761b3 100644
+--- a/hw/misc/ivshmem.c
++++ b/hw/misc/ivshmem.c
+@@ -36,6 +36,7 @@
+ #include "chardev/char-fe.h"
+ #include "sysemu/hostmem.h"
+ #include "qapi/visitor.h"
++#include "hw/sysbus.h"
+ 
+ #include "hw/misc/ivshmem.h"
+ #include "qom/object.h"
+@@ -59,6 +60,7 @@
+ 
+ #define TYPE_IVSHMEM_COMMON "ivshmem-common"
+ typedef struct IVShmemState IVShmemState;
++typedef struct IvshmemFTState IvshmemFTState;
+ DECLARE_INSTANCE_CHECKER(IVShmemState, IVSHMEM_COMMON,
+                          TYPE_IVSHMEM_COMMON)
+ 
+@@ -74,6 +76,9 @@ DECLARE_INSTANCE_CHECKER(IVShmemState, IVSHMEM_DOORBELL,
+ DECLARE_INSTANCE_CHECKER(IVShmemState, IVSHMEM,
+                          TYPE_IVSHMEM)
+ 
++#define TYPE_IVSHMEM_FLAT "ivshmem-flat"
++DECLARE_INSTANCE_CHECKER(IvshmemFTState, IVSHMEM_FLAT, TYPE_IVSHMEM_FLAT)
++
+ typedef struct Peer {
+     int nb_eventfds;
+     EventNotifier *eventfds;
+@@ -117,6 +122,15 @@ struct IVShmemState {
+     /* migration stuff */
+     OnOffAuto master;
+     Error *migration_blocker;
++
++    /* flat memory stuff */
++    uint64_t flataddr;
++    DeviceState *flat_dev;
++    MemoryRegion flat_mem;
++};
++
++struct IvshmemFTState {
++    SysBusDevice parent_obj;
+ };
+ 
+ /* registers for the Inter-VM shared memory device */
+@@ -476,8 +490,11 @@ static void setup_interrupt(IVShmemState *s, int vector, Error **errp)
+ 
+ static void process_msg_shmem(IVShmemState *s, int fd, Error **errp)
+ {
++    Error *local_err = NULL;
+     struct stat buf;
+     size_t size;
++    void *ptr;
++    SysBusDevice *sbd;
+ 
+     if (s->ivshmem_bar2) {
+         error_setg(errp, "server sent unexpected shared memory message");
+@@ -494,13 +511,26 @@ static void process_msg_shmem(IVShmemState *s, int fd, Error **errp)
+ 
+     size = buf.st_size;
+ 
++    if (s->flataddr) {
++
++        ptr = mmap(0, size, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_HUGETLB|MAP_LOCKED,
++                fd, 0);
++        s->flat_dev = sysbus_create_simple(TYPE_IVSHMEM_FLAT, -1, 0);
++
++        memory_region_init_ram_ptr(&s->flat_mem, OBJECT(IVSHMEM_FLAT(s->flat_dev)),
++                                   "ivshmem.flat", size, ptr);
++        sbd = SYS_BUS_DEVICE(s->flat_dev);
++        sysbus_init_mmio(sbd, &s->flat_mem);
++        sysbus_mmio_map(sbd, 0, s->flataddr);
++    }
++
+     /* mmap the region and map into the BAR2 */
+-    if (!memory_region_init_ram_from_fd(&s->server_bar2, OBJECT(s),
+-                                        "ivshmem.bar2", size, RAM_SHARED,
+-                                        fd, 0, errp)) {
++    memory_region_init_ram_from_fd(&s->server_bar2, OBJECT(s), "ivshmem.bar2",
++                                   size, RAM_SHARED, fd, 0, &local_err);
++    if (local_err) {
++        error_propagate(errp, local_err);
+         return;
+     }
+-
+     s->ivshmem_bar2 = &s->server_bar2;
+ }
+ 
+@@ -832,7 +862,6 @@ static void ivshmem_write_config(PCIDevice *pdev, uint32_t address,
+ 
+ static void ivshmem_common_realize(PCIDevice *dev, Error **errp)
+ {
+-    ERRP_GUARD();
+     IVShmemState *s = IVSHMEM_COMMON(dev);
+     Error *err = NULL;
+     uint8_t *pci_conf;
+@@ -902,7 +931,8 @@ static void ivshmem_common_realize(PCIDevice *dev, Error **errp)
+     if (!ivshmem_is_master(s)) {
+         error_setg(&s->migration_blocker,
+                    "Migration is disabled when using feature 'peer mode' in device 'ivshmem'");
+-        if (migrate_add_blocker(&s->migration_blocker, errp) < 0) {
++        if (migrate_add_blocker(s->migration_blocker, errp) < 0) {
++            error_free(s->migration_blocker);
+             return;
+         }
+     }
+@@ -920,7 +950,10 @@ static void ivshmem_exit(PCIDevice *dev)
+     IVShmemState *s = IVSHMEM_COMMON(dev);
+     int i;
+ 
+-    migrate_del_blocker(&s->migration_blocker);
++    if (s->migration_blocker) {
++        migrate_del_blocker(s->migration_blocker);
++        error_free(s->migration_blocker);
++    }
+ 
+     if (memory_region_is_mapped(s->ivshmem_bar2)) {
+         if (!s->hostmem) {
+@@ -1014,7 +1047,7 @@ static const VMStateDescription ivshmem_plain_vmsd = {
+     .minimum_version_id = 0,
+     .pre_load = ivshmem_pre_load,
+     .post_load = ivshmem_post_load,
+-    .fields = (const VMStateField[]) {
++    .fields = (VMStateField[]) {
+         VMSTATE_PCI_DEVICE(parent_obj, IVShmemState),
+         VMSTATE_UINT32(intrstatus, IVShmemState),
+         VMSTATE_UINT32(intrmask, IVShmemState),
+@@ -1068,7 +1101,7 @@ static const VMStateDescription ivshmem_doorbell_vmsd = {
+     .minimum_version_id = 0,
+     .pre_load = ivshmem_pre_load,
+     .post_load = ivshmem_post_load,
+-    .fields = (const VMStateField[]) {
++    .fields = (VMStateField[]) {
+         VMSTATE_PCI_DEVICE(parent_obj, IVShmemState),
+         VMSTATE_MSIX(parent_obj, IVShmemState),
+         VMSTATE_UINT32(intrstatus, IVShmemState),
+@@ -1083,6 +1116,7 @@ static Property ivshmem_doorbell_properties[] = {
+     DEFINE_PROP_BIT("ioeventfd", IVShmemState, features, IVSHMEM_IOEVENTFD,
+                     true),
+     DEFINE_PROP_ON_OFF_AUTO("master", IVShmemState, master, ON_OFF_AUTO_OFF),
++    DEFINE_PROP_UINT64("flataddr", IVShmemState, flataddr, 0),
+     DEFINE_PROP_END_OF_LIST(),
+ };
+ 
+@@ -1115,6 +1149,20 @@ static void ivshmem_doorbell_class_init(ObjectClass *klass, void *data)
+     dc->vmsd = &ivshmem_doorbell_vmsd;
+ }
+ 
++static Property ivshmem_flat_props[] = {
++    DEFINE_PROP_END_OF_LIST(),
++};
++
++static void ivshmem_flat_class_init(ObjectClass *klass, void *data)
++{
++    DeviceClass *dc = DEVICE_CLASS(klass);
++
++    dc->hotpluggable = true;
++    set_bit(DEVICE_CATEGORY_MISC, dc->categories);
++    device_class_set_props(dc, ivshmem_flat_props);
++    dc->user_creatable = false;
++}
++
+ static const TypeInfo ivshmem_doorbell_info = {
+     .name          = TYPE_IVSHMEM_DOORBELL,
+     .parent        = TYPE_IVSHMEM_COMMON,
+@@ -1123,11 +1171,19 @@ static const TypeInfo ivshmem_doorbell_info = {
+     .class_init    = ivshmem_doorbell_class_init,
+ };
+ 
++static const TypeInfo ivshmem_flat_info = {
++    .name = TYPE_IVSHMEM_FLAT,
++    .parent = TYPE_SYS_BUS_DEVICE,
++    .instance_size = sizeof(IvshmemFTState),
++    .class_init = ivshmem_flat_class_init,
++};
++
+ static void ivshmem_register_types(void)
+ {
+     type_register_static(&ivshmem_common_info);
+     type_register_static(&ivshmem_plain_info);
+     type_register_static(&ivshmem_doorbell_info);
++    type_register_static(&ivshmem_flat_info);
+ }
+ 
+ type_init(ivshmem_register_types)
+diff --git a/include/hw/misc/ivshmem.h b/include/hw/misc/ivshmem.h
+index 433ef53..43aeab7 100644
+--- a/include/hw/misc/ivshmem.h
++++ b/include/hw/misc/ivshmem.h
+@@ -21,5 +21,6 @@
+ #define IVSHMEM_H
+ 
+ #define IVSHMEM_PROTOCOL_VERSION 0
++#define TYPE_IVSHMEM_FLAT "ivshmem-flat"
+ 
+ #endif /* IVSHMEM_H */
+-- 
+2.45.2
+

--- a/overlays/custom-packages/qemu/default.nix
+++ b/overlays/custom-packages/qemu/default.nix
@@ -12,6 +12,16 @@ prev.qemu_kvm.overrideAttrs (
     patches = prev.patches ++ [ ./acpi-devices-passthrough-qemu-8.0.patch ];
   })
   // (final.lib.optionalAttrs (final.lib.versionAtLeast qemu_version "8.1") {
-    patches = prev.patches ++ [ ./acpi-devices-passthrough-qemu-8.1.patch ];
+    patches = prev.patches ++ [
+      ./acpi-devices-passthrough-qemu-8.1.patch
+      ./0001-ivshmem-flat-memory-support.patch
+    ];
   })
+  // {
+    postInstall =
+      (prev.postInstall or "")
+      + ''
+        cp contrib/ivshmem-server/ivshmem-server $out/bin
+      '';
+  }
 )

--- a/packages/memsocket/default.nix
+++ b/packages/memsocket/default.nix
@@ -1,0 +1,36 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenv,
+  lib,
+  debug ? false,
+  vms,
+  fetchFromGitHub,
+  ...
+}:
+stdenv.mkDerivation {
+  name = "memsocket";
+
+  src = fetchFromGitHub {
+    owner = "tiiuae";
+    repo = "shmsockproxy";
+    rev = "2357926b94ed12c050fdbfbfc0f248393a4c9ea1";
+    sha256 = "sha256-9KlHuVbe5qvjRUXj7oyJ1X7CLvqj7/OoVGDWRqpIY2s=";
+  };
+
+  CFLAGS = "-O2 -DVM_COUNT=" + (toString vms) + (if debug then " -DDEBUG_ON" else "");
+  sourceRoot = "source/app";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install ./memsocket $out/bin/memsocket
+  '';
+
+  meta = with lib; {
+    description = "memsocket";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/packages/memsocket/module.nix
+++ b/packages/memsocket/module.nix
@@ -1,0 +1,42 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenv,
+  lib,
+  kernel,
+  fetchFromGitHub,
+  vmCount,
+  ...
+}:
+stdenv.mkDerivation {
+  inherit vmCount;
+  name = "ivshmem-driver-${kernel.version}";
+
+  src = fetchFromGitHub {
+    owner = "tiiuae";
+    repo = "shmsockproxy";
+    rev = "2357926b94ed12c050fdbfbfc0f248393a4c9ea1";
+    sha256 = "sha256-9KlHuVbe5qvjRUXj7oyJ1X7CLvqj7/OoVGDWRqpIY2s=";
+  };
+
+  sourceRoot = "source/module";
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "MODULEDIR=$(out)/lib/modules/${kernel.modDirVersion}/kernel/drivers/char"
+    "CFLAGS_kvm_ivshmem.o=\"-DCONFIG_KVM_IVSHMEM_VM_COUNT=${builtins.toString vmCount}\""
+  ];
+
+  meta = with lib; {
+    description = "Shared memory Linux kernel module";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/packages/wifi-signal-strength/default.nix
+++ b/packages/wifi-signal-strength/default.nix
@@ -41,7 +41,7 @@ writeShellApplication {
         -o UserKnownHostsFile=/dev/null \
         -o StreamLocalBindUnlink=yes \
         -o ExitOnForwardFailure=yes \
-        -L /tmp/ssh_session_dbus.sock:/run/user/1000/bus \
+        -L /tmp/ssh_session_dbus.sock:/run/user/${builtins.toString config.ghaf.users.accounts.uid}/bus \
         -L /tmp/ssh_system_dbus.sock:/run/dbus/system_bus_socket
     signal0="\UF091F"
     signal1="\UF0922"


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Add memory sharing mechanism between virtual machines and use it for wayland/waypipe displaying.

#### Main changes:

### Host

- Added the shared memory manager within QEMU.
- Direct Memory Mapping via SysBus:
  - Modified QEMU's code to map shared memory directly into the VM's memory address space using the SysBus interface.
- Option for Defining Shared Memory Manager:
  - Added an option to QEMU for defining a shared memory manager when running VMs.
- BigPages Area Allocation:
  - Allocated shared memory within the BigPages area for optimized memory usage.
 
### GUI and app VMs

1. **Linux Driver for Shared Memory and Interrupts:**
   - Added a Linux driver to manage shared memory operations and interrupts and creating the `/dev/ivshmem` device.

2. **Memsocket Application for Inter-VM Communication:**
   - Introduced the `memsocket` application to facilitate socket data forwarding between VMs.

3. **Integration with Waypipe:**
   - Modified Waypipe service options to interface with the `memsocket` application, enabling seamless communication between VMs.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) [ticket id](https://ssrc.atlassian.net/browse/SP-3805)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
Run Chromium and other wayland enabled application. Verify that they execute and display properly.
Run performance tests described in [documentation](https://ssrc.atlassian.net/wiki/spaces/~62552e6ffdb60b006927ad98/pages/825720835/Wayland+displaying+with+shared+memory)
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->

## Jira ticket:
https://ssrc.atlassian.net/browse/SP-3805

## Documentation:
https://ssrc.atlassian.net/wiki/spaces/~62552e6ffdb60b006927ad98/blog/2022/09/29/612958326/Memory+sharing+between+virtual+machines
https://ssrc.atlassian.net/wiki/spaces/~62552e6ffdb60b006927ad98/pages/825720835/Wayland+displaying+with+shared+memory

## Summary of performance
Playing YouTube is smooth, up to a resolution of 2160p. 
CPU consumption by the memsocket application is below 5%, usually 3-6%.
iperf results are presented in [documentation](https://ssrc.atlassian.net/wiki/spaces/~62552e6ffdb60b006927ad98/pages/825720835/Wayland+displaying+with+shared+memory)
