### PR TITLE
Add USB network card kernel patch

### DIFF
--- a/modules/common/hardware/default.nix
+++ b/modules/common/hardware/default.nix
@@ -5,5 +5,7 @@
     ./x86_64-linux.nix
     ./x86_64-generic
     ./definition.nix
+
+    ./usb-network-kernel-patch.nix
   ];
 }

--- a/modules/common/hardware/usb-network-kernel-patch.nix
+++ b/modules/common/hardware/usb-network-kernel-patch.nix
@@ -1,0 +1,24 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  kernelVersion = config.boot.kernelPackages.kernel.version;
+  kernelMajor = lib.strings.toInt (lib.versions.major kernelVersion);
+  kernelMinor = lib.strings.toInt (lib.versions.minor kernelVersion);
+  kernelPatch = lib.strings.toInt (lib.versions.patch kernelVersion);
+in {
+  boot.kernelPatches = lib.optionals (kernelMajor == 6 && kernelMinor == 1 && kernelPatch >= 82) [
+    # Fix MAC-address randomized on USB network cards because of kernel bug.
+    # This specifically affects network cards used in testing.
+    {
+      patch = pkgs.fetchpatch2 {
+        url = "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/patch/?id=2e91bb99b9d4f756e92e83c4453f894dda220f09";
+        hash = "sha256-fX7yBsXW1oFt1Nfns42oZnCXf36qehXijvCNEmqBGsE=";
+      };
+    }
+  ];
+}


### PR DESCRIPTION

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Fix MAC-address randomized on USB network cards because of kernel bug. This specifically affects network cards used in testing.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [x] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
