### PR TITLE
Add SSH key to ghaf installer

### DIFF
--- a/targets/lenovo-x1-installer/flake-module.nix
+++ b/targets/lenovo-x1-installer/flake-module.nix
@@ -27,6 +27,12 @@
             "${toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
           ];
 
+          # SSH key to installer for test automation.
+          users.users.nixos.openssh.authorizedKeys.keys = [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAolaKCuIUBQSBFGFZI1taNX+JTAr8edqUts7A6k2Kv7"
+          ];
+          services.openssh.enable = true;
+
           systemd.services.wpa_supplicant.wantedBy = lib.mkForce ["multi-user.target"];
           systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];
 

--- a/targets/lenovo-x1-installer/flake-module.nix
+++ b/targets/lenovo-x1-installer/flake-module.nix
@@ -28,10 +28,9 @@
           ];
 
           # SSH key to installer for test automation.
-          users.users.nixos.openssh.authorizedKeys.keys = [
+          users.users.nixos.openssh.authorizedKeys.keys = lib.mkIf (variant == "debug") [
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAolaKCuIUBQSBFGFZI1taNX+JTAr8edqUts7A6k2Kv7"
           ];
-          services.openssh.enable = true;
 
           systemd.services.wpa_supplicant.wantedBy = lib.mkForce ["multi-user.target"];
           systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];


### PR DESCRIPTION
Add SSH key to ghaf installer in debug mode. This enables ci-test-automation to run the installer.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

The public SSH key which this PR adds corresponds to private key accessible only by test automation. If you want to test with some other key pair clone the repository and add public key to `targets/lenovo-x1-installer/flake-module.nix`

**Debug mode**

Build the installer in debug mode
`nix build .#lenovo-x1-carbon-gen11-debug-installer`

Boot Lenovo-X1 from the installer image and connect it to local network with Ethernet cable + USB adapter.

Check IP address on Lenovo-X1
`ifconfig` 

Test that you can ssh to installer running on Lenovo-X1 from your computer (where the ssh key pair was created)
`ssh nixos@ip_address`

**Release mode**

Build the installer in release mode
`nix build .#lenovo-x1-carbon-gen11-release-installer`

Boot Lenovo-X1 from the installer image and connect it to local network with Ethernet cable + USB adapter.

Check IP address on Lenovo-X1
`ifconfig` 

Test that you can NOT ssh to installer running on Lenovo-X1 from your computer (where the ssh key pair was created)
`ssh nixos@ip_address`



<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
