### PR TITLE
[X1]: logging: To centralize logs using grafana

### DIFF
--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -18,5 +18,6 @@
     ./services
     ./networking
     ../hardware/definition.nix
+    ./logging
   ];
 }

--- a/modules/common/logging/client.nix
+++ b/modules/common/logging/client.nix
@@ -45,5 +45,9 @@ in {
     };
 
     services.alloy.enable = true;
+    # Once alloy.service in admin-vm stopped this service will
+    # still keep on retrying to send logs batch, so we need to
+    # stop it forcefully.
+    systemd.services.alloy.serviceConfig.TimeoutStopSec = 4;
   };
 }

--- a/modules/common/logging/client.nix
+++ b/modules/common/logging/client.nix
@@ -1,0 +1,49 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.ghaf.logging.client;
+  endpointUrl = config.ghaf.logging.client.endpoint;
+in {
+  options.ghaf.logging.client.endpoint = lib.mkOption {
+    description = ''
+      Assign endpoint url value to the alloy.service running in
+      different log producers. This endpoint URL will include
+      protocol, upstream, address along with port value.
+    '';
+    type = lib.types.str;
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc."alloy/client.alloy" = {
+      text = ''
+        discovery.relabel "journal" {
+          targets = []
+          rule {
+            source_labels = ["__journal__hostname"]
+            target_label  = "nodename"
+          }
+        }
+
+        loki.source.journal "journal" {
+          path          = "/var/log/journal"
+          relabel_rules = discovery.relabel.journal.rules
+          forward_to    = [loki.write.adminvm.receiver]
+        }
+
+        loki.write "adminvm" {
+          endpoint {
+            url = "${endpointUrl}"
+          }
+        }
+      '';
+      # The UNIX file mode bits
+      mode = "0644";
+    };
+
+    services.alloy.enable = true;
+  };
+}

--- a/modules/common/logging/default.nix
+++ b/modules/common/logging/default.nix
@@ -1,0 +1,38 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{lib, ...}: let
+  inherit (lib) mkOption types;
+in {
+  # Creating logging configuration options needed across the host and vms
+  options.ghaf.logging = {
+    client.enable = mkOption {
+      description = ''
+        Enable logging client service. Currently we have grafana alloy
+        running as client which will upload system journal logs to
+        grafana alloy running in admin-vm.
+      '';
+      type = types.bool;
+      default = false;
+    };
+
+    listener.address = mkOption {
+      description = ''
+        Listener address will be used where log producers will
+        push logs and where admin-vm alloy.service will be
+        keep on listening or receiving logs.
+      '';
+      type = types.str;
+    };
+
+    listener.port = mkOption {
+      description = ''
+        Listener port for the logproto endpoint which will be
+        used to receive logs from different log producers.
+        Also this port value will be used to open the port in
+        the admin-vm firewall.
+      '';
+      type = types.port;
+      default = 9999;
+    };
+  };
+}

--- a/modules/common/logging/hw-mac-retrieve.nix
+++ b/modules/common/logging/hw-mac-retrieve.nix
@@ -1,0 +1,42 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  # TODO: replace sshCommand and MacCommand with givc rpc to retrieve Mac Address
+  sshCommand = "${pkgs.sshpass}/bin/sshpass -p ghaf ${pkgs.openssh}/bin/ssh -o StrictHostKeyChecking=no ghaf@net-vm";
+  macCommand = "cat /sys/class/net/wlp0s5f0/address";
+  macAddressPath = config.ghaf.logging.identifierFilePath;
+in {
+  options.ghaf.logging.identifierFilePath = lib.mkOption {
+    description = ''
+      This configuration option used to specify the identifier file path.
+      The identifier file will be text file which have unique identification
+      value per machine so that when logs will be uploaded to cloud
+      we can identify its origin.
+    '';
+    type = lib.types.path;
+    example = "/tmp/MACAddress";
+  };
+
+  config = lib.mkIf config.ghaf.logging.client.enable {
+    # TODO: Remove hw-mac.service and replace with givc rpc later
+    systemd.services."hw-mac" = {
+      description = "Retrieve MAC address from net-vm";
+      wantedBy = ["alloy.service"];
+      requires = ["network-online.target"];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = "yes";
+        # Make sure we can ssh before we retrieve mac address
+        ExecStartPre = "${sshCommand} ls";
+        ExecStart = ''
+          ${pkgs.bash}/bin/bash -c "echo -n $(${sshCommand} ${macCommand}) > ${macAddressPath}"
+        '';
+      };
+    };
+  };
+}

