### PR TITLE
Fix installer issues

### DIFF
--- a/targets/default.nix
+++ b/targets/default.nix
@@ -12,7 +12,7 @@ in
   lib.foldr lib.recursiveUpdate {} [
     (import ./nvidia-jetson-orin {inherit lib nixpkgs nixos-generators microvm jetpack-nixos;})
     (import ./vm.nix {inherit lib nixos-generators microvm;})
-    (import ./generic-x86_64.nix {inherit lib nixos-generators microvm;})
+    (import ./generic-x86_64.nix {inherit lib nixos-generators microvm disko;})
     (import ./lenovo-x1-carbon.nix {inherit lib nixos-generators microvm lanzaboote nixpkgs disko;})
     (import ./imx8qm-mek.nix {inherit lib nixos-generators nixos-hardware microvm;})
     (import ./microchip-icicle-kit.nix {inherit lib nixpkgs nixos-hardware;})

--- a/targets/generic-x86_64.nix
+++ b/targets/generic-x86_64.nix
@@ -6,6 +6,7 @@
   lib,
   nixos-generators,
   microvm,
+  disko,
 }: let
   name = "generic-x86_64";
   system = "x86_64-linux";
@@ -81,7 +82,7 @@
         ++ extraModules;
     };
   in {
-    inherit hostConfiguration;
+    hostConfiguration = hostConfiguration.extendModules {modules = [disko.nixosModules.disko (import ../templates/targets/x86_64/generic/disk-config.nix)];} // {rawConfiguration = hostConfiguration;};
     name = "${name}-${variant}";
     package = let inherit ((hostConfiguration.extendModules {modules = [formatModule];})) config; in config.system.build.${config.formatAttr};
   };

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -509,11 +509,12 @@
     };
     package = let inherit ((hostConfiguration.extendModules {modules = [formatModule];})) config; in config.system.build.${config.formatAttr};
   in {
-    inherit hostConfiguration package;
+    inherit package;
+    hostConfiguration = hostConfiguration.extendModules {modules = [disko.nixosModules.disko (import ../templates/targets/x86_64/generic/disk-config.nix)];} // {rawConfiguration = hostConfiguration;};
     name = "${name}-${variant}";
     installer = let
       pkgs = import nixpkgs {inherit system;};
-      inherit ((hostConfiguration.extendModules {modules = [disko.nixosModules.disko (import ../templates/targets/x86_64/generic/disk-config.nix)];}).config.system.build) toplevel;
+      inherit (hostConfiguration.config.system.build) toplevel;
       installerScript = import ../modules/installer/standalone-installer {
         inherit pkgs;
         toplevelDrv = toplevel;

--- a/templates/targets/x86_64/generic/flake.nix
+++ b/templates/targets/x86_64/generic/flake.nix
@@ -47,6 +47,7 @@
   };
 
   outputs = {
+    # deadnix: skip
     self,
     ghaf,
     disko,
@@ -66,11 +67,9 @@
         formatter = nixpkgs.legacyPackages.${system}.alejandra;
       }))
 
-      {
-        nixosConfigurations.PROJ_NAME-ghaf-debug = ghaf.nixosConfigurations.generic-x86_64-debug.extendModules {
+      (let
+        nixosConfiguration = ghaf.nixosConfigurations.generic-x86_64-debug.rawConfiguration.extendModules {
           modules = [
-            disko.nixosModules.disko
-            ./disk-config.nix
             # deadnix: skip
             ({lib, ...}: {
               #insert your additional modules here e.g.
@@ -93,12 +92,14 @@
             })
           ];
         };
+      in {
+        nixosConfigurations.PROJ_NAME-ghaf-debug = nixosConfiguration.extendModules {modules = [disko.nixosModules.disko ./disk-config.nix];};
         packages.x86_64-linux.PROJ_NAME-ghaf-debug = let
-          hostConfiguration = self.nixosConfigurations.PROJ_NAME-ghaf-debug;
+          hostConfiguration = nixosConfiguration;
           formatModule = nixos-generators.nixosModules.raw-efi;
           inherit ((hostConfiguration.extendModules {modules = [formatModule];})) config;
         in
           config.system.build.${config.formatAttr};
-      }
+      })
     ];
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Fixes problem with building:

- raw-efi image from user-defined configuraiton in template
- toplevel derivation required for `nixos-rebuild` command.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

```sh
nix flake init -t github:remimimimimi/ghaf/Fix-installer-issues#target-x86_64-generic
sed -i 's/github:tiiuae\/ghaf/github:remimimimimi\/ghaf\/Fix-installer-issues/g' flake.nix
nix flake show .
nix build .#PROJ_NAME-ghaf-debug
```