### PR TITLE
Introduce new disk partitioning scheme

### DIFF
--- a/modules/common/systemd/hardened-configs/common/systemd-remount-fs.nix
+++ b/modules/common/systemd/hardened-configs/common/systemd-remount-fs.nix
@@ -43,7 +43,7 @@
   # Devices #
   ###########
 
-  PrivateDevices = true;
+  # PrivateDevices = true;
   # DeviceAllow=/dev/null
 
   ##########

--- a/modules/disko/disko-ab-partitions.nix
+++ b/modules/disko/disko-ab-partitions.nix
@@ -1,0 +1,161 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This partition scheme contains three common partitions and ZFS pool.
+# Some partitions are duplicated for the future AB SWupdate implementation.
+#
+# First three partitions are related to the boot process:
+# - boot : Bootloader partition
+# - ESP-A : (500M) Kernel and initrd
+# - ESP-B : (500M)
+#
+# ZFS datasets do not necessary need to have specified size and can be
+# allocated dynamically. Quotas only restrict the maximum size of
+# datasets, but do not reserve the space in the pool.
+# The ZFS pool contains next datasets:
+# - root-A : (30G) Root FS
+# - root-B : (30G)
+# - vm-storage-A : (30G) Possible standalone pre-built VM images are stored here
+# - vm-storage-B : (30G)
+# - reserved-A : (10G) Reserved dataset, no use
+# - reserved-B : (10G)
+# - gp-storage : (50G) General purpose storage for some common insecure cases
+# - recovery : (no quota) Recovery factory image is stored here
+# - storagevm: (no quota) Dataset is meant to be used for StorageVM
+{pkgs, ...}: {
+  #TODO Probably the 'networking.hostId' should be set
+  # somewhere else instead.
+  networking.hostId = "8425e349";
+  disko = {
+    memSize = 4096;
+    extraPostVM = ''
+      ${pkgs.zstd}/bin/zstd --compress $out/*raw
+      rm $out/*raw
+    '';
+    extraRootModules = ["zfs"];
+    devices = {
+      disk.disk1 = {
+        type = "disk";
+        imageSize = "15G";
+        content = {
+          type = "gpt";
+          partitions = {
+            boot = {
+              name = "boot";
+              size = "1M";
+              type = "EF02";
+              priority = 1; # Needs to be first partition
+            };
+            esp_a = {
+              name = "ESP_A";
+              size = "500M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+                mountOptions = [
+                  "umask=0077"
+                  "nofail"
+                ];
+              };
+            };
+            esp_b = {
+              name = "ESP_B";
+              size = "500M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountOptions = [
+                  "umask=0077"
+                  "nofail"
+                ];
+              };
+            };
+            zfs_1 = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "zfspool";
+              };
+            };
+          };
+        };
+      };
+      zpool = {
+        zfspool = {
+          type = "zpool";
+          rootFsOptions = {
+            mountpoint = "none";
+            acltype = "posixacl";
+          };
+          datasets = {
+            "root_a" = {
+              type = "zfs_fs";
+              mountpoint = "/";
+              options = {
+                mountpoint = "/";
+                quota = "30G";
+              };
+            };
+            "vm_storage_a" = {
+              type = "zfs_fs";
+              options = {
+                mountpoint = "/vm_storage";
+                quota = "30G";
+              };
+            };
+            "reserved_a" = {
+              type = "zfs_fs";
+              options = {
+                mountpoint = "none";
+                quota = "10G";
+              };
+            };
+            "root_b" = {
+              type = "zfs_fs";
+              options = {
+                mountpoint = "none";
+                quota = "30G";
+              };
+            };
+            "vm_storage_b" = {
+              type = "zfs_fs";
+              options = {
+                mountpoint = "none";
+                quota = "30G";
+              };
+            };
+            "reserved_b" = {
+              type = "zfs_fs";
+              options = {
+                mountpoint = "none";
+                quota = "10G";
+              };
+            };
+            "gp_storage" = {
+              type = "zfs_fs";
+              options = {
+                mountpoint = "/gp_storage";
+                quota = "50G";
+              };
+            };
+            "recovery" = {
+              type = "zfs_fs";
+              options = {
+                mountpoint = "none";
+              };
+            };
+            "storagevm" = {
+              type = "zfs_fs";
+              options = {
+                mountpoint = "/storagevm";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/disko/disko-zfs-postboot.nix
+++ b/modules/disko/disko-zfs-postboot.nix
@@ -1,0 +1,36 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{pkgs, ...}: let
+  postBootCmds = ''
+    set -xeuo pipefail
+
+    # Check which physical disk is used by ZFS
+    ZFS_POOLNAME=$(${pkgs.zfs}/bin/zpool list | ${pkgs.gnugrep}/bin/grep -v NAME |  ${pkgs.gawk}/bin/awk '{print $1}')
+    ZFS_LOCATION=$(${pkgs.zfs}/bin/zpool status -P | ${pkgs.gnugrep}/bin/grep dev | ${pkgs.gawk}/bin/awk '{print $1}')
+
+    # Get the actual device path
+    P_DEVPATH=$(readlink -f "$ZFS_LOCATION")
+
+    # Extract the partition number using regex
+    if [[ "$P_DEVPATH" =~ [0-9]+$ ]]; then
+      PARTNUM=$(echo "$P_DEVPATH" | ${pkgs.gnugrep}/bin/grep -o '[0-9]*$')
+      PARENT_DISK=$(echo "$P_DEVPATH" | ${pkgs.gnused}/bin/sed 's/[0-9]*$//')
+    else
+      echo "No partition number found in device path: $P_DEVPATH"
+    fi
+
+    # Fix GPT first
+    ${pkgs.gptfdisk}/bin/sgdisk "$PARENT_DISK" -e
+
+    # Call partprobe to update kernel's partitions
+    ${pkgs.parted}/bin/partprobe
+
+    # Extend the partition to use unallocated space
+    ${pkgs.parted}/bin/parted -s -a opt "$PARENT_DISK" "resizepart $PARTNUM 100%"
+
+    # Extend ZFS pool to use newly allocated space
+    ${pkgs.zfs}/bin/zpool online -e "$ZFS_POOLNAME" "$ZFS_LOCATION"
+  '';
+in {
+  boot.postBootCommands = postBootCmds;
+}

--- a/modules/disko/flake-module.nix
+++ b/modules/disko/flake-module.nix
@@ -7,5 +7,11 @@
       ./disko-basic-partition-v1.nix
       ./disko-basic-postboot.nix
     ];
+
+    disko-ab-partitions-v1.imports = [
+      inputs.disko.nixosModules.disko
+      ./disko-ab-partitions.nix
+      ./disko-zfs-postboot.nix
+    ];
   };
 }

--- a/modules/hardware/x86_64-generic/x86_64-linux.nix
+++ b/modules/hardware/x86_64-generic/x86_64-linux.nix
@@ -32,11 +32,14 @@ in {
       initrd.availableKernelModules = [
         "nvme"
         "uas"
+        "zfs"
       ];
       loader = {
         efi.canTouchEfiVariables = true;
         systemd-boot.enable = true;
       };
+      supportedFilesystems = ["zfs"];
+      kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
     };
   };
 }

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -14,7 +14,7 @@
   targets = [
     # Laptop Debug configurations
     (laptop-configuration "lenovo-x1-carbon-gen10" "debug" [
-      self.nixosModules.disko-basic-partition-v1
+      self.nixosModules.disko-ab-partitions-v1
       {
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen10.nix";
@@ -23,7 +23,7 @@
       }
     ])
     (laptop-configuration "lenovo-x1-carbon-gen11" "debug" [
-      self.nixosModules.disko-basic-partition-v1
+      self.nixosModules.disko-ab-partitions-v1
       {
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen11.nix";
@@ -52,7 +52,7 @@
 
     # Laptop Release configurations
     (laptop-configuration "lenovo-x1-carbon-gen10" "release" [
-      self.nixosModules.disko-basic-partition-v1
+      self.nixosModules.disko-ab-partitions-v1
       {
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen10.nix";
@@ -61,7 +61,7 @@
       }
     ])
     (laptop-configuration "lenovo-x1-carbon-gen11" "release" [
-      self.nixosModules.disko-basic-partition-v1
+      self.nixosModules.disko-ab-partitions-v1
       {
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen11.nix";


### PR DESCRIPTION
New disk configuration provides grounds for upcoming features, such as AB software updates and Storage VM and many more.

The Lenovo X1 config has two LVM pools, first one is fixed-size 250G "system" partition (which is going to be encrypted) and the rest of the disk is dedicated to the StorageVM.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
Current upstream partition scheme is as follows:
```
[ghaf@ghaf-host:~]$ lsblk
NAME          MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
sda             8:0    0 465.8G  0 disk 
├─sda1          8:1    0   236M  0 part 
└─sda2          8:2    0   8.6G  0 part 
nvme0n1       259:0    0 953.9G  0 disk 
├─nvme0n1p1   259:1    0     1M  0 part 
├─nvme0n1p2   259:2    0   500M  0 part /boot
└─nvme0n1p3   259:3    0 953.4G  0 part 
  └─pool-root 254:0    0 953.4G  0 lvm  /nix/store
                                        /
```
To test new partitioning scheme, run `lenovo-x1-carbon-gen11-debug-installer` image and install Ghaf into the internal SSD storage of Lenovo-X1.
After insallation is completed and the laptop is booted into the Ghaf system, check partitions with `lsblk` command.
It should be as follows:
```
[ghaf@ghaf-host:~]$ lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
nvme0n1     259:0    0 953.9G  0 disk 
├─nvme0n1p1 259:1    0     1M  0 part 
├─nvme0n1p2 259:2    0   500M  0 part /boot
├─nvme0n1p3 259:3    0   500M  0 part 
└─nvme0n1p4 259:4    0    14G  0 part 
```
Check zpool is online:
```
[ghaf@ghaf-host:~]$ zpool list
NAME      SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
zroot_1    14G  5.00G  9.00G        -         -     0%    35%  1.00x    ONLINE  -
```
Check datasets are mounted successfully:
```
[ghaf@ghaf-host:~]$ mount | grep zroot_1
zroot_1/root_a on / type zfs (rw,relatime,xattr,posixacl,casesensitive,x-initrd.mount)
zroot_1/root_a on /nix/store type zfs (ro,relatime,xattr,posixacl,casesensitive)
zroot_1/storagevm on /storagevm type zfs (rw,relatime,xattr,posixacl,casesensitive)
zroot_1/vm_storage_a on /vm_storage type zfs (rw,relatime,xattr,posixacl,casesensitive)
zroot_1/gp_storage on /gp_storage type zfs (rw,relatime,xattr,posixacl,casesensitive)
```
Optionally - check there are no failed `systemd` units:
```
[ghaf@ghaf-host:~]$ systemctl list-units --all --state=failed
  UNIT LOAD ACTIVE SUB DESCRIPTION

0 loaded units listed.
To show all installed unit files use 'systemctl list-unit-files'.
```
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
