### PR TITLE
Fix a bug: gps location not working, issue SP-4643-lenovo-x-1-loca…

### DIFF
--- a/modules/hardware/lenovo-x1/definitions/default.nix
+++ b/modules/hardware/lenovo-x1/definitions/default.nix
@@ -57,6 +57,8 @@ in {
       KERNEL=="3-8", SUBSYSTEM=="usb", ATTR{busnum}=="3", ATTR{devnum}=="3", GROUP="kvm"
       # Lenovo X1 integrated fingerprint reader
       KERNEL=="3-6", SUBSYSTEM=="usb", ATTR{busnum}=="3", ATTR{devnum}=="2", GROUP="kvm"
+      # External USB GPS receiver
+      SUBSYSTEM=="usb", ATTR{idVendor}=="067b", ATTR{idProduct}=="23a3", GROUP="kvm"
       # Mouse and Touchpad
       ${lib.strings.concatMapStringsSep "\n" (d: ''SUBSYSTEM=="input", ATTRS{name}=="${d}", KERNEL=="event*", GROUP="kvm", SYMLINK+="mouse"'') hwDefinition.mouse}
       ${lib.strings.concatMapStringsSep "\n" (d: ''SUBSYSTEM=="input", ATTRS{name}=="${d}", KERNEL=="event*", GROUP="kvm", SYMLINK+="touchpad"'') hwDefinition.touchpad}

--- a/packages/element-gps/main.py
+++ b/packages/element-gps/main.py
@@ -38,7 +38,10 @@ class GpsProcessState:
 
 async def read_continuous_gps(data):
     process = await asyncio.create_subprocess_exec(
-        "gpspipe", "-w", stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE
+        "./run/current-system/sw/bin/gpspipe",
+        "-w",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
     )
     print("GPS reader process PID:", {process.pid}, "starting...")
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This PR fixes https://ssrc.atlassian.net/browse/SP-4643 bug.

Add the udev rules to allow GPS receiver passthrough for appvm, for some reason this was not merged from earlier PR (https://github.com/tiiuae/ghaf/pull/430)
Add fully qualified path to gpspipe application in main.py.


Details:
https://ssrc.atlassian.net/wiki/spaces/SP/pages/948502685/Element-desktop+-+location+sharing+using+GPS+receiver




<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing


Build image and run the image on Lenovo X1
Enable Wifi using wifi-connector
Start the Element-desktop from GUIVM desktop icon
Login to element, and share location to someone if GPS transceiver is connected to USB port, otherwise error dialog appears
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
