### PR TITLE
Initial AudioVM implementation with pipewire and pulseaudio

### DIFF
--- a/modules/common/hardware/definition.nix
+++ b/modules/common/hardware/definition.nix
@@ -139,5 +139,40 @@
         SUBSYSTEM=="input",ATTRS{name}=="AT Translated Set 2 keyboard",GROUP="kvm"
       '';
     };
+
+    audio = {
+      # With the current implementation, the whole PCI IOMMU group 14:
+      #   00:1f.x in the example from Lenovo X1 Carbon
+      #   must be defined for passthrough to AudioVM
+      pciDevices = mkOption {
+        description = "PCI Devices to passthrough to AudioVM";
+        type = types.listOf pciDevSubmodule;
+        default = [];
+        example = literalExpression ''
+          [
+            {
+              path = "0000:00:1f.0";
+              vendorId = "8086";
+              productId = "5194";
+            }
+            {
+              path = "0000:00:1f.3";
+              vendorId = "8086";
+              productId = "51ca";
+            }
+            {
+              path = "0000:00:1f.4";
+              vendorId = "8086";
+              productId = "51a3";
+            }
+            {
+              path = "0000:00:1f.5";
+              vendorId = "8086";
+              productId = "51a4";
+            }
+          ]
+        '';
+      };
+    };
   };
 }

--- a/modules/common/hardware/lenovo-x1/definitions/default.nix
+++ b/modules/common/hardware/lenovo-x1/definitions/default.nix
@@ -12,6 +12,7 @@ in {
   inherit (hwDefinition) disks;
   inherit (hwDefinition) network;
   inherit (hwDefinition) gpu;
+  inherit (hwDefinition) audio;
 
   # Notes:
   #   1. This assembles udev rules for different hw configurations (i.e., different mice/touchpads) by adding

--- a/modules/common/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/common/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -29,4 +29,6 @@
       productId = "46a6";
     }
   ];
+
+  audio.pciDevices = [];
 }

--- a/modules/common/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/common/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -38,4 +38,34 @@
       productId = "a7a1";
     }
   ];
+
+  # With the current implementation, the whole PCI IOMMU group 14:
+  #   00:1f.x in the example from Lenovo X1 Carbon
+  #   must be defined for passthrough to AudioVM
+  audio.pciDevices = [
+    {
+      # ISA bridge: Intel Corporation Raptor Lake LPC/eSPI Controller (rev 01)
+      path = "0000:00:1f.0";
+      vendorId = "8086";
+      productId = "5194";
+    }
+    {
+      # Audio device: Intel Corporation Raptor Lake-P/U/H cAVS (rev 01)
+      path = "0000:00:1f.3";
+      vendorId = "8086";
+      productId = "51ca";
+    }
+    {
+      # SMBus: Intel Corporation Alder Lake PCH-P SMBus Host Controller (rev 01)
+      path = "0000:00:1f.4";
+      vendorId = "8086";
+      productId = "51a3";
+    }
+    {
+      # Serial bus controller: Intel Corporation Alder Lake-P PCH SPI Controller (rev 01)
+      path = "0000:00:1f.5";
+      vendorId = "8086";
+      productId = "51a4";
+    }
+  ];
 }

--- a/modules/microvm/default.nix
+++ b/modules/microvm/default.nix
@@ -9,6 +9,7 @@
     ./virtualization/microvm/netvm.nix
     ./virtualization/microvm/appvm.nix
     ./virtualization/microvm/guivm.nix
