### PR TITLE
Integration of Dendrite to Ghaf

### DIFF
--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -17,5 +17,6 @@
     ./version
     ./virtualization/docker.nix
     ./systemd
+    ./services
   ];
 }

--- a/modules/common/services/default.nix
+++ b/modules/common/services/default.nix
@@ -1,0 +1,7 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  imports = [
+    ./dendrite-pinecone.nix
+  ];
+}

--- a/modules/common/services/dendrite-pinecone.nix
+++ b/modules/common/services/dendrite-pinecone.nix
@@ -1,0 +1,152 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.ghaf.services.dendrite-pinecone;
+  dendrite-pineconePkg = import ../../../packages/dendrite-pinecone/default.nix {inherit pkgs;};
+in
+  with lib; {
+    imports = [
+    ];
+
+    options.ghaf.services.dendrite-pinecone = {
+      firewallConfig = mkEnableOption "Enable dendrite pinecone module firewall configurations. It must be enabled only in netvm";
+
+      enable = mkEnableOption "Enable dendrite pinecone module";
+
+      externalNic = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          External network interface
+        '';
+      };
+      internalNic = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Internal network interface
+        '';
+      };
+
+      serverIpAddr = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Dendrite Server Ip address
+        '';
+      };
+    };
+
+    config = mkIf (cfg.firewallConfig && cfg.enable) {
+      assertions = [
+        {
+          assertion = cfg.externalNic != "";
+          message = "External Nic must be set";
+        }
+        {
+          assertion = cfg.internalNic != "";
+          message = "Internal Nic must be set";
+        }
+        {
+          assertion = cfg.serverIpAddr != "";
+          message = "Dendrite Pinecone server ip must be set";
+        }
+      ];
+
+      # ip forwarding functionality is needed for iptables
+      boot.kernel.sysctl."net.ipv4.ip_forward" = 1;
+
+      # https://github.com/troglobit/smcroute?tab=readme-ov-file#linux-requirements
+      boot.kernelPatches = [
+        {
+          name = "multicast-routing-config";
+          patch = null;
+          extraStructuredConfig = with lib.kernel; {
+            IP_MULTICAST = yes;
+            IP_MROUTE = yes;
+            IP_PIMSM_V1 = yes;
+            IP_PIMSM_V2 = yes;
+            IP_MROUTE_MULTIPLE_TABLES = yes; # For multiple routing tables
+          };
+        }
+      ];
+      environment.systemPackages = [pkgs.smcroute];
+      systemd.services."smcroute" = {
+        description = "Static Multicast Routing daemon";
+        bindsTo = ["sys-subsystem-net-devices-${cfg.externalNic}.device"];
+        after = ["sys-subsystem-net-devices-${cfg.externalNic}.device"];
+        preStart = ''
+                configContent=$(cat <<EOF
+          mgroup from ${cfg.externalNic} group ${dendrite-pineconePkg.McastUdpIp}
+          mgroup from ${cfg.internalNic} group ${dendrite-pineconePkg.McastUdpIp}
+          mroute from ${cfg.externalNic} group ${dendrite-pineconePkg.McastUdpIp} to ${cfg.internalNic}
+          mroute from ${cfg.internalNic} group ${dendrite-pineconePkg.McastUdpIp} to ${cfg.externalNic}
+          EOF
+          )
+          filePath="/etc/smcroute.conf"
+          touch $filePath
+            chmod 200 $filePath
+            echo "$configContent" > $filePath
+            chmod 400 $filePath
+
+          # wait until ${cfg.externalNic} has an ip
+          while [ -z "$ip" ]; do
+           ip=$(${pkgs.nettools}/bin/ifconfig ${cfg.externalNic} | ${pkgs.gawk}/bin/awk '/inet / {print $2}')
+                [ -z "$ip" ] && ${pkgs.coreutils}/bin/sleep 1
+          done
+          exit 0
+        '';
+
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkgs.smcroute}/sbin/smcrouted -n -s -f /etc/smcroute.conf";
+          #TODO sudo setcap cap_net_admin=ep ${pkgs.smcroute}/sbin/smcroute
+          User = "root";
+          # Automatically restart service when it exits.
+          Restart = "always";
+          # Wait a second before restarting.
+          RestartSec = "5s";
+        };
+        wantedBy = ["multi-user.target"];
+      };
+
+      networking = {
+        firewall.enable = true;
+        firewall.extraCommands = "
+        # Set the default policies
+        iptables -P INPUT DROP
+        iptables -P FORWARD DROP
+        iptables -P OUTPUT ACCEPT
+
+        # Allow loopback traffic
+        iptables -A INPUT -i lo -j ACCEPT
+
+        # Forward incoming TCP traffic on port ${dendrite-pineconePkg.TcpPort} to internal network(element-vm)
+        iptables -t nat -A PREROUTING -i ${cfg.externalNic} -p tcp --dport ${dendrite-pineconePkg.TcpPort} -j DNAT --to-destination  ${cfg.serverIpAddr}:${dendrite-pineconePkg.TcpPort}
+
+        # Enable NAT for outgoing traffic
+        iptables -t nat -A POSTROUTING -o ${cfg.externalNic} -p tcp --dport ${dendrite-pineconePkg.TcpPort} -j MASQUERADE
+
+        # Enable NAT for outgoing traffic
+        iptables -t nat -A POSTROUTING -o ${cfg.externalNic} -p tcp --sport ${dendrite-pineconePkg.TcpPort} -j MASQUERADE
+
+        # Enable NAT for outgoing udp multicast traffic
+        iptables -t nat -A POSTROUTING -o ${cfg.externalNic} -p udp -d ${dendrite-pineconePkg.McastUdpIp} --dport ${dendrite-pineconePkg.McastUdpPort} -j MASQUERADE
+
+        # https://github.com/troglobit/smcroute?tab=readme-ov-file#usage
+        iptables -t mangle -I PREROUTING -i ${cfg.externalNic} -d ${dendrite-pineconePkg.McastUdpIp} -j TTL --ttl-set 1
+        # ttl value must be set to 1 for avoiding multicast looping
+        iptables -t mangle -I PREROUTING -i ${cfg.internalNic} -d ${dendrite-pineconePkg.McastUdpIp} -j TTL --ttl-inc 1
+
+        # Accept forwarding
+        iptables -A FORWARD -j ACCEPT
+      ";
+      };
+    };
+  }

