### PR TITLE
labwc: remove not-working icons from drawer

### DIFF
--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -43,6 +43,7 @@
       });
 
     boot.enableContainers = false;
+    documentation.nixos.enable = false;
     ##### Remove to here
   };
 }

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -15,4 +15,7 @@
   nm-launcher = final.callPackage ../../packages/nm-launcher {};
   labwc = import ./labwc {inherit final prev;};
   tpm2-pkcs11 = import ./tpm2-pkcs11 {inherit prev;};
+  # launcher overlays
+  networkmanagerapplet = import ./networkmanagerapplet {inherit prev;};
+  htop = import ./htop {inherit prev;};
 })

--- a/overlays/custom-packages/htop/default.nix
+++ b/overlays/custom-packages/htop/default.nix
@@ -1,0 +1,11 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This overlay hides the desktop entry for htop
+#
+{prev}:
+prev.htop.overrideAttrs {
+  postInstall = ''
+    echo "Hidden=true" >> $out/share/applications/htop.desktop
+  '';
+}

--- a/overlays/custom-packages/networkmanagerapplet/default.nix
+++ b/overlays/custom-packages/networkmanagerapplet/default.nix
@@ -1,0 +1,11 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This overlay hides the desktop entry for network settings
+#
+{prev}:
+prev.networkmanagerapplet.overrideAttrs {
+  postInstall = ''
+    echo "Hidden=true" >> $out/share/applications/nm-connection-editor.desktop
+  '';
+}


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This removes not-working icons from the drawer, by making these entries "Hidden."

It also removes NixOS documentation from the Ghaf image, that results in a slightly smaller image and removes the NixOS documentation launcher entry.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
Can only be tested in labwc. All icons in the launcher drawer should be functional and work.