### PR TITLE
Fix dbus-python cross-compilation

### DIFF
--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -13,4 +13,9 @@
   # libck is dependency of sysbench
   libck = import ./libck {inherit prev;};
   sysbench = import ./sysbench {inherit final prev;};
+
+  python311 = import ./python {
+    inherit final;
+    python = prev.python311;
+  };
 })

--- a/overlays/cross-compilation/python/default.nix
+++ b/overlays/cross-compilation/python/default.nix
@@ -1,0 +1,19 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This is generic overlay to override stuff inside Python package collections,
+# and can be applied to various different versions of Python.
+#
+{
+  final,
+  python,
+}:
+python.override {
+  packageOverrides = _finalPy: prevPy: {
+    # Make dbus-python cross-compileable
+    # https://github.com/NixOS/nixpkgs/issues/309395
+    dbus-python = prevPy.dbus-python.overrideAttrs (_finalAttrs: prevAttrs: {
+      nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [final.dbus];
+    });
+  };
+}


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Added fix for dbus-python into the cross-compilation overlay.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->
Tested only building at this point, because there are other cross-compilation errors on Jetson targets as well

## Testing

`nix build .#nixosConfigurations.nvidia-jetson-orin-agx-debug-from-x86_64.pkgs.python311Packages.dbus-python`