### PR TITLE
Get rid of specialArgs by defining ghaf.version in nixos directly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,38 +256,6 @@
         "type": "github"
       }
     },
-    "lib-extras": {
-      "inputs": {
-        "devshell": [
-          "devshell"
-        ],
-        "flake-parts": [
-          "flake-parts"
-        ],
-        "flake-root": [
-          "flake-root"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1699974671,
-        "narHash": "sha256-4EsuPiX4pGEg8ME9ONn8ebY1ZKYLOp9DRCcdTrOj8sY=",
-        "owner": "aldoborrero",
-        "repo": "lib-extras",
-        "rev": "83c8935af27738b8b155e0077522220d81865269",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aldoborrero",
-        "repo": "lib-extras",
-        "type": "github"
-      }
-    },
     "microvm": {
       "inputs": {
         "flake-utils": [
@@ -445,7 +413,6 @@
         "flake-utils": "flake-utils_2",
         "jetpack-nixos": "jetpack-nixos",
         "lanzaboote": "lanzaboote",
-        "lib-extras": "lib-extras",
         "microvm": "microvm",
         "nix-fast-build": "nix-fast-build",
         "nixos-generators": "nixos-generators",

--- a/flake.nix
+++ b/flake.nix
@@ -38,17 +38,6 @@
 
     flake-root.url = "github:srid/flake-root";
 
-    lib-extras = {
-      url = "github:aldoborrero/lib-extras";
-      inputs = {
-        devshell.follows = "devshell";
-        flake-parts.follows = "flake-parts";
-        flake-root.follows = "flake-root";
-        nixpkgs.follows = "nixpkgs";
-        treefmt-nix.follows = "treefmt-nix";
-      };
-    };
-
     # Format all the things
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";

--- a/flake.nix
+++ b/flake.nix
@@ -138,9 +138,6 @@
     flake-parts.lib.mkFlake
     {
       inherit inputs;
-      specialArgs = {
-        inherit lib;
-      };
     } {
       # Toggle this to allow debugging in the repl
       # see:https://flake.parts/debug

--- a/lib.nix
+++ b/lib.nix
@@ -6,22 +6,14 @@
 # https://github.com/divnix/digga
 {inputs, ...}: let
   inherit (inputs) nixpkgs;
-  # TODO REPLACE ME with hash pointed to by /run/current-system in built image
-  ghaf-version = nixpkgs.lib.strings.fileContents ./.version;
 in
   nixpkgs.lib.extend (lib: _:
     # some utils for importing trees
     rec {
       /*
-      *
-       Ghaf versioning info
-      */
-      inherit ghaf-version;
-
-      /*
-      *
-      Filters Nix packages based on the target system platform.
-      Returns a filtered attribute set of Nix packages compatible with the target system.
+         *
+         Filters Nix packages based on the target system platform.
+         Returns a filtered attribute set of Nix packages compatible with the target system.
 
       # Example
 

--- a/lib.nix
+++ b/lib.nix
@@ -10,163 +10,152 @@
   ghaf-version = nixpkgs.lib.strings.fileContents ./.version;
 in
   nixpkgs.lib.extend (lib: _:
-      # some utils for importing trees
-      rec {
-        #
-        # Ghaf versioning info
-        #
-        inherit ghaf-version;
+    # some utils for importing trees
+    rec {
+      /*
+      *
+       Ghaf versioning info
+      */
+      inherit ghaf-version;
 
-       /**
-         Filters Nix packages based on the target system platform.
-         Returns a filtered attribute set of Nix packages compatible with the target system.
+      /*
+      *
+      Filters Nix packages based on the target system platform.
+      Returns a filtered attribute set of Nix packages compatible with the target system.
 
-         # Example
+      # Example
 
-         ```
-         lib.platformPkgs "x86_64-linux" {
-            hello-compatible = pkgs.hello.overrideAttrs (old: { meta.platforms = ["x86_64-linux"]; });
-            hello-inccompatible = pkgs.hello.overrideAttrs (old: { meta.platforms = ["aarch-linux"]; });
-         }
-         => { hello-compatible = «derivation /nix/store/g2mxdrkwr1hck4y5479dww7m56d1x81v-hello-2.12.1.drv»; }
-         ```
+      ```
+      lib.platformPkgs "x86_64-linux" {
+         hello-compatible = pkgs.hello.overrideAttrs (old: { meta.platforms = ["x86_64-linux"]; });
+         hello-inccompatible = pkgs.hello.overrideAttrs (old: { meta.platforms = ["aarch-linux"]; });
+      }
+      => { hello-compatible = «derivation /nix/store/g2mxdrkwr1hck4y5479dww7m56d1x81v-hello-2.12.1.drv»; }
+      ```
 
-         # Type
+      # Type
 
-         ```
-         filterAttrs :: String -> AttrSet -> AttrSet
-         ```
+      ```
+      filterAttrs :: String -> AttrSet -> AttrSet
+      ```
 
-         # Arguments
+      # Arguments
 
-         - [system] Target system platform (e.g., "x86_64-linux").
-         - [pkgsSet] a set of Nix packages.
-       */
-        platformPkgs = system:
-          lib.filterAttrs
-          (_: value: let
+      - [system] Target system platform (e.g., "x86_64-linux").
+      - [pkgsSet] a set of Nix packages.
+      */
+      platformPkgs = system:
+        lib.filterAttrs
+        (_: value: let
           platforms = lib.attrByPath ["meta" "platforms"] [] value;
         in
           lib.elem system platforms);
 
-        flattenTree =
-          /*
-          *
-          Synopsis: flattenTree _tree_
+      /*
+        *
+      Flattens a _tree_ of the shape that is produced by rakeLeaves.
+      An attrset with names in the spirit of the Reverse DNS Notation form
+      that fully preserve information about grouping from nesting.
 
-          Flattens a _tree_ of the shape that is produced by rakeLeaves.
+      # Example
 
-          Output Format:
-          An attrset with names in the spirit of the Reverse DNS Notation form
-          that fully preserve information about grouping from nesting.
-
-          Example input:
-          ```
-          {
-          a = {
+      ```
+      flattenTree {
+        a = {
           b = {
-          c = <path>;
+            c = <path>;
           };
-          };
-          }
-          ```
+        };
+      }
+      => { "a.b.c" = <path>; }
+      ```
+      */
+      flattenTree = tree: let
+        op = sum: path: val: let
+          pathStr = builtins.concatStringsSep "." path; # dot-based reverse DNS notation
+        in
+          if builtins.isPath val
+          then
+            # builtins.trace "${toString val} is a path"
+            (sum
+              // {
+                "${pathStr}" = val;
+              })
+          else if builtins.isAttrs val
+          then
+            # builtins.trace "${builtins.toJSON val} is an attrset"
+            # recurse into that attribute set
+            (recurse sum path val)
+          else
+            # ignore that value
+            # builtins.trace "${toString path} is something else"
+            sum;
 
-          Example output:
-          ```
-          {
-          "a.b.c" = <path>;
-          }
-          ```
-          *
-          */
-          tree: let
-            op = sum: path: val: let
-              pathStr = builtins.concatStringsSep "." path; # dot-based reverse DNS notation
-            in
-              if builtins.isPath val
-              then
-                # builtins.trace "${toString val} is a path"
-                (sum
-                  // {
-                    "${pathStr}" = val;
-                  })
-              else if builtins.isAttrs val
-              then
-                # builtins.trace "${builtins.toJSON val} is an attrset"
-                # recurse into that attribute set
-                (recurse sum path val)
-              else
-                # ignore that value
-                # builtins.trace "${toString path} is something else"
-                sum;
+        recurse = sum: path: val:
+          builtins.foldl'
+          (sum: key: op sum (path ++ [key]) val.${key})
+          sum
+          (builtins.attrNames val);
+      in
+        recurse {} [] tree;
 
-            recurse = sum: path: val:
-              builtins.foldl'
-              (sum: key: op sum (path ++ [key]) val.${key})
-              sum
-              (builtins.attrNames val);
-          in
-            recurse {} [] tree;
+      /*
+      *
+      Recursively collect the nix files of _path_ into attrs.
+      Return an attribute set where all `.nix` files and directories with `default.nix` in them
+      are mapped to keys that are either the file with .nix stripped or the folder name.
+      All other directories are recursed further into nested attribute sets with the same format.
 
-        rakeLeaves =
-          /*
-          *
-          Synopsis: rakeLeaves _path_
+      # Example
 
-          Recursively collect the nix files of _path_ into attrs.
+      Example file structure:
 
-          Output Format:
-          An attribute set where all `.nix` files and directories with `default.nix` in them
-          are mapped to keys that are either the file with .nix stripped or the folder name.
-          All other directories are recursed further into nested attribute sets with the same format.
+      ```
+      ./core/default.nix
+      ./base.nix
+      ./main/dev.nix
+      ./main/os/default.nix
+      ```
 
-          Example file structure:
-          ```
-          ./core/default.nix
-          ./base.nix
-          ./main/dev.nix
-          ./main/os/default.nix
-          ```
-
-          Example output:
-          ```
-          {
-          core = ./core;
-          base = base.nix;
-          main = {
+      ```nix
+      rakeLeaves .
+      => {
+        core = ./core;
+        base = base.nix;
+        main = {
           dev = ./main/dev.nix;
           os = ./main/os;
-          };
-          }
-          ```
-          *
-          */
-          dirPath: let
-            seive = file: type:
-            # Only rake `.nix` files or directories
-              (type == "regular" && lib.hasSuffix ".nix" file) || (type == "directory");
+        };
+      }
+      ```
+      */
 
-            collect = file: type: {
-              name = lib.removeSuffix ".nix" file;
-              value = let
-                path = dirPath + "/${file}";
-              in
-                if
-                  (type == "regular")
-                  || (type == "directory" && builtins.pathExists (path + "/default.nix"))
-                then path
-                # recurse on directories that don't contain a `default.nix`
-                else rakeLeaves path;
-            };
+      rakeLeaves = dirPath: let
+        seive = file: type:
+        # Only rake `.nix` files or directories
+          (type == "regular" && lib.hasSuffix ".nix" file) || (type == "directory");
 
-            files = lib.filterAttrs seive (builtins.readDir dirPath);
+        collect = file: type: {
+          name = lib.removeSuffix ".nix" file;
+          value = let
+            path = dirPath + "/${file}";
           in
-            lib.filterAttrs (_n: v: v != {}) (lib.mapAttrs' collect files);
+            if
+              (type == "regular")
+              || (type == "directory" && builtins.pathExists (path + "/default.nix"))
+            then path
+            # recurse on directories that don't contain a `default.nix`
+            else rakeLeaves path;
+        };
 
-        importLeaves =
-          #
-          # Create an import stanza by recursing a directory to find all default.nix and <file.nix>
-          # files beneath withough manually having to list all the subsequent files.
-          #
-          path: builtins.attrValues (lib.mapAttrs (_: import) (rakeLeaves path));
-      })
+        files = lib.filterAttrs seive (builtins.readDir dirPath);
+      in
+        lib.filterAttrs (_n: v: v != {}) (lib.mapAttrs' collect files);
+
+      importLeaves =
+        #
+        # Create an import stanza by recursing a directory to find all default.nix and <file.nix>
+        # files beneath withough manually having to list all the subsequent files.
+        #
+        path: builtins.attrValues (lib.mapAttrs (_: import) (rakeLeaves path));
+    })

--- a/modules/common/version/default.nix
+++ b/modules/common/version/default.nix
@@ -6,13 +6,25 @@
 {
   pkgs,
   lib,
+  config,
   ...
 }: let
   ghafVersion = pkgs.writeShellScriptBin "ghaf-version" ''
-    echo "${lib.ghaf-version}"
+    echo "${config.ghaf.version}"
   '';
 in {
-  environment.systemPackages = [
-    ghafVersion
-  ];
+  options = {
+    ghaf.version = lib.mkOption {
+      type = lib.types.str;
+      # TODO REPLACE ME with hash pointed to by /run/current-system in built image
+      default = lib.strings.fileContents ../../../.version;
+      readOnly = true;
+      description = "The version of Ghaf";
+    };
+  };
+  config = {
+    environment.systemPackages = [
+      ghafVersion
+    ];
+  };
 }

--- a/modules/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -110,7 +110,7 @@ in
           echo "============================================================"
           echo "ghaf flashing script"
           echo "============================================================"
-          echo "ghaf version: ${lib.ghaf-version}"
+          echo "ghaf version: ${config.ghaf.version}"
           echo "cross-compiled build: @isCross@"
           echo "l4tVersion: @l4tVersion@"
           echo "som: ${config.hardware.nvidia-jetpack.som}"

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -111,7 +111,6 @@
   in {
     autostart = true;
     config = appvmConfiguration // {imports = appvmConfiguration.imports ++ cfg.extraModules ++ vm.extraModules ++ [{environment.systemPackages = vm.packages;}];};
-    specialArgs = {inherit lib;};
   };
 in {
   options.ghaf.virtualization.microvm.appvm = with lib; {

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -178,7 +178,6 @@ in {
             guivmBaseConfiguration.imports
             ++ cfg.extraModules;
         };
-      specialArgs = {inherit lib;};
     };
 
     # This directory needs to be created before any of the microvms start.

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -120,7 +120,6 @@ in {
             netvmBaseConfiguration.imports
             ++ cfg.extraModules;
         };
-      specialArgs = {inherit lib;};
     };
   };
 }

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -1,6 +1,6 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{
+{self, ...}: {
   perSystem = {
     pkgs,
     lib,
@@ -9,13 +9,13 @@
   }: let
     inherit (pkgs) callPackage;
   in {
-    packages = lib.platformPkgs system {
+    packages = self.lib.platformPkgs system {
       gala-app = callPackage ./gala {};
       kernel-hardening-checker = callPackage ./kernel-hardening-checker {};
       windows-launcher = callPackage ./windows-launcher {enableSpice = false;};
       windows-launcher-spice = callPackage ./windows-launcher {enableSpice = true;};
       doc = callPackage ../docs {
-        revision = lib.ghaf-version;
+        revision = lib.strings.fileContents ../.version;
         # options = ;
         # TODO Add the options in from the self.nixosModules
         # The below is not needed anymore to setoptions

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -7,10 +7,9 @@
     system,
     ...
   }: let
-    inherit (lib.flakes) platformPkgs;
     inherit (pkgs) callPackage;
   in {
-    packages = platformPkgs system {
+    packages = lib.platformPkgs system {
       gala-app = callPackage ./gala {};
       kernel-hardening-checker = callPackage ./kernel-hardening-checker {};
       windows-launcher = callPackage ./windows-launcher {enableSpice = false;};

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -33,7 +33,6 @@
     ];
     hostConfiguration = lib.nixosSystem {
       inherit system;
-      specialArgs = {inherit lib;};
       modules =
         [
           microvm.nixosModules.host

--- a/targets/imx8qm-mek/flake-module.nix
+++ b/targets/imx8qm-mek/flake-module.nix
@@ -14,7 +14,6 @@
   imx8qm-mek = variant: extraModules: let
     hostConfiguration = lib.nixosSystem {
       inherit system;
-      specialArgs = {inherit lib;};
       modules =
         [
           microvm.nixosModules.host

--- a/targets/lenovo-x1-installer/flake-module.nix
+++ b/targets/lenovo-x1-installer/flake-module.nix
@@ -13,7 +13,6 @@
     imagePath = self.packages.x86_64-linux."lenovo-x1-carbon-gen11-${variant}" + "/disk1.raw";
     hostConfiguration = lib.nixosSystem {
       inherit system;
-      specialArgs = {inherit lib;};
       modules = [
         ({
           pkgs,

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -22,7 +22,6 @@
   lenovo-x1 = variant: extraModules: let
     hostConfiguration = lib.nixosSystem {
       inherit system;
-      specialArgs = {inherit lib;};
       modules =
         [
           disko.nixosModules.disko

--- a/targets/microchip-icicle-kit/flake-module.nix
+++ b/targets/microchip-icicle-kit/flake-module.nix
@@ -14,7 +14,6 @@
   microchip-icicle-kit = variant: extraModules: let
     hostConfiguration = lib.nixosSystem {
       inherit system;
-      specialArgs = {inherit lib;};
       modules =
         [
           nixos-hardware.nixosModules.microchip-icicle-kit

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -34,7 +34,6 @@
     ];
     hostConfiguration = lib.nixosSystem {
       inherit system;
-      specialArgs = {inherit lib;};
 
       modules =
         [

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -12,7 +12,6 @@
   vm = variant: let
     hostConfiguration = lib.nixosSystem {
       inherit system;
-      specialArgs = {inherit lib;};
       modules = [
         microvm.nixosModules.host
         nixos-generators.nixosModules.vm


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This makes it a lot easier to instantiate NixOS systems as you no longer have to pass in special things.

Depends on: https://github.com/tiiuae/ghaf/pull/509

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
