### PR TITLE
Create a virtual machine with a virtio-gpu device

### DIFF
--- a/modules/microvm/default.nix
+++ b/modules/microvm/default.nix
@@ -10,5 +10,6 @@
     ./virtualization/microvm/appvm.nix
     ./virtualization/microvm/guivm.nix
     ./networking.nix
+    ./virtualization/microvm/virtgpuvm.nix
   ];
 }

--- a/modules/microvm/virtualization/microvm/virtgpuvm.nix
+++ b/modules/microvm/virtualization/microvm/virtgpuvm.nix
@@ -1,0 +1,156 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  configHost = config;
+  vmName = "virtgpu-vm";
+  virtgpuvmBaseConfiguration = {
+    imports = [
+      (import ./common/vm-networking.nix {
+        inherit vmName;
+        macAddress = "02:00:00:03:05:01";
+      })
+      ({
+        lib,
+        pkgs,
+        ...
+      }: {
+        ghaf = {
+          users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
+
+          development = {
+            ssh.daemon.enable = lib.mkDefault configHost.ghaf.development.ssh.daemon.enable;
+            debug.tools.enable = lib.mkDefault configHost.ghaf.development.debug.tools.enable;
+            nix-setup.enable = lib.mkDefault configHost.ghaf.development.nix-setup.enable;
+          };
+        };
+
+        # SSH is very picky about the file permissions and ownership and will
+        # accept neither direct path inside /nix/store or symlink that points
+        # there. Therefore we copy the file to /etc/ssh/get-auth-keys (by
+        # setting mode), instead of symlinking it.
+        environment.etc."ssh/get-auth-keys" = {
+          source = let
+            script = pkgs.writeShellScriptBin "get-auth-keys" ''
+              [[ "$1" != "ghaf" ]] && exit 0
+              ${pkgs.coreutils}/bin/cat /run/waypipe-ssh-public-key/id_ed25519.pub
+            '';
+          in "${script}/bin/get-auth-keys";
+          mode = "0555";
+        };
+        services.openssh = {
+          authorizedKeysCommand = "/etc/ssh/get-auth-keys";
+          authorizedKeysCommandUser = "nobody";
+        };
+
+        system.stateVersion = lib.trivial.release;
+
+        nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
+        nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
+
+        environment.systemPackages = [
+          pkgs.sommelier
+          pkgs.wayland-proxy-virtwl
+          pkgs.waypipe
+          pkgs.zathura
+          pkgs.chromium
+        ];
+
+        # DRM fbdev emulation is disabled to get rid of the popup console window that appears when running a VM with virtio-gpu device
+        boot.kernelParams = ["drm_kms_helper.fbdev_emulation=false"];
+
+        hardware.opengl.enable = true;
+
+        microvm = {
+          optimize.enable = false;
+          mem = 4096;
+          vcpu = 4;
+          hypervisor = "crosvm";
+          shares = [
+            {
+              tag = "waypipe-ssh-public-key";
+              source = "/run/waypipe-ssh-public-key";
+              mountPoint = "/run/waypipe-ssh-public-key";
+              proto = "virtiofs";
+            }
+            {
+              tag = "ro-store";
+              source = "/nix/store";
+              mountPoint = "/nix/.ro-store";
+              proto = "virtiofs";
+            }
+          ];
+
+          # Adds run-sommelier, run-wayland-proxy and run-waypipe scripts as well as drm and virtio_gpu kernel modules
+          graphics.enable = true;
+
+          # VSOCK is required for waypipe, 3 is the first available CID
+          vsock.cid = 3;
+        };
+        fileSystems."/run/waypipe-ssh-public-key".options = ["ro"];
+
+        imports = [../../../common];
+      })
+    ];
+  };
+  cfg = config.ghaf.virtualization.microvm.virtgpuvm;
+in {
+  options.ghaf.virtualization.microvm.virtgpuvm = {
+    enable = lib.mkEnableOption "VirtgpuVM";
+
+    extraModules = lib.mkOption {
+      description = ''
+        List of additional modules to be imported and evaluated as part of
+        VirtgpuVM's NixOS configuration.
+      '';
+      default = [];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    microvm.vms."${vmName}" = {
+      autostart = false;
+      config = virtgpuvmBaseConfiguration // {imports = virtgpuvmBaseConfiguration.imports ++ cfg.extraModules;};
+      specialArgs = {inherit lib;};
+    };
+
+    # This directory needs to be created before any of the microvms start.
+    systemd.services."create-waypipe-ssh-public-key-directory" = let
+      script = pkgs.writeShellScriptBin "create-waypipe-ssh-public-key-directory" ''
+        mkdir -pv /run/waypipe-ssh-public-key
+        chown -v microvm /run/waypipe-ssh-public-key
+      '';
+    in {
+      enable = true;
+      description = "Create shared directory on host";
+      path = [];
+      wantedBy = ["microvms.target"];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        StandardOutput = "journal";
+        StandardError = "journal";
+        ExecStart = "${script}/bin/create-waypipe-ssh-public-key-directory";
+      };
+    };
+
+    # MicroVM.nix contains a run-waypipe script that expects Waypipe to be running on the host and listening on port 6000
+    systemd.user.services.waypipe = {
+      enable = true;
+      description = "waypipe";
+      after = ["weston.service" "labwc.service"];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.waypipe}/bin/waypipe --vsock -s 6000 client";
+        Restart = "always";
+        RestartSec = "1";
+      };
+      startLimitIntervalSec = 0;
+      wantedBy = ["ghaf-session.target"];
+    };
+  };
+}

