### PR TITLE
Fix electron cross-build on recent nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -358,11 +358,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702914124,
-        "narHash": "sha256-EjmBJGB6DOdJnMoUKkNVMvJOYN11KU+U3IJcuGlhi38=",
+        "lastModified": 1710695816,
+        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a9928df838d1470a0e308cef74c251e90fc83a8",
+        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
         "type": "github"
       },
       "original": {

--- a/overlays/cross-compilation/chromium/default.nix
+++ b/overlays/cross-compilation/chromium/default.nix
@@ -1,0 +1,42 @@
+# Copyright 2023-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Chromium & Electron cross-compilation fixes
+#
+{
+  final,
+  prev,
+}: let
+  inherit (builtins) map;
+  inherit (final.lib) pipe;
+  opusWithCustomModes = final.pkgsBuildBuild.libopus.override {
+    withCustomModes = true;
+  };
+  opusWithCustomModes' = final.pkgsBuildTarget.libopus.override {
+    withCustomModes = true;
+  };
+  replace = needle: replacement: haystack:
+    map (each:
+      if each == needle
+      then replacement
+      else each)
+    haystack;
+in
+  prev.chromium.overrideAttrs (oa: {
+    passthru =
+      oa.passthru
+      // {
+        mkDerivation = fun:
+          oa.passthru.mkDerivation (finalAttrs:
+            {
+              depsBuildBuild = pipe finalAttrs.depsBuildBuild [
+                (replace (final.libpng.override {apngSupport = false;}) (final.pkgsBuildBuild.libpng.override {apngSupport = false;}))
+                (replace final.zlib final.pkgsBuildBuild.zlib)
+                (replace opusWithCustomModes opusWithCustomModes')
+              ];
+              buildInputs = replace opusWithCustomModes' opusWithCustomModes finalAttrs.buildInputs;
+              env = finalAttrs.env // {NIX_DEBUG = "1";};
+            }
+            // fun finalAttrs);
+      };
+  })

--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -4,6 +4,7 @@
 # This overlay is for specific fixes needed only to enable cross-compilation.
 #
 (final: prev: {
+  chromium = import ./chromium {inherit prev final;};
   edk2 = import ./edk2 {inherit final prev;};
   element-desktop = import ./element-desktop {inherit prev;};
   jbig2dec = import ./jbig2dec {inherit prev;};


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Fix chromium/electron cross-compilation via reverting https://github.com/NixOS/nixpkgs/commit/fcdea38355b817b86101b9bb6f717858bc96b4eb
This commit is "do nothing" on current ghaf, but fix problem with upcoming nixpkgs update (which have commit above).

## Checklist for things done

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Update nixpkgs input via `nix flake lock --update-input nixpkgs`, build.
(I personally checked on 14bc70677726d6d5989e6d5db6c4f618e70259ac, where problem was introduced)