### PR TITLE
UI boot speedup

### DIFF
--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -9,7 +9,7 @@
   # Ghaf systemd config
   cfg = config.ghaf.systemd;
 
-  inherit (lib) mkEnableOption mkOption mkIf types;
+  inherit (lib) mkEnableOption mkOption mkIf mkForce types;
 
   # Override minimal systemd package configuration
   package =
@@ -306,6 +306,9 @@ in {
       # Misc. configurations
       enableEmergencyMode = cfg.withDebug;
       coredump.enable = cfg.withDebug || cfg.withMachines;
+
+      # Service startup optimization
+      services.systemd-networkd-wait-online.enable = mkForce false;
     };
   };
 }

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -274,7 +274,7 @@ in {
         StandardError = "journal";
         ExecStart = "${pkgs.labwc}/bin/labwc -C /etc/labwc -s ${autostart}/bin/labwc-autostart";
         #GPU pt needs some time to start - labwc fails to restart 3 times in avg.
-        ExecStartPre = "${pkgs.coreutils}/bin/sleep 3";
+        # ExecStartPre = "${pkgs.coreutils}/bin/sleep 3";
         Restart = "on-failure";
         RestartSec = "1";
 

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -131,6 +131,8 @@
   # Host service dependencies
   after = optional configHost.sound.enable "pulseaudio.service";
   requires = after;
+  # Sleep appvms to give gui-vm time to start
+  serviceConfig.ExecStartPre = "/bin/sh -c 'sleep 8'";
 in {
   options.ghaf.virtualization.microvm.appvm = {
     enable = lib.mkEnableOption "appvm";
@@ -229,7 +231,7 @@ in {
       serviceDependencies =
         map (vm: {
           "microvm@${vm.name}-vm" = {
-            inherit after requires;
+            inherit after requires serviceConfig;
           };
         })
         cfg.vms;

--- a/targets/lenovo-x1/appvms/element.nix
+++ b/targets/lenovo-x1/appvms/element.nix
@@ -20,7 +20,7 @@ in {
       pkgs.pulseaudio
     ]
     ++ pkgs.lib.optionals isDendritePineconeEnabled [dendrite-pinecone];
-  macAddress = "02:00:00:03:08:01";
+  macAddress = "02:00:00:03:09:01";
   ramMb = 4096;
   cores = 4;
   extraModules = [

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -64,12 +64,6 @@
               extraConfig = "load-module module-combine-sink module-native-protocol-unix auth-anonymous=1";
             };
 
-            # Add systemd to require pulseaudio before starting chromium-vm
-            systemd.services = {
-              "microvm@chromium-vm".after = ["pulseaudio.service"];
-              "microvm@chromium-vm".requires = ["pulseaudio.service"];
-            };
-
             users.extraUsers.microvm.extraGroups = ["audio" "pulse-access"];
 
             disko.devices.disk = config.ghaf.hardware.definition.disks;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Temporary fixes to decrease time until UI shows from ~25s to ~16s on Lenovo x1. 
The filthy appvm delay should be changed once we have better system management.  

### Changes
Decrease time until UI shows by ~9 seconds, by

- removing `labwc.service` 3 seconds startup delay
- delaying appvm startup by 8 seconds

Gui-vm now boots in 6 seconds compared to 13 seconds previously.

Other changes
- move pulseaudio service dependency to appvm config
- disable `systemd-networkd-wait-online`
- fix MAC address conflict for element / appflowy

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
Tested on Lenovo x1.
- Measure time from boot menu to UI shown.
- Use systemd-analyze in guivm to confirm speedup. 