--- a/overlays/custom-packages/crosvm/default.nix
+++ b/overlays/custom-packages/crosvm/default.nix
@@ -1,0 +1,27 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  final,
+  prev,
+}:
+prev.crosvm.overrideAttrs (_final: prevAttrs: rec {
+  version = "122.1";
+  src = prev.fetchgit {
+    url = "https://chromium.googlesource.com/chromiumos/platform/crosvm";
+    rev = "562d81eb28a49ed6e0d771a430c21a458cdd33f9";
+    sha256 = "sha256-l5sIUInOhhkn3ernQLIEwEpRCyICDH/1k4C/aidy1/I=";
+    fetchSubmodules = true;
+  };
+
+  patches = [];
+
+  cargoBuildFeatures = final.lib.lists.remove "virgl_renderer_next" prevAttrs.cargoBuildFeatures;
+  cargoCheckFeatures = final.lib.lists.remove "virgl_renderer_next" prevAttrs.cargoCheckFeatures;
+  CROSVM_USE_SYSTEM_MINIGBM = true;
+
+  cargoDeps = prevAttrs.cargoDeps.overrideAttrs (prev.lib.const {
+    inherit src;
+    name = "crosvm-vendor.tar.gz";
+    outputHash = "sha256-yTdho6lW+XqB/iGf+bT2iwnAdjz3TrrI7YAaLoenR1U=";
+  });
+})

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -19,4 +19,6 @@
   # launcher overlays
   networkmanagerapplet = import ./networkmanagerapplet {inherit prev;};
   htop = import ./htop {inherit prev;};
+  sommelier = import ./sommelier {inherit final prev;};
+  crosvm = import ./crosvm {inherit final prev;};
 })

--- a/overlays/custom-packages/sommelier/default.nix
+++ b/overlays/custom-packages/sommelier/default.nix
@@ -1,0 +1,20 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  final,
+  prev,
+}:
+prev.sommelier.overrideAttrs (_final: prevAttrs: {
+  version = "122.0";
+  src = prev.fetchzip rec {
+    url = "https://chromium.googlesource.com/chromiumos/platform2/+archive/${passthru.rev}/vm_tools/sommelier.tar.gz";
+    passthru.rev = "2d4f46c679da7a4e8c447c8cf68c74b80f9de3fe";
+    stripRoot = false;
+    sha256 = "sha256-LNGA1r2IO3Ekh+dK6HUge001qC2TFvxwjhM0iaY0DbU=";
+  };
+
+  nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [final.python3 final.python3.pkgs.jinja2];
+  postPatch = ''
+    patchShebangs gen-shim.py
+  '';
+})

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -64,6 +64,9 @@
                 #graphics.compositor = "labwc";
               };
               windows-launcher.enable = true;
+
+              # Uncomment this line to enable the virtgpu-vm with a virtio-gpu device:
+              #virtualization.microvm.virtgpuvm.enable = true;
             };
 
             #TODO: how to handle the majority of laptops that need a little


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Currently Ghaf uses Waypipe to run graphical application in virtual machines. It works quite well over VSOCK but it might be not very optimal in terms of performance as it serializes all data including pixel buffers over sockets. Also, Waypipe has some security implications, see [this section of the man page](https://gitlab.freedesktop.org/mstoeckl/waypipe/-/blob/master/waypipe.scd?ref_type=heads#L330).

As an alternative solution designed specifically for virtual machine we can evaluate using crosvm virtual machines with a [virtio-gpu device](https://crosvm.dev/book/devices/wayland.html). It requires a proxy Wayland compositor running in the guest, which can be either Sommelier or Wayland-proxy-virtwl.

This PR adds a virtiogpu-vm virtual machine which can be enabled for generic-x86_64 target. It has both Sommelier and Wayland-proxy-virtwl installed as well as Waypipe. The idea is that it can be used as a playground to test virtio-gpu device implemented in crosvm. It's possible to run applications using all available methods with the following scripts: run-sommelier, run-wayland-proxy, run-waypipe.

Known issues:
- The virtiogpu-vm can only be used in generic-x86_64 target at the moment. The use case with GPU passthrough in the GUIVM is not supported.
- The virtiogpu-vm doesn’t autostart because it requires a wayland socket which is only available after the compositor starts. There is also a permissions problem because microvm virtual machines are system services while the compositor is a user service.

My current observations show that Sommelier is a bit unstable. Sometimes it crashes when moving windows, etc. but Wayland-proxy-virtwl seems to be pretty stable. Comparing to Waypipe the performance looks better and the system load is lower but more testing is required.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Enable virtgpu-vm for the generic-x86_64 target by uncommenting `virtualization.microvm.virtgpuvm.enable = true;`
- Build the image, boot Lenovo X1 and manually start the VM with the following command: `sudo -E /var/lib/microvms/virtgpu-vm/current/bin/microvm-run`
- Run Chromium using different methods, test performance, stability, system load, etc:
```
ghaf@virtiogpu-vm$ run-sommelier chromium --ozone-platform=wayland --disable-gpu
ghaf@virtiogpu-vm$ run-wayland-proxy chromium --ozone-platform=wayland --disable-gpu
ghaf@virtiogpu-vm$ run-waypipe chromium --ozone-platform=wayland --disable-gpu
```