### PR TITLE
DRAFT: Change netvm hypervisor to cloud-hypervisor

### DIFF
--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -35,7 +35,7 @@
         nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
         nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
 
-        microvm.hypervisor = "qemu";
+        microvm.hypervisor = "cloud-hypervisor";
 
         networking = {
           firewall.allowedTCPPorts = [53];
@@ -93,6 +93,7 @@
               tag = "ro-store";
               source = "/nix/store";
               mountPoint = "/nix/.ro-store";
+              proto = "virtiofs";
             }
           ];
           writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";

--- a/targets/lenovo-x1/netvmExtraModules.nix
+++ b/targets/lenovo-x1/netvmExtraModules.nix
@@ -26,6 +26,7 @@
           tag = configH.ghaf.security.sshKeys.waypipeSshPublicKeyName;
           source = configH.ghaf.security.sshKeys.waypipeSshPublicKeyDir;
           mountPoint = configH.ghaf.security.sshKeys.waypipeSshPublicKeyDir;
+          proto = "virtiofs";
         }
       ];
     };


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Use cloud-hypervisor for Net VM guest instead of qemu.

Also requires change of the share protocol from 9p to virtiofs, since cloud-hypervisor does not support 9p.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [X] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Tested by building an X1 image and running it, verifying that network configuration and connection works via the top bar applet.

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
