### PR TITLE
Wayland java - DRAFT

### DIFF
--- a/modules/common/development/default.nix
+++ b/modules/common/development/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./debug-tools.nix
     ./usb-serial.nix
+    ./java.nix
     ./nix.nix
     ./ssh.nix
   ];

--- a/modules/common/development/java.nix
+++ b/modules/common/development/java.nix
@@ -1,0 +1,22 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.ghaf.development.java;
+in
+  with lib; {
+    options.ghaf.development.java = {
+      enable = mkEnableOption "Java Support";
+    };
+
+    config = mkIf cfg.enable {
+      programs.java = {
+        enable = true;
+        package = pkgs.jdk20;
+      };
+    };
+  }

--- a/modules/common/profiles/debug.nix
+++ b/modules/common/profiles/debug.nix
@@ -7,24 +7,26 @@
   ...
 }: let
   cfg = config.ghaf.profiles.debug;
-in {
-  options.ghaf.profiles.debug = {
-    enable = lib.mkEnableOption "debug profile";
-  };
+in
+  with lib; {
+    options.ghaf.profiles.debug = {
+      enable = mkEnableOption "debug profile";
+    };
 
-  config = lib.mkIf cfg.enable {
-    # Enable default accounts and passwords
-    ghaf = {
-      users.accounts.enable = true;
-      # Enable development on target
-      development = {
-        nix-setup.enable = true;
-        # Enable some basic monitoring and debug tools
-        debug.tools.enable = true;
-        # Let us in.
-        ssh.daemon.enable = true;
-        usb-serial.enable = true;
+    config = mkIf cfg.enable {
+      # Enable default accounts and passwords
+      ghaf = {
+        users.accounts.enable = true;
+        # Enable development on target
+        development = {
+          nix-setup.enable = true;
+          # Enable some basic monitoring and debug tools
+          debug.tools.enable = true;
+          # Let us in.
+          ssh.daemon.enable = true;
+          # Enable java
+          java.enable = true;
+        };
       };
     };
-  };
-}
+  }

--- a/modules/desktop/graphics/default.nix
+++ b/modules/desktop/graphics/default.nix
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   imports = [
+    # ./sway.nix
+    ./gnome.nix
     ./weston.nix
     ./labwc.nix
     ./weston.ini.nix

--- a/modules/desktop/graphics/gnome.nix
+++ b/modules/desktop/graphics/gnome.nix
@@ -1,0 +1,49 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# GNOME Desktop support
+#
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  cfg = config.ghaf.graphics.gnome;
+in {
+  options.ghaf.graphics.gnome = {
+    enable = lib.mkEnableOption "gnome";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.opengl = {
+      enable = true;
+      driSupport = true;
+    };
+
+    environment.noXlibs = false;
+    #environment.variables = rec {
+    #  LIBGL_ALWAYS_INDIRECT = "0";
+    #};
+
+    services.xserver = {
+      enable = true;
+      displayManager.lightdm = {
+        enable = true;
+        greeters.gtk.enable = true;
+      };
+      desktopManager.gnome.enable = true;
+      windowManager.qtile.enable = true;
+    };
+    
+    users.extraUsers.ghaf.extraGroups = ["video"];
+    users.extraUsers.lightdm.extraGroups = ["video"];
+    environment.gnome.excludePackages = with pkgs; [
+      gnome-tour
+      gnome.geary
+      gnome.gnome-music
+      gnome.gnome-contacts
+      gnome.cheese
+    ];
+  };
+}

--- a/modules/desktop/graphics/window-manager.nix
+++ b/modules/desktop/graphics/window-manager.nix
@@ -8,9 +8,9 @@
 }: let
   cfg = config.ghaf.graphics.window-manager-common;
 in {
-  options.ghaf.graphics.window-manager-common = {
-    enable = lib.mkOption {
-      type = lib.types.bool;
+  options.ghaf.graphics.window-manager-common = with lib; {
+    enable = mkOption {
+      type = types.bool;
       default = false;
       description = ''
         Common parts for every wlroots-based window manager/compositor.
@@ -26,79 +26,75 @@ in {
 
     environment.noXlibs = false;
 
-    environment.systemPackages = [
+    environment.systemPackages = with pkgs; [
       # Seatd is needed to manage log-in process for wayland sessions
-      pkgs.seatd
+      seatd
     ];
 
     # Next services/targets are taken from official weston documentation:
     # https://wayland.pages.freedesktop.org/weston/toc/running-weston.html
 
-    systemd = {
-      user.targets."ghaf-session" = {
-        description = "Ghaf graphical session";
-        bindsTo = ["ghaf-session.target"];
-        before = ["ghaf-session.target"];
+    systemd.user.targets."ghaf-session" = {
+      description = "Ghaf graphical session";
+      bindsTo = ["ghaf-session.target"];
+      before = ["ghaf-session.target"];
+    };
+
+    systemd.services."ghaf-session" = {
+      description = "Ghaf graphical session";
+
+      # Make sure we are started after logins are permitted.
+      after = ["systemd-user-sessions.service"];
+
+      # if you want you can make it part of the graphical session
+      #Before=graphical.target
+
+      # not necessary but just in case
+      #ConditionPathExists=/dev/tty7
+
+      serviceConfig = {
+        Type = "simple";
+        Environment = "XDG_SESSION_TYPE=X11";
+        ExecStart = "${pkgs.systemd}/bin/systemctl --wait --user start ghaf-session.target";
+
+        # The user to run the session as. Pick one!
+        User = config.ghaf.users.accounts.user;
+        Group = config.ghaf.users.accounts.user;
+
+        # Set up a full user session for the user, required by desktop environment.
+        PAMName = "${pkgs.shadow}/bin/login";
+
+        # A virtual terminal is needed.
+        TTYPath = "/dev/tty7";
+        TTYReset = "yes";
+        TTYVHangup = "yes";
+        TTYVTDisallocate = "yes";
+
+        # Try to grab tty .
+        StandardInput = "tty-force";
+
+        # Defaults to journal, in case it doesn't adjust it accordingly
+        #StandardOutput=journal
+        StandardError = "journal";
+
+        # Log this user with utmp, letting it show up with commands 'w' and 'who'.
+        UtmpIdentifier = "tty7";
+        UtmpMode = "user";
       };
+      wantedBy = ["multi-user.target"];
+    };
 
-      services = {
-        "ghaf-session" = {
-          description = "Ghaf graphical session";
-
-          # Make sure we are started after logins are permitted.
-          after = ["systemd-user-sessions.service"];
-
-          # if you want you can make it part of the graphical session
-          #Before=graphical.target
-
-          # not necessary but just in case
-          #ConditionPathExists=/dev/tty7
-
-          serviceConfig = {
-            Type = "simple";
-            Environment = "XDG_SESSION_TYPE=wayland";
-            ExecStart = "${pkgs.systemd}/bin/systemctl --wait --user start ghaf-session.target";
-
-            # The user to run the session as. Pick one!
-            User = config.ghaf.users.accounts.user;
-            Group = config.ghaf.users.accounts.user;
-
-            # Set up a full user session for the user, required by desktop environment.
-            PAMName = "${pkgs.shadow}/bin/login";
-
-            # A virtual terminal is needed.
-            TTYPath = "/dev/tty7";
-            TTYReset = "yes";
-            TTYVHangup = "yes";
-            TTYVTDisallocate = "yes";
-
-            # Try to grab tty .
-            StandardInput = "tty-force";
-
-            # Defaults to journal, in case it doesn't adjust it accordingly
-            #StandardOutput=journal
-            StandardError = "journal";
-
-            # Log this user with utmp, letting it show up with commands 'w' and 'who'.
-            UtmpIdentifier = "tty7";
-            UtmpMode = "user";
-          };
-          wantedBy = ["multi-user.target"];
-        };
-
-        # systemd service for seatd
-        "seatd" = {
-          description = "Seat management daemon";
-          documentation = ["man:seatd(1)"];
-          serviceConfig = {
-            Type = "simple";
-            ExecStart = "${pkgs.seatd}/bin/seatd -g video";
-            Restart = "always";
-            RestartSec = "1";
-          };
-          wantedBy = ["multi-user.target"];
-        };
+    # systemd service for seatd
+    systemd.services."seatd" = {
+      description = "Seat management daemon";
+      documentation = ["man:seatd(1)"];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.seatd}/bin/seatd -g video";
+        Restart = "always";
+        RestartSec = "1";
       };
+      wantedBy = ["multi-user.target"];
     };
   };
 }

--- a/modules/desktop/profiles/graphics.nix
+++ b/modules/desktop/profiles/graphics.nix
@@ -7,52 +7,50 @@
   ...
 }: let
   cfg = config.ghaf.profiles.graphics;
-  compositors = ["weston" "labwc"];
-  inherit (lib) mkEnableOption mkOption types mkIf;
-in {
-  options.ghaf.profiles.graphics = {
-    enable = mkEnableOption "Graphics profile";
-    compositor = mkOption {
-      type = types.enum compositors;
-      default = "weston";
-      description = ''
-        Which Wayland compositor to use.
+  compositors = ["weston" "labwc" "gnome"];
+in
+  with lib; {
+    options.ghaf.profiles.graphics = {
+      enable = mkEnableOption "Graphics profile";
+      compositor = mkOption {
+        type = types.enum compositors;
+        default = "gnome";
+        description = ''
+          Which Wayland compositor to use.
 
-        Choose one of: ${lib.concatStringsSep "," compositors}
-      '';
+          Choose one of: ${lib.concatStringsSep "," compositors}
+        '';
+      };
     };
-  };
 
-  options.ghaf.graphics = {
-    launchers = mkOption {
-      description = "Labwc application launchers to show in launch bar";
-      default = [];
-      type =
-        types.listOf
-        (types.submodule {
-          options = {
-            name = mkOption {
+    options.ghaf.graphics = with lib; {
+      launchers = mkOption {
+        description = "Labwc application launchers to show in launch bar";
+        default = [];
+        type = with types;
+          listOf
+          (submodule {
+            options.name = mkOption {
               description = "Name of the application";
-              type = types.str;
+              type = str;
             };
-            path = mkOption {
+            options.path = mkOption {
               description = "Path to the executable to be launched";
-              type = types.path;
+              type = path;
             };
-            icon = mkOption {
+            options.icon = mkOption {
               description = "Path of the icon";
-              type = types.path;
+              type = path;
             };
-          };
-        });
+          });
+      };
+      enableDemoApplications = mkEnableOption "some applications for demoing";
     };
-    enableDemoApplications = mkEnableOption "some applications for demoing";
-  };
 
-  config = mkIf cfg.enable {
-    ghaf.graphics = {
-      weston.enable = cfg.compositor == "weston";
-      labwc.enable = cfg.compositor == "labwc";
+    config = mkIf cfg.enable {
+      ghaf.graphics.weston.enable = cfg.compositor == "weston";
+      ghaf.graphics.labwc.enable = cfg.compositor == "labwc";
+      #ghaf.graphics.sway.enable = cfg.compositor == "sway";
+      ghaf.graphics.gnome.enable = cfg.compositor == "gnome";
     };
-  };
-}
+  }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

This work is for trying to achieve a pure Wayland support version of OpenJDK in Ghaf. The work includes two steps. First is to replace the stock JDK with Wayland version of it. The second stage is a little more problematic where the developers of the Pure Wayland OpenJDK has created a libwakefield library inside their source but not compiling it with the OpenJDK builds. The libwakefield should be seperately build from its subdirectory and manually added into OpenJDK prerequisites. The work is aimed for Nvidia Orin but it will also work on Lenovo and other platforms with wayland display.

Some very bad news here as the libwakefield requires the weston9 where our weston version is 12 the weston development interface has changed far beyond repair for porting this. Now my build errors are completely weston.h specific and fixing one by one is not going to fix it anymore as every fix introduces multiple new problems. We may not even have a chance for a proper working version.

<!--
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
Pending
-->
