### PR TITLE
Initial minimal systemd for Ghaf

### DIFF
--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -3,11 +3,7 @@
 #
 # TODO: Refactor even more.
 #       This is the old "host/default.nix" file.
-{
-  lib,
-  pkgs,
-  ...
-}: {
+{lib, ...}: {
   imports = [
     # TODO remove this when the minimal config is defined
     # Replace with the baseModules definition
@@ -24,24 +20,6 @@
     # temp means to reduce the image size
     # TODO remove this when the minimal config is defined
     appstream.enable = false;
-
-    systemd.package = pkgs.systemd.override ({
-        withCryptsetup = false;
-        withDocumentation = false;
-        withFido2 = false;
-        withHomed = false;
-        withHwdb = false;
-        withLibBPF = true;
-        withLocaled = false;
-        withPCRE2 = false;
-        withPortabled = false;
-        withTpm2Tss = false;
-        withUserDb = false;
-      }
-      // lib.optionalAttrs (lib.hasAttr "withRepart" (lib.functionArgs pkgs.systemd.override)) {
-        withRepart = false;
-      });
-
     boot.enableContainers = false;
     ##### Remove to here
   };

--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -15,5 +15,6 @@
     ./users/accounts.nix
     ./version
     ./virtualization/docker.nix
+    ./systemd
   ];
 }

