### PR TITLE
NXP i.MX8 MPlus platform support

### DIFF
--- a/docs/src/features/features.md
+++ b/docs/src/features/features.md
@@ -35,7 +35,7 @@ The following tables show the status of Ghaf Platform features:
 |-------------------|-------------|------------------|-------------------------------------|
 | Ghaf in virtual machine | &#x2705; | `x86` | `nix run .#packages.x86_64-linux.vm-debug` |
 | `aarch64` reference image | &#x2705; | `Orin`  | Based on [Jetson Linux](https://developer.nvidia.com/embedded/jetson-linux), [OE4T](https://github.com/OE4T) and [jetpack-nixos](https://github.com/anduril/jetpack-nixos). |
-| `aarch64` reference image | &#x2705; | `imx8qm`  | Based on NXP BSP, implemented as [nixos-hardware module](https://github.com/NixOS/nixos-hardware/tree/master/nxp)|
+| `aarch64` reference image | &#x2705; | `imx8mp`  | Based on NXP BSP, implemented as [nixos-hardware module](https://github.com/NixOS/nixos-hardware/tree/master/nxp)|
 | `x86` generic image | &#x2705; | `x86` | Generic x86 computer, based on generic [NixOS](https://nixos.org/). NOTE: requires device specific configuration.|
 | `Lenovo X1` reference image | &#x2705; | `Lenovo X1` | x86_64 laptop computer, supports basic compartmentalized environment |
 | Native build      | &#x2705;         | `aarch64, x86`   | Remote `aarc64` nixos builders recommended |
@@ -50,7 +50,7 @@ The following tables show the status of Ghaf Platform features:
 |-------------------|-------------|------------------|----------------------------------------------|
 | Quick target update  | &#x2705; | `all`  | `nixos-rebuild --flake .#nvidia-jetson-orin-debug --target-host root@ghaf-host --fast switch` |
 | `aarch64` device flashing   | &#x2705;   | `Orin`  | [Full device software flashing using `x86` machine](https://tiiuae.github.io/ghaf/ref_impl/build_and_run.html#flashing-nvidia-jetson-orin-agx) |
-| root filesystem flashing | &#x2705;   | `x86, imx8qm`  | `dd` image to bootable media - [see](https://tiiuae.github.io/ghaf/ref_impl/build_and_run.html#running-ghaf-image-for-x86-computer) |
+| root filesystem flashing | &#x2705;   | `x86, imx8mp`  | `dd` image to bootable media - [see](https://tiiuae.github.io/ghaf/ref_impl/build_and_run.html#running-ghaf-image-for-x86-computer) |
 | Debug: SSH        | &#x2705;      | `Orin`, `x86` | Host access only in `-debug`-target, see [authentication.nix](https://github.com/tiiuae/ghaf/blob/main/modules/development/authentication.nix) |
 | Debug: Serial     | &#x2705;      | `all` | Host access only in `-debug`-target - e.g. `screen /dev/ttyACM0 115200` |
 | Compartmentalized environment     | &#x1f6A7;      | `Lenovo X1` | NetVM, GUI VM (with GPU passthrough) plus some Application VMs |

