### PR TITLE
Add TPM2-PKCS11 support for X1 Carbon

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -17,6 +17,7 @@
   ./profiles/graphics.nix
   ./profiles/installer.nix
   ./profiles/release.nix
+  ./security/tpm2.nix
   ./users/accounts.nix
   ./version
   ./virtualization/docker.nix

--- a/modules/security/tpm2.nix
+++ b/modules/security/tpm2.nix
@@ -1,0 +1,35 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.ghaf.security.tpm2;
+in
+  with lib; {
+    options.ghaf.security.tpm2 = {
+      enable = mkEnableOption "TPM2 PKCS#11 interface";
+    };
+
+    config = mkIf cfg.enable {
+      security.tpm2 = {
+        enable = true;
+        pkcs11.enable = true;
+        abrmd.enable = true;
+      };
+
+      environment.systemPackages = mkIf config.ghaf.profiles.debug.enable [
+        pkgs.opensc
+        pkgs.tpm2-tools
+      ];
+
+      assertions = [
+        {
+          assertion = pkgs.stdenv.isx86_64;
+          message = "TPM2 is only supported on x86_64";
+        }
+      ];
+    };
+  }

--- a/modules/users/accounts.nix
+++ b/modules/users/accounts.nix
@@ -37,7 +37,10 @@ in
           isNormalUser = true;
           inherit (cfg) password;
           #TODO add "docker" use "lib.optionals"
-          extraGroups = ["wheel" "video" "networkmanager"];
+          extraGroups =
+            ["wheel" "video" "networkmanager"]
+            ++ optionals
+            config.ghaf.security.tpm2.enable ["tss"];
         };
         groups."${cfg.user}" = {
           name = cfg.user;

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -13,5 +13,6 @@ _: {
     (import ./qemu)
     (import ./nm-launcher)
     (import ./labwc)
+    (import ./tpm2-pkcs11)
   ];
 }

--- a/overlays/custom-packages/tpm2-pkcs11/default.nix
+++ b/overlays/custom-packages/tpm2-pkcs11/default.nix
@@ -1,0 +1,10 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This overlay customizes tpm2-pkcs11 - see comments for details
+#
+(_final: prev: {
+  tpm2-pkcs11 = prev.tpm2-pkcs11.overrideAttrs (_prevAttrs: {
+    configureFlags = ["--with-fapi=no --enable-fapi=no"];
+  });
+})

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -327,6 +327,8 @@
 
               hardware.x86_64.common.enable = true;
 
+              security.tpm2.enable = true;
+
               virtualization.microvm-host.enable = true;
               host.networking.enable = true;
               virtualization.microvm.netvm = {


### PR DESCRIPTION
This adds the initial support by providing a PKCS11 interface on the host system for the X1 Carbon, utilising the hardware TPM2.

We had to temporarily disable Feature API (FAPI) by overlaying the package, as the tests were failing. And we don't use it anyways.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->
Added TPM2-PKCS11 package and double-checked it worked.



## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
How to test:
1. SSH into the debug system.
2. SSH into host: `ssh 192.168.101.2`
3. Create an alias: `alias tpm2pkcs11-tool="pkcs11-tool --module /run/current-system/sw/lib/libtpm2_pkcs11.so"`
4. Test: `tpm2pkcs11-tool --list-token-slots`


Find more details on this page: https://github.com/tpm2-software/tpm2-pkcs11/blob/master/docs/INITIALIZING.md