--- a/modules/common/logging/logs-aggregator.nix
+++ b/modules/common/logging/logs-aggregator.nix
@@ -1,0 +1,58 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}: let
+  endpointUrl = config.ghaf.logging.server.endpoint;
+  listenerAddress = config.ghaf.logging.listener.address;
+  listenerPort = toString config.ghaf.logging.listener.port;
+  macAddressPath = config.ghaf.logging.identifierFilePath;
+in {
+  options.ghaf.logging.server.endpoint = lib.mkOption {
+    description = ''
+      Assign endpoint url value to the alloy.service running in
+      admin-vm. This endpoint URL will include protocol, upstream
+      address along with port value.
+    '';
+    type = lib.types.str;
+  };
+
+  config = lib.mkIf config.ghaf.logging.client.enable {
+    environment.etc."alloy/logs-aggregator.alloy" = {
+      text = ''
+        local.file "macAddress" {
+          // Alloy service can read file in this specific location
+          filename = "${macAddressPath}"
+        }
+
+        loki.write "remote" {
+          endpoint {
+            url = "${endpointUrl}"
+          }
+          external_labels = {systemdJournalLogs = local.file.macAddress.content }
+        }
+
+        loki.source.api "listener" {
+          http {
+            listen_address = "${listenerAddress}"
+            listen_port = ${listenerPort}
+          }
+
+          forward_to = [
+            loki.write.remote.receiver,
+          ]
+        }
+      '';
+      # The UNIX file mode bits
+      mode = "0644";
+    };
+
+    services.alloy.enable = true;
+    systemd.services.alloy.serviceConfig.after = ["hw-mac.service"];
+    # If there is no internet connection , shutdown/reboot will take around 100sec
+    # So, to fix that problem we need to add stop timeout
+    systemd.services.alloy.serviceConfig.TimeoutStopSec = 2;
+  };
+}

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -12,4 +12,8 @@
   nixpkgs.overlays = [
     (import ../../overlays/custom-packages)
   ];
+  imports = [
+    # To push logs to central location
+    ../common/logging/client.nix
+  ];
 }

--- a/modules/microvm/virtualization/microvm/adminvm.nix
+++ b/modules/microvm/virtualization/microvm/adminvm.nix
@@ -83,8 +83,8 @@
                 # Creating a persistent log-store which is mapped on ghaf-host
                 # This is only to preserve logs state across adminvm reboots
                 tag = "log-store";
-                source = "/var/lib/loki";
-                mountPoint = "/var/lib/loki";
+                source = "/var/lib/private/alloy";
+                mountPoint = "/var/lib/private/alloy";
                 proto = "virtiofs";
               }
             ];

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -32,6 +32,8 @@
           inherit (vm) macAddress;
           internalIP = index + 100;
         })
+        # To push logs to central location
+        ../../../common/logging/client.nix
         ({
           lib,
           config,
@@ -66,6 +68,9 @@
               withDebug = configHost.ghaf.profiles.debug.enable;
               withHardenedConfigs = true;
             };
+            # Logging client configuration
+            logging.client.enable = configHost.ghaf.logging.client.enable;
+            logging.client.endpoint = configHost.ghaf.logging.client.endpoint;
           };
 
           # SSH is very picky about the file permissions and ownership and will

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -15,6 +15,8 @@
         inherit config lib vmName macAddress;
         internalIP = 3;
       })
+      # To push logs to central location
+      ../../../common/logging/client.nix
       ({
         lib,
         pkgs,
@@ -43,6 +45,9 @@
             withDebug = config.ghaf.profiles.debug.enable;
             withHardenedConfigs = true;
           };
+          # Logging client configuration
+          logging.client.enable = config.ghaf.logging.client.enable;
+          logging.client.endpoint = config.ghaf.logging.client.endpoint;
         };
 
         systemd.services."waypipe-ssh-keygen" = let

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -23,6 +23,8 @@
         internalIP = 1;
         gateway = [];
       })
+      # To push logs to central location
+      ../../../common/logging/client.nix
       ({lib, ...}: {
         imports = [
           ../../../common
@@ -47,6 +49,9 @@
             withDebug = config.ghaf.profiles.debug.enable;
             withHardenedConfigs = true;
           };
+          # Logging client configuration
+          logging.client.enable = config.ghaf.logging.client.enable;
+          logging.client.endpoint = config.ghaf.logging.client.endpoint;
         };
 
         time.timeZone = config.time.timeZone;

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -8,6 +8,8 @@
 }: let
   powerControl = pkgs.callPackage ../../packages/powercontrol {};
   cfg = config.ghaf.profiles.laptop-x86;
+  listenerAddress = config.ghaf.logging.listener.address;
+  listenerPort = toString config.ghaf.logging.listener.port;
 in {
   imports = [
     ../desktop/graphics
@@ -112,6 +114,12 @@ in {
       profiles = {
         applications.enable = false;
       };
+
+      # Logging configuration
+      logging.client.enable = true;
+      logging.client.endpoint = "http://${listenerAddress}:${listenerPort}/loki/api/v1/push";
+      logging.listener.address = "admin-vm-debug";
+      logging.listener.port = 9999;
     };
   };
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
This PR can be tested with multiple `Lenovo X1` devices and each system will upload system logs with unique `mac address`  to remote cloud server.

**Prerequisite:** 
Its recommended to  connect with `wifi` to get unique Mac Address and to upload logs to remote server.

By default system will start collecting logs once its booted.

WAL(Write Ahead Log) will be stored in `/var/lib/private/alloy/data-alloy/loki.write.remote/wal` path which can be accessed through `admin-vm` as well `ghaf-host` (WAL is not in human readable format)

**To View logs remotely on grafana-server**

Open browser and type following [address](https://ghaflogs.vedenemo.dev/explore), it will prompt with `credentials`.

Please request for `Credentials`.  Once you managed to login, choose appropriate labels as in example below.

**Note**:

- If there are are logs from multiple devices, it will be go under `systemdJournalLogs` label.
- To find `mac address` with which logs are pushed run below command in `admin-vm`
 [ghaf@admin-vm:~]$ sudo cat /var/lib/private/alloy/MACAddress


![image](https://github.com/tiiuae/ghaf/assets/147831196/c0fef2aa-3193-4bb9-8d06-77e0b282b2fc)
 
