### PR TITLE
zathura VM: Use regular clipboard instead of primary

### DIFF
--- a/targets/lenovo-x1/appvms/zathura.nix
+++ b/targets/lenovo-x1/appvms/zathura.nix
@@ -10,6 +10,11 @@
   extraModules = [
     {
       time.timeZone = "Asia/Dubai";
+
+      # Use regular clipboard instead of primary clipboard.
+      environment.etc."zathurarc".text = ''
+        set selection-clipboard clipboard
+      '';
     }
   ];
   borderColor = "#122263";


### PR DESCRIPTION
End users shouldn't need to understand the difference between multiple clipboards.
This only applies to X1 Carbon, not to Orin. Zathura is not yet properly integrated on Orin.

## Description of changes

Simply adds configuration for Zathura to set the default clipboard.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Open a PDF (download from internet).
- Select text, should copy to normal clipboard.
- Paste on another window/VM normally with Ctrl+V, this should now work as expected.
