### PR TITLE
Change internal installation approach

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,7 @@
         ./packages/flake-module.nix
         ./targets/flake-module.nix
         ./hydrajobs/flake-module.nix
+        ./tests/flake-module.nix
         ./templates/flake-module.nix
       ];
 

--- a/packages/installer/default.nix
+++ b/packages/installer/default.nix
@@ -1,23 +1,30 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  bash,
-  imagePath,
-  substituteAll,
-}:
-substituteAll {
-  dir = "bin";
-  isExecutable = true;
-
-  pname = "ghaf-installer";
-  src = ./ghaf-installer.sh;
-  inherit imagePath;
-
-  buildInputs = [
-    bash
-  ];
-
-  postInstall = ''
-    patchShebangs $out/bin/ghaf-installer.sh
-  '';
-}
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  diskoInstall,
+  targetName,
+  ghafSource,
+  diskName,
+}: let
+  name = "ghaf-installer";
+in
+  stdenvNoCC.mkDerivation {
+    inherit name;
+    src = ./.;
+    nativeBuildInputs = [
+      makeWrapper
+    ];
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${name}.sh $out/bin/${name}.sh
+      chmod 755 $out/bin/${name}.sh
+      wrapProgram $out/bin/${name}.sh \
+        --set GHAF_SOURCE "${ghafSource}" \
+        --set TARGET_NAME "${targetName}" \
+        --set DISKO_DISK_NAME "${diskName}" \
+        --prefix PATH : ${lib.makeBinPath [diskoInstall]}
+    '';
+  }

--- a/packages/installer/ghaf-installer.sh
+++ b/packages/installer/ghaf-installer.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+
+# FIXME: Otherwise test fails
+if [ -z ${DEVICE_PATH+x} ]; then
+    set -euo pipefail
+fi
+
 clear
 cat <<"EOF"
   ,----..     ,---,
@@ -20,15 +26,17 @@ EOF
 
 echo "Welcome to Ghaf installer!"
 
-echo "To install image choose path to the device on which image will be installed."
+if [ -z ${DEVICE_PATH+x} ]; then
+    echo "To install image choose path to the device on which image will be installed."
 
-lsblk
-read -r -p "Device name [e.g. /dev/nvme0n1]: " DEVICE_NAME
+    lsblk
+    read -r -p "Device path [e.g. /dev/nvme0n1]: " DEVICE_PATH
 
-read -r -p 'WARNING: Next command will destroy all previous data from your device, press Enter to proceed. '
+    read -r -p 'WARNING: Next command will destroy all previous data from your device, press Enter to proceed. '
+fi
 
 echo "Installing..."
-dd if=@imagePath@ of="${DEVICE_NAME}" bs=32M status=progress
+disko-install --write-efi-boot-entries --debug --flake "$GHAF_SOURCE#$TARGET_NAME" --disk "$DISKO_DISK_NAME" "$DEVICE_PATH" --option substitute false --option binary-caches ""
 
 echo ""
 echo "Installation done. Please remove the installation media and reboot"

--- a/tests/flake-module.nix
+++ b/tests/flake-module.nix
@@ -1,0 +1,13 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{self, ...}: {
+  flake.checks = let
+    pkgsPerSystem = system: self.inputs.nixpkgs.legacyPackages.${system};
+  in {
+    x86_64-linux = let
+      pkgs = pkgsPerSystem "x86_64-linux";
+    in {
+      installer = pkgs.callPackage ./installer {inherit self;};
+    };
+  };
+}

--- a/tests/installer/default.nix
+++ b/tests/installer/default.nix
@@ -1,0 +1,70 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  pkgs,
+  self,
+}: let
+  testConfig = "lenovo-x1-carbon-gen11-debug";
+  system = "x86_64-linux";
+  expectedHostname = "ghaf-host";
+
+  target = self.outputs.nixosConfigurations.${testConfig};
+
+  dependencies =
+    [
+      target.config.system.build.toplevel
+      target.config.system.build.diskoScript
+      target.pkgs.stdenv.drvPath
+      (target.pkgs.closureInfo {rootPaths = [];}).drvPath
+    ]
+    ++ builtins.map (i: i.outPath) (builtins.attrValues self.inputs);
+
+  closureInfo = pkgs.closureInfo {rootPaths = dependencies;};
+
+  diskoInstall = self.inputs.disko.packages.${system}.disko-install;
+  installScript = pkgs.callPackage ../../packages/installer {
+    inherit diskoInstall;
+    targetName = testConfig;
+    ghafSource = self;
+
+    # Suppose that we have only one "main" disk required
+    diskName = with builtins; head (attrNames target.config.ghaf.hardware.definition.disks);
+  };
+in
+  pkgs.nixosTest {
+    name = "installer-test";
+    nodes.machine = {
+      virtualisation.emptyDiskImages = [(1024 * 16)];
+      virtualisation.memorySize = 1024 * 8;
+      environment.etc.installClosure.source = "${closureInfo}/store-paths";
+      environment.systemPackages = [installScript];
+    };
+
+    testScript = ''
+      def create_test_machine(oldmachine, args={}): # taken from <nixpkgs/nixos/tests/installer.nix>
+          startCommand = "${pkgs.qemu_test}/bin/qemu-kvm"
+          startCommand += " -cpu max -m 1024 -virtfs local,path=/nix/store,security_model=none,mount_tag=nix-store"
+          startCommand += f" -drive file={oldmachine.state_dir}/empty0.qcow2,id=drive1,if=none,index=1,werror=report"
+          startCommand += " -device virtio-blk-pci,drive=drive1"
+          startCommand += " -drive if=pflash,format=raw,unit=0,readonly=on,file=${pkgs.OVMF.firmware}"
+          startCommand += " -drive if=pflash,format=raw,unit=1,readonly=on,file=${pkgs.OVMF.variables}"
+          machine = create_machine({
+            "startCommand": startCommand,
+          } | args)
+          driver.machines.append(machine)
+          return machine
+      machine.succeed("lsblk >&2")
+
+      print(machine.succeed("tty"))
+
+      machine.succeed("DEVICE_PATH='/dev/vdb' unshare -n ghaf-installer.sh")
+      machine.shutdown()
+
+      # # FIXME: boot stucks
+      # new_machine = create_test_machine(oldmachine=machine, args={ "name": "after_install" })
+      # new_machine.start()
+      # name = new_machine.succeed("hostname").strip()
+      # assert name == "${expectedHostname}", f"expected hostname '${expectedHostname}', got {name}"
+      # new_machine.shutdown()
+    '';
+  }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Change approach which is used on installer. Instead of flashing pre-build image - partition disk and assemble system during installation process. Like it's done during normal NixOS installation process using `nixos-install` command.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

To run introduced test execute `nix build .#checks.x86_64-linux.installer --log-format bar-with-logs`, otherwise testing process same as in previous installer-related PRs.