### PR TITLE
admin-vm: VM for ghaf administration

### DIFF
--- a/modules/microvm/default.nix
+++ b/modules/microvm/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ./virtualization/microvm/microvm-host.nix
     ./virtualization/microvm/netvm.nix
+    ./virtualization/microvm/adminvm.nix
     ./virtualization/microvm/idsvm/idsvm.nix
     ./virtualization/microvm/idsvm/mitmproxy
     ./virtualization/microvm/appvm.nix

--- a/modules/microvm/virtualization/microvm/adminvm.nix
+++ b/modules/microvm/virtualization/microvm/adminvm.nix
@@ -1,0 +1,103 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}: let
+  configHost = config;
+  vmName = "admin-vm";
+  macAddress = "02:00:00:AD:01:01";
+
+  adminvmBaseConfiguration = {
+    imports = [
+      (import ./common/vm-networking.nix {inherit vmName macAddress;})
+      ({lib, ...}: {
+        ghaf = {
+          users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
+          development = {
+            # NOTE: SSH port also becomes accessible on the network interface
+            #       that has been passed through to VM
+            ssh.daemon.enable = lib.mkDefault configHost.ghaf.development.ssh.daemon.enable;
+            debug.tools.enable = lib.mkDefault configHost.ghaf.development.debug.tools.enable;
+            nix-setup.enable = lib.mkDefault configHost.ghaf.development.nix-setup.enable;
+          };
+          systemd = {
+            enable = true;
+            withName = "adminvm-systemd";
+            withPolkit = true;
+            withDebug = configHost.ghaf.profiles.debug.enable;
+          };
+        };
+
+        system.stateVersion = lib.trivial.release;
+
+        nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
+        nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
+
+        networking = {
+          firewall.allowedTCPPorts = [];
+          firewall.allowedUDPPorts = [];
+        };
+
+        systemd.network = {
+          enable = true;
+          networks."10-ethint0" = {
+            matchConfig.MACAddress = macAddress;
+            addresses = [
+              {
+                addressConfig.Address = "192.168.100.10/24";
+              }
+              {
+                # IP-address for debugging subnet
+                addressConfig.Address = "192.168.101.10/24";
+              }
+            ];
+            linkConfig.ActivationPolicy = "always-up";
+          };
+        };
+
+        microvm = {
+          optimize.enable = true;
+          hypervisor = "cloud-hypervisor";
+          shares = [
+            {
+              tag = "ro-store";
+              source = "/nix/store";
+              mountPoint = "/nix/.ro-store";
+              proto = "virtiofs";
+            }
+          ];
+          writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
+        };
+        imports = [../../../common];
+      })
+    ];
+  };
+  cfg = config.ghaf.virtualization.microvm.adminvm;
+in {
+  options.ghaf.virtualization.microvm.adminvm = {
+    enable = lib.mkEnableOption "AdminVM";
+
+    extraModules = lib.mkOption {
+      description = ''
+        List of additional modules to be imported and evaluated as part of
+        AdminVM's NixOS configuration.
+      '';
+      default = [];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    microvm.vms."${vmName}" = {
+      autostart = true;
+      config =
+        adminvmBaseConfiguration
+        // {
+          imports =
+            adminvmBaseConfiguration.imports
+            ++ cfg.extraModules;
+        };
+    };
+  };
+}

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -91,6 +91,10 @@
                 };
               };
 
+              virtualization.microvm.adminvm = {
+                enable = true;
+              };
+
               virtualization.microvm.idsvm = {
                 enable = false;
                 mitmproxy.enable = false;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

* required to integrate givc admin and centralized logging

https://ssrc.atlassian.net/wiki/x/xoCCKw

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

```
[vilvo@carrie:~/ghaf]$ ssh ghaf@<host_debug_ethernet_ip_address>
Last login: Thu May 16 10:08:17 2024 from ...

[ghaf@ghaf-host:~]$ microvm -l
admin-vm: current(nixos-system-admin-vm-23.11pre-git)
appflowy-vm: current(nixos-system-appflowy-vm-23.11pre-git)
chromium-vm: current(nixos-system-chromium-vm-23.11pre-git)
element-vm: current(nixos-system-element-vm-23.11pre-git)
gala-vm: current(nixos-system-gala-vm-23.11pre-git)
gui-vm: current(nixos-system-gui-vm-23.11pre-git)
net-vm: current(nixos-system-net-vm-23.11pre-git)
zathura-vm: current(nixos-system-zathura-vm-23.11pre-git)

[ghaf@ghaf-host:~]$ ssh 192.168.101.10
The authenticity of host '192.168.101.10 (192.168.101.10)' can't be established.
ED25519 key fingerprint is SHA256:LrXxZSQOqsBGvLE4vqt0LZ0NvJVlZRL6e657Hzk83Qo.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.101.10' (ED25519) to the list of known hosts.
(ghaf@192.168.101.10) Password: 

[ghaf@admin-vm:~]$
```
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
