### PR TITLE
Add another patch for ax88179_178a USB network

### DIFF
--- a/modules/common/hardware/ax88179_178a.nix
+++ b/modules/common/hardware/ax88179_178a.nix
@@ -24,6 +24,13 @@ in {
           hash = "sha256-fX7yBsXW1oFt1Nfns42oZnCXf36qehXijvCNEmqBGsE=";
         };
       }
+      # net: usb: ax88179_178a: avoid writing the mac address before first reading
+      {
+        patch = pkgs.fetchpatch2 {
+          url = "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/patch/drivers/net/usb?id=56f78615bcb1c3ba58a5d9911bad3d9185cf141b";
+          hash = "sha256-EVBJX0rhbLPktSlmCdYhVIMP7LRAFycq/YqOaOE9mKI=";
+        };
+      }
     ];
   };
 }


### PR DESCRIPTION

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Add another patch for ax88179_178a USB network card, to fix random MAC-address problems.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
