### PR TITLE
Add efibootmgr to debug tools

### DIFF
--- a/modules/common/development/debug-tools.nix
+++ b/modules/common/development/debug-tools.nix
@@ -37,6 +37,9 @@ in
           dig
           evtest
 
+          # For deleting Linux Boot Manager entries in automated testing
+          efibootmgr
+
           # Performance testing
           speedtest-cli
           iperf


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This PR just adds efibootmgr utility to debug tools. This is to enable automated removal of Linux Boot Manager entries. Once PR#585 gets merged ghaf-installer will create always a new Linux Boot Manager entry to UEFI Boot order list.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

The plan is to run
```
for f in $(efibootmgr | grep Linux | awk 'NR > 0 {print $1}' | cut -c 5-8)
do
    sudo efibootmgr -q -b ${f} -B
done
```
for Lenovo-X1 in automated setup every time after testing ghaf-installer/ghaf.

Command `efibootmgr` lists the current boot order.

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
