### PR TITLE
Enlargen the LVM partition on first boot

### DIFF
--- a/modules/partitioning/disko-basic-postboot.nix
+++ b/modules/partitioning/disko-basic-postboot.nix
@@ -1,0 +1,62 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{pkgs, ...}: let
+  postBootCmds = ''
+    set -xeuo pipefail
+
+    readarray -t partitions <<<"$(${pkgs.util-linux}/bin/lsblk -np -o PATH,MAJ:MIN,PKNAME,MOUNTPOINT)"
+
+    # Find out the root partition in a loop, and its LVM pool parent disk
+    for p in "''${partitions[@]}"
+    do
+            P_DEVPATH=$(echo "$p" | ${pkgs.gawk}/bin/awk '{print $1}')
+            P_PKNAME=$(echo "$p" | ${pkgs.gawk}/bin/awk '{print $3}')
+            P_MOUNTPOINT=$(echo "$p" | ${pkgs.gawk}/bin/awk '{print $4}')
+
+            [[ "$P_MOUNTPOINT" == "/" ]] && {
+                    FOUND=1
+                    DEVPATH="$P_DEVPATH"
+                    PKNAME="$P_PKNAME"
+            }
+    done
+
+    # If root partition was not found, exit at this point, but still return 0, so
+    # it won't stop device from booting.
+    [[ "$FOUND" != 1 ]] && echo "Did not find root partition" && exit 0
+
+    # Find parent device of the root partition
+    for p in "''${partitions[@]}"
+    do
+            P_DEVPATH=$(echo "$p" | ${pkgs.gawk}/bin/awk '{print $1}')
+            P_MAJMIN=$(echo "$p" | ${pkgs.gawk}/bin/awk '{print $2}')
+            P_PKNAME=$(echo "$p" | ${pkgs.gawk}/bin/awk '{print $3}')
+
+            [[ "$P_DEVPATH" == "$PKNAME" ]] && {
+                    FOUND_PARENT=1
+                    PARENT_DISK="$P_PKNAME"
+                    PARTNUM=$(echo "$P_MAJMIN" | ${pkgs.gawk}/bin/awk -F: '{print $2}')
+            }
+    done
+
+    # If boot device was not found, exit at this point, but still return 0, so it
+    # won't stop device from booting.
+    [[ "$FOUND_PARENT" != 1 ]] && echo "Did not find boot device" && exit 0
+
+    # First enlarge the physical volume on the disk
+    echo ",+," | ${pkgs.util-linux}/bin/sfdisk -N"$PARTNUM" --no-reread "$PARENT_DISK"
+
+    # Call partprobe to update kernel's partitions
+    ${pkgs.parted}/bin/partprobe
+
+    # Extend the phyiscal volume
+    ${pkgs.lvm2.bin}/bin/pvresize "$PKNAME"
+
+    # Extend the logical volume
+    ${pkgs.lvm2.bin}/bin/lvextend --noudevsync -l +100%FREE "$DEVPATH"
+
+    # Finally resize the filesystem inside the logical volume
+    ${pkgs.e2fsprogs}/bin/resize2fs "$DEVPATH"
+  '';
+in {
+  boot.postBootCommands = postBootCmds;
+}

--- a/targets/lenovo-x1-carbon.nix
+++ b/targets/lenovo-x1-carbon.nix
@@ -272,6 +272,7 @@
           microvm.nixosModules.host
           disko.nixosModules.disko
           (import ../modules/partitioning/lenovo-x1-disko-basic.nix {device = "/dev/nvme0n1";}) #TODO define device in hw def file
+          ../modules/partitioning/disko-basic-postboot.nix
           ../modules/host
           ../modules/virtualization/microvm/microvm-host.nix
           ../modules/virtualization/microvm/netvm.nix


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Enlargen the LVM partition on first boot

Ready for review!

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Flash the Lenovo X1 Carbon image to USB disk. Boot from it. After boot run `df -h` and `lsblk` to see that the filesystem and partition have been really resized. The root-filesystem should fill the originally empty space from the disk, just like in this screenshot.
![image](https://github.com/tiiuae/ghaf/assets/826368/11c616ed-0233-4e8d-a843-9524a24dbf11)

