### PR TITLE
dd: add status and oflag

### DIFF
--- a/docs/src/ref_impl/build_and_run.md
+++ b/docs/src/ref_impl/build_and_run.md
@@ -59,7 +59,7 @@ Do the following:
     ```
 2. After the build is completed, prepare a USB boot media with the target image you built:
     ```
-    dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M
+    dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M status=progress oflag=direct
     ```
 3. Boot the computer from the USB media.
 
@@ -76,7 +76,7 @@ Do the following:
     ```
 2. After the build is completed, prepare a USB boot media with the target image you built:
     ```
-    dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M
+    dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M status=progress oflag=direct
     ```
 3. Boot the computer from the USB media.
 
@@ -129,7 +129,7 @@ After the latest firmware is [flashed](./build_and_run.md#flashing-nvidia-jetson
     ```
 2. After the build is completed, prepare a USB boot media with the target image you built:
     ```
-    dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M
+    dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M status=progress oflag=direct
     ```
 3. Boot the hardware from the USB media.
 
@@ -175,7 +175,7 @@ In the case of i.MX8, Ghaf deployment consists of creating a bootable SD card wi
 
 2. To build and flash the Ghaf image:
    1. Run the `nix build .#packages.aarch64-linux.imx8qm-mek-release` command.
-   2. Prepare the USB boot media with the target HW image you built: `dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M`.
+   2. Prepare the USB boot media with the target HW image you built: `dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M status=progress oflag=direct`.
 
 3. Insert an SD card and USB boot media into the board and switch the power on.
 
@@ -199,11 +199,11 @@ In the case of the Icicle Kit, Ghaf deployment consists of creating an SD image 
 2. Flash the Ghaf SD image:
 
    * If you want to use a SD card:
-     * Prepare the SD card with the target HW image you built: dd if=./result/nixos.img of=/dev/<YOUR_SD_DEVICE> bs=32M.
+     * Prepare the SD card with the target HW image you built: `dd if=./result/nixos.img of=/dev/<YOUR_SD_DEVICE> bs=32M status=progress oflag=direct`.
      * Insert an SD card into the board and switch the power on.
 
    * If you want to use the onboard MMC:
-     * You can directly flash a NixOS image to onboard an MMC card: dd if=./result/nixos.img of=/dev/<YOUR_MMC_DEVICE> bs=32M.
+     * You can directly flash a NixOS image to onboard an MMC card: `dd if=./result/nixos.img of=/dev/<YOUR_MMC_DEVICE> bs=32M status=progress oflag=direct`.
 
 For more information on how to access the MMC card as a USB disk, see [MPFS Icicle Kit User Guide](https://tinyurl.com/48wycdka).
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

- oflag=direct uses direct I/O for data transfer, which is faster by avoiding the kernel buffer cache.
- status=progress shows the progress of the dd command.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
