### PR TITLE
Systemd stage1 boot (initrd)

### DIFF
--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -38,6 +38,7 @@
       withPam = true;
       inherit (cfg) withPolkit;
       inherit (cfg) withResolved;
+      inherit (cfg) withRepart;
       withShellCompletions = cfg.withDebug;
       withTimedated = true;
       inherit (cfg) withTimesyncd;
@@ -198,6 +199,12 @@ in
 
       withResolved = mkOption {
         description = "Enable systemd resolve daemon.";
+        type = types.bool;
+        default = false;
+      };
+
+      withRepart = mkOption {
+        description = "Enable systemd repart functionality.";
         type = types.bool;
         default = false;
       };

--- a/modules/common/systemd/boot.nix
+++ b/modules/common/systemd/boot.nix
@@ -1,0 +1,66 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  # Ghaf configuration flags
+  cfg = config.ghaf.systemd.boot;
+  cfgBase = config.ghaf.systemd;
+
+  # Package configuration
+  package = pkgs.systemdMinimal.override {
+    pname = "stage1-systemd";
+    inherit (cfgBase) withAudit;
+    inherit (cfgBase) withCryptsetup;
+    inherit (cfgBase) withEfi;
+    inherit (cfgBase) withFido2;
+    inherit (cfgBase) withRepart;
+    inherit (cfgBase) withTpm2Tss;
+  };
+
+  # Suppressed initrd systemd units
+  suppressedUnits =
+    [
+      "multi-user.target"
+    ]
+    ++ (lib.optionals ((!cfgBase.withDebug) && (!cfgBase.withJournal)) [
+      "systemd-journald.service"
+      "systemd-journald.socket"
+      "systemd-journald-dev-log.socket"
+    ])
+    ++ (lib.optionals ((!cfgBase.withDebug) && (!cfgBase.withAudit)) [
+      "systemd-journald-audit.socket"
+    ])
+    ++ (lib.optionals (!cfgBase.withDebug) [
+      "kexec.target"
+      "systemd-kexec.service"
+      "emergency.service"
+      "emergency.target"
+      "rescue.service"
+      "rescue.target"
+      "rpcbind.target"
+    ]);
+in
+  with lib; {
+    options.ghaf.systemd.boot = {
+      enable = mkEnableOption "Enable systemd in stage 1 of the boot (initrd).";
+    };
+
+    config = mkIf cfg.enable {
+      boot.initrd = {
+        verbose = config.ghaf.profiles.debug.enable;
+        services.lvm.enable = true;
+        systemd = {
+          enable = true;
+          inherit package;
+          inherit suppressedUnits;
+          emergencyAccess = config.ghaf.profiles.debug.enable;
+          enableTpm2 = cfgBase.withTpm2Tss;
+          initrdBin = optionals config.ghaf.profiles.debug.enable [pkgs.lvm2 pkgs.util-linux];
+        };
+      };
+    };
+  }

--- a/modules/common/systemd/default.nix
+++ b/modules/common/systemd/default.nix
@@ -3,7 +3,7 @@
 {
   imports = [
     ./base.nix
+    ./boot.nix
     # TODO hardened configs
-    # TODO stage 1
   ];
 }

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: let
   cfg = config.ghaf.virtualization.microvm-host;
@@ -10,18 +11,23 @@ in
   with lib; {
     options.ghaf.virtualization.microvm-host = {
       enable = mkEnableOption "MicroVM Host";
-      hostNetworkSupport = mkEnableOption "Network support services to run host applications.";
+      networkSupport = mkEnableOption "Network support services to run host applications.";
     };
 
     config = mkIf cfg.enable {
       microvm.host.enable = true;
       ghaf.systemd = {
-        enable = true;
         withName = "host-systemd";
+        enable = true;
+        boot.enable = true;
         withPolkit = true;
-        withTimesyncd = cfg.hostNetworkSupport;
-        withNss = cfg.hostNetworkSupport;
-        withResolved = cfg.hostNetworkSupport;
+        withTpm2Tss = pkgs.stdenv.hostPlatform.isx86;
+        withRepart = true;
+        withFido2 = true;
+        withCryptsetup = true;
+        withTimesyncd = cfg.networkSupport;
+        withNss = cfg.networkSupport;
+        withResolved = cfg.networkSupport;
         withSerial = config.ghaf.profiles.debug.enable;
         withDebug = config.ghaf.profiles.debug.enable;
       };

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -47,7 +47,7 @@
               hardware.x86_64.common.enable = true;
 
               virtualization.microvm-host.enable = true;
-              virtualization.microvm-host.hostNetworkSupport = true;
+              virtualization.microvm-host.networkSupport = true;
               host.networking.enable = true;
               virtualization.microvm.netvm = {
                 enable = true;

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -131,7 +131,7 @@
                 ++ config.ghaf.hardware.definition.gpu.pciDevices
               ));
             in [
-              "intel_iommu=on,igx_off,sm_on"
+              "intel_iommu=on,sm_on"
               "iommu=pt"
               # Prevent i915 module from being accidentally used by host
               "module_blacklist=i915"

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -82,7 +82,8 @@
               security.tpm2.enable = true;
 
               virtualization.microvm-host.enable = true;
-              virtualization.microvm-host.hostNetworkSupport = true;
+              virtualization.microvm-host.networkSupport = true;
+
               host.networking.enable = true;
               virtualization.microvm.netvm = {
                 enable = true;

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -64,7 +64,7 @@
               };
 
               virtualization.microvm-host.enable = true;
-              virtualization.microvm-host.hostNetworkSupport = true;
+              virtualization.microvm-host.networkSupport = true;
               host.networking.enable = true;
 
               virtualization.microvm.netvm.enable = true;

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -25,7 +25,7 @@
             hardware.x86_64.common.enable = true;
 
             virtualization.microvm-host.enable = true;
-            virtualization.microvm-host.hostNetworkSupport = true;
+            virtualization.microvm-host.networkSupport = true;
             host.networking.enable = true;
             # TODO: NetVM enabled, but it does not include anything specific
             #       for this Virtual Machine target


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This PR enables systemd in initrd for stage1 boot. For x1-carbon, enabled systemd `tpm`, `repart`, and `cryptsetup` for further work.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Build and run on x1-carbon (gen11), generic-x86, vm, and Orin AGX.
Proper testing needed.

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
