### PR TITLE
networking: module for static names

### DIFF
--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -17,5 +17,6 @@
     ./systemd
     ./services
     ./programs
+    ./networking
   ];
 }

--- a/modules/common/networking/default.nix
+++ b/modules/common/networking/default.nix
@@ -1,0 +1,7 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  imports = [
+    ./hosts.nix
+  ];
+}

--- a/modules/common/networking/hosts.nix
+++ b/modules/common/networking/hosts.nix
@@ -1,0 +1,74 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}: let
+  # please note that .100. network is not
+  # reachable from ghaf-host. It's only reachable
+  # guest-to-guest.
+  # Use to .101. (debug) to access guests from host.
+  # debug network hosts are post-fixed: <hostname>-debug
+  ipBase = "192.168.100";
+  debugBase = "192.168.101";
+  hostsEntries = [
+    {
+      ip = 1;
+      name = "net-vm";
+    }
+    {
+      ip = 2;
+      name = "ghaf-host";
+    }
+    {
+      ip = 3;
+      name = "gui-vm";
+    }
+    {
+      ip = 4;
+      name = "ids-vm";
+    }
+    {
+      ip = 5;
+      name = "audio-vm";
+    }
+    {
+      ip = 10;
+      name = "admin-vm";
+    }
+    {
+      ip = 100;
+      name = "chromium-vm";
+    }
+    {
+      ip = 101;
+      name = "gala-vm";
+    }
+    {
+      ip = 102;
+      name = "zathura-vm";
+    }
+    {
+      ip = 103;
+      name = "element-vm";
+    }
+    {
+      ip = 104;
+      name = "appflowy-vm";
+    }
+  ];
+  mkHostEntry = {
+    ip,
+    name,
+  }:
+    "${ipBase}.${toString ip}\t${name}\n"
+    + lib.optionalString config.ghaf.profiles.debug.enable
+    "${debugBase}.${toString ip}\t${name}-debug\n";
+  entries = map mkHostEntry hostsEntries;
+in {
+  environment.etc.hosts = lib.mkForce {
+    text = lib.foldl' (acc: x: acc + x) "127.0.0.1 localhost\n" entries;
+    mode = "0444";
+  };
+}

