### PR TITLE
Update jetpack-nixos in flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,11 +192,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707323143,
-        "narHash": "sha256-Mfj2l2aE+3Vu/u1M1PtQTvIoOZfCkINgtCQagSZFU6Q=",
+        "lastModified": 1712200868,
+        "narHash": "sha256-eSBfjRL6cOhGcawxRhkdNxalRXMPimeVO16W2Jsp4WA=",
         "owner": "anduril",
         "repo": "jetpack-nixos",
-        "rev": "6ae4ce1d368fb56235a8b15ef926db28c4643eb8",
+        "rev": "99ff19f877ad05dc4d171a1f543a90b997cef240",
         "type": "github"
       },
       "original": {

--- a/lib/mk-flash-script/default.nix
+++ b/lib/mk-flash-script/default.nix
@@ -48,12 +48,14 @@
     [
       "@pzstd@"
       "@sed@"
+      "@patch@"
       "@l4tVersion@"
       "@isCross@"
     ]
     [
       "${nixpkgs.legacyPackages.${flash-tools-system}.zstd}/bin/pzstd"
       "${nixpkgs.legacyPackages.${flash-tools-system}.gnused}/bin/sed"
+      "${nixpkgs.legacyPackages.${flash-tools-system}.patch}/bin/patch"
       "${l4tVersion}"
       "${
         if isCross

--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -11,43 +11,50 @@
 
   # Override minimal systemd package configuration
   package =
-    pkgs.systemdMinimal.override {
-      pname = cfg.withName;
-      withAcl = true;
-      withAnalyze = cfg.withDebug;
-      inherit (cfg) withApparmor;
-      inherit (cfg) withAudit;
-      withCompression = true;
-      withCoredump = cfg.withDebug || cfg.withMachines;
-      inherit (cfg) withCryptsetup;
-      inherit (cfg) withEfi;
-      withBootloader = cfg.withEfi; # systemd-boot fails if not explicity set
-      inherit (cfg) withFido2;
-      inherit (cfg) withHostnamed;
-      withImportd = cfg.withMachines;
-      withKexectools = cfg.withDebug;
-      withKmod = true;
-      withLibBPF = true;
-      withLibseccomp = true;
-      inherit (cfg) withLocaled;
-      inherit (cfg) withLogind;
-      withMachined = cfg.withMachines;
-      inherit (cfg) withNetworkd;
-      inherit (cfg) withNss;
-      withOomd = true;
-      withPam = true;
-      inherit (cfg) withPolkit;
-      inherit (cfg) withResolved;
-      inherit (cfg) withRepart;
-      withShellCompletions = cfg.withDebug;
-      withTimedated = true;
-      inherit (cfg) withTimesyncd;
-      inherit (cfg) withTpm2Tss;
-      withUtmp = cfg.withJournal || cfg.withAudit;
-    } # To be removed, current systemd version 254.6 < 255
-    // lib.optionalAttrs (lib.hasAttr "withVmspawn" (lib.functionArgs pkgs.systemd.override)) {
-      withVmspawn = cfg.withMachines;
-    };
+    (pkgs.systemdMinimal.override {
+        pname = cfg.withName;
+        withAcl = true;
+        withAnalyze = cfg.withDebug;
+        inherit (cfg) withApparmor;
+        inherit (cfg) withAudit;
+        withCompression = true;
+        withCoredump = cfg.withDebug || cfg.withMachines;
+        inherit (cfg) withCryptsetup;
+        inherit (cfg) withEfi;
+        withBootloader = cfg.withEfi; # systemd-boot fails if not explicity set
+        inherit (cfg) withFido2;
+        inherit (cfg) withHostnamed;
+        withImportd = cfg.withMachines;
+        withKexectools = cfg.withDebug;
+        withKmod = true;
+        withLibBPF = true;
+        withLibseccomp = true;
+        inherit (cfg) withLocaled;
+        inherit (cfg) withLogind;
+        withMachined = cfg.withMachines;
+        inherit (cfg) withNetworkd;
+        inherit (cfg) withNss;
+        withOomd = true;
+        withPam = true;
+        inherit (cfg) withPolkit;
+        inherit (cfg) withResolved;
+        inherit (cfg) withRepart;
+        withShellCompletions = cfg.withDebug;
+        withTimedated = true;
+        inherit (cfg) withTimesyncd;
+        inherit (cfg) withTpm2Tss;
+        withUtmp = cfg.withJournal || cfg.withAudit;
+      } # To be removed, current systemd version 254.6 < 255
+      // lib.optionalAttrs (lib.hasAttr "withVmspawn" (lib.functionArgs pkgs.systemd.override)) {
+        withVmspawn = cfg.withMachines;
+      })
+    .overrideAttrs (prevAttrs: {
+      patches =
+        prevAttrs.patches
+        ++ [
+          ./systemd-boot-double-dtb-buffer-size.patch
+        ];
+    });
 
   # Definition of suppressed system units in systemd configuration. This removes the units and has priority.
   # Required to avoid build failures compared to only disabling units for some options. Note that errors will be silently ignored.