--- a/packages/dendrite-pinecone/default.nix
+++ b/packages/dendrite-pinecone/default.nix
@@ -1,0 +1,26 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{pkgs, ...}:
+with pkgs;
+  buildGo119Module rec {
+    pname = "dendrite-pinecone";
+    version = "0.9.1";
+
+    TcpPort = "49000";
+    McastUdpPort = "60606";
+    McastUdpIp = "239.0.0.114";
+    TcpPortInt = 49000;
+    McastUdpPortInt = 60606;
+    src = pkgs.fetchFromGitHub {
+      owner = "tiiuae";
+      repo = "dendrite";
+      # branch is feature/ghaf-integration
+      rev = "53036309e34420bde92b81ac214985c3fa3fb975";
+      sha256 = "sha256-UhA9deqWu3ERa08GMGV6/NVHEBZaAdPf7hXQb3GTRcA=";
+    };
+    subPackages = ["cmd/dendrite-demo-pinecone"];
+    # patches = [./turnserver-crendentials-flags.patch];
+
+    vendorHash = "sha256-xMOd4N3hjajpNl9zxJnPrPIJjS292mFthpIQUHWqoYI=";
+  }

--- a/targets/lenovo-x1/appvms/default.nix
+++ b/targets/lenovo-x1/appvms/default.nix
@@ -9,7 +9,7 @@
   chromium = import ./chromium.nix {inherit pkgs;};
   gala = import ./gala.nix {inherit pkgs;};
   zathura = import ./zathura.nix {inherit pkgs;};
-  element = import ./element.nix {inherit pkgs;};
+  element = import ./element.nix {inherit pkgs config;};
   includeAppflowy = pkgs.stdenv.isx86_64;
   appflowy =
     if includeAppflowy