+    ./virtualization/microvm/audiovm.nix
     ./networking.nix
   ];
 }

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -1,0 +1,120 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}: let
+  configHost = config;
+  vmName = "audio-vm";
+  macAddress = "02:00:00:03:03:03";
+  audiovmBaseConfiguration = {
+    imports = [
+      (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      ({
+        lib,
+        pkgs,
+        ...
+      }: {
+        ghaf = {
+          users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
+          profiles.debug.enable = lib.mkDefault configHost.ghaf.profiles.debug.enable;
+
+          development = {
+            ssh.daemon.enable = lib.mkDefault configHost.ghaf.development.ssh.daemon.enable;
+            debug.tools.enable = lib.mkDefault configHost.ghaf.development.debug.tools.enable;
+            nix-setup.enable = lib.mkDefault configHost.ghaf.development.nix-setup.enable;
+          };
+          systemd = {
+            enable = true;
+            withName = "audiovm-systemd";
+            withNss = true;
+            withResolved = true;
+            withTimesyncd = true;
+            withDebug = configHost.ghaf.profiles.debug.enable;
+          };
+        };
+
+        environment = {
+          systemPackages = [
+            pkgs.pulseaudio
+            pkgs.pamixer
+            pkgs.pipewire
+          ];
+        };
+
+        system.stateVersion = lib.trivial.release;
+
+        nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
+        nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
+
+        microvm = {
+          optimize.enable = true;
+          vcpu = 1;
+          mem = 256;
+          hypervisor = "qemu";
+          shares = [
+            {
+              tag = "ro-store";
+              source = "/nix/store";
+              mountPoint = "/nix/.ro-store";
+            }
+          ];
+          writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
+          qemu = {
+            machine =
+              {
+                # Use the same machine type as the host
+                x86_64-linux = "q35";
+                aarch64-linux = "virt";
+              }
+              .${configHost.nixpkgs.hostPlatform.system};
+          };
+        };
+
+        imports = [
+          ../../../common
+        ];
+
+        # Fixed IP-address for debugging subnet
+        systemd.network.networks."10-ethint0".addresses = [
+          {
+            addressConfig.Address = "192.168.101.4/24";
+          }
+        ];
+      })
+    ];
+  };
+  cfg = config.ghaf.virtualization.microvm.audiovm;
+  # Importing kernel builder function and building guest_audio_hardened_kernel
+  # Maybe this also needs actual hardenening & remove unused modules etc.
+in {
+  options.ghaf.virtualization.microvm.audiovm = {
+    enable = lib.mkEnableOption "AudioVM";
+
+    extraModules = lib.mkOption {
+      description = ''
+        List of additional modules to be imported and evaluated as part of
+        AudioVM's NixOS configuration.
+      '';
+      default = [];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    microvm.vms."${vmName}" = {
+      autostart = true;
+      config =
+        audiovmBaseConfiguration
+        // {
+          #          boot.kernelPackages =
+          #            lib.mkIf config.ghaf.guest.kernel.hardening.audio.enable
+          #            (pkgs.linuxPackagesFor guest_audio_hardened_kernel);
+
+          imports =
+            audiovmBaseConfiguration.imports
+            ++ cfg.extraModules;
+        };
+    };
+  };
+}

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -67,6 +67,7 @@
             pkgs.waypipe
             pkgs.networkmanagerapplet
             pkgs.nm-launcher
+            pkgs.pamixer
           ];
         };
 

--- a/targets/lenovo-x1/audiovmExtraModules.nix
+++ b/targets/lenovo-x1/audiovmExtraModules.nix
@@ -1,0 +1,91 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{
+  lib,
+  pkgs,
+  microvm,
+  configH,
+  ...
+}: let
+  # TCP port used by Pipewire-pulseaudio service
+  pulseaudioTcpPort = 4713;
+
+  audiovmPCIPassthroughModule = {
+    microvm.devices = lib.mkForce (
+      builtins.map (d: {
+        bus = "pci";
+        inherit (d) path;
+      })
+      configH.ghaf.hardware.definition.audio.pciDevices
+    );
+  };
+
+  audiovmExtraConfigurations = {
+    ghaf.hardware.definition.network.pciDevices = configH.ghaf.hardware.definition.network.pciDevices;
+
+    time.timeZone = "Asia/Dubai";
+
+    # Enable pipewire service for audioVM with pulseaudio support
+    security.rtkit.enable = true;
+    sound.enable = true;
+
+    services.pipewire = {
+      enable = true;
+      #      alsa.enable = true;
+      #      alsa.support32Bit = true;
+      pulse.enable = true;
+      systemWide = true;
+    };
+
+    environment.etc."pipewire/pipewire.conf.d/10-remote-simple.conf".text = ''
+      context.modules = [
+        {   name = libpipewire-module-protocol-pulse
+            args = {
+              server.address = [
+                  "tcp:4713"    # IPv4 and IPv6 on all addresses
+              ];
+              pulse.min.req          = 128/48000;     # 2.7ms
+              pulse.default.req      = 960/48000;     # 20 milliseconds
+              pulse.min.frag         = 128/48000;     # 2.7ms
+              pulse.default.frag     = 512/48000;     # ~10 ms
+              pulse.default.tlength  = 512/48000;     # ~10 ms
+              pulse.min.quantum      = 128/48000;     # 2.7ms
+            }
+        }
+      ]
+    '';
+
+    # Allow ghaf user to access pulseaudio and pipewire
+    users.extraUsers.ghaf.extraGroups = ["audio" "video" "pulse-access" "pipewire"];
+
+    # Dummy service to get pipewire and pulseaudio services started at boot
+    # Normally Pipewire and pulseaudio are started when they are needed by user,
+    # We don't have users in audiovm so we need to give PW/PA a slight kick..
+    # This calls pulseaudios pa-info binary to get information about pulseaudio current
+    # state which starts pipewire-pulseaudio service in the process.
+
+    systemd.services.pulseaudio-starter = {
+      after = ["pipewire.service" "network-online.target"];
+      requires = ["pipewire.service"];
+      wantedBy = ["default.target"];
+      path = [pkgs.coreutils];
+      enable = true;
+      serviceConfig = {
+        User = "ghaf";
+        Group = "ghaf";
+      };
+      script = ''${pkgs.pulseaudio}/bin/pa-info > /dev/null 2>&1'';
+    };
+
+    # Open TCP port for the PDF XDG socket
+    networking.firewall.allowedTCPPorts = [pulseaudioTcpPort];
+
+    microvm.qemu.extraArgs = [
+    ];
+  };
+in [
+  ./sshkeys.nix
+  audiovmPCIPassthroughModule
+  audiovmExtraConfigurations
+]

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -47,18 +47,6 @@
             services.udev.extraRules = hwDefinition.udevRules;
             time.timeZone = "Asia/Dubai";
 