--- a/modules/common/systemd/systemd-boot-double-dtb-buffer-size.patch
+++ b/modules/common/systemd/systemd-boot-double-dtb-buffer-size.patch
@@ -1,0 +1,46 @@
+From f3b523c80624a164889928bc255c6d16da7b20da Mon Sep 17 00:00:00 2001
+From: Mika Tammi <mika.tammi@unikie.com>
+Date: Thu, 11 Apr 2024 20:23:32 +0300
+Subject: Double the device tree buffer size
+
+Signed-off-by: Mika Tammi <mika.tammi@unikie.com>
+---
+ src/boot/efi/devicetree.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/boot/efi/devicetree.c b/src/boot/efi/devicetree.c
+index caafef24d3..8395fd2c79 100644
+--- a/src/boot/efi/devicetree.c
++++ b/src/boot/efi/devicetree.c
+@@ -4,6 +4,8 @@
+ #include "proto/dt-fixup.h"
+ #include "util.h"
+
++#include <endian.h>
++
+ #define FDT_V1_SIZE (7*4)
+ 
+ static EFI_STATUS devicetree_allocate(struct devicetree_state *state, size_t size) {
+@@ -87,7 +89,8 @@ EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE *root_dir
+                 /* 32MB device tree blob doesn't seem right */
+                 return EFI_INVALID_PARAMETER;
+ 
+-        len = info->FileSize;
++        /* Double the length to be allocated so there's space for modifications */
++        len = info->FileSize * 4;
+ 
+         err = devicetree_allocate(state, len);
+         if (err != EFI_SUCCESS)
+@@ -101,6 +104,10 @@ EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE *root_dir
+         if (err != EFI_SUCCESS)
+                 return err;
+ 
++        /* Double the size inside the device tree structure */
++        uint32_t *totalsize = (uint32_t *)(((char *)PHYSICAL_ADDRESS_TO_POINTER(state->addr) + 4));
++        (*totalsize) = htobe32(be32toh(*totalsize) * 4);
++
+         return BS->InstallConfigurationTable(
+                         MAKE_GUID_PTR(EFI_DTB_TABLE), PHYSICAL_ADDRESS_TO_POINTER(state->addr));
+ }
+--
+2.42.0

--- a/modules/jetpack-microvm/pci-passthrough-agx-test.patch
+++ b/modules/jetpack-microvm/pci-passthrough-agx-test.patch
@@ -1,11 +1,11 @@
 diff --git a/nvidia/platform/t23x/concord/kernel-dts/Makefile b/nvidia/platform/t23x/concord/kernel-dts/Makefile
-index 1be5b3f76bf8..01d3dea90cb5 100644
+index 8e040d61f72f..dace3ef9a86d 100644
 --- a/nvidia/platform/t23x/concord/kernel-dts/Makefile
 +++ b/nvidia/platform/t23x/concord/kernel-dts/Makefile
-@@ -23,6 +23,9 @@ dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-as-p3767-0001-p3737-0000.dtb
- dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-as-pxxxx-p3737-0000.dtb
- dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-p3737-0000-kexec.dtb
+@@ -25,6 +25,9 @@ dtb-$(BUILD_ENABLE) += tegra234-p3701-0000-p3737-0000-kexec.dtb
  dtb-$(BUILD_ENABLE) += tegra234-p3701-0004-p3737-0000.dtb