--- a/modules/microvm/virtualization/microvm/adminvm.nix
+++ b/modules/microvm/virtualization/microvm/adminvm.nix
@@ -11,10 +11,14 @@
 
   adminvmBaseConfiguration = {
     imports = [
-      (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      (import ./common/vm-networking.nix {
+        inherit config lib vmName macAddress;
+        internalIP = 10;
+      })
       ({lib, ...}: {
         ghaf = {
           users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
+          profiles.debug.enable = lib.mkDefault configHost.ghaf.profiles.debug.enable;
           development = {
             # NOTE: SSH port also becomes accessible on the network interface
             #       that has been passed through to VM
@@ -44,15 +48,6 @@
           enable = true;
           networks."10-ethint0" = {
             matchConfig.MACAddress = macAddress;
-            addresses = [
-              {
-                addressConfig.Address = "192.168.100.10/24";
-              }
-              {
-                # IP-address for debugging subnet
-                addressConfig.Address = "192.168.101.10/24";
-              }
-            ];
             linkConfig.ActivationPolicy = "always-up";
           };
         };

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -28,8 +28,9 @@
     appvmConfiguration = {
       imports = [
         (import ./common/vm-networking.nix {
-          inherit vmName;
+          inherit config lib vmName;
           inherit (vm) macAddress;
+          internalIP = index + 100;
         })
         ({
           lib,
@@ -48,6 +49,7 @@
         in {
           ghaf = {
             users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
+            profiles.debug.enable = lib.mkDefault configHost.ghaf.profiles.debug.enable;
 
             development = {
               ssh.daemon.enable = lib.mkDefault configHost.ghaf.development.ssh.daemon.enable;

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -10,7 +10,10 @@
   macAddress = "02:00:00:03:03:03";
   audiovmBaseConfiguration = {
     imports = [
-      (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      (import ./common/vm-networking.nix {
+        inherit config lib vmName macAddress;
+        internalIP = 5;
+      })
       ({
         lib,
         pkgs,

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -12,7 +12,10 @@
   inherit (import ../../../../lib/launcher.nix {inherit pkgs lib;}) rmDesktopEntries;
   guivmBaseConfiguration = {
     imports = [
-      (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      (import ./common/vm-networking.nix {
+        inherit config lib vmName macAddress;
+        internalIP = 3;
+      })
       ({
         lib,
         pkgs,
@@ -127,27 +130,18 @@
         ];
 
         # Waypipe service runs in the GUIVM and listens for incoming connections from AppVMs
-        systemd = {
-          user.services.waypipe = {
-            enable = true;
-            description = "waypipe";
-            after = ["labwc.service"];
-            serviceConfig = {
-              Type = "simple";
-              ExecStart = "${pkgs.waypipe}/bin/waypipe --vsock -s ${toString cfg.waypipePort} client";
-              Restart = "always";
-              RestartSec = "1";
-            };
-            startLimitIntervalSec = 0;
-            wantedBy = ["ghaf-session.target"];
+        systemd.user.services.waypipe = {
+          enable = true;
+          description = "waypipe";
+          after = ["labwc.service"];
+          serviceConfig = {
+            Type = "simple";
+            ExecStart = "${pkgs.waypipe}/bin/waypipe --vsock -s ${toString cfg.waypipePort} client";
+            Restart = "always";
+            RestartSec = "1";
           };
-
-          # Fixed IP-address for debugging subnet
-          network.networks."10-ethint0".addresses = [
-            {
-              addressConfig.Address = "192.168.101.3/24";
-            }
-          ];
+          startLimitIntervalSec = 0;
+          wantedBy = ["ghaf-session.target"];
         };
       })
     ];

--- a/modules/microvm/virtualization/microvm/idsvm/idsvm.nix
+++ b/modules/microvm/virtualization/microvm/idsvm/idsvm.nix
@@ -9,13 +9,16 @@
   configHost = config;
   vmName = "ids-vm";
   macAddress = "02:00:00:01:01:02";
-  networkName = "ethint0";
   idsvmBaseConfiguration = {
     imports = [
-      (import ../common/vm-networking.nix {inherit vmName macAddress;})
+      (import ../common/vm-networking.nix {
+        inherit config lib vmName macAddress;
+        internalIP = 4;
+      })
       ({lib, ...}: {
         ghaf = {
           users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
+          profiles.debug.enable = lib.mkDefault configHost.ghaf.profiles.debug.enable;
 
           virtualization.microvm.idsvm.mitmproxy.enable = configHost.ghaf.virtualization.microvm.idsvm.mitmproxy.enable;
 
@@ -40,18 +43,6 @@
             pkgs.snort # TODO: put into separate module
           ]
           ++ (lib.optional configHost.ghaf.profiles.debug.enable pkgs.tcpdump);
-
-        systemd.network = {
-          networks."10-${networkName}" = {
-            gateway = ["192.168.100.1"];
-            addresses = [
-              {
-                # IP-address for debugging subnet
-                addressConfig.Address = "192.168.101.4/24";
-              }
-            ];
-          };
-        };
 
         microvm = {
           optimize.enable = true;

--- a/packages/mitmweb-ui/default.nix
+++ b/packages/mitmweb-ui/default.nix
@@ -7,7 +7,7 @@
   ...
 }: let
   waypipePort = 1100; # TODO: remove hardcoded port number
-  idsvmIP = "192.168.100.4";
+  idsvmIP = "ids-vm";
   mitmwebUI =
     pkgs.writeShellScript
     "mitmweb-ui"
@@ -15,13 +15,13 @@
       # Create ssh-tunnel between chromium-vm and ids-vm
       ${pkgs.openssh}/bin/ssh -i /run/waypipe-ssh/id_ed25519 \
           -o StrictHostKeyChecking=no \
-          -t ghaf@chromium-vm.ghaf \
+          -t ghaf@chromium-vm \
               ${pkgs.openssh}/bin/ssh -M -S /tmp/control_socket \
               -f -N -L 8081:localhost:8081 ghaf@${idsvmIP}
       # TODO: check pipe creation failures
 
       # Launch chromium application and open mitmweb page
-      ${pkgs.openssh}/bin/ssh -i /run/waypipe-ssh/id_ed25519 -o StrictHostKeyChecking=no chromium-vm.ghaf \
+      ${pkgs.openssh}/bin/ssh -i /run/waypipe-ssh/id_ed25519 -o StrictHostKeyChecking=no chromium-vm \
           ${pkgs.waypipe}/bin/waypipe --border=#ff5733,5 --vsock -s ${toString waypipePort} server \
           chromium --enable-features=UseOzonePlatform --ozone-platform=wayland \
           http://localhost:8081
@@ -29,7 +29,7 @@
       # Use the control socket to close the ssh tunnel between chromium-vm and ids-vm
       ${pkgs.openssh}/bin/ssh -i /run/waypipe-ssh/id_ed25519 \
           -o StrictHostKeyChecking=no \
-          -t ghaf@chromium-vm.ghaf \
+          -t ghaf@chromium-vm \
               ${pkgs.openssh}/bin/ssh -q -S /tmp/control_socket -O exit ghaf@${idsvmIP}
     '';
 in

--- a/packages/nm-launcher/default.nix
+++ b/packages/nm-launcher/default.nix
@@ -18,7 +18,7 @@ writeShellApplication {
     export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
     export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/ssh_system_dbus.sock
     ${openssh}/bin/ssh -M -S /tmp/control_socket \
-        -f -N -q ghaf@192.168.100.1 \
+        -f -N -q ghaf@net-vm \
         -i /run/waypipe-ssh/id_ed25519 \
         -o StrictHostKeyChecking=no \
         -o StreamLocalBindUnlink=yes \
@@ -27,7 +27,7 @@ writeShellApplication {
         -L /tmp/ssh_system_dbus.sock:/run/dbus/system_bus_socket
     ${networkmanagerapplet}/bin/nm-connection-editor
     # Use the control socket to close the ssh tunnel.
-    ${openssh}/bin/ssh -q -S /tmp/control_socket -O exit ghaf@192.168.100.1
+    ${openssh}/bin/ssh -q -S /tmp/control_socket -O exit ghaf@net-vm
   '';
 
   meta = {

--- a/packages/openPdf/default.nix
+++ b/packages/openPdf/default.nix
@@ -17,21 +17,21 @@ writeShellApplication {
     read -r sourcepath
     filename=$(basename "$sourcepath")
     zathurapath="/var/tmp/$filename"
-    chromiumip=$(dig +short chromium-vm.ghaf | head -1)
+    chromiumip=$(dig +short chromium-vm | head -1)
 
     if [[ "$chromiumip" != "$REMOTE_ADDR" ]]; then
-      echo "Open PDF request received from $REMOTE_ADDR, but it is only permitted for chromium-vm.ghaf with IP $chromiumip"
+      echo "Open PDF request received from $REMOTE_ADDR, but it is only permitted for chromium-vm with IP $chromiumip"
       exit 0
     fi
 
     echo "Copying $sourcepath from $REMOTE_ADDR to $zathurapath in zathura-vm"
-    scp -i ${sshKeyPath} -o StrictHostKeyChecking=no "$REMOTE_ADDR":"$sourcepath" zathura-vm.ghaf:"$zathurapath"
+    scp -i ${sshKeyPath} -o StrictHostKeyChecking=no "$REMOTE_ADDR":"$sourcepath" zathura-vm:"$zathurapath"
 
     echo "Opening $zathurapath in zathura-vm"
-    ssh -i ${sshKeyPath} -o StrictHostKeyChecking=no zathura-vm.ghaf run-waypipe zathura "'$zathurapath'"
+    ssh -i ${sshKeyPath} -o StrictHostKeyChecking=no zathura-vm run-waypipe zathura "'$zathurapath'"
 
     echo "Deleting $zathurapath in zathura-vm"
-    ssh -i ${sshKeyPath} -o StrictHostKeyChecking=no zathura-vm.ghaf rm -f "$zathurapath"
+    ssh -i ${sshKeyPath} -o StrictHostKeyChecking=no zathura-vm rm -f "$zathurapath"
 
   '';
 }

--- a/packages/wifi-signal-strength/default.nix
+++ b/packages/wifi-signal-strength/default.nix
@@ -6,8 +6,6 @@
   wifiDevice,
   ...
 }: let
-  # Replace the IP address with "net-vm.ghaf" after DNS/DHCP module merge
-  netvm_address = "192.168.100.1";
   wifiSignalStrength =
     pkgs.writeShellScript
     "wifi-signal-strength"
@@ -23,11 +21,11 @@
       ${pkgs.util-linux}/bin/flock -w 60 -x 99 || exit 1
 
       # Return the result as json format for waybar and use the control socket to close the ssh tunnel.
-      trap "${pkgs.openssh}/bin/ssh -q -S /tmp/nmcli_socket -O exit ghaf@${netvm_address} && ${pkgs.coreutils-full}/bin/cat $NETWORK_STATUS_FILE" EXIT
+      trap "${pkgs.openssh}/bin/ssh -q -S /tmp/nmcli_socket -O exit ghaf@net-vm && ${pkgs.coreutils-full}/bin/cat $NETWORK_STATUS_FILE" EXIT
 
       # Connect to netvm
       ${pkgs.openssh}/bin/ssh -M -S /tmp/nmcli_socket \
-          -f -N -q ghaf@${netvm_address} \
+          -f -N -q ghaf@net-vm \
           -i /run/waypipe-ssh/id_ed25519 \
           -o StrictHostKeyChecking=no \
           -o StreamLocalBindUnlink=yes \

--- a/targets/lenovo-x1/appvms/chromium.nix
+++ b/targets/lenovo-x1/appvms/chromium.nix
@@ -17,7 +17,7 @@ in {
     xdgOpenPdf = pkgs.writeShellScriptBin "xdgopenpdf" ''
       filepath=$(realpath "$1")
       echo "Opening $filepath" | systemd-cat -p info
-      echo $filepath | ${pkgs.netcat}/bin/nc -N gui-vm.ghaf ${toString xdgPdfPort}
+      echo $filepath | ${pkgs.netcat}/bin/nc -N gui-vm ${toString xdgPdfPort}
     '';
   in [
     pkgs.chromium
@@ -40,8 +40,8 @@ in {
       hardware.pulseaudio = {
         enable = true;
         extraConfig = ''
-          load-module module-tunnel-sink sink_name=chromium-speaker server=audio-vm.ghaf:4713 format=s16le channels=2 rate=48000
-          load-module module-tunnel-source source_name=chromium-mic server=audio-vm.ghaf:4713 format=s16le channels=1 rate=48000
+          load-module module-tunnel-sink sink_name=chromium-speaker server=audio-vm:4713 format=s16le channels=2 rate=48000
+          load-module module-tunnel-source source_name=chromium-mic server=audio-vm:4713 format=s16le channels=1 rate=48000
 
           # Set sink and source default max volume to about 90% (0-65536)
           set-sink-volume chromium-speaker 60000

--- a/targets/lenovo-x1/appvms/element.nix
+++ b/targets/lenovo-x1/appvms/element.nix
@@ -33,8 +33,8 @@ in {
       hardware.pulseaudio = {
         enable = true;
         extraConfig = ''
-          load-module module-tunnel-sink sink_name=element-speaker server=audio-vm.ghaf:4713 format=s16le channels=2 rate=48000
-          load-module module-tunnel-source source_name=element-mic server=audio-vm.ghaf:4713 format=s16le channels=1 rate=48000
+          load-module module-tunnel-sink sink_name=element-speaker server=audio-vm:4713 format=s16le channels=2 rate=48000
+          load-module module-tunnel-source source_name=element-mic server=audio-vm:4713 format=s16le channels=1 rate=48000
 
           # Set sink and source default max volume to about 90% (0-65536)
           set-sink-volume element-speaker 60000
@@ -66,22 +66,6 @@ in {
               RestartSec = "2";
             };
             wantedBy = ["multi-user.target"];
-          };
-        };
-
-        network = {
-          enable = true;
-          networks."10-ethint0" = {
-            DHCP = pkgs.lib.mkForce "no";
-            matchConfig.Name = "ethint0";
-            addresses = [
-              {
-                addressConfig.Address = "192.168.100.253/24";
-              }
-            ];
-            routes = [{routeConfig.Gateway = "192.168.100.1";}];
-            linkConfig.RequiredForOnline = "routable";
-            linkConfig.ActivationPolicy = "always-up";
           };
         };
       };

--- a/targets/lenovo-x1/guivmExtraModules.nix
+++ b/targets/lenovo-x1/guivmExtraModules.nix
@@ -56,32 +56,32 @@
             name = "Chromium";
             path =
               if configH.ghaf.virtualization.microvm.idsvm.mitmproxy.enable
-              then "${pkgs.openssh}/bin/ssh -i ${privateSshKeyPath} -o StrictHostKeyChecking=no chromium-vm.ghaf run-waypipe chromium --enable-features=UseOzonePlatform --ozone-platform=wayland --user-data-dir=/home/${configH.ghaf.users.accounts.user}/.config/chromium/Default --ignore-certificate-errors-spki-list=Bq49YmAq1CG6FuBzp8nsyRXumW7Dmkp7QQ/F82azxGU="
-              else "${pkgs.openssh}/bin/ssh -i ${privateSshKeyPath} -o StrictHostKeyChecking=no chromium-vm.ghaf run-waypipe chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
+              then "${pkgs.openssh}/bin/ssh -i ${privateSshKeyPath} -o StrictHostKeyChecking=no chromium-vm run-waypipe chromium --enable-features=UseOzonePlatform --ozone-platform=wayland --user-data-dir=/home/${configH.ghaf.users.accounts.user}/.config/chromium/Default --ignore-certificate-errors-spki-list=Bq49YmAq1CG6FuBzp8nsyRXumW7Dmkp7QQ/F82azxGU="
+              else "${pkgs.openssh}/bin/ssh -i ${privateSshKeyPath} -o StrictHostKeyChecking=no chromium-vm run-waypipe chromium --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${pkgs.icon-pack}/chromium.svg";
           }
 
           {
             name = "GALA";
-            path = "${pkgs.openssh}/bin/ssh -i ${privateSshKeyPath} -o StrictHostKeyChecking=no gala-vm.ghaf run-waypipe gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            path = "${pkgs.openssh}/bin/ssh -i ${privateSshKeyPath} -o StrictHostKeyChecking=no gala-vm run-waypipe gala --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${pkgs.icon-pack}/distributor-logo-android.svg";
           }
 
           {
             name = "PDF Viewer";
-            path = "${pkgs.openssh}/bin/ssh -i ${privateSshKeyPath} -o StrictHostKeyChecking=no zathura-vm.ghaf run-waypipe zathura";
+            path = "${pkgs.openssh}/bin/ssh -i ${privateSshKeyPath} -o StrictHostKeyChecking=no zathura-vm run-waypipe zathura";
             icon = "${pkgs.icon-pack}/document-viewer.svg";
           }
 
           {
             name = "Element";
-            path = "${pkgs.openssh}/bin/ssh -i ${configH.ghaf.security.sshKeys.sshKeyPath} -o StrictHostKeyChecking=no element-vm.ghaf run-waypipe element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            path = "${pkgs.openssh}/bin/ssh -i ${configH.ghaf.security.sshKeys.sshKeyPath} -o StrictHostKeyChecking=no element-vm run-waypipe element-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland";
             icon = "${pkgs.icon-pack}/element-desktop.svg";
           }
 
           {
             name = "AppFlowy";
-            path = "${pkgs.openssh}/bin/ssh -i ${configH.ghaf.security.sshKeys.sshKeyPath} -o StrictHostKeyChecking=no appflowy-vm.ghaf run-waypipe appflowy";
+            path = "${pkgs.openssh}/bin/ssh -i ${configH.ghaf.security.sshKeys.sshKeyPath} -o StrictHostKeyChecking=no appflowy-vm run-waypipe appflowy";
             icon = "${pkgs.appflowy}/opt/data/flutter_assets/assets/images/flowy_logo.svg";
           }
 

--- a/targets/lenovo-x1/netvmExtraModules.nix
+++ b/targets/lenovo-x1/netvmExtraModules.nix
@@ -25,12 +25,15 @@
 
     internalNic = let
       vmNetworking = import ../../modules/microvm/virtualization/microvm/common/vm-networking.nix {
+        config = configH;
+        inherit lib;
         vmName = microvm.name;
         inherit (microvm) macAddress;
+        internalIP = 1;
       };
     in "${lib.head vmNetworking.networking.nat.internalInterfaces}";
 
-    elemen-vmIp = "192.168.100.253";
+    element-vmIp = "192.168.100.103";
   in {
     # For WLAN firmwares
     hardware = {
@@ -65,7 +68,7 @@
           ];
 
         # DNS host record has been added for element-vm static ip
-        host-record = "element-vm,element-vm.ghaf,${elemen-vmIp}";
+        host-record = "element-vm,element-vm,${element-vmIp}";
       };
 
       openssh = configH.ghaf.security.sshKeys.sshAuthorizedKeysCommand;
@@ -107,7 +110,7 @@
       firewallConfig = true;
       externalNic = "${externalNic}";
       internalNic = "${internalNic}";
-      serverIpAddr = "${elemen-vmIp}";
+      serverIpAddr = "${element-vmIp}";
     };
   };
 in [netvmPCIPassthroughModule netvmAdditionalConfig]


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

* based on decisions to use static names over internal DNS https://github.com/tiiuae/ghaf/pull/427
* removes dnsmasq and dhcp from net-vm to other guests
* `/etc/hosts` with static hosts to IP mapping generated and made available to host and guests
* resolves https://github.com/tiiuae/ghaf/pull/600

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

### Testing the debug network access with names - PASS

Connect to `ghaf-host` over debug ethernet. Check the IP in your network.
```
❯ ssh ghaf@nn.nn.nn.nn
Last login: Tue Jun  4 10:09:53 2024 from yy.yy.yy.yy

[ghaf@ghaf-host:~]$ less /etc/hosts

[ghaf@ghaf-host:~]$ ssh gui-vm-debug
(ghaf@gui-vm-debug) Password:
[ghaf@gui-vm:~]$
logout
Connection to gui-vm-debug closed.

[ghaf@ghaf-host:~]$ ssh net-vm-debug
(ghaf@net-vm-debug) Password:

[ghaf@net-vm:~]$ ssh gui-vm-debug
(ghaf@gui-vm-debug) Password:
Last login: Tue Jun  4 10:11:35 2024 from 192.168.101.2

[ghaf@gui-vm:~]$
logout
Connection to gui-vm-debug closed.

[ghaf@net-vm:~]$ ifconfig ethint0
ethint0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.100.1  netmask 255.255.255.0  broadcast 192.168.100.255
        inet6 fe80::ff:fe01:101  prefixlen 64  scopeid 0x20<link>
        ether 02:00:00:01:01:01  txqueuelen 1000  (Ethernet)
        RX packets 940  bytes 171017 (167.0 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 891  bytes 543302 (530.5 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
### Testing the access to internet over Wifi - PASS
1. Connect to WIFI using nm-applet in the Ghaf desktop - PASS
2. Start chromium - PASS
3. Test browsing with chromium - PASS