### PR TITLE
Fix generic-x86_64 build with labwc enabled

### DIFF
--- a/modules/desktop/graphics/fonts.nix
+++ b/modules/desktop/graphics/fonts.nix
@@ -8,17 +8,10 @@
 }: let
   inherit (config.ghaf.graphics) weston labwc;
 in {
-  config =
-    lib.mkIf weston.enable {
-      fonts.fonts = with pkgs; [
-        fira-code
-        hack-font
-      ];
-    }
-    // lib.mkIf labwc.enable {
-      fonts.packages = with pkgs; [
-        (nerdfonts.override {fonts = ["FiraCode"];})
-        hack-font
-      ];
-    };
+  config = lib.mkIf (weston.enable || labwc.enable) {
+    fonts.packages = with pkgs; [
+      fira-code-nerdfont
+      hack-font
+    ];
+  };
 }

--- a/modules/desktop/graphics/waybar.config.nix
+++ b/modules/desktop/graphics/waybar.config.nix
@@ -17,8 +17,13 @@
       $out/share/icons/hicolor/24x24/apps/ghaf-icon-24x24.png
   '';
 
-  wifi-signal-strength = pkgs.callPackage ../../../packages/wifi-signal-strength {wifiDevice = (lib.lists.findFirst (d: d.name != null) null networkDevice).name;};
+  wifiDevice = lib.lists.findFirst (d: d.name != null) null networkDevice;
+  wifi-signal-strength = pkgs.callPackage ../../../packages/wifi-signal-strength {wifiDevice = wifiDevice.name;};
   ghaf-launcher = pkgs.callPackage ./ghaf-launcher.nix {inherit config pkgs;};
+  timeZone =
+    if config.time.timeZone != null
+    then config.time.timeZone
+    else "UTC";
 in {
   config = lib.mkIf cfg.enable {
     ghaf.graphics.launchers = [
@@ -32,56 +37,60 @@ in {
       text =
         # Modified from default waybar configuration file https://github.com/Alexays/Waybar/blob/master/resources/config
         ''
-            {
-              "height": 30, // Waybar height (to be removed for auto height)
-              "spacing": 4, // Gaps between modules (4px)
-              "modules-left": ["custom/launcher"],
-              "modules-center": ["sway/window"],
-              "modules-right": ["pulseaudio", "custom/network1", "backlight", "battery", "clock", "tray"],
-              "keyboard-state": {
-                  "numlock": true,
-                  "capslock": true,
-                  "format": "{name} {icon}",
-                  "format-icons": {
-                      "locked": "",
-                      "unlocked": ""
-                  }
-              },
-              "tray": {
-                  // "icon-size": 21,
-                  "spacing": 10
-              },
-              "clock": {
-                  "timezone": "${config.time.timeZone}",
-                  "tooltip-format": "<big>{:%d %b %Y}</big>\n<tt><small>{calendar}</small></tt>",
-                  // should be "{:%a %-d %b %-I:%M %#p}"
-                  // see github.com/Alexays/Waybar/issues/1469
-                  "format": "{:%a %d %b   %I:%M %p}"
-              },
-              "backlight": {
-                  // "device": "acpi_video1",
-                  "format": "{percent}% {icon}",
-                  "tooltip-format": "Brightness: {percent}%",
-                  "format-icons": ["", "", "", "", "", "", "", "", ""]
-              },
-              "battery": {
-                  "states": {
-                      "critical": 15
-                  },
-                  "interval": 5,
-                  "format": "{capacity}% {icon}",
-                  "format-charging": "{capacity}% 󰢟",
-                  "format-plugged": "{capacity}% ",
-                  "format-alt": "{time} {icon}",
-                  "format-icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
-              },
-              "custom/network1": {
-                "format": "{}",
-                "interval": 15,
-                "exec": "${wifi-signal-strength}/bin/wifi-signal-strength",
-                "return-type": "json",
-                "on-click": "nm-launcher",
-              },
+          {
+            "height": 30, // Waybar height (to be removed for auto height)
+            "spacing": 4, // Gaps between modules (4px)
+            "modules-left": ["custom/launcher"],
+            "modules-center": ["sway/window"],
+            "modules-right": ["pulseaudio", "custom/network1", "backlight", "battery", "clock", "tray"],
+            "keyboard-state": {
+                "numlock": true,
+                "capslock": true,
+                "format": "{name} {icon}",
+                "format-icons": {
+                    "locked": "",
+                    "unlocked": ""
+                }
+            },
+            "tray": {
+                // "icon-size": 21,
+                "spacing": 10
+            },
+            "clock": {
+                "timezone": "${timeZone}",
+                "tooltip-format": "<big>{:%d %b %Y}</big>\n<tt><small>{calendar}</small></tt>",
+                // should be "{:%a %-d %b %-I:%M %#p}"
+                // see github.com/Alexays/Waybar/issues/1469
+                "format": "{:%a %d %b   %I:%M %p}"
+            },
+            "backlight": {
+                // "device": "acpi_video1",
+                "format": "{percent}% {icon}",
+                "tooltip-format": "Brightness: {percent}%",
+                "format-icons": ["", "", "", "", "", "", "", "", ""]
+            },
+            "battery": {
+                "states": {
+                    "critical": 15
+                },
+                "interval": 5,
+                "format": "{capacity}% {icon}",
+                "format-charging": "{capacity}% 󰢟",
+                "format-plugged": "{capacity}% ",
+                "format-alt": "{time} {icon}",
+                "format-icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+            },
+        ''
+        + lib.optionalString (wifiDevice != null) ''
+          "custom/network1": {
+            "format": "{}",
+            "interval": 15,
+            "exec": "${wifi-signal-strength}/bin/wifi-signal-strength",
+            "return-type": "json",
+            "on-click": "nm-launcher",
+          },
+        ''
+        + ''
               "custom/launcher": {
                 "format": " ",
                 "on-click": "${ghaf-launcher}/bin/ghaf-launcher",

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -59,8 +59,11 @@
                 applications.enable = true;
                 release.enable = variant == "release";
                 debug.enable = variant == "debug";
+                # Uncomment this line to use Labwc instead of Weston:
+                #graphics.compositor = "labwc";
               };
               windows-launcher.enable = true;
+              graphics.enableDemoApplications = lib.mkForce false;
             };
 
             #TODO: how to handle the majority of laptops that need a little


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This fixes minor build issues for the generic-x86_64 target when the Labwc compositor is enabled. Also, it disables demo launchers since there are no AppVMs there. While generic-x86_64 target is not currently the main priority, it can still be useful for testing scenarios that don't work with GuiVM and GPU passthrough.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

1. Enable Labwc in the generic-x86_64 target by adding `ghaf.profiles.graphics.compositor = "labwc";` and build it.
2. It fails to build on the current version of Ghaf but builds fine with this PR.
