### PR TITLE
lenovo-x1: don't create anymous NixOS module for disko configuration

### DIFF
--- a/modules/common/hardware/definition.nix
+++ b/modules/common/hardware/definition.nix
@@ -63,6 +63,24 @@
       };
     };
 
+    disks = mkOption {
+      description = "Disks to format and mount";
+      type = types.attrsOf (types.submodule {
+        options.device = mkOption {
+          type = types.str;
+          description = ''
+            Path to the disk
+          '';
+        };
+      });
+      default = {};
+      example = literalExpression ''
+        {
+          disk1.device = "/dev/nvme0n1";
+        }
+      '';
+    };
+
     gpu = {
       # TODO? Should add GuiVM enabler here?
       # guivm.enable = mkEnableOption = "NetVM";

--- a/modules/disko/flake-module.nix
+++ b/modules/disko/flake-module.nix
@@ -1,0 +1,13 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{inputs, ...}: {
+  flake.nixosModules = {
+    # TODO: rename this module to what it actually does rather than what model it's for.
+    # We version the disko partitiong module so that we can update it without breaking existing systems
+    disko-lenovo-x1-basic-v1.imports = [
+      inputs.disko.nixosModules.disko
+      ./lenovo-x1-disko-basic.nix
+      ./disko-basic-postboot.nix
+    ];
+  };
+}

--- a/modules/disko/lenovo-x1-disko-basic.nix
+++ b/modules/disko/lenovo-x1-disko-basic.nix
@@ -1,10 +1,11 @@
 # Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 # Example to create a bios compatible gpt partition
-{device ? throw "Set your device e.g. /dev/nvme0n1", ...}: {
+# To use this example, you will need to specify a device i.e.
+#   { disko.devices.disk1.device = "/dev/sda"; }
+{
   disko.devices = {
     disk.disk1 = {
-      inherit device;
       type = "disk";
       #TODO: hardcoding the size for now until 544 is merged
       #https://github.com/nix-community/disko/pull/544

--- a/modules/flake-module.nix
+++ b/modules/flake-module.nix
@@ -4,6 +4,8 @@
 # Modules to be exported from Flake
 #
 {inputs, ...}: {
+  imports = [./disko/flake-module.nix];
+
   flake.nixosModules = {
     common.imports = [
       ./common

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -35,7 +35,8 @@
           self.nixosModules.microvm
 
           # TODO: Refactor the disko module a bit
-          (import ../../modules/disko/lenovo-x1-disko-basic.nix {device = "/dev/nvme0n1";}) #TODO define device in hw def file
+          ../../modules/disko/lenovo-x1-disko-basic.nix #TODO define device in hw def file
+          { disko.disk.disk1.device = "/dev/nvme0n1"; }
           ../../modules/disko/disko-basic-postboot.nix
 
           ./sshkeys.nix

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -6,7 +6,6 @@
   lib,
   microvm,
   lanzaboote,
-  disko,
   name,
   system,
   ...
@@ -25,7 +24,6 @@
       specialArgs = {inherit lib;};
       modules =
         [
-          disko.nixosModules.disko
           lanzaboote.nixosModules.lanzaboote
           microvm.nixosModules.host
           self.nixosModules.common
@@ -34,10 +32,7 @@
           self.nixosModules.lanzaboote
           self.nixosModules.microvm
 
-          # TODO: Refactor the disko module a bit
-          ../../modules/disko/lenovo-x1-disko-basic.nix #TODO define device in hw def file
-          { disko.disk.disk1.device = "/dev/nvme0n1"; }
-          ../../modules/disko/disko-basic-postboot.nix
+          self.nixosModules.disko-lenovo-x1-basic-v1
 
           ./sshkeys.nix
           ({
@@ -80,6 +75,8 @@
 
             environment.etc.${config.ghaf.security.sshKeys.getAuthKeysFilePathInEtc} = import ./getAuthKeysSource.nix {inherit pkgs config;};
             services.openssh = config.ghaf.security.sshKeys.sshAuthorizedKeysCommand;
+
+            disko.devices.disk = config.ghaf.hardware.definition.disks;
 
             ghaf = {
               hardware.definition = hwDefinition;

--- a/targets/lenovo-x1/hardwareDefinition.nix
+++ b/targets/lenovo-x1/hardwareDefinition.nix
@@ -28,4 +28,6 @@
     # Lenovo X1 trackpoint (red button/joystick)
     "/dev/input/by-path/platform-i8042-serio-1-event-mouse"
   ];
+
+  disks.disk1.device = "/dev/nvme0n1";
 }


### PR DESCRIPTION
The NixOS module will already throw an error if an option is not set. Anymous NixOS modules will contain no file name in the error message.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
