### PR TITLE
Remove libcamera from pipewire

### DIFF
--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -8,7 +8,7 @@
   edk2 = import ./edk2 {inherit final prev;};
   element-desktop = import ./element-desktop {inherit prev;};
   jbig2dec = import ./jbig2dec {inherit prev;};
-  pipewire = import ./pipewire {inherit prev;};
+  pipewire = import ./pipewire {inherit final prev;};
 
   # libck is dependency of sysbench
   libck = import ./libck {inherit prev;};

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -22,4 +22,5 @@
   # launcher overlays
   networkmanagerapplet = import ./networkmanagerapplet {inherit prev;};
   htop = import ./htop {inherit prev;};
+  pipewire = import ./pipewire {inherit final prev;};
 })

--- a/overlays/custom-packages/pipewire/default.nix
+++ b/overlays/custom-packages/pipewire/default.nix
@@ -4,15 +4,8 @@
   final,
   prev,
 }:
-# It defaulted to
-# { ...
-# , x11Support ? true
-# , ffadoSupport ? x11Support && stdenv.buildPlatform.canExecute stdenv.hostPlatform
-# }
-# It should evaluate to `false` in case of cross-compilation, but it doesn't happens for unknown reasons.
 (
   prev.pipewire.override {
-    ffadoSupport = false;
     #TODO review the use of libcamera as if causes a lot of FOD errors
     libcameraSupport = false;
   }


### PR DESCRIPTION
Pipewire pulls in libcamera, which is currently unused. Libcamera causes many builds to fail because of the FOD creating a different result when built on different machines.

````
error: hash mismatch importing path '/nix/store/glazsqngfws5m5m8nzq5mxai6rljw1lc-libcamera-0.0.5';
specified: sha256:0vk0r73zczhg58zqrk2fz6wa648bdxrr1pza4vjgglglndx6d4dv
got:       sha256:1gffy40qlljmb74vnb074b1yc8ippd3cp41l7z4rmwyja0i969v0
````

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