--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -1,0 +1,295 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  # Ghaf systemd config
+  cfg = config.ghaf.systemd;
+
+  # Override minimal systemd package configuration
+  package =
+    pkgs.systemdMinimal.override {
+      pname = cfg.withName;
+      withAcl = true;
+      withAnalyze = cfg.withDebug;
+      inherit (cfg) withApparmor;
+      inherit (cfg) withAudit;
+      withCompression = true;
+      withCoredump = cfg.withDebug || cfg.withMachines;
+      inherit (cfg) withCryptsetup;
+      inherit (cfg) withEfi;
+      withBootloader = cfg.withEfi; # systemd-boot fails if not explicity set
+      inherit (cfg) withFido2;
+      inherit (cfg) withHostnamed;
+      withImportd = cfg.withMachines;
+      withKexectools = cfg.withDebug;
+      withKmod = true;
+      withLibBPF = true;
+      withLibseccomp = true;
+      inherit (cfg) withLocaled;
+      inherit (cfg) withLogind;
+      withMachined = cfg.withMachines;
+      inherit (cfg) withNetworkd;
+      inherit (cfg) withNss;
+      withOomd = true;
+      withPam = true;
+      inherit (cfg) withPolkit;
+      inherit (cfg) withResolved;
+      withShellCompletions = cfg.withDebug;
+      withTimedated = true;
+      inherit (cfg) withTimesyncd;
+      inherit (cfg) withTpm2Tss;
+      withUtmp = cfg.withJournal || cfg.withAudit;
+    } # To be removed, current systemd version 254.6 < 255
+    // lib.optionalAttrs (lib.hasAttr "withVmspawn" (lib.functionArgs pkgs.systemd.override)) {
+      withVmspawn = cfg.withMachines;
+    };
+
+  # Definition of suppressed system units in systemd configuration. This removes the units and has priority.
+  # Required to avoid build failures compared to only disabling units for some options. Note that errors will be silently ignored.
+  suppressedSystemUnits =
+    [
+      ## Default disabled units
+      "remote-cryptsetup.service"
+      "remote-cryptsetup.target"
+      "remote-fs-pre.service"
+      "remote-fs-pre.target"
+      "remote-fs.service"
+      "remote-fs.target"
+      "rpcbind.service"
+      "rpcbind.target"
+      "systemd-update-done.service"
+      "system-update.target"
+      "system-update-pre.target"
+      "system-update-cleanup.service"
+    ]
+    ++ (lib.optionals (!cfg.withMachines) [
+      "container-getty.service"
+      "container-getty@.service"
+      "container@.service"
+      "systemd-nspawn@.service"
+    ])
+    ++ (lib.optionals ((!cfg.withDebug) && (!cfg.withSerial)) [
+      "getty.service"
+      "getty@.service"
+      "getty.target"
+      "getty-pre.target"
+      "serial-getty.service"
+      "serial-getty@.service"
+      "serial-getty.target"
+      "serial-getty@.target"
+    ])
+    ++ (lib.optionals ((!cfg.withDebug) && (!cfg.withJournal)) [
+      "systemd-journald-audit.socket"
+      "systemd-journal-catalog-update.service"
+      "systemd-journal-flush.service"
+      "systemd-journald.service"
+      "systemd-journald@.service"
+      "systemd-journal-gatewayd.socket"
+      "systemd-journald-audit.socket"
+      "systemd-journald-dev-log.socket"
+      "systemd-journald-varlink@.socket"
+      "systemd-journald.socket"
+      "systemd-journald@.socket"
+      "systemd-update-utmp.service"
+    ])
+    ++ (lib.optionals (!cfg.withAudit) [
+      "audit.service"
+      "auditd.service"
+      "systemd-journald-audit.socket"
+    ])
+    ++ (lib.optionals ((!cfg.withDebug) && (!cfg.withMachines)) [
+      "systemd-coredump.socket"
+    ])
+    ++ (lib.optionals (!cfg.withLogind) [
+      "systemd-logind.service"
+      "dbus-org.freedesktop.login1.service"
+    ])
+    ++ (lib.optionals (!cfg.withNss) [
+      "nscd.service"
+      "nss.service"
+      "nss.target"
+      "nss-lookup.target"
+      "nss-user-lookup.target"
+      "nss-lookup.target.requires"
+      "nss-user-lookup.target.requires"
+    ])
+    ++ (lib.optionals (!cfg.withTimesyncd) [
+      "systemd-timesyncd.service"
+    ])
+    ++ (lib.optionals (!cfg.withResolved) [
+      "systemd-resolved.service"
+    ])
+    ++ (lib.optionals (!cfg.withNetworkd) [
+      "network.target"
+      "network-pre.target"
+      "network-online.target"
+      "network-interfaces.target"
+      "network-setup.service"
+      "network-local-commands.service"
+      "systemd-timesyncd.service"
+      "systemd-networkd-wait-online.service"
+      "systemd-networkd.service"
+      "systemd-networkd.socket"
+    ])
+    ++ (lib.optionals (!cfg.withDebug) [
+      ## Units kept with debug
+      "kbrequest.target"
+      "rescue.service"
+      "rescue.target"
+      "emergency.service"
+      "emergency.target"
+      "systemd-vconsole-setup.service"
+      "reload-systemd-vconsole-setup.service"
+      "console-getty.service"
+      "sys-kernel-debug.mount"
+      "sys-fs-fuse-connections.mount"
+      "systemd-pstore.service"
+      "mount-pstore.service"
+      "systemd-ask-password-console.path"
+      "systemd-ask-password-console.service"
+      "systemd-ask-password-wall.path"
+      "systemd-ask-password-wall.service"
+      "systemd-kexec.service"
+      "kexec.service"
+      "kexec.target"
+      "kexec-tools.service"
+      "kexec-tools.target"
+      "prepare-kexec.service"
+      "prepare-kexec.target"
+    ]);
+in
+  with lib; {
+    options.ghaf.systemd = {
+      enable = mkEnableOption "Enable minimal systemd configuration.";
+
+      withName = mkOption {
+        description = "Set systemd name.";
+        type = types.str;
+        default = "base-systemd";
+      };
+
+      withLogind = mkOption {
+        description = "Enable systemd login daemon.";
+        type = types.bool;
+        default = true;
+      };
+
+      withJournal = mkOption {
+        description = "Enable systemd journal daemon.";
+        type = types.bool;
+        default = true;
+      };
+
+      withNetworkd = mkOption {
+        description = "Enable systemd networking daemon.";
+        type = types.bool;
+        default = true;
+      };
+
+      withTimesyncd = mkOption {
+        description = "Enable systemd timesync daemon.";
+        type = types.bool;
+        default = false;
+      };
+
+      withResolved = mkOption {
+        description = "Enable systemd resolve daemon.";
+        type = types.bool;
+        default = false;
+      };
+
+      withHostnamed = mkOption {
+        description = "Enable systemd hostname daemon.";
+        type = types.bool;
+        default = false;
+      };
+
+      withNss = mkOption {
+        description = "Enable systemd Name Service Switch (NSS) functionality.";
+        type = types.bool;
+        default = false;
+      };
+
+      withEfi = mkOption {
+        description = "Enable systemd EFI+bootloader functionality.";
+        type = types.bool;
+        default = pkgs.stdenv.hostPlatform.isEfi;
+      };
+
+      withApparmor = mkOption {
+        description = "Enable systemd apparmor functionality.";
+        type = types.bool;
+        default = false;
+      };
+
+      withMachines = mkOption {
+        description = "Enable systemd container and VM functionality.";
+        type = types.bool;
+        default = false;
+      };
+
+      withAudit = mkOption {
+        description = "Enable systemd audit functionality.";
+        type = types.bool;
+        default = false;
+      };
+
+      withCryptsetup = mkOption {
+        description = "Enable systemd LUKS2 functionality.";
+        type = types.bool;
+        default = false;
+      };
+
+      withFido2 = mkOption {
+        description = "Enable systemd Fido2 token functionality.";
+        type = types.bool;
+        default = false;
+      };
+
+      withTpm2Tss = mkOption {
+        description = "Enable systemd TPM functionality.";
+        type = types.bool;
+        default = false;
+      };
+
+      withPolkit = mkOption {
+        description = "Enable systemd polkit functionality.";
+        type = types.bool;
+        default = false;
+      };
+
+      withSerial = mkOption {
+        description = "Enable systemd serial console.";
+        type = types.bool;
+        default = false;
+      };
+
+      withLocaled = mkOption {
+        description = "Enable systemd locale daemon.";
+        type = types.bool;
+        default = false;
+      };
+
+      withDebug = mkOption {
+        description = "Enable systemd debug functionality.";
+        type = types.bool;
+        default = false;
+      };
+    };
+
+    config = mkIf cfg.enable {
+      systemd = {
+        # Package and unit configuration
+        inherit package;
+        inherit suppressedSystemUnits;
+
+        # Misc. configurations
+        enableEmergencyMode = cfg.withDebug;
+        coredump.enable = cfg.withDebug || cfg.withMachines;
+      };
+    };
+  }

