### PR TITLE
Add audio passthrough for audioVM on Lenovo X1 gen10

### DIFF
--- a/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -30,5 +30,33 @@
     }
   ];
 
-  audio.pciDevices = [];
+  # With the current implementation, the whole PCI IOMMU group 13:
+  #   00:1f.x in the Lenovo X1 Carbon 10 gen
+  #   must be defined for passthrough to AudioVM
+  audio.pciDevices = [
+    {
+      # ISA bridge: Intel Corporation Alder Lake PCH eSPI Controller(rev 01)
+      path = "0000:00:1f.0";
+      vendorId = "8086";
+      productId = "5182";
+    }
+    {
+      # Audio device: Intel Corporation Alder Lake PCH-P High Definition Audio Controller (rev 01)
+      path = "0000:00:1f.3";
+      vendorId = "8086";
+      productId = "51c8";
+    }
+    {
+      # SMBus: Intel Corporation Alder Lake PCH-P SMBus Host Controller (rev 01)
+      path = "0000:00:1f.4";
+      vendorId = "8086";
+      productId = "51a3";
+    }
+    {
+      # Serial bus controller: Intel Corporation Alder Lake-P PCH SPI Controller (rev 01)
+      path = "0000:00:1f.5";
+      vendorId = "8086";
+      productId = "51a4";
+    }
+  ];
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Audio VM pci passthrough devices for Lenovo X1 gen 10

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

Tested only on Lenovo X1 gen 11 (that has a bit different pcie devices/config)

## Testing
Tested by playback and audio recording on chromium app
- Integrated mic and speaker works
- 3.5mm headset jack works
- Automatic changing between integrated and 3.5mm jack works
- NOTE USB/Bluetooth audio devices/headsets don't work (yet)
- ElementVM DNS settings has a bug so audio with element VM might not work