--- a/targets/lenovo-x1/appvms/element.nix
+++ b/targets/lenovo-x1/appvms/element.nix
@@ -1,15 +1,58 @@
-# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-{pkgs, ...}: {
+{
+  pkgs,
+  config,
+  ...
+}: let
+  dendrite-pinecone = pkgs.callPackage ../../../packages/dendrite-pinecone {};
+  isDendritePineconeEnabled = config.ghaf.services.dendrite-pinecone.enable;
+in {
   name = "element";
-  packages = [pkgs.element-desktop pkgs.element-gps pkgs.gpsd];
-  #packages = [pkgs.element-desktop pkgs.gpsd pkgs.element-gps];
+
+  packages =
+    [
+      pkgs.element-desktop
+      pkgs.element-gps
+      pkgs.gpsd
+      pkgs.tcpdump
+      pkgs.pulseaudio
+    ]
+    ++ pkgs.lib.optionals isDendritePineconeEnabled [dendrite-pinecone];
   macAddress = "02:00:00:03:08:01";
   ramMb = 4096;
-  cores = 1;
+  cores = 4;
   extraModules = [
     {
+      # Enable pulseaudio for user ghaf to access mic
+      sound.enable = true;
+      hardware.pulseaudio.enable = true;
+      users.extraUsers.ghaf.extraGroups = ["audio" "video"];
+
+      systemd.network = {
+        enable = true;
+        networks."10-ethint0" = {
+          DHCP = pkgs.lib.mkForce "no";
+          matchConfig.Name = "ethint0";
+          addresses = [
+            {
+              addressConfig.Address = "192.168.100.253/24";
+            }
+          ];
+          routes = [{routeConfig.Gateway = "192.168.100.1";}];
+          linkConfig.RequiredForOnline = "routable";
+          linkConfig.ActivationPolicy = "always-up";
+        };
+      };
+
+      networking = pkgs.lib.mkIf isDendritePineconeEnabled {
+        firewall.allowedTCPPorts = [dendrite-pinecone.TcpPortInt];
+        firewall.allowedUDPPorts = [dendrite-pinecone.McastUdpPortInt];
+      };
+
+      time.timeZone = "${config.time.timeZone}";
+
       services.gpsd = {
         enable = true;
         devices = ["/dev/ttyUSB0"];
@@ -31,17 +74,26 @@
         wantedBy = ["multi-user.target"];
       };
 
-      time.timeZone = "Asia/Dubai";
+      systemd.services."dendrite-pinecone" = pkgs.lib.mkIf isDendritePineconeEnabled {
+        description = "Dendrite is a second-generation Matrix homeserver with Pinecone which is a next-generation P2P overlay network";
+        enable = true;
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${dendrite-pinecone}/bin/dendrite-demo-pinecone";
+          Restart = "on-failure";
+          RestartSec = "2";
+        };
+        wantedBy = ["multi-user.target"];
+      };
 
       microvm.qemu.extraArgs = [
+        # Note: If you want to enable integrated camera in element-vm,
+        # remove enabling camera line from chromium-vm
         # Lenovo X1 integrated usb webcam
         "-device"
         "qemu-xhci"
         "-device"
-        "usb-host,vendorid=0x04f2,productid=0xb751"
-        # External USB GPS receiver
-        "-device"
-        "usb-host,vendorid=0x067b,productid=0x23a3"
+        "usb-host,hostbus=3,hostport=8"
         # Connect sound device to hosts pulseaudio socket
         "-audiodev"
         "pa,id=pa1,server=unix:/run/pulse/native"
@@ -50,7 +102,11 @@
         "intel-hda"
         "-device"
         "hda-duplex,audiodev=pa1"
+        # External USB GPS receiver
+        "-device"
+        "usb-host,vendorid=0x067b,productid=0x23a3"
       ];
     }
   ];
+  borderColor = "#337aff";
 }

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -83,6 +83,8 @@
 
               host.networking.enable = true;
               host.powercontrol.enable = true;
+              # dendrite-pinecone service is enabled
+              services.dendrite-pinecone.enable = true;
 
               virtualization.microvm.netvm = {
                 enable = true;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--

-->
The element chat application was intended to facilitate data transmission with the custom netvm and element-vm firewall setup. PR ensures allowing operation of Dendrite Server communication with the external network by enabling TCP port 49000 and routing UDP port 60606 multicast packets. The network security in netvm was strengthened by changing INPUT default behavior from ACCEPT to DROP. `smcroute` multicast routing app was used to forward UDP  bidirectional multicast packets between external/internal networks.

To be reviewed in conjunction with https://github.com/tiiuae/ghaf/pull/430.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

1. Normally, dendrite-pinecone runs as a system service, and the `sudo systemctl status dendrite-pinecone.service` output should look like the picture below.
![WhatsApp Image 2024-04-03 at 9 13 45 AM](https://github.com/tiiuae/ghaf/assets/23314775/5b5cfb38-019d-4ef0-b2cc-bcff56051287)

2. We should stop with `sudo systemctl stop dendrite-pinecone.service` . Then the dendrite-pinecone should be run by `dendrite-pinecone` command service to see logs on stdout. I also run one dendrite-pinecone instance from a different PC (192.168.1.7) which is the same wifi network as ThinkPad-x1 (netvm:192.168.1.11, element-vm: 192.168.100.253). In the second terminal, `sudo tcpdump -i ethint0 '((udp port 60606) or (tcp port 49000))'` should be executed to filter udp port 60606 and TCP port 49000 packets. 

**Packet 1:** It shows the multicast pinecone packets from 192.168.1.7 to element-vm
**Packet 2:** It shows the TCP pinecone connection initiated from 192.168.100.253 with source port: 54019 to 192.168.1.7 with destination port: 49000 
**Packet 3:** It shows the multicast pinecone packets from element-vm to the external network (192.168.1.7)
**Note** : `tcpdump` shows port 49000 as matahari. You can find further information why it shows like that.
[link](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/6.3_technical_notes/matahari)

![test-1 drawio](https://github.com/tiiuae/ghaf/assets/23314775/217515aa-798b-4919-8f19-9c24f0b45230)


**Note** : If you want to do end-to-end testing with element chat app, @TPiUnikie 's [PR](https://github.com/tiiuae/ghaf/pull/430#issue-2053617784) should be merged with this PR.  It is available in [my private repo](https://github.com/enesoztrk/ghaf/tree/element-app-demo-with-dendrite)  if you need an already merged version of Timo's changes and this PR.
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
