### PR TITLE
Add Ghaf DNS server setting for ElementVM static network config

### DIFF
--- a/targets/lenovo-x1/appvms/element.nix
+++ b/targets/lenovo-x1/appvms/element.nix
@@ -46,9 +46,12 @@ in {
         };
       };
 
-      networking = pkgs.lib.mkIf isDendritePineconeEnabled {
-        firewall.allowedTCPPorts = [dendrite-pinecone.TcpPortInt];
-        firewall.allowedUDPPorts = [dendrite-pinecone.McastUdpPortInt];
+      networking = {
+        nameservers = ["192.168.100.1"];
+        firewall = pkgs.lib.mkIf isDendritePineconeEnabled {
+          allowedTCPPorts = [dendrite-pinecone.TcpPortInt];
+          allowedUDPPorts = [dendrite-pinecone.McastUdpPortInt];
+        };
       };
 
       time.timeZone = "${config.time.timeZone}";


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Add Ghaf internal DNS settings for ElementVM


## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [X] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
- ssh to element-vm
- From element VM ping to any other .ghaf internal name address

- Check dns settins with "systemd-resolve --status"
