### PR TITLE
labwc: Screen locking when system is idle

### DIFF
--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -22,6 +22,8 @@
           profiles.graphics.enable = true;
           # Uncomment this line to take LabWC in use
           # profiles.graphics.compositor = "labwc";
+          # To enable screen locking set graphics.labwc.lock to true
+          graphics.labwc.lock.enable = false;
           profiles.applications.enable = false;
           windows-launcher.enable = false;
           development = {


### PR DESCRIPTION
This patch will add functionality of checking if there is no user interaction with the system for 5 minutes, it will lock the screen resulting in the user needing to type the password to unlock the system.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

This feature can be enabled by making following code change
```
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -23,7 +23,7 @@
           # Uncomment this line to take LabWC in use
           # profiles.graphics.compositor = "labwc";
           # To enable screen locking set graphics.labwc.lock to true
-          graphics.labwc.lock.enable = false;
+          graphics.labwc.lock.enable = true;
           profiles.applications.enable = false;
           windows-launcher.enable = false;
```
Once feature is enabled system will automatically lock after 5 minutes of idle time, resulting which below screen can be seen
![image](https://github.com/tiiuae/ghaf/assets/147831196/3f3bc163-4821-4455-9166-24dda46b33b4)

Enter the password for `gui-vm` and hit "Enter". That will unlock the system. 