### PR TITLE
Set labwc as default compositor for Nvidia Jetson

### DIFF
--- a/modules/desktop/graphics/demo-apps.nix
+++ b/modules/desktop/graphics/demo-apps.nix
@@ -66,13 +66,8 @@ in {
       ++ lib.optional cfg.zathura {
         name = "zathura";
         path = "${pkgs.zathura}/bin/zathura";
-        icon = "${pkgs.zathura}/share/icons/hicolor/32x32/apps/org.pwmt.zathura.png";
+        # Nvidia Jetson build cannot find the file "${pkgs.zathura}/share/icons/hicolor/32x32/apps/org.pwmt.zathura.png" even it is exist
+        icon = "${../../../assets/icons/png/pdf.png}";
       };
-    environment.systemPackages =
-      lib.optional cfg.chromium pkgs.chromium
-      ++ lib.optional cfg.element-desktop pkgs.element-desktop
-      ++ lib.optional cfg.firefox pkgs.firefox
-      ++ lib.optional cfg.gala-app pkgs.gala-app
-      ++ lib.optional cfg.zathura pkgs.zathura;
   };
 }

--- a/modules/desktop/profiles/graphics.nix
+++ b/modules/desktop/profiles/graphics.nix
@@ -14,7 +14,7 @@ in
       enable = mkEnableOption "Graphics profile";
       compositor = mkOption {
         type = types.enum compositors;
-        default = "weston";
+        default = "labwc";
         description = ''
           Which Wayland compositor to use.
 

--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -12,4 +12,9 @@
   # libck is dependency of sysbench
   libck = import ./libck {inherit prev;};
   sysbench = import ./sysbench {inherit final prev;};
+
+  # wlroots and gcr_4 are dependency of waybar
+  wlroots = import ./wlroots {inherit final prev;};
+  gcr_4 = import ./gcr_4 {inherit final prev;};
+  waybar = import ./waybar {inherit final prev;};
 })

--- a/overlays/cross-compilation/gcr_4/default.nix
+++ b/overlays/cross-compilation/gcr_4/default.nix
@@ -1,0 +1,12 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# gcr_4 cross-compilation fixes
+#
+{
+  final,
+  prev,
+}:
+prev.gcr_4.overrideAttrs (old: {
+  nativeBuildInputs = [final.gnupg] ++ old.nativeBuildInputs;
+})

--- a/overlays/cross-compilation/waybar/default.nix
+++ b/overlays/cross-compilation/waybar/default.nix
@@ -1,0 +1,13 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Waybar cross-compilation fixes
+#
+{
+  final,
+  prev,
+}:
+prev.waybar.overrideAttrs (old: {
+  nativeBuildInputs = [final.buildPackages.scdoc final.wrapGAppsHook final.catch2_3] ++ old.nativeBuildInputs;
+  depsBuildBuild = [final.buildPackages.pkg-config final.buildPackages.wayland-scanner];
+})

--- a/overlays/cross-compilation/wlroots/default.nix
+++ b/overlays/cross-compilation/wlroots/default.nix
@@ -1,0 +1,12 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# wlroots cross-compilation fixes
+#
+{
+  final,
+  prev,
+}:
+prev.wlroots.overrideAttrs (old: {
+  nativeBuildInputs = old.nativeBuildInputs ++ [final.hwdata];
+})

--- a/packages/nm-launcher/default.nix
+++ b/packages/nm-launcher/default.nix
@@ -34,6 +34,7 @@ writeShellApplication {
     description = "Script to launch nm-connection-editor to configure network of netvm using D-Bus over SSH.";
     platforms = [
       "x86_64-linux"
+      "aarch64-linux"
     ];
   };
 }

--- a/packages/wifi-signal-strength/default.nix
+++ b/packages/wifi-signal-strength/default.nix
@@ -57,6 +57,7 @@ in
       description = "Script to get wifi data from nmcli to show network of netvm using D-Bus over SSH on Waybar.";
       platforms = [
         "x86_64-linux"
+        "aarch64-linux"
       ];
     };
   }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Update the default compositor as Labwc instead of Weston.
Double launchers in nwg-drawer are solved.
Tested on AGX Orin and X1.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
