### PR TITLE
disko: Enable Luks disk encryption

### DIFF
--- a/modules/common/hardware/definition.nix
+++ b/modules/common/hardware/definition.nix
@@ -84,11 +84,18 @@
             Path to the disk
           '';
         };
+        options.imageSize = mkOption {
+          type = types.str;
+          description = ''
+            Size of the image
+          '';
+        };
       });
       default = {};
       example = literalExpression ''
         {
           disk1.device = "/dev/nvme0n1";
+          disk1.imageSize = "100G"
         }
       '';
     };

--- a/modules/common/hardware/lenovo-x1/definitions/default.nix
+++ b/modules/common/hardware/lenovo-x1/definitions/default.nix
@@ -9,9 +9,16 @@
 in {
   inherit (hwDefinition) mouse;
   inherit (hwDefinition) touchpad;
-  inherit (hwDefinition) disks;
   inherit (hwDefinition) network;
   inherit (hwDefinition) gpu;
+
+  disks = {
+    disk1.device = "/dev/nvme0n1";
+    # 250G is the size of the 1st LVM pool, 10G is reserved for the second LVM pool
+    # Second LVM pool can be extended safely to the end of the disk, and its restricted size
+    # makes flashing quicker.
+    disk1.imageSize = "260G";
+  };
 
   # Notes:
   #   1. This assembles udev rules for different hw configurations (i.e., different mice/touchpads) by adding

--- a/modules/common/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/common/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -7,10 +7,6 @@
   mouse = ["ELAN067B:00 04F3:31F8 Mouse" "SYNA8016:00 06CB:CEB3 Mouse"];
   touchpad = ["ELAN067B:00 04F3:31F8 Touchpad" "SYNA8016:00 06CB:CEB3 Touchpad"];
 
-  disks = {
-    disk1.device = "/dev/nvme0n1";
-  };
-
   network.pciDevices = [
     {
       # Passthrough Intel WiFi card

--- a/modules/common/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/common/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -16,10 +16,6 @@
     "ELAN067B:00 04F3:31F8 Touchpad"
   ];
 
-  disks = {
-    disk1.device = "/dev/nvme0n1";
-  };
-
   network.pciDevices = [
     {
       # Passthrough Intel WiFi card

--- a/modules/disko/disko-ab-partitions.nix
+++ b/modules/disko/disko-ab-partitions.nix
@@ -1,0 +1,181 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# !!! To utilize this partition scheme, the disk size must be >252G !!!
+#
+# This partition scheme contains three common partitions and two LVM pools.
+# First LVM pool occupies 250G and second one occupies the rest of the disk space.
+# Some paritions are duplicated for the future AB SWupdate implementation.
+#
+# First three partitions are related to the boot process:
+# - boot : Bootloader partition
+# - ESP-A : (500M) Kernel and initrd
+# - ESP-B : (500M)
+#
+# First LVM pool contains next partitions:
+# - root-A : (50G) Root FS
+# - root-B : (50G)
+# - vm-storage-A : (30G) Possible standalone pre-built VM images are stored here
+# - vm-storage-B : (30G)
+# - reserved-A : (10G) Reserved partition, no use
+# - reserved-B : (10G)
+# - gp-storage : (50G) General purpose storage for some common insecure cases
+# - recovery : (rest of the LVM pool) Recovery factory image is stored here
+#
+# Second LVM pool is dedicated for Storage VM completely.
+_: {
+  disko.memSize = 2048;
+  disko.devices = {
+    disk.disk1 = {
+      type = "disk";
+      content = {
+        type = "gpt";
+        partitions = {
+          boot = {
+            name = "boot";
+            size = "1M";
+            type = "EF02";
+          };
+          esp_a = {
+            name = "ESP_A";
+            size = "500M";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [
+                "umask=0077"
+                "nofail"
+              ];
+            };
+          };
+          esp_b = {
+            name = "ESP_B";
+            size = "500M";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountOptions = [
+                "umask=0077"
+                "nofail"
+              ];
+            };
+          };
+          other_1 = {
+            name = "lvm_pv_1";
+            size = "250G";
+            content = {
+              type = "lvm_pv";
+              vg = "pool";
+            };
+          };
+          # LVM pool that is going to be passed to the Storage VM
+          other_2 = {
+            name = "lvm_pv_2";
+            size = "100%";
+            content = {
+              type = "lvm_pv";
+              vg = "vmstore";
+            };
+          };
+        };
+      };
+    };
+    lvm_vg = {
+      pool = {
+        type = "lvm_vg";
+        lvs = {
+          root_a = {
+            size = "50G";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/";
+              mountOptions = [
+                "defaults"
+                "noatime"
+              ];
+            };
+          };
+          vm_storage_a = {
+            size = "30G";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/vmstore";
+              mountOptions = [
+                "defaults"
+                "nofail"
+                "noatime"
+              ];
+            };
+          };
+          reserved_a = {
+            size = "10G";
+          };
+          root_b = {
+            size = "50G";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountOptions = [
+                "defaults"
+                "noatime"
+              ];
+            };
+          };
+          vm_storage_b = {
+            size = "30G";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountOptions = [
+                "defaults"
+                "nofail"
+                "noatime"
+              ];
+            };
+          };
+          reserved_b = {
+            size = "10G";
+          };
+          gp_storage = {
+            size = "50G";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountOptions = [
+                "defaults"
+                "nofail"
+                "noatime"
+              ];
+            };
+          };
+          recovery = {
+            size = "100%FREE";
+          };
+        };
+      };
+      vmstore = {
+        # Dedicated partition for StorageVM
+        type = "lvm_vg";
+        lvs = {
+          storagevm = {
+            size = "100%FREE";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountOptions = [
+                "defaults"
+                "nofail"
+                "noatime"
+              ];
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/disko/flake-module.nix
+++ b/modules/disko/flake-module.nix
@@ -13,6 +13,7 @@
     disko-ab-partitions-v1.imports = [
       inputs.disko.nixosModules.disko
       ./disko-ab-partitions.nix
+      ./lenovo-x1-disk-encryption.nix
       ./disko-basic-postboot.nix
     ];
   };

--- a/modules/disko/flake-module.nix
+++ b/modules/disko/flake-module.nix
@@ -9,5 +9,11 @@
       ./lenovo-x1-disko-basic.nix
       ./disko-basic-postboot.nix
     ];
+
+    disko-ab-partitions-v1.imports = [
+      inputs.disko.nixosModules.disko
+      ./disko-ab-partitions.nix
+      ./disko-basic-postboot.nix
+    ];
   };
 }

