### PR TITLE
targets: Make icicle-kit use overlays through self

### DIFF
--- a/targets/microchip-icicle-kit/flake-module.nix
+++ b/targets/microchip-icicle-kit/flake-module.nix
@@ -46,7 +46,7 @@
               buildPlatform.system = "x86_64-linux";
               hostPlatform.system = "riscv64-linux";
               overlays = [
-                (import ../../overlays/cross-compilation)
+                self.overlays.cross-compilation
               ];
             };
             boot.kernelParams = ["root=/dev/mmcblk0p2" "rootdelay=5"];


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Use cross-compilation overlay through self instead of directly importing it from path.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [X] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

This again did not cause any rebuild.