### PR TITLE
Fix the graphics FW not loading in the GUIvm

### DIFF
--- a/targets/lenovo-x1/guivmExtraModules.nix
+++ b/targets/lenovo-x1/guivmExtraModules.nix
@@ -157,10 +157,20 @@
       };
     };
 
-    # Open TCP port for the PDF XDG socket
+    # Enable all firmware for graphics firmware
+    hardware = {
+      enableRedistributableFirmware = true;
+      enableAllFirmware = true;
+    };
+
+    # Early KMS needed for ui to start work inside GuiVM
+    boot = {
+      initrd.kernelModules = ["i915"];
+      kernelParams = ["earlykms"];
+    };
+
+    # Open TCP port for the PDF XDG socket.
     networking.firewall.allowedTCPPorts = [xdgPdfPort];
-    # Early KMS needed for GNOME to work inside GuiVM
-    boot.initrd.kernelModules = ["i915"];
 
     microvm.qemu = {
       extraArgs =

--- a/targets/lenovo-x1/netvmExtraModules.nix
+++ b/targets/lenovo-x1/netvmExtraModules.nix
@@ -33,7 +33,10 @@
     elemen-vmIp = "192.168.100.253";
   in {
     # For WLAN firmwares
-    hardware.enableRedistributableFirmware = true;
+    hardware = {
+      enableRedistributableFirmware = true;
+      enableAllFirmware = true;
+    };
 
     networking = {
       # wireless is disabled because we use NetworkManager for wireless
@@ -43,6 +46,7 @@
         unmanaged = ["ethint0"];
       };
     };
+
     services = {
       dnsmasq.settings = {
         # set static IP for IDS-VM


### PR DESCRIPTION
- Enable redistributable fw
- ensure correct driver
- enable GuC

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This patch ensure that there is the FW available in the VM for the graphics driver to load into the GPU.

There are still things to fix that still needs to be investigated.


## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
X86 targets for now.
