### PR TITLE
microvm: Add initial vTPMs implementation for applications VMs

### DIFF
--- a/targets/lenovo-x1/appvms/chromium.nix
+++ b/targets/lenovo-x1/appvms/chromium.nix
@@ -68,4 +68,5 @@ in {
     }
   ];
   borderColor = "#630505";
+  vtpm.enable = true;
 }


### PR DESCRIPTION
Add initial vTPMs implementation for applications VMs using `swtpm`.

This doesn't include the PKCS11 interface, as that requires persistence in the guest VMs.

## Description of changes

- Automatically setup `swtpm` for VMs with vTPM enabled.
- vTPM can be enabled by setting `vtpm.enable = true;` in an app VM.
- vTPM can only be applied to app VMs, not other system or peripheral VMs.

## Checklist for things done

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- vTPM is enabled for Chromium for now.
- SSH into Chromium VM.
- `/dev/tpm0` and `/dev/tpmrm0` should be available.
- tpm2-tools is available for additional testing.