--- a/modules/common/systemd/default.nix
+++ b/modules/common/systemd/default.nix
@@ -1,0 +1,9 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  imports = [
+    ./base.nix
+    # TODO hardened configs
+    # TODO stage 1
+  ];
+}

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -46,6 +46,14 @@
               debug.tools.enable = lib.mkDefault configHost.ghaf.development.debug.tools.enable;
               nix-setup.enable = lib.mkDefault configHost.ghaf.development.nix-setup.enable;
             };
+            systemd = {
+              enable = true;
+              withName = "appvm-systemd";
+              withNss = true;
+              withResolved = true;
+              withPolkit = true;
+              withDebug = configHost.ghaf.profiles.debug.enable;
+            };
           };
 
           # SSH is very picky about the file permissions and ownership and will

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -31,6 +31,14 @@
             debug.tools.enable = lib.mkDefault configHost.ghaf.development.debug.tools.enable;
             nix-setup.enable = lib.mkDefault configHost.ghaf.development.nix-setup.enable;
           };
+          systemd = {
+            enable = true;
+            withName = "guivm-systemd";
+            withNss = true;
+            withResolved = true;
+            withTimesyncd = true;
+            withDebug = configHost.ghaf.profiles.debug.enable;
+          };
         };
 
         systemd.services."waypipe-ssh-keygen" = let

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -10,9 +10,20 @@ in
   with lib; {
     options.ghaf.virtualization.microvm-host = {
       enable = mkEnableOption "MicroVM Host";
+      hostNetworkSupport = mkEnableOption "Network support services to run host applications.";
     };
 
     config = mkIf cfg.enable {
       microvm.host.enable = true;
+      ghaf.systemd = {
+        enable = true;
+        withName = "host-systemd";
+        withPolkit = true;
+        withTimesyncd = cfg.hostNetworkSupport;
+        withNss = cfg.hostNetworkSupport;
+        withResolved = cfg.hostNetworkSupport;
+        withSerial = config.ghaf.profiles.debug.enable;
+        withDebug = config.ghaf.profiles.debug.enable;
+      };
     };
   }

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -22,6 +22,12 @@
             debug.tools.enable = lib.mkDefault configHost.ghaf.development.debug.tools.enable;
             nix-setup.enable = lib.mkDefault configHost.ghaf.development.nix-setup.enable;
           };
