### PR TITLE
hardening: Adding hardening profile for lenovo X1 target

### DIFF
--- a/modules/common/profiles/default.nix
+++ b/modules/common/profiles/default.nix
@@ -4,5 +4,6 @@
   imports = [
     ./debug.nix
     ./release.nix
+    ./hardening.nix
   ];
 }

--- a/modules/common/profiles/hardening.nix
+++ b/modules/common/profiles/hardening.nix
@@ -7,36 +7,47 @@
   ...
 }: let
   cfg = config.ghaf.profiles.hardening;
+  has_host = builtins.hasAttr "host" config.ghaf;
+  has_secureBoot = builtins.hasAttr "secureboot" config.ghaf.host;
+  has_guest = builtins.hasAttr "guest" config.ghaf;
 in {
   options.ghaf.profiles.hardening = {
     enable = lib.mkEnableOption "hardened profile";
   };
+  imports = [../../hardware/x86_64-generic/kernel/hardening.nix];
 
   config = lib.mkIf cfg.enable {
-    ghaf = {
-      host = {
-        # Enable some security features in the host configuration
-        secureboot.enable = true;
-
-        # Kernel hardening
-        kernel.hardening = {
-          enable = true;
-          usb.enable = true;
-          debug.enable = true;
-          virtualization.enable = true;
-          networking.enable = true;
-          inputdevices.enable = true;
-          hypervisor.enable = true;
+    ghaf =
+      {}
+      // lib.optionalAttrs has_host {
+        host =
+          {
+            # Kernel hardening
+            kernel.hardening = {
+              enable = false;
+              usb.enable = false;
+              debug.enable = false;
+              virtualization.enable = false;
+              networking.enable = false;
+              inputdevices.enable = false;
+              hypervisor.enable = false;
+            };
+          }
+          # Enable secure boot in the host configuration
+          // (
+            if has_secureBoot
+            then {secureboot.enable = true;}
+            else {}
+          );
+      }
+      // lib.optionalAttrs has_guest {
+        guest = {
+          # Kernel hardening
+          kernel.hardening = {
+            enable = false;
+            graphics.enable = false;
+          };
         };
       };
-
-      guest = {
-        # Kernel hardening
-        kernel.hardening = {
-          enable = true;
-          graphics.enable = true;
-        };
-      };
-    };
   };
 }

--- a/modules/hardware/x86_64-generic/kernel/hardening.nix
+++ b/modules/hardware/x86_64-generic/kernel/hardening.nix
@@ -7,30 +7,4 @@
     ./host/pkvm
     # other host hardening modules - to be defined later
   ];
-
-  config = {
-    # host kernel hardening
-    ghaf = {
-      host = {
-        kernel.hardening = {
-          enable = false;
-          virtualization.enable = false;
-          networking.enable = false;
-          usb.enable = false;
-          inputdevices.enable = false;
-          debug.enable = false;
-          # host kernel hypervisor (KVM) hardening
-          hypervisor.enable = false;
-        };
-      };
-      # guest kernel hardening
-      guest = {
-        kernel.hardening = {
-          enable = false;
-          graphics.enable = false;
-        };
-      };
-      # other host hardening options - user space, etc. - to be defined later
-    };
-  };
 }

--- a/modules/hardware/x86_64-generic/kernel/host/default.nix
+++ b/modules/hardware/x86_64-generic/kernel/host/default.nix
@@ -57,7 +57,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    boot.kernelPackages = pkgs.linuxPackagesFor host_hardened_kernel;
+    boot.kernelPackages = lib.mkDefault (pkgs.linuxPackagesFor host_hardened_kernel);
     # https://github.com/NixOS/nixpkgs/issues/109280#issuecomment-973636212
     nixpkgs.overlays = [
       (_final: prev: {

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -80,6 +80,7 @@
               profiles = {
                 debug.enable = variant == "debug";
                 release.enable = variant == "release";
+                hardening.enable = false;
               };
 
               # Hardware definitions


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Booting Issue: [SP-4701](https://ssrc.atlassian.net/browse/SP-4701)
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
1) If we test only `host.secureboot` by disabling `host.kernel.hardening` it works fine on Lenovo X1 Carbon.
2) If we enable `host.kernel.hardening`  without `secureboot` system cannot boot and it will be stuck at `EFI stub: Measured initrd data into PCR9` stage as we are using Linux latest and is currently its pointing to `6.8.9` which is not tested before.
Booting Issue: [SP-4701](https://ssrc.atlassian.net/browse/SP-4701)
3) Last time hardened kernel was tested with `6.6.7` version and it was working fine. 