+ dtb-$(BUILD_ENABLE) += tegra234-p3701-0005-p3737-0000.dtb
+ dtb-$(BUILD_ENABLE) += tegra234-p3701-0008-p3737-0000.dtb
 +
 +dtb-$(BUILD_ENABLE) += tegra234-p3701-host-passthrough.dtb
 +
@@ -14,7 +14,7 @@ index 1be5b3f76bf8..01d3dea90cb5 100644
  dtbo-$(BUILD_ENABLE) += tegra234-p3737-audio-codec-rt5640.dtbo
 diff --git a/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-host-passthrough.dts b/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-host-passthrough.dts
 new file mode 100644
-index 000000000000..e4656287da82
+index 000000000000..5e9a0885d318
 --- /dev/null
 +++ b/nvidia/platform/t23x/concord/kernel-dts/tegra234-p3701-host-passthrough.dts
 @@ -0,0 +1,12 @@

--- a/modules/jetpack/nvidia-jetson-orin/edk2-nvidia-always-reset-display.patch
+++ b/modules/jetpack/nvidia-jetson-orin/edk2-nvidia-always-reset-display.patch
@@ -1,0 +1,38 @@
+From 3868fd2024f767b86b45698c580b5758e47660b5 Mon Sep 17 00:00:00 2001
+From: Mika Tammi <mikatammi@gmail.com>
+Date: Tue, 9 Apr 2024 03:54:04 +0300
+Subject: Always Reset Display
+
+Signed-off-by: Mika Tammi <mikatammi@gmail.com>
+---
+ .../NvDisplayControllerDxe/NvDisplayControllerDxe.c        | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/Silicon/NVIDIA/Drivers/NvDisplayControllerDxe/NvDisplayControllerDxe.c b/Silicon/NVIDIA/Drivers/NvDisplayControllerDxe/NvDisplayControllerDxe.c
+index 7b898575..7f18f24d 100644
+--- a/Silicon/NVIDIA/Drivers/NvDisplayControllerDxe/NvDisplayControllerDxe.c
++++ b/Silicon/NVIDIA/Drivers/NvDisplayControllerDxe/NvDisplayControllerDxe.c
+@@ -1591,7 +1591,6 @@ DeviceDiscoveryNotify (
+   TEGRA_PLATFORM_TYPE                Platform;
+   NON_DISCOVERABLE_DEVICE            *EdkiiNonDiscoverableDevice;
+   NVIDIA_DISPLAY_CONTROLLER_CONTEXT  *Context;
+-  EFI_GRAPHICS_OUTPUT_PROTOCOL       *Gop;
+ 
+   switch (Phase) {
+     case DeviceDiscoveryDriverBindingSupported:
+@@ -1669,12 +1668,6 @@ DeviceDiscoveryNotify (
+ 
+         return DisplayStop (Context);
+       } else {
+-        Status = DisplayLocateChildGop (Context, &Gop);
+-        if (!EFI_ERROR (Status) && CheckGopModeActiveWithFrameBuffer (Gop)) {
+-          /* We have an active GOP child, leave the display running. */
+-          return EFI_ABORTED;
+-        }
+-
+         /* The display is inactive, reset to known good state. */
+         Status = DisplayBypassSorClocks (Context);
+         ASSERT_EFI_ERROR (Status);
+-- 
+2.39.3 (Apple Git-146)
+

--- a/modules/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -48,7 +48,19 @@ in
           flashArgs = lib.mkForce ["-r" config.hardware.nvidia-jetpack.flashScriptOverrides.targetBoard "mmcblk0p1"];
         };
 
-        firmware.uefi.logo = ../../../docs/src/img/1600px-Ghaf_logo.svg;
+        firmware.uefi = {
+          logo = ../../../docs/src/img/1600px-Ghaf_logo.svg;
+          edk2NvidiaPatches = [
+            # This effectively disables EFI FB Simple Framebuffer, which does
+            # not work properly but causes kernel panic during the boot if the
+            # HDMI cable is connected during boot time.
+            #
+            # The patch reverts back to old behavior, which is to always reset
+            # the display when exiting UEFI, instead of doing handoff, when
+            # means not to reset anything.
+            ./edk2-nvidia-always-reset-display.patch
+          ];
+        };
       };
 
       nixpkgs.hostPlatform.system = "aarch64-linux";

--- a/modules/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -121,6 +121,13 @@ in
           echo "Removing bootlodaer/esp.img if it exists ..."
           rm -fv "$WORKDIR/bootloader/esp.img"
           mkdir -pv "$WORKDIR/bootloader"
+
+          # See https://developer.download.nvidia.com/embedded/L4T/r35_Release_v4.1/docs/Jetson_Linux_Release_Notes_r35.4.1.pdf
+          # and https://developer.download.nvidia.com/embedded/L4T/r35_Release_v5.0/docs/Jetson_Linux_Release_Notes_r35.5.0.pdf
+          #
+          # In Section: Adaptation to the Carrier Board with HDMI for the Orin
+          #             NX/Nano Modules
+          @patch@ -p0 < ${./tegra2-mb2-bct-scr.patch}
         ''
         + lib.optionalString (!cfg.flashScriptOverrides.onlyQSPI) ''
           ESP_OFFSET=$(cat "${images}/esp.offset")

--- a/modules/jetpack/nvidia-jetson-orin/tegra2-mb2-bct-scr.patch
+++ b/modules/jetpack/nvidia-jetson-orin/tegra2-mb2-bct-scr.patch
@@ -1,0 +1,28 @@
+--- bootloader/t186ref/BCT/tegra234-mb2-bct-scr-p3767-0000.dts
++++ bootloader/t186ref/BCT/tegra234-mb2-bct-scr-p3767-0000.dts
+@@ -5,6 +5,11 @@
+
+ / {
+     tfc {
++        reg@322 { /* GPIO_M_SCR_00_0 */
++            exclusion-info = <2>;
++            value = <0x38009696>;
++        };
++
+         reg@5138 { /* CBB_CENTRAL_CBB_FIREWALL_QSPI0_BLF, READ_CTL */
+             exclusion-info = <2>;
+             value = <0x00100009>;
+--- bootloader/t186ref/BCT/tegra234-mb2-bct-scr-p3701-0000.dts
++++ bootloader/t186ref/BCT/tegra234-mb2-bct-scr-p3701-0000.dts
+@@ -5,6 +5,11 @@
+
+ / {
+     tfc {
++        reg@322 { /* GPIO_M_SCR_00_0 */
++            exclusion-info = <2>;
++            value = <0x38009696>;
++        };
++
+         reg@5138 { /* CBB_CENTRAL_CBB_FIREWALL_QSPI0_BLF, READ_CTL */
+             exclusion-info = <2>;
+             value = <0x00100009>;

--- a/targets/nvidia-jetson-orin/optee.nix
+++ b/targets/nvidia-jetson-orin/optee.nix
@@ -17,7 +17,7 @@
     opteeSource = pkgs.fetchgit {
       url = "https://nv-tegra.nvidia.com/r/tegra/optee-src/nv-optee";
       rev = "jetson_${l4tVersion}";
-      sha256 = "sha256-44RBXFNUlqZoq3OY/OFwhiU4Qxi4xQNmetFmlrr6jzY=";
+      sha256 = "sha256-jJOMig2+9FlKA9gJUCH/dva7ZtAq1typZSNGKyM7tlg=";
     };
 
     opteeXtest = stdenv.mkDerivation {
@@ -120,6 +120,8 @@
           "ffd2bded-ab7d-4988-95ee-e4962fff7154.ta"
           "b3091a65-9751-4784-abf7-0298a7cc35ba.ta"
           "f157cda0-550c-11e5-a6fa-0002a5d5c51b.ta"
+          "5c206987-16a3-59cc-ab0f-64b9cfc9e758.ta"
+          "a720ccbb-51da-417d-b82e-e5445d474a7a.ta"
         ];
       pkcs11TaPath = {
         name = "fd02c9da-306c-48c7-a49c-bbd827ae86ee.ta";


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX *and* AGX `aarch64`
  - [x] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Basic test sets on all platforms.

Still would need to test by hand how does this affect BPMP passthrough and UART passthrough, etc. NVIDIA kernel related patches that are part of ghaf and not tested yet by our test suites