### PR TITLE
boot: add plymouth with Ghaf logo as an optional module

### DIFF
--- a/modules/desktop/graphics/boot.nix
+++ b/modules/desktop/graphics/boot.nix
@@ -1,0 +1,33 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.ghaf.graphics.boot;
+in
+  with lib; {
+    options.ghaf.graphics.boot = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enables graphical boot with plymouth.
+        '';
+      };
+    };
+
+    config = mkIf cfg.enable {
+      boot = {
+        plymouth = {
+          enable = true;
+          logo = ../../../assets/ghaf-logo.png;
+        };
+        # Hide boot log from user completely
+        kernelParams = ["quiet" "udev.log_priority=3"];
+        consoleLogLevel = 0;
+        initrd.verbose = false;
+      };
+    };
+  }

--- a/modules/desktop/graphics/default.nix
+++ b/modules/desktop/graphics/default.nix
@@ -10,5 +10,6 @@
     ./fonts.nix
     ./gnome.nix
     ./window-manager.nix
+    ./boot.nix
   ];
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This allows enabling plymouth for booting graphical systems, showing a spinning circle and the Ghaf logo underneath.



<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
1. Enable the option `ghaf.graphics.boot.enable = true;` on the host.
2. Reboot, you should see the boot spinner and Ghaf logo on boot. (only visible sometimes when boot is slow, maybe ~20% of time)
