### PR TITLE
Add Linux kernel tests derivation (lkp-tests)

### DIFF
--- a/modules/common/development/debug-tools.nix
+++ b/modules/common/development/debug-tools.nix
@@ -13,6 +13,7 @@
   sysbench-test-script = pkgs.callPackage ./scripts/sysbench_test.nix {};
   sysbench-fileio-test-script = pkgs.callPackage ./scripts/sysbench_fileio_test.nix {};
   nvpmodel-check = pkgs.callPackage ./scripts/nvpmodel_check.nix {};
+  lkp-tests = pkgs.callPackage ../../../packages/lkp-tests {};
 
   inherit (lib) mkEnableOption mkIf;
   inherit (import ../../../lib/launcher.nix {inherit pkgs lib;}) rmDesktopEntries;
@@ -63,6 +64,7 @@ in {
         sysbench-fileio-test-script
         nvpmodel-check
         rm-linux-bootmgrs
+        lkp-tests
       ]
       ++ rmDesktopEntries [pkgs.htop]
       # TODO Can this be changed to platformPkgs to filter ?

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -16,6 +16,7 @@
       kernel-hardening-checker = callPackage ./kernel-hardening-checker {};
       windows-launcher = callPackage ./windows-launcher {enableSpice = false;};
       windows-launcher-spice = callPackage ./windows-launcher {enableSpice = true;};
+      lkp-tests = callPackage ./lkp-tests {};
       doc = callPackage ../docs {
         revision = lib.strings.fileContents ../.version;
         # options = ;

--- a/packages/lkp-tests/default.nix
+++ b/packages/lkp-tests/default.nix
@@ -9,10 +9,10 @@ pkgs.stdenv.mkDerivation {
     owner = "intel";
     repo = "lkp-tests";
     rev = "master";
-    sha256 = "sha256-+NTEVg1+Xwd05tEMvmFBCkCx2rplXk7rlXuIt6XuQf4=";
+    sha256 = "sha256-tDx2RGLKGMrJ/kbfPurOX2KErndv/TW7u8mdf8Rfl74=";
   };
 
-  buildInputs = [pkgs.makeWrapper pkgs.ruby_2_7];
+  buildInputs = [pkgs.makeWrapper pkgs.ruby_3_3];
 
   phases = ["unpackPhase" "installPhase"];
 

--- a/packages/lkp-tests/default.nix
+++ b/packages/lkp-tests/default.nix
@@ -1,0 +1,29 @@
+{pkgs}:
+pkgs.stdenv.mkDerivation {
+  pname = "lkp-tests";
+  version = "unstable-2024-04-17";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "intel";
+    repo = "lkp-tests";
+    rev = "master";
+    sha256 = "sha256-+NTEVg1+Xwd05tEMvmFBCkCx2rplXk7rlXuIt6XuQf4=";
+  };
+
+  buildInputs = [pkgs.makeWrapper pkgs.ruby_2_7];
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r . $out
+    make install TARGET_DIR_BIN=$out
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Linux Kernel Performance tests";
+    homepage = "https://github.com/intel/lkp-tests";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/packages/lkp-tests/default.nix
+++ b/packages/lkp-tests/default.nix
@@ -3,8 +3,7 @@
 #
 {pkgs}:
 pkgs.stdenv.mkDerivation {
-  pname = "lkp-tests";
-  version = "unstable-2024-04-17";
+  name = "lkp-tests";
 
   src = pkgs.fetchFromGitHub {
     owner = "intel";

--- a/packages/lkp-tests/default.nix
+++ b/packages/lkp-tests/default.nix
@@ -1,3 +1,6 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
 {pkgs}:
 pkgs.stdenv.mkDerivation {
   pname = "lkp-tests";

--- a/packages/lkp-tests/default.nix
+++ b/packages/lkp-tests/default.nix
@@ -12,7 +12,8 @@ pkgs.stdenv.mkDerivation {
     sha256 = "sha256-owXTb5+O/V7Fu4myakx2h5wBph4LCLOW/N5Qq8D2Qec=";
   };
 
-  buildInputs = [pkgs.makeWrapper pkgs.ruby_3_3];
+  nativeBuildInputs = [pkgs.makeWrapper];
+  buildInputs = [pkgs.ruby_3_3];
 
   phases = ["unpackPhase" "installPhase"];
 

--- a/packages/lkp-tests/default.nix
+++ b/packages/lkp-tests/default.nix
@@ -9,10 +9,10 @@ pkgs.stdenv.mkDerivation {
     owner = "intel";
     repo = "lkp-tests";
     rev = "master";
-    sha256 = "sha256-tDx2RGLKGMrJ/kbfPurOX2KErndv/TW7u8mdf8Rfl74=";
+    sha256 = "sha256-owXTb5+O/V7Fu4myakx2h5wBph4LCLOW/N5Qq8D2Qec=";
   };
 
-  buildInputs = [pkgs.ruby_3_3];
+  buildInputs = [pkgs.makeWrapper pkgs.ruby_3_3];
 
   phases = ["unpackPhase" "installPhase"];
 

--- a/packages/lkp-tests/default.nix
+++ b/packages/lkp-tests/default.nix
@@ -12,7 +12,7 @@ pkgs.stdenv.mkDerivation {
     sha256 = "sha256-tDx2RGLKGMrJ/kbfPurOX2KErndv/TW7u8mdf8Rfl74=";
   };
 
-  buildInputs = [pkgs.makeWrapper pkgs.ruby_3_3];
+  buildInputs = [pkgs.ruby_3_3];
 
   phases = ["unpackPhase" "installPhase"];
 


### PR DESCRIPTION
## Description of changes

Add a derivation for Linux Kernel Performance tests (lkp-tests).

## Checklist for things done

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
