### PR TITLE
Changes for systemd 255

### DIFF
--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -11,7 +11,7 @@
 
   # Override minimal systemd package configuration
   package =
-    (pkgs.systemdMinimal.override {
+    (pkgs.systemdMinimal.override ({
         pname = cfg.withName;
         withAcl = true;
         withAnalyze = cfg.withDebug;
@@ -31,7 +31,7 @@
         withLibseccomp = true;
         inherit (cfg) withLocaled;
         inherit (cfg) withLogind;
-        withMachined = cfg.withMachines;
+        withMachined = cfg.withMachines || cfg.withNss; # Required for NSS in nixos
         inherit (cfg) withNetworkd;
         inherit (cfg) withNss;
         withOomd = true;
@@ -44,10 +44,11 @@
         inherit (cfg) withTimesyncd;
         inherit (cfg) withTpm2Tss;
         withUtmp = cfg.withJournal || cfg.withAudit;
-      } # To be removed, current systemd version 254.6 < 255
-      // lib.optionalAttrs (lib.hasAttr "withVmspawn" (lib.functionArgs pkgs.systemd.override)) {
+      }
+      // lib.optionalAttrs (lib.strings.versionAtLeast pkgs.systemdMinimal.version "255.0") {
         withVmspawn = cfg.withMachines;
-      })
+        withQrencode = true; # Required for systemd-bsod (currently hardcoded in nixos)
+      }))
     .overrideAttrs (prevAttrs: {
       patches =
         prevAttrs.patches

--- a/modules/common/systemd/boot.nix
+++ b/modules/common/systemd/boot.nix
@@ -11,15 +11,18 @@
   cfgBase = config.ghaf.systemd;
 
   # Package configuration
-  package = pkgs.systemdMinimal.override {
-    pname = "stage1-systemd";
-    inherit (cfgBase) withAudit;
-    inherit (cfgBase) withCryptsetup;
-    inherit (cfgBase) withEfi;
-    inherit (cfgBase) withFido2;
-    inherit (cfgBase) withRepart;
-    inherit (cfgBase) withTpm2Tss;
-  };
+  package = pkgs.systemdMinimal.override ({
+      pname = "stage1-systemd";
+      inherit (cfgBase) withAudit;
+      inherit (cfgBase) withCryptsetup;
+      inherit (cfgBase) withEfi;
+      inherit (cfgBase) withFido2;
+      inherit (cfgBase) withRepart;
+      inherit (cfgBase) withTpm2Tss;
+    }
+    // lib.optionalAttrs (lib.strings.versionAtLeast pkgs.systemdMinimal.version "255.0") {
+      withQrencode = true; # Required for systemd-bsod, which is currently hardcoded in nixos
+    });
 
   # Suppressed initrd systemd units
   suppressedUnits =


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

- fix hardcoded NSS dependency
- fix hardcoded systemd-bosd.service dependency

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