+          systemd = {
+            enable = true;
+            withName = "netvm-systemd";
+            withPolkit = true;
+            withDebug = configHost.ghaf.profiles.debug.enable;
+          };
         };
 
         system.stateVersion = lib.trivial.release;

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -47,6 +47,7 @@
               hardware.x86_64.common.enable = true;
 
               virtualization.microvm-host.enable = true;
+              virtualization.microvm-host.hostNetworkSupport = true;
               host.networking.enable = true;
               virtualization.microvm.netvm = {
                 enable = true;

--- a/targets/lenovo-x1-installer/flake-module.nix
+++ b/targets/lenovo-x1-installer/flake-module.nix
@@ -19,7 +19,7 @@
           modulesPath,
           ...
         }: let
-          installScript = pkgs.callPackage ../packages/installer {
+          installScript = pkgs.callPackage ../../packages/installer {
             inherit imagePath;
           };
         in {

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -64,6 +64,7 @@
               };
 
               virtualization.microvm-host.enable = true;
+              virtualization.microvm-host.hostNetworkSupport = true;
               host.networking.enable = true;
 
               virtualization.microvm.netvm.enable = true;

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -25,6 +25,7 @@
             hardware.x86_64.common.enable = true;
 
             virtualization.microvm-host.enable = true;
+            virtualization.microvm-host.hostNetworkSupport = true;
             host.networking.enable = true;
             # TODO: NetVM enabled, but it does not include anything specific
             #       for this Virtual Machine target


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Initial PR for minimal systemd for Ghaf (x1 only at the moment). Based on NixOS systemdMinimal, it aims to provide a baseline systemd configuration with options to extend or limit the functionality per VM and host to the necessary minimal.

The implementation provides 2 things:
1. Systemd package configuration
2. Removal of unwanted units (in some cases necessary to allow built)

Hereby, most exposed options follow the respective NixOS systemd config flags. Some options are removing units only, or group flags together. Both package config and unit removal was done in anticipation of future removals and configuration, and will be subject to change.

While the original idea was also to reduce image size; this is not the case at the moment with a shared nix store compared to individual VM images. 

Going forward, this change may require some work on the developer side to ensure that appropriate systemd functionality is available.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->


## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->

Tested on x1:
- Startup and applications work with the exception of sound in chromium (pulseaudio blames snd_hda_intel), but this doesn't seem to work in current version at all.
- Note that the disablement of timesyncd in the VMs bypasses an issue with networkd that causes internal DNS failure 

Tested on AGX:
- Works, proper usage of host applications requires this change in microvm-host.nix:
```
        withNss = config.ghaf.hardware.nvidia.orin.enable;
        withResolved = config.ghaf.hardware.nvidia.orin.enable;
``` 
(and setting net-vm as default gw)