### PR TITLE
Ignore patch file number in shouldOverride

### DIFF
--- a/overlays/custom-packages/systemd/default.nix
+++ b/overlays/custom-packages/systemd/default.nix
@@ -6,7 +6,7 @@
     # the patch is already present.
     #
     # https://github.com/NixOS/nixpkgs/pull/239201
-    shouldOverride = !(final.lib.lists.any (p: final.lib.strings.hasSuffix "0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch" (toString p)) prev.systemd.patches);
+    shouldOverride = !(final.lib.lists.any (p: final.lib.strings.hasSuffix "timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch" (toString p)) prev.systemd.patches);
   in
     prev.systemd.overrideAttrs (prevAttrs:
       final.lib.optionalAttrs shouldOverride {


### PR DESCRIPTION
On checking if the systemd timesyncd patch is applied nixpkgs upstream, do not require a match on the sequential patch file number. Patches can be applied in different order, or the total number of patches might change over time, so it's incorrect to assume the timesyncd patch would always have the sequential order number of '0020'.

Also, please consider the suggestion below:
> _... on longer term, I believe the correct course of action, if possible, would be to get rid of the Ghaf [systemd override](https://github.com/tiiuae/ghaf/blob/cfec51ba6330a1236f8a4395fdc31ee5ed28e260/modules/host/default.nix#L32-L45) altogether, so we would not have to rebuild systemd for Ghaf. As a benefit of doing that we would get rid of the re-builds of systemd, and more importantly, the massive rebuilds of all Ghaf packages that depend on the systemd. This would greatly improve the Ghaf build times especially during flake updates when we could re-use the binaries already build by the community and made available on the cache.nixos.org._


<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

This issue was noticed on attempting to build a version of Ghaf where nixpkgs is pinned to nixos-unstable (which now includes the timesyncd patch).

Test steps:
- Temporarily pin the Ghaf nixpkgs to nixos-unstable, e.g.: https://github.com/henrirosten/ghaf/commit/25dac70b8c706e124ac306f59e4f0cd91016331d
- Try building an x86_64 target, e.g.: packages.x86_64-linux.generic-x86_64-debug
- Notice the build failure:
```
error: builder for '/nix/store/km1rcmlcnylcnnj10gzpqhlsr3554rlm-systemd-minimal-255.2.drv' failed with exit code 1;
       last 10 log lines:
       > applying patch /nix/store/s7h748g85p6kviq6n705qfrc9nxzwdj0-0017-meson.build-do-not-create-systemdstatedir.patch
       > patching file meson.build
       > applying patch /nix/store/585sshb8d53rlg2igkll14qb0ayybwi1-0018-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
       > patching file src/timesync/timesyncd.c
       > applying patch /nix/store/x8vcfrqp90hqiif4bpmbr2wn688xanfd-systemd-timesyncd-disable-nscd.patch
       > patching file src/timesync/timesyncd.c
       > Reversed (or previously applied) patch detected!  Assume -R? [n]
       > Apply anyway? [n]
       > Skipping patch.
       > 2 out of 2 hunks ignored -- saving rejects to file src/timesync/timesyncd.c.rej
       For full logs, run 'nix log /nix/store/km1rcmlcnylcnnj10gzpqhlsr3554rlm-systemd-minimal-255.2.drv'.
error (ignored): error: cannot unlink '/tmp/nix-build-nftables-1.0.9.drv-0/nftables-1.0.9': Directory not empty
error: builder for '/nix/store/rjap51pa6dd3j5k7w8583bq4rj0m6gmp-systemd-minimal-libs-255.2.drv' failed with exit code 1;
       last 10 log lines:
       > applying patch /nix/store/s7h748g85p6kviq6n705qfrc9nxzwdj0-0017-meson.build-do-not-create-systemdstatedir.patch
       > patching file meson.build
       > applying patch /nix/store/585sshb8d53rlg2igkll14qb0ayybwi1-0018-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
       > patching file src/timesync/timesyncd.c
       > applying patch /nix/store/x8vcfrqp90hqiif4bpmbr2wn688xanfd-systemd-timesyncd-disable-nscd.patch
       > patching file src/timesync/timesyncd.c
       > Reversed (or previously applied) patch detected!  Assume -R? [n]
       > Apply anyway? [n]
       > Skipping patch.
       > 2 out of 2 hunks ignored -- saving rejects to file src/timesync/timesyncd.c.rej
       For full logs, run 'nix log /nix/store/rjap51pa6dd3j5k7w8583bq4rj0m6gmp-systemd-minimal-libs-255.2.drv'.
error: 1 dependencies of derivation '/nix/store/3wmqkdgh31aj6dlnp4jrwlz5303g5cvy-nixos-disk-image.drv' failed to build
```
- After applying the change from this PR, the build gets pass the above error

Notice: even after the changes from this PR the systemd build still fails due to:
```
error: builder for '/nix/store/6m3qgzyg61wp88hvpcznxrfmf1m672m5-systemd-255.2.drv' failed with exit code 1;
       last 10 log lines:
       > Dependency xkbcommon skipped: feature xkbcommon disabled
       > Dependency libpcre2-8 skipped: feature pcre2 disabled
       > Dependency glib-2.0 skipped: feature glib disabled
       > Dependency gobject-2.0 skipped: feature glib disabled
       > Dependency gio-2.0 skipped: feature glib disabled
       > Dependency dbus-1 skipped: feature dbus disabled
       >
       > meson.build:1534:31: ERROR: Feature sysupdate cannot be enabled: fdisk and openssl required
       >
       > A full log can be found at /build/source/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/6m3qgzyg61wp88hvpcznxrfmf1m672m5-systemd-255.2.drv'.
```
As a follow-up to this PR on longer term and to fix the above error, I believe the correct course of action (if possible) would be to get rid of the Ghaf[ systemd override](https://github.com/tiiuae/ghaf/blob/cfec51ba6330a1236f8a4395fdc31ee5ed28e260/modules/host/default.nix#L32-L45) altogether, so we would not have to rebuild systemd for Ghaf. As a benefit of doing that we would get rid of the massive re-builds of systemd, and more importantly, the rebuilds of all the packages that depend on systemd. This would greatly improve the build times of Ghaf especially during flake updates when we could re-use the binaries already build by the community and made available on the cache.nixos.org.

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