-            # Enable pulseaudio support for host as a service
-            sound.enable = true;
-            hardware.pulseaudio.enable = true;
-            hardware.pulseaudio.systemWide = true;
-            # Add systemd to require pulseaudio before starting chromium-vm
-            systemd.services."microvm@chromium-vm".after = ["pulseaudio.service"];
-            systemd.services."microvm@chromium-vm".requires = ["pulseaudio.service"];
-
-            # Allow microvm user to access pulseaudio
-            hardware.pulseaudio.extraConfig = "load-module module-combine-sink module-native-protocol-unix auth-anonymous=1";
-            users.extraUsers.microvm.extraGroups = ["audio" "pulse-access"];
-
             environment.etc.${config.ghaf.security.sshKeys.getAuthKeysFilePathInEtc} = import ./getAuthKeysSource.nix {inherit pkgs config;};
             services.openssh = config.ghaf.security.sshKeys.sshAuthorizedKeysCommand;
 
@@ -102,6 +90,13 @@
                     configH = config;
                   };
               };
+              virtualization.microvm.audiovm = {
+                enable = true;
+                extraModules = import ./audiovmExtraModules.nix {
+                  inherit lib pkgs microvm;
+                  configH = config;
+                };
+              };
               virtualization.microvm.appvm = {
                 enable = true;
                 vms = import ./appvms/default.nix {inherit pkgs;};
@@ -130,6 +125,7 @@
               vfioPciIds = mapPciIdsToString (filterDevices (
                 config.ghaf.hardware.definition.network.pciDevices
                 ++ config.ghaf.hardware.definition.gpu.pciDevices
+                ++ config.ghaf.hardware.definition.audio.pciDevices
               ));
             in [
               "intel_iommu=on,sm_on"

--- a/targets/lenovo-x1/guivmExtraModules.nix
+++ b/targets/lenovo-x1/guivmExtraModules.nix
@@ -147,9 +147,6 @@
         # Lenovo X1 AC adapter
         "-device"
         "acad"
-        # Connect sound device to hosts pulseaudio socket
-        "-audiodev"
-        "pa,id=pa1,server=unix:/run/pulse/native"
       ];
     };
   };


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Initial version of AudioVM with Pipewire backend and pulseaudio TCP remote communication layer for the guest VMs. Note that this is not really secure design (yet) basically all VMs can access the pulseaudio TCP service.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

On Lenovo X1 integrated sound card is passed through to the new AudioVM.
Chromium VM plays back sound through audiovm after boot.
Tested mostly with 3.5mm headset (both playback and mic).
Also playback with integrated speakers works (did not test integrated mic).

