### PR TITLE
GhA: build.yml: rebase before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,12 +133,27 @@ jobs:
           echo
           echo "Available storage after cleanup:"
           df -h
+      - name: Apt install
+        run: sudo apt-get update; sudo apt-get install -y inxi git
       - name: Print runner system info
-        run: sudo apt-get update; sudo apt-get install -y inxi; sudo inxi -c0 --width -1 --basic --memory-short
+        run: sudo inxi -c0 --width -1 --basic --memory-short
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+      - name: Rebase
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          COMMITS="$(git rev-list "$BASE".. --count)"
+          CONTEXT=5
+          echo -e "\n[+] Git log before rebase (with $CONTEXT commits context):"
+          git log --oneline -n$(( COMMITS + CONTEXT ))
+          echo -e "\n[+] Rebasing $COMMITS commit(s) on top of '$BASE'"
+          git config user.email "foo@bar.com"; git config user.name "Foo Bar"
+          git rebase "$BASE"
+          echo -e "\n[+] Git log after rebase (with $CONTEXT commits context):"
+          git log --oneline -n$(( COMMITS + CONTEXT ))
       - name: Install nix
         uses: cachix/install-nix-action@v24
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,7 @@ jobs:
           extra_nix_config: |
             trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://ghaf-dev.cachix.org?priority=20 https://cache.vedenemo.dev https://cache.nixos.org
+            connect-timeout = 5
             system-features = nixos-test benchmark big-parallel kvm
             builders-use-substitutes = true
             builders = @/etc/nix/machines


### PR DESCRIPTION
- Rebase the PR changes on top of the target base head before running the build step. Intentionally do the rebase locally in the github action only, without committing the rebased changes. We also intentionally fail the build step if the automatic git rebase fails to encourage manual rebase.
- Adds verbose logging to the 'Rebase' step to explicitly state the commit hexshas on which the build step was executed (or rebase failed).
- Moves the apt installation as its own step.

In addition, this change set the[ connect-timeout](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-connect-timeout) to 5 seconds to make nix package manager gracefully degrade if the binary cache is not responding.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->

This change was tested in a forked repository at: https://github.com/henrirosten/ghaf/pull/22, https://github.com/henrirosten/ghaf/pull/24, and https://github.com/henrirosten/ghaf/pull/23.