### PR TITLE
GhA: Re-enable x1 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,9 @@ jobs:
     needs: [check-identity]
     runs-on: ubuntu-latest
     if: ${{ needs.check-identity.outputs.authorized_user == 'False' }}
-    environment: 
+    environment:
       ${{ ( github.event_name == 'pull_request_target' &&
-            github.event.pull_request.head.repo.full_name != github.repository && 
+            github.event.pull_request.head.repo.full_name != github.repository &&
             'external-build-workflow' ) || ( 'internal-build-workflow' ) }}
     steps:
       - name: Authorize external
@@ -85,8 +85,8 @@ jobs:
     strategy:
       matrix:
         include:
-   #       - arch: x86_64-linux
-   #         target: lenovo-x1-carbon-gen11-debug
+          - arch: x86_64-linux
+            target: lenovo-x1-carbon-gen11-debug
           - arch: x86_64-linux
             target: nvidia-jetson-orin-agx-debug-from-x86_64
           - arch: x86_64-linux
@@ -167,5 +167,5 @@ jobs:
             echo "Running nix build, with cachix watch-exec"
             cachix authtoken ${{ secrets.CACHIX_AUTH_TOKEN }}
             cachix watch-exec ghaf-dev -- \
-              nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
+              nix build -L .#packages.${{ matrix.arch }}.${{ matrix.target }}
           fi


### PR DESCRIPTION
- Re-enable `lenovo-x1-carbon-gen11-debug` in github action build workflow
- Add `-L` option to github action build workflow `nix build` command to print build logs

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
This change was tested in a forked repo at: https://github.com/henrirosten/ghaf/pull/22
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
