### PR TITLE
Move to using nixci from nix-build-all

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,22 +33,6 @@
         "type": "github"
       }
     },
-    "devour-flake": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1699722684,
-        "narHash": "sha256-LapKkHNZ8D3k/uLaJjmGxx7GuYRinGBxEkIAGb/8pCo=",
-        "owner": "srid",
-        "repo": "devour-flake",
-        "rev": "c89ad7a611caef31899292bc8f9aae9e7aa251cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "devour-flake",
-        "type": "github"
-      }
-    },
     "devshell": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -404,7 +388,6 @@
     },
     "root": {
       "inputs": {
-        "devour-flake": "devour-flake",
         "devshell": "devshell",
         "disko": "disko",
         "flake-compat": "flake-compat",

--- a/flake.nix
+++ b/flake.nix
@@ -83,12 +83,6 @@
       inputs.systems.follows = "systems";
     };
 
-    # Used to evaluate a flake outputs all at once
-    devour-flake = {
-      url = "github:srid/devour-flake";
-      flake = false;
-    };
-
     #
     # Target Building and services
     #

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -15,43 +15,25 @@
     system,
     ...
   }: {
-    devShells.default = let
-      nix-build-all = pkgs.writeShellApplication {
-        name = "nix-build-all";
-        runtimeInputs = let
-          devour-flake = pkgs.callPackage inputs.devour-flake {};
-        in [
-          pkgs.nix
-          devour-flake
-        ];
-        text = ''
-          # Make sure that flake.lock is sync
-          nix flake lock --no-update-lock-file
+    devShells.default = pkgs.mkShell {
+      name = "Ghaf devshell";
+      #TODO look at adding Mission control etc here
+      packages = with pkgs;
+        [
+          git
+          nix
+          nixci
+          nixos-rebuild
+          reuse
+          alejandra
+          mdbook
+          inputs'.nix-fast-build.packages.default
+          self'.packages.kernel-hardening-checker
+        ]
+        ++ lib.optional (pkgs.hostPlatform.system != "riscv64-linux") cachix;
 
-          # Do a full nix build (all outputs)
-          devour-flake . "$@"
-        '';
-      };
-    in
-      pkgs.mkShell {
-        name = "Ghaf devshell";
-        #TODO look at adding Mission control etc here
-        packages = with pkgs;
-          [
-            git
-            nix
-            nixos-rebuild
-            reuse
-            alejandra
-            mdbook
-            nix-build-all
-            inputs'.nix-fast-build.packages.default
-            self'.packages.kernel-hardening-checker
-          ]
-          ++ lib.optional (pkgs.hostPlatform.system != "riscv64-linux") cachix;
-
-        # TODO Add pre-commit.devShell (needs to exclude RiscV)
-        # https://flake.parts/options/pre-commit-hooks-nix
-      };
+      # TODO Add pre-commit.devShell (needs to exclude RiscV)
+      # https://flake.parts/options/pre-commit-hooks-nix
+    };
   };
 }


### PR DESCRIPTION
nixci provides a cleaner interface to the devour-flake

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
