### PR TITLE
Remote journald services for systemd log collection.

### DIFF
--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -39,6 +39,7 @@
         withOomd = true;
         withPam = true;
         inherit (cfg) withPolkit;
+        withRemote = cfg.withRemoteJournal.enable || cfg.withRemoteJournalServer.enable;
         inherit (cfg) withResolved;
         inherit (cfg) withRepart;
         withShellCompletions = cfg.withDebug;
@@ -173,6 +174,11 @@
       "prepare-kexec.target"
     ]);
 in {
+  imports = [
+    ./debug/journal-upload.nix
+    ./debug/journal-remote.nix
+  ];
+
   options.ghaf.systemd = {
     enable = mkEnableOption "Enable minimal systemd configuration.";
 

--- a/modules/common/systemd/debug/journal-remote.nix
+++ b/modules/common/systemd/debug/journal-remote.nix
@@ -1,0 +1,101 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Original source: https://gitlab.com/distrosync/nixos/-/blob/master/modules/journal/journal-remote.nix
+# Run this on your development machine, or a virtual machine to collect logs.
+{
+  config,
+  lib,
+  ...
+}: let
+  # Ghaf configuration flag
+  cfg = config.ghaf.systemd.withRemoteJournalServer;
+in
+  with lib; {
+    options.ghaf.systemd.withRemoteJournalServer = {
+      enable = mkOption {
+        description = ''
+          Enable remote journaling server for systemd debugging. Note that this option uses
+          insecure http and is only intended for local debugging purposes.
+        '';
+        type = types.bool;
+        default = false;
+      };
+    };
+
+    config = mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = config.ghaf.systemd.withJournal;
+          message = ''
+            The systemd journal must be enabled when enabling systemd-journal-upload.
+            Hint: Set `ghaf.systemd.withJournal` to true.
+          '';
+        }
+        {
+          assertion = !config.ghaf.profiles.release.enable;
+          message = ''
+            This module should never by used in release.
+          '';
+        }
+      ];
+
+      # This configuration is adapted from this service file example:
+      # /run/current-system/systemd/example/systemd/system/systemd-journal-remote.service
+
+      # To allow journal-upload clients to access the journal-remote listener
+      networking.firewall.allowedTCPPorts = [19532];
+      # Create a new user for journal-remote, and use existing systemd-journal group
+      users.users.systemd-journal-remote = {
+        isSystemUser = true;
+        group = "systemd-journal";
+      };
+      # Create a directory for the remote logs, so that they inherit the ACLs of the parent /var/log/journal directory.
+      # This is probably not necessary, but it is part of trying to debug journald configs not applying to remote journal files.
+      systemd.tmpfiles.rules = ["d /var/log/journal/remote 755 systemd-journal-remote systemd-journal"];
+
+      systemd.services.systemd-journal-remote = {
+        enable = true;
+        description = "Journal Remote Sink Service";
+        documentation = ["man:systemd-journal-remote(8)" "man:journal-remote.conf(5)"];
+        requires = ["systemd-journal-remote.socket"];
+
+        serviceConfig = {
+          ExecStart = "/run/current-system/systemd/lib/systemd/systemd-journal-remote --listen-http=-3 --output=/var/log/journal/remote/";
+          LockPersonality = "yes";
+          LogsDirectory = "journal/remote";
+          MemoryDenyWriteExecute = "yes";
+          NoNewPrivileges = "yes";
+          PrivateDevices = "yes";
+          PrivateNetwork = "yes";
+          PrivateTmp = "yes";
+          ProtectControlGroups = "yes";
+          ProtectHome = "yes";
+          ProtectHostname = "yes";
+          ProtectKernelModules = "yes";
+          ProtectKernelTunables = "yes";
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+          RestrictNamespaces = "yes";
+          RestrictRealtime = "yes";
+          RestrictSUIDSGID = "yes";
+          SystemCallArchitectures = "native";
+          User = "systemd-journal-remote";
+          Group = "systemd-journal";
+          WatchdogSec = "10";
+          # If there are many split up journal files we need a lot of fds to access them all in parallel.
+          LimitNOFILE = "524288";
+        };
+        # Added so that the service will start automatically.
+        # Possibly also add a "Restart" to the serviceConfig if it doesn't recover from failures.
+        wantedBy = ["multi-user.target"];
+      };
+
+      systemd.sockets.systemd-journal-remote = {
+        enable = true;
+        description = "Journal Remote Sink Socket";
+        listenStreams = ["19532"];
+        wantedBy = ["sockets.target"];
+      };
+    };
+  }

