### PR TITLE
Add perf and unixbench to debug tools

### DIFF
--- a/modules/common/development/debug-tools.nix
+++ b/modules/common/development/debug-tools.nix
@@ -37,16 +37,13 @@ in
           # Performance testing
           speedtest-cli
           iperf
-
-          # Let's have this fixed version according to kernel.
-          # It would be possible to select also latest producing currently (12-3-2024) perf version 6.6.7
-          # linuxPackages_latest.perf
-          linuxKernel.packages.linux_6_1.perf
+          # Match perf version with kernel.
+          config.boot.kernelPackages.perf
         ]
         # TODO Can this be changed to platformPkgs to filter ?
         # LuaJIT (which is sysbench dependency) not available on RISC-V
-        ++ lib.lists.optionals (config.nixpkgs.hostPlatform.system != "riscv64-linux") [sysbench]
+        ++ lib.optional (config.nixpkgs.hostPlatform.system != "riscv64-linux") sysbench
         # runtimeShell (unixbench dependency) not available on RISC-V nor on cross-compiled Orin AGX/NX
-        ++ lib.lists.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [unixbench];
+        ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) unixbench;
     };
   }

--- a/modules/common/development/debug-tools.nix
+++ b/modules/common/development/debug-tools.nix
@@ -37,10 +37,16 @@ in
           # Performance testing
           speedtest-cli
           iperf
+
+          # Let's have this fixed version according to kernel.
+          # It would be possible to select also latest producing currently (12-3-2024) perf version 6.6.7
+          # linuxPackages_latest.perf
+          linuxKernel.packages.linux_6_1.perf
         ]
         ++
         # LuaJIT (which is sysbench dependency) not available on RISC-V
+        # runtimeShell (unixbench dependency) not available on RISC-V
         # TODO Can this be changed to platformPkgs to filter ?
-        lib.optional (config.nixpkgs.hostPlatform.system != "riscv64-linux") sysbench;
+        lib.lists.optionals (config.nixpkgs.hostPlatform.system != "riscv64-linux") [ sysbench unixbench ];
     };
   }

--- a/modules/common/development/debug-tools.nix
+++ b/modules/common/development/debug-tools.nix
@@ -43,10 +43,10 @@ in
           # linuxPackages_latest.perf
           linuxKernel.packages.linux_6_1.perf
         ]
-        ++
-        # LuaJIT (which is sysbench dependency) not available on RISC-V
-        # runtimeShell (unixbench dependency) not available on RISC-V
         # TODO Can this be changed to platformPkgs to filter ?
-        lib.lists.optionals (config.nixpkgs.hostPlatform.system != "riscv64-linux") [ sysbench unixbench ];
+        # LuaJIT (which is sysbench dependency) not available on RISC-V
+        ++ lib.lists.optionals (config.nixpkgs.hostPlatform.system != "riscv64-linux") [sysbench]
+        # runtimeShell (unixbench dependency) not available on RISC-V nor on cross-compiled Orin AGX/NX
+        ++ lib.lists.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [unixbench];
     };
   }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Add perf and unixbench to debug-tools.nix. Need to exclude unixbench from RISCV because runtimeShell is not enabled for that target.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [x] Tested on Polarfire `riscv64`
- [x] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

These tools are meant for performance monitoring, mainly for Q&A team. 

Perf was added especially for RISCV Icicle-kit target but it was tested also on Lenovo-X1. On Icicle-kit custom perf script will be used (to get execution time decreased):
`{ perf bench sched messaging; perf bench sched pipe -l 50000; perf bench syscall basic; perf bench mem memcpy; perf bench mem memset; perf bench mem find_bit -i 5 -j 1000; perf bench numa mem -p 1 -t 1 -P 1024 -C 0 -M 0 -s 5 -zZq --thp 1 --no-data_rand_walk; perf bench futex all; perf bench epoll wait; perf bench epoll ctl; perf bench internals synthesize -i 1000; perf bench internals kallsyms-parse -i 10; } | tee -a perf_results`

The plan is to run unixbench (default) index test once per month on ghaf-host and on net-vm for Lenovo-X1 and Orin AGX/NX. Unixbench is not included to cross-compiled targets since they lack runtimeShell. Run the index test set with command:
`ubench`

Single unixbench index run takes around 0,5h. In multi-core environment it takes 1h (1 parallel process / multiple parallel processes).

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
