### PR TITLE
labwc: Use the Ghaf wallpaper with swaybg.

### DIFF
--- a/overlays/custom-packages/labwc/default.nix
+++ b/overlays/custom-packages/labwc/default.nix
@@ -22,7 +22,7 @@ prev.labwc.overrideAttrs (prevAttrs: {
   preInstallPhases = ["preInstallPhase"];
   preInstallPhase = ''
     substituteInPlace ../docs/autostart \
-     --replace swaybg ${final.swaybg}/bin/swaybg \
+     --replace "swaybg -c '#113344'" '${final.swaybg}/bin/swaybg -m fill -i ${../../../assets/wallpaper.png}' \
      --replace kanshi ${final.kanshi}/bin/kanshi \
      --replace waybar "${final.waybar}/bin/waybar -s /etc/waybar/style.css -c /etc/waybar/config" \
      --replace mako ${final.mako}/bin/mako \


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Use Ghaf wallpaper just like with weston.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
1. Boot on Lenovo X1
2. Green wallpaper with ghaf logo should be on screen, filled.