### PR TITLE
networking: module for static names

### DIFF
--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -17,5 +17,6 @@
     ./version
     ./virtualization/docker.nix
     ./systemd
+    ./networking
   ];
 }

--- a/modules/common/networking/default.nix
+++ b/modules/common/networking/default.nix
@@ -1,0 +1,7 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  imports = [
+    ./hosts.nix
+  ];
+}

--- a/modules/common/networking/hosts.nix
+++ b/modules/common/networking/hosts.nix
@@ -1,0 +1,21 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{lib, ...}: {
+  environment.etc.hosts = lib.mkForce {
+    # please note that .100. network is not
+    # reachable from ghaf-host. It's only reachable
+    # guest-to-guest. Use to .101. (debug) to access
+    # guests from host (no names)
+    text = ''
+      127.0.0.1 localhost
+      192.168.100.1 net-vm
+      192.168.100.2 log-vm
+      192.168.100.3 gala-vm
+      192.168.100.4 chromium-vm
+      192.168.100.5 zathura-vm
+      192.168.100.6 element-vm
+      192.168.100.7 gui-vm
+    '';
+    mode = "0444";
+  };
+}

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -51,29 +51,7 @@
         # Add simple wi-fi connection helper
         environment.systemPackages = lib.mkIf config.ghaf.profiles.debug.enable [pkgs.wifi-connector];
 
-        # Dnsmasq is used as a DHCP/DNS server inside the NetVM
-        services.dnsmasq = {
-          enable = true;
-          resolveLocalQueries = true;
-          settings = {
-            server = ["8.8.8.8"];
-            dhcp-range = ["192.168.100.2,192.168.100.254"];
-            dhcp-sequential-ip = true;
-            dhcp-authoritative = true;
-            domain = "ghaf";
-            listen-address = ["127.0.0.1,192.168.100.1"];
-            dhcp-option = [
-              "option:router,192.168.100.1"
-              "6,192.168.100.1"
-            ];
-            expand-hosts = true;
-            domain-needed = true;
-            bogus-priv = true;
-          };
-        };
-
-        # Disable resolved since we are using Dnsmasq
-        services.resolved.enable = false;
+        services.resolved.enable = true;
 
         systemd.network = {
           enable = true;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

* based on decisions to use static names over internal DNS https://github.com/tiiuae/ghaf/pull/427
* Assumption is that #565 depends on this to use hostnames for `systems-journal` filenames instead of IPs

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Static names work as expected - guest to guest - but IPs are not statically allocated to support this.
For example:
```
[ghaf@ghaf-host:~]$ ssh 192.168.101.1

[ghaf@net-vm:~]$ ssh gui-vm
logout
Connection to log-vm closed.

[ghaf@net-vm:~]$ ssh log-vm

[ghaf@gala-vm:~]$ 
logout
Connection to log-vm closed.

[ghaf@net-vm:~]$ ssh gala-vm

[ghaf@log-vm:~]$ 
logout
Connection to gala-vm closed.

[ghaf@net-vm:~]$ ssh chromium-vm

[ghaf@zathura-vm:~]$ 
logout
Connection to chromium-vm closed.

[ghaf@net-vm:~]$ 
logout
Connection to 192.168.101.1 closed.

[ghaf@ghaf-host:~]$ 
```
IPs also get reallocated over `nixes-rebuild ... switch`es.
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
