### PR TITLE
Fix icon IFD: Move the icon path existstance check to checkPhase

### DIFF
--- a/modules/desktop/graphics/launchers.nix
+++ b/modules/desktop/graphics/launchers.nix
@@ -7,16 +7,22 @@
   ...
 }: let
   toDesktop = elem:
-    if !builtins.pathExists elem.icon
-    then throw "The icon's path ${elem.icon} doesn't exist"
-    else
-      makeDesktopItem {
-        inherit (elem) name icon;
-        genericName = elem.name;
-        desktopName = elem.name;
-        comment = "Secured Ghaf Application";
-        exec = elem.path;
-      };
+    (makeDesktopItem {
+      inherit (elem) name icon;
+      genericName = elem.name;
+      desktopName = elem.name;
+      comment = "Secured Ghaf Application";
+      exec = elem.path;
+    })
+    .overrideAttrs (prevAttrs: {
+      checkPhase =
+        prevAttrs.checkPhase
+        + ''
+
+          # Check that the icon's path exists
+          [[ -f "${elem.icon}" ]] || (echo "The icon's path ${elem.icon} doesn't exist" && exit 1)
+        '';
+    });
 in
   pkgs.symlinkJoin {
     name = "ghaf-desktop-entries";


### PR DESCRIPTION

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Move the icon path exists check to checkPhase of makeDesktopItem, to remove the IFD.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [X] Tested on Polarfire `riscv64`
- [X] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Run `nix flake check` to see there is no IFD failure anymore