--- a/modules/common/systemd/debug/journal-upload.nix
+++ b/modules/common/systemd/debug/journal-upload.nix
@@ -1,0 +1,110 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Original configuration source: https://gitlab.com/distrosync/nixos/-/blob/master/modules/journal/journal-upload.nix
+{
+  config,
+  lib,
+  ...
+}: let
+  # Ghaf configuration flag
+  cfg = config.ghaf.systemd.withRemoteJournal;
+in
+  with lib; {
+    options.ghaf.systemd.withRemoteJournal = {
+      enable = mkOption {
+        description = ''
+          Enable remote journaling for systemd debugging. Note that this option uses
+          insecure http and is only intended for local debugging purposes.
+        '';
+        type = types.bool;
+        default = false;
+      };
+      debugServerIpv4 = mkOption {
+        description = "The IPv4 address of the debug server to which the journal should be uploaded.";
+        type = types.str;
+        default = "192.168.101.1";
+        example = "192.168.101.1";
+      };
+    };
+
+    config = mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = config.ghaf.systemd.withJournal;
+          message = ''
+            The systemd journal must be enabled when enabling systemd-journal-upload.
+            Hint: Set `ghaf.systemd.withJournal` to true.
+          '';
+        }
+        {
+          assertion = cfg.debugServerIpv4 != "";
+          message = ''
+            The debug server IP address must be set when enabling systemd-journal-upload.
+            Hint: Set `ghaf.systemd.withRemoteJournal.debugServerIpv4` to the IP address of the debug server.
+          '';
+        }
+        {
+          assertion = !config.ghaf.profiles.release.enable;
+          message = ''
+            This module should never by used in release.
+          '';
+        }
+      ];
+
+      # Systemd >= 255 / unstable implementation
+      # services.journald.upload = {
+      #   enable = true;
+      #   settings = {
+      #     Upload.URL = "http://${cfg.debugServerIpv4}:19532";
+      #   };
+      # };
+
+      users = {
+        users.systemd-journal-upload = {
+          isSystemUser = true;
+          group = "systemd-journal-upload";
+        };
+        groups.systemd-journal-upload = {};
+      };
+
+      systemd.services.systemd-journal-upload = {
+        enable = true;
+        description = "Journal Remote Upload Service";
+        documentation = ["man:systemd-journal-upload(8)"];
+        wants = ["network-online.target"];
+        after = ["network-online.target"];
+        wantedBy = ["multi-user.target"];
+        serviceConfig = {
+          ExecStart = "/run/current-system/systemd/lib/systemd/systemd-journal-upload --save-state -u http://${cfg.debugServerIpv4}:19532";
+          DynamicUser = "yes";
+          LockPersonality = "yes";
+          MemoryDenyWriteExecute = "yes";
+          PrivateDevices = "yes";
+          ProtectControlGroups = "yes";
+          ProtectHome = "yes";
+          ProtectHostname = "yes";
+          ProtectKernelModules = "yes";
+          ProtectKernelTunables = "yes";
+          Restart = "always";
+          RestartSec = "10";
+          RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+          RestrictNamespaces = "yes";
+          RestrictRealtime = "yes";
+          StateDirectory = "systemd/journal-upload";
+          SupplementaryGroups = "systemd-journal";
+          SystemCallArchitectures = "native";
+          User = "systemd-journal-upload";
+          WatchdogSec = "10";
+          # If there are many split up journal files we need a lot of fds to access them all in parallel.
+          LimitNOFILE = "524288";
+        };
+      };
+
+      # Add route to enable remote logging (for debugging only)
+      systemd.network.networks."10-virbr0".routes =
+        if (config.system.name == "ghaf-host")
+        then [{routeConfig.Gateway = "192.168.101.1";}]
+        else [];
+    };
+  }

--- a/modules/microvm/virtualization/microvm/adminvm.nix
+++ b/modules/microvm/virtualization/microvm/adminvm.nix
@@ -38,6 +38,7 @@
             withPolkit = true;
             withTimesyncd = true;
             withDebug = configHost.ghaf.profiles.debug.enable;
+            withRemoteJournal.enable = true;
           };
 
           # Log aggregation configuration

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -67,6 +67,10 @@
               withPolkit = true;
               withDebug = configHost.ghaf.profiles.debug.enable;
               withHardenedConfigs = true;
+              withRemoteJournal = {
+                enable = true;
+                debugServerIpv4 = "192.168.100.1";
+              };
             };
             # Logging client configuration
             logging.client.enable = configHost.ghaf.logging.client.enable;

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -47,6 +47,7 @@
             withResolved = true;
             withTimesyncd = true;
             withDebug = configHost.ghaf.profiles.debug.enable;
+            withRemoteJournal.enable = true;
           };
           services.audio.enable = true;
         };

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -44,6 +44,7 @@
             withTimesyncd = true;
             withDebug = config.ghaf.profiles.debug.enable;
             withHardenedConfigs = true;
+            withRemoteJournal.enable = true;
           };
           # Logging client configuration
           logging.client.enable = config.ghaf.logging.client.enable;

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -30,6 +30,7 @@ in {
       withSerial = config.ghaf.profiles.debug.enable;
       withDebug = config.ghaf.profiles.debug.enable;
       withHardenedConfigs = true;
+      withRemoteJournal.enable = true;
     };
 
     # TODO: remove hardcoded paths

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -48,6 +48,7 @@
             withTimesyncd = true;
             withDebug = config.ghaf.profiles.debug.enable;
             withHardenedConfigs = true;
+            withRemoteJournalServer.enable = true;
           };
           # Logging client configuration
           logging.client.enable = config.ghaf.logging.client.enable;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

This draft PR is only intended to share my config to upload and receive systemd journals remotely for debug purposes.

Changes:

1. Enable `withRemote` in base systemd config
2. Add `systemd-journal-upload` service, exposed with the option `withRemoteJournal`. It allows to set the target IP, by default it is set to the `netvm` here
3. Add `systemd-journal-remote` service, exposed via `withRemoteJournalServer`
4. Add default logging to all VMs and host to `netvm`. You can retrieve all logs from the `netvm` in this configuration, e.g., via `scp`


Note: This is an insecure configuration and should only be used for debug purposes, as it uses `http` and adds a route from host.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
