### PR TITLE
fix: x86_64 template

### DIFF
--- a/templates/targets/x86_64/generic/flake.nix
+++ b/templates/targets/x86_64/generic/flake.nix
@@ -43,6 +43,8 @@
     ghaf,
     nixpkgs,
     flake-utils,
+    # deadnix: skip
+    nixos-hardware,
   }: let
     systems = with flake-utils.lib.system; [
       x86_64-linux


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

- fixes tiiuae/ghaf#555

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
  - [X] Tested on generic `x86_64` template
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
```
$ nix flake new --template github:vilvo/ghaf/issue_555#target-x86_64-generic ~/test-ghaf-downstream-fix
cd test-ghaf-downstream-fix/
nix flake show
```
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