--- a/docs/src/ref_impl/build_and_run.md
+++ b/docs/src/ref_impl/build_and_run.md
@@ -32,9 +32,8 @@ Then you can use one of the following instructions for the supported targets:
 | Generic x86 Сomputer | x86_64           | [Running Ghaf Image for x86 Computer](./build_and_run.md#running-ghaf-image-for-x86-computer) |
 | Lenovo X1 Carbon Gen 11 | x86_64           | [Running Ghaf Image for Lenovo X1](./build_and_run.md#running-ghaf-image-for-lenovo-x1) |
 | NVIDIA Jetson AGX Orin  | AArch64          | [Ghaf Image for NVIDIA Jetson Orin AGX](./build_and_run.md#ghaf-image-for-nvidia-jetson-orin-agx)     |
-| NXP i.MX 8QM-MEK        | AArch64          | [Building Ghaf Image for NXP i.MX 8QM-MEK](./build_and_run.md#building-ghaf-image-for-nxp-imx-8qm-mek)     |
+| NXP i.MX 8MP-EVK        | AArch64          | [Building Ghaf Image for NXP i.MX 8MP-EVK](./build_and_run.md#building-ghaf-image-for-nxp-imx-8mp-evk)     |
 | MICROCHIP icicle-kit    | RISCV64          | [Building Ghaf Image for Microchip Icicle Kit](./build_and_run.md#building-ghaf-image-for-microchip-icicle-kit) |
-
 
 ---
 
@@ -159,25 +158,17 @@ In the current state of Ghaf, it is a bit tricky to make NVIDIA Jetson Orin AGX 
 
 ---
 
-## Building Ghaf Image for NXP i.MX 8QM-MEK
+## Building Ghaf Image for NXP i.MX 8MP-EVK
 
 Before you begin, check device-independent [prerequisites](./build_and_run.md#prerequisites).
 
-In the case of i.MX8, Ghaf deployment consists of creating a bootable SD card with a first-stage bootloader (Tow-Boot) and USB media with the Ghaf image:
+In the case of i.MX8, Ghaf deployment consists of creating a bootable SD card and USB media with the Ghaf image:
 
-1. To build and flash [**Tow-Boot**](https://github.com/tiiuae/Tow-Boot) bootloader:
-
-    ```
-    $ git clone https://github.com/tiiuae/Tow-Boot.git && cd Tow-Boot
-    $ nix-build -A imx8qm-mek
-    $ sudo dd if=result/ shared.disk-image.img of=/dev/<SDCARD>
-    ```
-
-2. To build and flash the Ghaf image:
-   1. Run the `nix build .#packages.aarch64-linux.imx8qm-mek-release` command.
+1. To build and flash the Ghaf image:
+   1. Run the `nix build .#packages.aarch64-linux.imx8mp-evk-release` command.
    2. Prepare the USB boot media with the target HW image you built: `dd if=./result/nixos.img of=/dev/<YOUR_USB_DRIVE> bs=32M status=progress oflag=direct`.
 
-3. Insert an SD card and USB boot media into the board and switch the power on.
+2. Insert an SD card and USB boot media into the board and switch the power on.
 
 ---
 

--- a/flake.lock
+++ b/flake.lock
@@ -328,11 +328,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1715148395,
-        "narHash": "sha256-lRxjTxY3103LGMjWdVqntKZHhlmMX12QUjeFrQMmGaE=",
+        "lastModified": 1715881912,
+        "narHash": "sha256-e4LJk5uV1wvrRkffGFZekPWvFUx29NnnOahBlLaq8Ek=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a4e2b7909fc1bdf30c30ef21d388fde0b5cdde4a",
+        "rev": "ff1be1e3cdf884df0935ab28745ab13c3c26d828",
         "type": "github"
       },
       "original": {

--- a/hydrajobs/flake-module.nix
+++ b/hydrajobs/flake-module.nix
@@ -20,10 +20,10 @@ in {
     nvidia-jetson-orin-agx-debug.aarch64-linux = self.packages.aarch64-linux.nvidia-jetson-orin-agx-debug;
     nvidia-jetson-orin-nx-debug.aarch64-linux = self.packages.aarch64-linux.nvidia-jetson-orin-nx-debug;
     intel-vm-debug.x86_64-linux = self.packages.x86_64-linux.vm-debug;
+    nxp-imx8mp-evk-debug.x86_64-linux = self.packages.aarch64-linux.nxp-imx8mp-evk-debug;
     docs.x86_64-linux = self.packages.x86_64-linux.doc;
     docs.aarch64-linux = self.packages.aarch64-linux.doc;
     microchip-icicle-kit-debug.x86_64-linux = self.packages.riscv64-linux.microchip-icicle-kit-debug;
-
     # Build cross-copmiled images
     nvidia-jetson-orin-agx-debug-from-x86_64.x86_64-linux = self.packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64;
     nvidia-jetson-orin-nx-debug-from-x86_64.x86_64-linux = self.packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64;

--- a/modules/flake-module.nix
+++ b/modules/flake-module.nix
@@ -21,5 +21,6 @@
     lanzaboote.imports = [./lanzaboote];
     microvm.imports = [./microvm];
     polarfire.imports = [./polarfire];
+    imx8.imports = [./imx8];
   };
 }

--- a/modules/imx8/default.nix
+++ b/modules/imx8/default.nix
@@ -1,0 +1,10 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Support for Microchip Polarfire Icicle-Kit
+#
+{
+  imports = [
+    ./imx8mp-sdimage.nix
+  ];
+}

--- a/modules/imx8/imx8mp-sdimage.nix
+++ b/modules/imx8/imx8mp-sdimage.nix
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2023-2024 TII (SSRC) and the Ghaf contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  pkgs,
+  modulesPath,
+  ...
+}: {
+  imports = [
+    (modulesPath + "/installer/sd-card/sd-image.nix")
+  ];
+
+  disabledModules = [(modulesPath + "/profiles/all-hardware.nix")];
+  sdImage = {
+    compressImage = false;
+
+    populateFirmwareCommands = ''
+      cp ${pkgs.imx8m-boot}/image/flash.bin firmware/
+    '';
+
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
+    '';
+
+    postBuildCommands = ''
+      sdimage="$out/nixos.img"
+      fwoffset=64
+      blocksize=512
+      fwsize=20400
+      rootoffset=20800
+
+      sfdisk --list $img | grep Linux
+      rootstart=$(sfdisk --list $img | grep Linux | awk '{print $3}')
+      rootsize=$(sfdisk --list $img | grep Linux | awk '{print $5}')
+      imagesize=$(((rootoffset + rootsize)*blocksize))
+      touch $sdimage
+      truncate -s $imagesize  $sdimage
+      echo -e "
+        label: dos
+        label-id: 0x2178694e
+        unit: sectors
+        sector-size: 512
+
+        start=$fwoffset, size=$fwsize, type=60
+        start=$rootoffset, size=$rootsize, type=83, bootable" > "$out/partition.txt"
+      sfdisk -d $img
+      sfdisk $sdimage < "$out/partition.txt"
+      dd conv=notrunc if=${pkgs.imx8m-boot}/image/flash.bin of=$sdimage seek=$fwoffset
+      dd conv=notrunc if=$img of=$sdimage seek=$rootoffset skip=$rootstart count=$rootsize
+      sfdisk --list $sdimage
+      rm -rf $out/sd-image
+    '';
+  };
+}

--- a/targets/flake-module.nix
+++ b/targets/flake-module.nix
@@ -6,6 +6,7 @@
 {
   imports = [
     ./generic-x86_64/flake-module.nix
+    ./imx8mp-evk/flake-module.nix
     ./lenovo-x1-installer/flake-module.nix
     ./lenovo-x1/flake-module.nix
     ./microchip-icicle-kit/flake-module.nix

--- a/targets/imx8mp-evk/flake-module.nix
+++ b/targets/imx8mp-evk/flake-module.nix
@@ -1,0 +1,77 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# i.MX8M Plus Evaluation Kit
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: let
+  inherit (inputs) nixos-hardware nixpkgs;
+  name = "nxp-imx8mp-evk";
+  system = "aarch64-linux";
+  nxp-imx8mp-evk = variant: extraModules: let
+    hostConfiguration = lib.nixosSystem {
+      inherit system;
+      specialArgs = {inherit lib;};
+      modules =
+        [
+          nixos-hardware.nixosModules.nxp-imx8mp-evk
+          self.nixosModules.common
+          self.nixosModules.host
+          self.nixosModules.imx8
+          {
+            boot = {
+              kernelParams = lib.mkForce ["root=/dev/mmcblk0p2"];
+              loader = {
+                grub.enable = false;
+                generic-extlinux-compatible.enable = true;
+              };
+            };
+
+            # Disable all the default UI applications
+            ghaf = {
+              profiles = {
+                release.enable = variant == "release";
+                debug.enable = variant == "debug";
+              };
+              development = {
+                debug.tools.enable = variant == "debug";
+                ssh.daemon.enable = true;
+              };
+              firewall.kernel-modules.enable = true;
+            };
+            nixpkgs = {
+              buildPlatform.system = "x86_64-linux";
+              overlays = [
+                self.overlays.cross-compilation
+              ];
+            };
+            hardware.deviceTree.name = lib.mkForce "freescale/imx8mp-evk.dtb";
+            disabledModules = ["profiles/all-hardware.nix"];
+          }
+        ]
+        ++ extraModules;
+    };
+  in {
+    inherit hostConfiguration;
+    name = "${name}-${variant}";
+    package = hostConfiguration.config.system.build.sdImage;
+  };
+  debugModules = [];
+  releaseModules = [];
+  targets = [
+    (nxp-imx8mp-evk "debug" debugModules)
+    (nxp-imx8mp-evk "release" releaseModules)
+  ];
+in {
+  flake = {
+    nixosConfigurations =
+      builtins.listToAttrs (map (t: lib.nameValuePair t.name t.hostConfiguration) targets);
+    packages = {
+      aarch64-linux =
+        builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+    };
+  };
+}

--- a/templates/flake-module.nix
+++ b/templates/flake-module.nix
@@ -21,6 +21,10 @@
       path = ./targets/aarch64/nvidia/orin-nx;
       description = "A Ghaf based configuration for the Nvidia Orin NX";
     };
+    target-aarch64-nxp-imx8mp-evk = {
+      path = ./targets/aarch64/nxp/imx8mp-evk;
+      description = "A Ghaf based configuration for the NXP iMX8 MPlus";
+    };
 
     # x86 targets
     target-x86_64-generic = {

--- a/templates/targets/aarch64/nxp/imx8mp-evk/flake.nix
+++ b/templates/targets/aarch64/nxp/imx8mp-evk/flake.nix
@@ -1,0 +1,77 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  description = "PROJ_NAME - Ghaf based configuration";
+
+  nixConfig = {
+    substituters = [
+      "https://cache.vedenemo.dev"
+      "https://cache.ssrcdevops.tii.ae"
+      "https://ghaf-dev.cachix.org"
+      "https://cache.nixos.org/"
+    ];
+    extra-trusted-substituters = [
+      "https://cache.vedenemo.dev"
+      "https://cache.ssrcdevops.tii.ae"
+      "https://ghaf-dev.cachix.org"
+      "https://cache.nixos.org/"
+    ];
+    extra-trusted-public-keys = [
+      "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
+      "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
+      "ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY="
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    ];
+  };
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    nixos-hardware.url = "github:NixOS/nixos-hardware";
+    ghaf = {
+      url = "github:tiiuae/ghaf";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+        nixos-hardware.follows = "nixos-hardware";
+      };
+    };
+  };
+
+  outputs = {
+    self,
+    ghaf,
+    nixpkgs,
+    flake-utils,
+    ...
+  }: let
+    systems = with flake-utils.lib.system; [
+      x86_64-linux
+      aarch64-linux
+    ];
+  in
+    # Combine list of attribute sets together
+    nixpkgs.lib.foldr nixpkgs.lib.recursiveUpdate {} [
+      (flake-utils.lib.eachSystem systems (system: {
+        formatter = nixpkgs.legacyPackages.${system}.alejandra;
+      }))
+
+      {
+        nixosConfigurations.PROJ_NAME-ghaf-debug = ghaf.nixosConfigurations.nxp-imx8mp-evk-debug.extendModules {
+          modules = [
+            {
+              #insert your additional modules here e.g.
+              # virtualisation.docker.enable = true;
+              # users.users."ghaf".extraGroups = ["docker"];
+            }
+            ({pkgs, ...}: {
+              environment.systemPackages = with pkgs; [
+                #Add additional system packages here
+              ];
+            })
+          ];
+        };
+        packages.aarch64-linux.PROJ_NAME-ghaf-debug = self.nixosConfigurations.PROJ_NAME-ghaf-debug.config.system.build.sdImage;
+      }
+    ];
+}


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

NXP i.MX8 MPlus EVK platform support.
- Added template platform
- Host only
- Cross build

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
  - [x] Tested on NXP iMX8 MPlus EVK `aarch64`
- [x] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
Basic testing on NXP iMX8 MPlus EVK platform.

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
