### PR TITLE
labwc: refactor labwc configuration

### DIFF
--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -7,25 +7,108 @@
   ...
 }: let
   cfg = config.ghaf.graphics.labwc;
-  screen_lock_cmd =
-    if config.ghaf.graphics.labwc.lock.enable
-    then ''
-      # Lock screen after 5 minutes
-      ${pkgs.swayidle}/bin/swayidle -w timeout 300 \
-      '${pkgs.swaylock-effects}/bin/swaylock -f -c 000000 \
-      --clock --indicator --indicator-radius 150 --inside-ver-color 5ac379' &
+  autostart =
+    pkgs.writeScriptBin "labwc-autostart" ''
+      # Import WAYLAND_DISPLAY variable to make it available to waypipe and other systemd services
+      ${pkgs.systemd}/bin/systemctl --user import-environment WAYLAND_DISPLAY 2>&1 &
+
+      # Set the wallpaper.
+      ${pkgs.swaybg}/bin/swaybg -m fill -i ${cfg.wallpaper} >/dev/null 2>&1 &
+
+      # Configure output directives such as mode, position, scale and transform.
+      ${pkgs.kanshi}/bin/kanshi >/dev/null 2>&1 &
+
+      # Launch the top task bar.
+      ${pkgs.waybar}/bin/waybar -s /etc/waybar/style.css -c /etc/waybar/config >/dev/null 2>&1 &
+
+      # Enable notifications.
+      ${pkgs.mako}/bin/mako >/dev/null 2>&1 &
+
+      ${lib.optionalString cfg.lock.enable ''
+        # Lock screen after 5 minutes
+        ${pkgs.swayidle}/bin/swayidle -w timeout 300 \
+        '${pkgs.swaylock-effects}/bin/swaylock -f -c 000000 \
+        --clock --indicator --indicator-radius 150 --inside-ver-color 5ac379' &
+      ''}
     ''