--- a/modules/disko/lenovo-x1-disk-encryption.nix
+++ b/modules/disko/lenovo-x1-disk-encryption.nix
@@ -1,0 +1,10 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{lib, ...}:
+with lib; {
+  options.ghaf.disk.encryption.enable = mkOption {
+    description = "Enable Ghaf disk encryption";
+    type = types.bool;
+    default = false;
+  };
+}

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -33,7 +33,7 @@
           self.nixosModules.lanzaboote
           self.nixosModules.microvm
 
-          self.nixosModules.disko-lenovo-x1-basic-v1
+          self.nixosModules.disko-ab-partitions-v1
 
           ./sshkeys.nix
           ({


### PR DESCRIPTION
This patch creates luks filesystem which is encrypted and can be decrypted using Yubikey or system password.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
Please follow the below steps:
1) After fresh installation on first boot system will ask for Yubikey PIN:
![image](https://github.com/tiiuae/ghaf/assets/147831196/182eead9-ad97-461a-bb0c-4832d25bbc96)
2) After which need to tap Yubikey 2 times (Repeat steps 1 and 2 depending on how many devices need to encrypted)
3) System will automatically continue to boot up, please check in ghaf-host terminal you will see lvm block devices encrypted.
 
![image](https://github.com/tiiuae/ghaf/assets/147831196/dbbb9a21-7bc0-49c9-af01-80bc24c65706)

4) On Next boot user need to enter Yubikey PIN once + tap on Yubikey device (depending on devices to be decrypted).
![image](https://github.com/tiiuae/ghaf/assets/147831196/cdf40243-dc24-4436-a835-171195ebf8ab)


## Improvements
-  For encryption depending on number of devices need to encrypted user need to enter Yubikey PIN each time + double tap the Yubikey.
- For decryption user need to enter Yubikey PIN once + tap once Yubikey for each device which need to be decrypted.
- More block devices can be added later.  