### PR TITLE
log-vm: To centralize logs using grafana promtail & loki

### DIFF
--- a/modules/common/log/promtail-agent.nix
+++ b/modules/common/log/promtail-agent.nix
@@ -1,6 +1,10 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{pkgs, ...}: let
+{
+  pkgs,
+  hostName,
+  ...
+}: let
   server-ip-port = "192.168.101.66:3100";
 in {
   environment.etc."promtail-local-config.yaml".text = ''
@@ -20,6 +24,7 @@ in {
           path: /var/log/journal
           labels:
             job: systemd-journal
+            hostname : "${hostName}"
         relabel_configs:
           - source_labels: ['__journal__systemd_unit']
             target_label: 'unit'

--- a/modules/common/log/promtail-agent.nix
+++ b/modules/common/log/promtail-agent.nix
@@ -1,0 +1,39 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{pkgs, ...}: let
+  server-ip-port = "192.168.101.66:3100";
+in {
+  environment.etc."promtail-local-config.yaml".text = ''
+    server:
+      http_listen_port: 9101
+      grpc_listen_port: 0
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    client:
+      url: http://${server-ip-port}/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: journal
+        journal:
+          path: /var/log/journal
+          labels:
+            job: systemd-journal
+        relabel_configs:
+          - source_labels: ['__journal__systemd_unit']
+            target_label: 'unit'
+  '';
+
+  systemd.services.promtail = {
+    description = "Service to upload journal logs";
+    enable = true;
+    after = ["network-online.target"];
+    serviceConfig = {
+      ExecStart = "${pkgs.grafana-loki}/bin/promtail -config.file=/etc/promtail-local-config.yaml";
+      Restart = "on-failure";
+      RestartSec = "1";
+    };
+    wantedBy = ["multi-user.target"];
+  };
+}

--- a/modules/microvm/default.nix
+++ b/modules/microvm/default.nix
@@ -11,6 +11,7 @@
     ./virtualization/microvm/idsvm/mitmproxy
     ./virtualization/microvm/appvm.nix
     ./virtualization/microvm/guivm.nix
+    ./virtualization/microvm/logvm.nix
     ./networking.nix
     ./power-control.nix
   ];

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -12,6 +12,10 @@
   guivmBaseConfiguration = {
     imports = [
       (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      (import ../../../common/log/promtail-agent.nix {
+        inherit pkgs;
+        hostName = vmName;
+      })
       ({
         lib,
         pkgs,

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -68,6 +68,7 @@
               pkgs.waypipe
               pkgs.networkmanagerapplet
               pkgs.nm-launcher
+              pkgs.grafana-loki
             ]
             ++ (lib.optional (configHost.ghaf.profiles.debug.enable && configHost.ghaf.virtualization.microvm.idsvm.mitmproxy.enable) pkgs.mitmweb-ui);
         };

--- a/modules/microvm/virtualization/microvm/logvm.nix
+++ b/modules/microvm/virtualization/microvm/logvm.nix
@@ -1,0 +1,116 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  configHost = config;
+  vmName = "log-vm";
+  macAddress = "02:00:00:01:01:02";
+  logvmBaseConfiguration = {
+    imports = [
+      (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      ({lib, ...}: {
+        ghaf = {
+          users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
+          development = {
+            # NOTE: SSH port also becomes accessible on the network interface
+            #       that has been passed through to NetVM
+            ssh.daemon.enable = lib.mkDefault configHost.ghaf.development.ssh.daemon.enable;
+            debug.tools.enable = lib.mkDefault configHost.ghaf.development.debug.tools.enable;
+            nix-setup.enable = lib.mkDefault configHost.ghaf.development.nix-setup.enable;
+          };
+          systemd = {
+            enable = true;
+            withName = "logvm-systemd";
+            withPolkit = true;
+            withDebug = configHost.ghaf.profiles.debug.enable;
+          };
+        };
+
+        system.stateVersion = lib.trivial.release;
+
+        nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
+        nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
+
+        networking = {
+          firewall.allowedTCPPorts = [19532];
+        };
+
+        environment.systemPackages = lib.mkIf config.ghaf.profiles.debug.enable [];
+
+        systemd.network = {
+          enable = true;
+          networks."10-ethint0" = {
+            matchConfig.MACAddress = macAddress;
+            addresses = [
+              {
+                addressConfig.Address = "192.168.100.66/24";
+              }
+              {
+                # IP-address for debugging subnet
+                addressConfig.Address = "192.168.101.66/24";
+              }
+            ];
+            linkConfig.ActivationPolicy = "always-up";
+          };
+        };
+
+        users.users.systemd-journal-remote = {
+          isSystemUser = true;
+          group = "systemd-journal";
+        };
+
+        systemd.tmpfiles.rules = [ "d /var/log/journal/remote 755 systemd-journal-remote systemd-journal" ];
+
+        systemd.services.systemd-journal-remote = {
+          enable = true;
+        };
+
+        microvm = {
+          optimize.enable = true;
+          hypervisor = "cloud-hypervisor";
+          shares = [
+            {
+              tag = "ro-store";
+              source = "/nix/store";
+              mountPoint = "/nix/.ro-store";
+              proto = "virtiofs";
+            }
+          ];
+          writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
+        };
+
+        imports = [../../../common];
+      })
+    ];
+  };
+  cfg = config.ghaf.virtualization.microvm.logvm;
+in {
+  options.ghaf.virtualization.microvm.logvm = {
+    enable = lib.mkEnableOption "LogVM";
+
+    extraModules = lib.mkOption {
+      description = ''
+        List of additional modules to be imported and evaluated as part of
+        LogVM's NixOS configuration.
+      '';
+      default = [];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    microvm.vms."${vmName}" = {
+      autostart = true;
+      config =
+        logvmBaseConfiguration
+        // {
+          imports =
+            logvmBaseConfiguration.imports
+            ++ cfg.extraModules;
+        };
+    };
+  };
+}

--- a/modules/microvm/virtualization/microvm/logvm.nix
+++ b/modules/microvm/virtualization/microvm/logvm.nix
@@ -35,10 +35,6 @@
         nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
         nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
 
-        networking = {
-          firewall.allowedTCPPorts = [3100];
-        };
-
         environment.systemPackages = [pkgs.grafana-loki];
 
         systemd.network = {
@@ -58,8 +54,9 @@
           };
         };
 
-        environment.etc."loki.yaml".source = ./loki-local-config.yaml;
+        networking.firewall.allowedTCPPorts = [3100];
 
+        environment.etc."loki.yaml".source = ./loki-local-config.yaml;
         systemd.services.loki = {
           enable = true;
           description = "Loki Service";

--- a/modules/microvm/virtualization/microvm/logvm.nix
+++ b/modules/microvm/virtualization/microvm/logvm.nix
@@ -35,10 +35,6 @@
         nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
         nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
 
-        networking = {
-          firewall.allowedTCPPorts = [19532];
-        };
-
         environment.systemPackages = lib.mkIf config.ghaf.profiles.debug.enable [];
 
         systemd.network = {
@@ -56,17 +52,6 @@
             ];
             linkConfig.ActivationPolicy = "always-up";
           };
-        };
-
-        users.users.systemd-journal-remote = {
-          isSystemUser = true;
-          group = "systemd-journal";
-        };
-
-        systemd.tmpfiles.rules = [ "d /var/log/journal/remote 755 systemd-journal-remote systemd-journal" ];
-
-        systemd.services.systemd-journal-remote = {
-          enable = true;
         };
 
         microvm = {

--- a/modules/microvm/virtualization/microvm/loki-local-config.yaml
+++ b/modules/microvm/virtualization/microvm/loki-local-config.yaml
@@ -27,7 +27,7 @@ query_range:
 
 schema_config:
   configs:
-    - from: 2020-10-24
+    - from: 2024-01-01
       store: tsdb
       object_store: filesystem
       schema: v13

--- a/modules/microvm/virtualization/microvm/loki-local-config.yaml
+++ b/modules/microvm/virtualization/microvm/loki-local-config.yaml
@@ -1,0 +1,39 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -20,6 +20,10 @@
   netvmBaseConfiguration = {
     imports = [
       (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      (import ../../../common/log/promtail-agent.nix {
+        inherit pkgs;
+        hostName = vmName;
+      })
       ({lib, ...}: {
         ghaf = {
           users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;

--- a/targets/lenovo-x1/appvms/chromium.nix
+++ b/targets/lenovo-x1/appvms/chromium.nix
@@ -61,6 +61,13 @@ in {
       programs.chromium.extraOpts."AlwaysOpenPdfExternally" = true;
       # Set default PDF XDG handler
       xdg.mime.defaultApplications."application/pdf" = "ghaf-pdf.desktop";
+      # Import promtail agent for remote upload of journal logs
+      imports = [
+        (import ../../../modules/common/log/promtail-agent.nix {
+          inherit pkgs;
+          hostName = "chromium-vm";
+        })
+      ];
     }
   ];
   borderColor = "#630505";

--- a/targets/lenovo-x1/appvms/gala.nix
+++ b/targets/lenovo-x1/appvms/gala.nix
@@ -18,6 +18,12 @@
       security.pki.certificateFiles =
         lib.mkIf config.ghaf.virtualization.microvm.idsvm.mitmproxy.enable
         [../../../modules/microvm/virtualization/microvm/idsvm/mitmproxy/mitmproxy-ca/mitmproxy-ca-cert.pem];
+      imports = [
+        (import ../../../modules/common/log/promtail-agent.nix {
+          inherit pkgs;
+          hostName = "gala-vm";
+        })
+      ];
     }
   ];
   borderColor = "#027d7b";

--- a/targets/lenovo-x1/appvms/zathura.nix
+++ b/targets/lenovo-x1/appvms/zathura.nix
@@ -10,6 +10,12 @@
   extraModules = [
     {
       time.timeZone = "Asia/Dubai";
+      imports = [
+        (import ../../../modules/common/log/promtail-agent.nix {
+          inherit pkgs;
+          hostName = "zathura-vm";
+        })
+      ];
     }
   ];
   borderColor = "#122263";

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -96,6 +96,9 @@
                 mitmproxy.enable = false;
               };
 
+              virtualization.microvm.logvm = {
+                enable = true;
+              };
               virtualization.microvm.guivm = {
                 enable = true;
                 extraModules =

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -33,9 +33,6 @@
           self.nixosModules.disko-lenovo-x1-basic-v1
           self.nixosModules.hw-lenovo-x1
 
-          # Import promtail agent for remote upload of journal logs
-          ../../modules/common/log/promtail-agent.nix
-
           ({
             pkgs,
             config,
@@ -61,6 +58,13 @@
             disko.devices.disk = config.ghaf.hardware.definition.disks;
 
             environment.systemPackages = [pkgs.grafana-loki];
+            # Import promtail agent for remote upload of journal logs
+            imports = [
+              (import ../../modules/common/log/promtail-agent.nix {
+                inherit pkgs;
+                hostName = "ghaf-host";
+              })
+            ];
 
             ghaf = {
               # Hardware definitions

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -33,6 +33,9 @@
           self.nixosModules.disko-lenovo-x1-basic-v1
           self.nixosModules.hw-lenovo-x1
 
+          # Import promtail agent for remote upload of journal logs
+          ../../modules/common/log/promtail-agent.nix
+
           ({
             pkgs,
             config,
@@ -56,6 +59,8 @@
             users.extraUsers.microvm.extraGroups = ["audio" "pulse-access"];
 
             disko.devices.disk = config.ghaf.hardware.definition.disks;
+
+            environment.systemPackages = [pkgs.grafana-loki];
 
             ghaf = {
               # Hardware definitions

--- a/targets/lenovo-x1/guivmExtraModules.nix
+++ b/targets/lenovo-x1/guivmExtraModules.nix
@@ -179,5 +179,7 @@ in
     guivmPCIPassthroughModule
     guivmVirtioInputHostEvdevModule
     guivmExtraConfigurations
+    # Import promtail agent for remote upload of journal logs
+    ../../modules/common/log/promtail-agent.nix
   ]
   ++ lib.optionals configH.ghaf.hardware.fprint.enable [configH.ghaf.hardware.fprint.extraConfigurations]

--- a/targets/lenovo-x1/guivmExtraModules.nix
+++ b/targets/lenovo-x1/guivmExtraModules.nix
@@ -179,7 +179,5 @@ in
     guivmPCIPassthroughModule
     guivmVirtioInputHostEvdevModule
     guivmExtraConfigurations
-    # Import promtail agent for remote upload of journal logs
-    ../../modules/common/log/promtail-agent.nix
   ]
   ++ lib.optionals configH.ghaf.hardware.fprint.enable [configH.ghaf.hardware.fprint.extraConfigurations]

--- a/targets/lenovo-x1/netvmExtraModules.nix
+++ b/targets/lenovo-x1/netvmExtraModules.nix
@@ -97,5 +97,18 @@
     };
     # DNS host record has been added for element-vm static ip
     services.dnsmasq.settings.host-record = "element-vm,element-vm.ghaf,${elemen-vmIp}";
+
+    # Forward 3100 port of net-vm to log-vm so that we can access loki service externally (for debugging only)
+    networking.nat = lib.mkIf configH.ghaf.profiles.debug.enable {
+      enable = true;
+      externalInterface = "wlp0s5f0";
+      forwardPorts = [
+        {
+          sourcePort = 3100;
+          proto = "tcp";
+          destination = "192.168.101.66:3100";
+        }
+      ];
+    };
   };
 in [netvmPCIPassthroughModule netvmAdditionalConfig]


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

**To view logs in locally on ghaf target machine**

ssh into log-vm and use `logcli` to view systemd journal logs
```
[ghaf@ghaf-host:~]$ ssh 192.168.101.66

[ghaf@log-vm:~]$ logcli query '{job="systemd-journal"}'

[ghaf@log-vm:~]$ logcli query '{hostname="ghaf-host"}'
```

**To view logs in grafana GUI on remote server/ dev machine.**

1) Move to dev machine / machine where you want to install `grafana`
 To install grafana on NixOS you can follow mentioned guide [here](https://nixos.wiki/wiki/Grafana) 
 
 **Example:**
```networking.firewall.allowedTCPPorts = [ 3000 ];
services.grafana = {
  enable   = true;
  settings = {
    server = {
      http_addr = "<your_local_network_grafana_instance_ip_address_here>";
      domain = "localdomain";
      http_port = 3000;
      protocol = "http";
    };
  };

  dataDir  = "/var/lib/grafana";
};
```
2) Make sure you have connected to WIFI using `nm-launcher` on `ghaf target` machine.

3) Run the below command to add `loki` data source, replace with `netvm-wifi-ip-address` with yours IP.
  [ghaf@log-vm:~]$ curl 'http://admin:admin@<grafana_ip_in_your_local_network>:3000/api/datasources'
-X POST -H 'Content-Type: application/json;charset=UTF-8' --data-binary '{"name":"loki","type":"loki","url":"http://<net-vm_wifi_ip_address>:3100","access":"proxy","isDefault":true,"database":"tsdb"}'

4) Go to browser where you want to view the logs and type following address `http://<grafana_ip_in_your_local_network>:3000/explore`
  Follow below steps in order to view logs/download logs.

![image](https://github.com/tiiuae/ghaf/assets/147831196/bef7f6a0-301e-4231-9846-b0aa4d31807d)

Also there is way to filter out logs based on hostName as in example below:
![image](https://github.com/tiiuae/ghaf/assets/147831196/090dbd80-1cf7-407d-9541-091fdf4d83b6)


## Next Steps
1) Build Grafana alloy nix package
2) Change from promtail agent to alloy