### PR TITLE
Fix windows-launcher

### DIFF
--- a/packages/windows-launcher/default.nix
+++ b/packages/windows-launcher/default.nix
@@ -108,7 +108,7 @@
         fi
       ''
       + ''
-        eval "${qemu_kvm}/bin/qemu_kvm ''${QEMU_PARAMS[@]} ''${@:2}"
+        eval "${qemu_kvm}/bin/qemu-kvm ''${QEMU_PARAMS[@]} ''${@:2}"
       '');
   windowsLauncherUI =
     writeShellScript
@@ -127,10 +127,10 @@
         if [ ! -f "$FILE" ]; then
       ''
       + lib.optionalString stdenv.isAarch64 ''
-        FILE=`${yad}/bin/yad --file-selection --title="Select Windows VM image (VHDX)"`
+        FILE=`${yad}/bin/yad --file --title="Select Windows VM image (VHDX)"`
       ''
       + lib.optionalString stdenv.isx86_64 ''
-        FILE=`${yad}/bin/yad --file-selection --title="Select Windows VM image (QCOW2 or ISO)"`
+        FILE=`${yad}/bin/yad --file --title="Select Windows VM image (QCOW2 or ISO)"`
       ''
       + ''
           if [ ''$? -ne 0 ]; then
@@ -143,7 +143,7 @@
         fi
 
         if ! ${windowsLauncher} $FILE; then
-          ${yad}/bin/yad --error --text="Failed to run Windows VM: $?"
+          ${yad}/bin/yad --image=gtk-dialog-error --text="Failed to run Windows VM: $?"
         fi
       '');
 in


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This fixes a small typo introduced in [QEMU fixes for version 8.2 ](https://github.com/tiiuae/ghaf/commit/d8e2f718c67ab3be67f5de8084ba905b295cdcaa) which broke the windows-launcher. It also replaces Zenity parameters with those supported by Yad.

Fixes [SP-4638](https://ssrc.atlassian.net/browse/SP-4638).

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Run windows-launcher on Lenovo X1 host with a Windows 11 qcow2 or iso.
- Make sure the VM starts.
