### PR TITLE
GhA: build: update before apt-get install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
           echo "Available storage after cleanup:"
           df -h
       - name: Print runner system info
-        run: sudo apt-get install -y inxi; sudo inxi -c0 --width -1 --basic --memory-short
+        run: sudo apt-get update; sudo apt-get install -y inxi; sudo inxi -c0 --width -1 --basic --memory-short
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Fix pre-merge build workflow: on installing `inxi` package during the build step `Print runner system info`, apt-get update needs to be run before apt-get install to make sure apt index is not stale as instructed in the relevant [documentation](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners):

> Note: Always run sudo apt-get update before installing a package. In case the apt index is stale, this command fetches and re-indexes any available packages, which helps prevent package installation failures.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
Tested the change in a forked repo at: https://github.com/henrirosten/ghaf/pull/21.

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
