### PR TITLE
openPdf: prevent word splitting when filename contains a space

### DIFF
--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -42,7 +42,7 @@
           runWaypipe = with pkgs;
             writeScriptBin "run-waypipe" ''
               #!${runtimeShell} -e
-              ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString configHost.ghaf.virtualization.microvm.guivm.waypipePort} ${waypipeBorder} server $@
+              ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString configHost.ghaf.virtualization.microvm.guivm.waypipePort} ${waypipeBorder} server "$@"
             '';
         in {
           ghaf = {

--- a/targets/lenovo-x1/appvms/chromium.nix
+++ b/targets/lenovo-x1/appvms/chromium.nix
@@ -15,7 +15,7 @@ in {
       mimeTypes = ["application/pdf"];
     };
     xdgOpenPdf = pkgs.writeShellScriptBin "xdgopenpdf" ''
-      filepath=$(realpath $1)
+      filepath=$(realpath "$1")
       echo "Opening $filepath" | systemd-cat -p info
       echo $filepath | ${pkgs.netcat}/bin/nc -N gui-vm.ghaf ${toString xdgPdfPort}
     '';

--- a/targets/lenovo-x1/openPdf.nix
+++ b/targets/lenovo-x1/openPdf.nix
@@ -26,7 +26,7 @@ pkgs.writeShellApplication {
     scp -i ${sshKeyPath} -o StrictHostKeyChecking=no "$REMOTE_ADDR":"$sourcepath" zathura-vm.ghaf:"$zathurapath"
 
     echo "Opening $zathurapath in zathura-vm"
-    ssh -i ${sshKeyPath} -o StrictHostKeyChecking=no zathura-vm.ghaf run-waypipe zathura "$zathurapath"
+    ssh -i ${sshKeyPath} -o StrictHostKeyChecking=no zathura-vm.ghaf run-waypipe zathura "'$zathurapath'"
 
     echo "Deleting $zathurapath in zathura-vm"
     ssh -i ${sshKeyPath} -o StrictHostKeyChecking=no zathura-vm.ghaf rm -f "$zathurapath"


### PR DESCRIPTION
When PDF names contain a space, word splitting occurs on multiple areas, resulting the action (openPdf) to fail.

## Description of changes

Properly quote arguments and variables, so they are passed properly.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Search for "pdf assoc example", open first link: `https://github.com/pdf-association/pdf20examples`
- Download the PDF file with a space. Should work.
- PDF files without spaces should work.
- As the `waypipe-run` command has been modified, double-check that all applications still run properly.