-    else "";
+    + cfg.extraAutostart;
+  rcXml = ''
+    <?xml version="1.0"?>
+    <labwc_config>
+    <core><gap>10</gap></core>
+    <keyboard>
+      <default />
+    </keyboard>
+    <mouse><default /></mouse>
+    <windowRules>
+      ${lib.concatStringsSep "\n" (map (rule: ''
+        <windowRule identifier="${rule.identifier}" borderColor="${rule.colour}" serverDecoration="yes" skipTaskbar="no"  />
+      '')
+      cfg.frameColouring)}
+    </windowRules>
+    </labwc_config>
+  '';
+
+  menuXml = ''
+    <?xml version="1.0" encoding="UTF-8"?>
+    <openbox_menu>
+      <menu id="client-menu">
+        <item label="Minimize">
+          <action name="Iconify" />
+        </item>
+        <item label="Maximize">
+          <action name="ToggleMaximize" />
+        </item>
+        <item label="Fullscreen">
+          <action name="ToggleFullscreen" />
+        </item>
+        <item label="Decorations">
+          <action name="ToggleDecorations" />
+        </item>
+        <item label="AlwaysOnTop">
+          <action name="ToggleAlwaysOnTop" />
+        </item>
+      </menu>
+    </openbox_menu>
+  '';
   launchers = pkgs.callPackage ./launchers.nix {inherit config;};
 in {
   options.ghaf.graphics.labwc = {
     enable = lib.mkEnableOption "labwc";
-  };
-
-  options.ghaf.graphics.labwc.lock.enable = lib.mkOption {
-    description = "Labwc screen locking";
-    type = lib.types.bool;
-    default = false;
+    lock.enable = lib.mkEnableOption "labwc screen locking";
+    wallpaper = lib.mkOption {
+      type = lib.types.path;
+      default = ../../../assets/wallpaper.png;
+      description = "Path to the wallpaper image";
+    };
+    frameColouring = lib.mkOption {
+      type = lib.types.listOf (lib.types.submodule {
+        options = {
+          identifier = lib.mkOption {
+            type = lib.types.str;
+            example = "foot";
+            description = "Identifier of the application";
+          };
+          colour = lib.mkOption {
+            type = lib.types.str;
+            example = "#00ffff";
+            description = "Colour of the window frame";
+          };
+        };
+      });
+      default = [
+        {
+          identifier = "foot";
+          colour = "#00ffff";
+        }
+      ];
+      description = "List of applications and their frame colours";
+    };
+    extraAutostart = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "These lines go to the end of labwc autoconfig";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -39,21 +122,16 @@ in {
     # It will create /etc/pam.d/swaylock file for authentication
     security.pam.services = lib.mkIf config.ghaf.graphics.labwc.lock.enable {swaylock = {};};
 
+    environment.etc = {
+      "labwc/rc.xml".text = rcXml;
+      "labwc/menu.xml".text = menuXml;
+      "labwc/themerc".source = "${pkgs.labwc}/share/doc/labwc/themerc";
+    };
+
     # Next 2 services/targets are taken from official weston documentation
     # and adjusted for labwc
     # https://wayland.pages.freedesktop.org/weston/toc/running-weston.html
-    systemd.user.services."labwc" = let
-      autostart =
-        pkgs.concatScript "labwc-autostart"
-        [
-          "${pkgs.labwc}/share/doc/labwc/autostart"
-          (pkgs.writeText "autostart-extra" ''
-            # Import WAYLAND_DISPLAY variable to make it available to waypipe and other systemd services
-            ${pkgs.systemd}/bin/systemctl --user import-environment WAYLAND_DISPLAY 2>&1 &
-            ${screen_lock_cmd}
-          '')
-        ];
-    in {
+    systemd.user.services."labwc" = {
       enable = true;
       description = "labwc, a Wayland compositor, as a user service TEST";
       documentation = ["man:labwc(1)"];
@@ -68,7 +146,7 @@ in {
         # Defaults to journal
         StandardOutput = "journal";
         StandardError = "journal";
-        ExecStart = "${pkgs.labwc}/bin/labwc -C ${pkgs.labwc}/share/doc/labwc -s ${autostart}";
+        ExecStart = "${pkgs.labwc}/bin/labwc -C /etc/labwc -s ${autostart}/bin/labwc-autostart";
         #GPU pt needs some time to start - labwc fails to restart 3 times in avg.
         ExecStartPre = "${pkgs.coreutils}/bin/sleep 3";
         Restart = "on-failure";
@@ -81,6 +159,12 @@ in {
         WLR_RENDERER = "pixman";
         # See: https://github.com/labwc/labwc/blob/0.6.5/docs/environment
         XKB_DEFAULT_LAYOUT = "us,fi";
+        XKB_DEFAULT_OPTIONS = "XKB_DEFAULT_OPTIONS=grp:alt_shift_toggle";
+        XDG_CURRENT_DESKTOP = "wlroots";
+        MOZ_ENABLE_WAYLAND = "1";
+        XCURSOR_THEME = "breeze_cursors";
+        WLR_NO_HARDWARE_CURSORS = "1";
+        _JAVA_AWT_WM_NONREPARENTING = "1";
       };
       wantedBy = ["default.target"];
     };

--- a/modules/desktop/graphics/waybar.config.nix
+++ b/modules/desktop/graphics/waybar.config.nix
@@ -21,6 +21,13 @@
   ghaf-launcher = pkgs.callPackage ./ghaf-launcher.nix {inherit config pkgs;};
 in {
   config = lib.mkIf cfg.enable {
+    ghaf.graphics.launchers = [
+      {
+        name = "Terminal";
+        path = "${pkgs.foot}/bin/foot";
+        icon = "${pkgs.foot}/share/icons/hicolor/48x48/apps/foot.png";
+      }
+    ];
     environment.etc."waybar/config" = {
       text =
         # Modified from default waybar configuration file https://github.com/Alexays/Waybar/blob/master/resources/config

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -13,6 +13,6 @@
   wifi-connector-nmcli = final.callPackage ../../packages/wifi-connector {useNmcli = true;};
   qemu_kvm = import ./qemu {inherit final prev;};
   nm-launcher = final.callPackage ../../packages/nm-launcher {};
-  labwc = import ./labwc {inherit final prev;};
+  labwc = import ./labwc {inherit prev;};
   tpm2-pkcs11 = import ./tpm2-pkcs11 {inherit prev;};
 })

--- a/overlays/custom-packages/labwc/default.nix
+++ b/overlays/custom-packages/labwc/default.nix
@@ -3,44 +3,7 @@
 #
 # This overlay customizes labwc - see comments for details
 #
-{
-  final,
-  prev,
-}:
-prev.labwc.overrideAttrs (prevAttrs: {
+{prev}:
+prev.labwc.overrideAttrs {
   patches = [./labwc-colored-borders.patch];
-  buildInputs = with final;
-    [
-      foot
-      swaybg
-      kanshi
-      waybar
-      mako
-      swayidle
-    ]
-    ++ prevAttrs.buildInputs;
-  preInstallPhases = ["preInstallPhase"];
-  preInstallPhase = ''
-    substituteInPlace ../docs/autostart \
-     --replace "swaybg -c '#113344'" '${final.swaybg}/bin/swaybg -m fill -i ${../../../assets/wallpaper.png}' \
-     --replace kanshi ${final.kanshi}/bin/kanshi \
-     --replace waybar "${final.waybar}/bin/waybar -s /etc/waybar/style.css -c /etc/waybar/config" \
-     --replace mako ${final.mako}/bin/mako \
-     --replace swayidle ${final.swayidle}/bin/swayidle
-
-    substituteInPlace ../docs/menu.xml \
-     --replace alacritty ${final.foot}/bin/foot
-
-    substituteInPlace ../docs/environment \
-     --replace 'XKB_DEFAULT_LAYOUT=se,de' ""
-    substituteInPlace ../docs/environment \
-     --replace 'XKB_DEFAULT_LAYOUT=se' ""
-
-    #frame coloring example
-    substituteInPlace ../docs/rc.xml \
-     --replace '</labwc_config>' \
-     '<windowRules><windowRule identifier="Foot" borderColor="#00ffff" serverDecoration="yes" skipTaskbar="no"  /></windowRules></labwc_config>'
-
-    chmod +x ../docs/autostart
-  '';
-})
+}


### PR DESCRIPTION
## Description of changes

This patch moves the configuration of labwc out of the overlay, allowing us to easily customise the system using ghaf's configuration.

This also makes the labwc package future-proof, as previously we were using configuration files in place from labwc's source `docs` folder. A recent change commented out these files, so labwc would break in nixpkgs 24.05.


## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
Not much changed in terms of functionality, except removal of some right click menu items.
Screen lock functionality is tested.