### PR TITLE
guivm: Passthrough the multimedia keys

### DIFF
--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -60,12 +60,18 @@
       </font>
     </theme>
     <keyboard>
+      <default />
       ${lib.optionalString config.ghaf.profiles.debug.enable ''
       <keybind key="Print">
         <action name="Execute" command="${pkgs.grim}/bin/grim" />
       </keybind>
     ''}
-      <default />
+      <keybind key="XF86_MonBrightnessUp">
+        <action name="Execute" command="${pkgs.brightnessctl}/bin/brightnessctl set +10%" />
+      </keybind>
+      <keybind key="XF86_MonBrightnessDown">
+        <action name="Execute" command="${pkgs.brightnessctl}/bin/brightnessctl set 10%-" />
+      </keybind>
     </keyboard>
     <mouse><default /></mouse>
     <windowRules>
@@ -288,5 +294,10 @@ in {
       };
       wantedBy = ["default.target"];
     };
+
+    #Allow video group to change brightness
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="backlight", RUN+="${pkgs.coreutils}/bin/chgrp video $sys$devpath/brightness", RUN+="${pkgs.coreutils}/bin/chmod a+w $sys$devpath/brightness"
+    '';
   };
 }

--- a/modules/hardware/lenovo-x1/definitions/default.nix
+++ b/modules/hardware/lenovo-x1/definitions/default.nix
@@ -29,6 +29,7 @@ in {
       virtioInputHostEvdevs = [
         # Lenovo X1 touchpad and keyboard
         "/dev/input/by-path/platform-i8042-serio-0-event-kbd"
+        "/dev/input/by-path/platform-thinkpad_acpi-event"
         "/dev/mouse"
         "/dev/touchpad"
         # Lenovo X1 trackpoint (red button/joystick)
@@ -48,6 +49,8 @@ in {
     services.udev.extraRules = ''
       # Laptop keyboard
       SUBSYSTEM=="input", ATTRS{name}=="AT Translated Set 2 keyboard", GROUP="kvm"
+      # Laptop keyboard multimedia buttons
+      SUBSYSTEM=="input", ATTRS{name}=="ThinkPad Extra Buttons", GROUP="kvm"
       # Laptop TrackPoint
       SUBSYSTEM=="input", ATTRS{name}=="TPPS/2 Elan TrackPoint", GROUP="kvm"
       # Lenovo X1 integrated webcam

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -139,6 +139,7 @@
               "iommu=pt"
               # Prevent i915 module from being accidentally used by host
               "module_blacklist=i915"
+              "acpi_backlight=vendor"
 
               "vfio-pci.ids=${builtins.concatStringsSep "," vfioPciIds}"
             ];


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->
Thinkpad multimedia function keys have a different input device than keyboard itself. It is connected to guivm with udev and brightness keybinds are set in labwc.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->

Use F5 and F6 keys to observe brightness change on the screen backlight in GUIVM.
