### PR TITLE
kernel hardening checker update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -221,6 +221,22 @@
         "type": "github"
       }
     },
+    "kernel-hardening-checker": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705445702,
+        "narHash": "sha256-xpVazB9G0cdc0GglGpna80EWHZXfTd5mc5mTvvvoPfE=",
+        "owner": "a13xp0p0v",
+        "repo": "kernel-hardening-checker",
+        "rev": "70ae2b93be46efe3f1356c025426cd0b43595c0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a13xp0p0v",
+        "repo": "kernel-hardening-checker",
+        "type": "github"
+      }
+    },
     "lanzaboote": {
       "inputs": {
         "crane": "crane",
@@ -444,6 +460,7 @@
         "flake-root": "flake-root",
         "flake-utils": "flake-utils_2",
         "jetpack-nixos": "jetpack-nixos",
+        "kernel-hardening-checker": "kernel-hardening-checker",
         "lanzaboote": "lanzaboote",
         "lib-extras": "lib-extras",
         "microvm": "microvm",

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,11 @@
         flake-compat.follows = "flake-compat";
       };
     };
+
+    kernel-hardening-checker = {
+      url = "github:a13xp0p0v/kernel-hardening-checker";
+      flake = false;
+    };
   };
 
   outputs = inputs @ {flake-parts, ...}: let

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,6 +1,6 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{
+{inputs, ...}: {
   perSystem = {
     pkgs,
     lib,
@@ -12,7 +12,7 @@
   in {
     packages = platformPkgs system {
       gala-app = callPackage ./gala {};
-      kernel-hardening-checker = callPackage ./kernel-hardening-checker {};
+      kernel-hardening-checker = callPackage ./kernel-hardening-checker { inherit inputs; };
       windows-launcher = callPackage ./windows-launcher {enableSpice = false;};
       windows-launcher-spice = callPackage ./windows-launcher {enableSpice = true;};
       doc = callPackage ../docs {

--- a/packages/kernel-hardening-checker/default.nix
+++ b/packages/kernel-hardening-checker/default.nix
@@ -2,16 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   python3Packages,
-  fetchFromGitHub,
+  inputs,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "kernel-hardening-checker";
   version = "0.6.1-git${src.rev}";
-
-  src = fetchFromGitHub {
-    owner = "a13xp0p0v";
-    repo = "kernel-hardening-checker";
-    rev = "cce3be96474ddb0e1e59b1b5e5b539c5e99c054b";
-    sha256 = "sha256-b+k2BSNF9Lc4WQnH7bYg87BEKLY2aSQ6a768SWT6w+Y=";
-  };
+  src = inputs.kernel-hardening-checker;
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

KHC tool is fast evolving, and bumping hash manually each time is inconvenient.
I propose using flake.nix/lock for managing kernel-hardening-checker version pinning.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

`kernel-hardening-checker --version` show newer version, also checker works on our baseline config
