### PR TITLE
common: Create options for applications, other fixes

### DIFF
--- a/lib/launcher.nix
+++ b/lib/launcher.nix
@@ -9,8 +9,6 @@ _: {
           then old.postInstall
           else "";
       in {
-        desktopItems = null;
-        desktopItem = null;
         postInstall = pInst + "rm -rf \"$out/share/applications\"";
       }))
     pkgs;

--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -16,5 +16,6 @@
     ./virtualization/docker.nix
     ./systemd
     ./services
+    ./programs
   ];
 }

--- a/modules/common/programs/chromium.nix
+++ b/modules/common/programs/chromium.nix
@@ -1,0 +1,23 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.ghaf.programs.chromium;
+in {
+  options.ghaf.programs.chromium = {
+    enable = lib.mkEnableOption "Enable Chromium program settings";
+    useZathuraVM = lib.mkEnableOption "Open PDFs in Zathura VM";
+  };
+  config = lib.mkIf cfg.enable {
+    programs.chromium.enable = true;
+
+    # Fix border glitch when going maximised->minimised.
+    programs.chromium.initialPrefs.browser.custom_chrome_frame = false;
+
+    # Don't use pdf.js, open externally.
+    programs.chromium.extraOpts."AlwaysOpenPdfExternally" = true;
+  };
+}

--- a/modules/common/programs/default.nix
+++ b/modules/common/programs/default.nix
@@ -1,0 +1,8 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  imports = [
+    ./zathura.nix
+    ./chromium.nix
+  ];
+}

--- a/modules/common/programs/zathura.nix
+++ b/modules/common/programs/zathura.nix
@@ -1,0 +1,19 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.ghaf.programs.zathura;
+in {
+  options.ghaf.programs.zathura = {
+    enable = lib.mkEnableOption "Enable Zathura program settings";
+  };
+  config = lib.mkIf cfg.enable {
+    # Use regular clipboard instead of primary clipboard.
+    environment.etc."zathurarc".text = ''
+      set selection-clipboard clipboard
+    '';
+  };
+}

--- a/modules/desktop/graphics/demo-apps.nix
+++ b/modules/desktop/graphics/demo-apps.nix
@@ -62,12 +62,5 @@ in {
         path = "${pkgs.appflowy}/bin/appflowy";
         icon = "${pkgs.appflowy}/opt/data/flutter_assets/assets/images/flowy_logo.svg";
       };
-    environment.systemPackages =
-      lib.optional cfg.chromium pkgs.chromium
-      ++ lib.optional cfg.element-desktop pkgs.element-desktop
-      ++ lib.optional cfg.firefox pkgs.firefox
-      ++ lib.optional cfg.gala-app pkgs.gala-app
-      ++ lib.optional cfg.zathura pkgs.zathura
-      ++ lib.optional (cfg.appflowy && pkgs.stdenv.isx86_64) pkgs.appflowy;
   };
 }

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -71,6 +71,10 @@ in {
           identifier = "org.pwmt.zathura";
           colour = "#122263";
         }
+        {
+          identifier = "Element";
+          colour = "#337aff";
+        }
       ];
       description = "List of applications and their frame colours";
     };

--- a/targets/lenovo-x1/appvms/chromium.nix
+++ b/targets/lenovo-x1/appvms/chromium.nix
@@ -60,9 +60,8 @@ in {
       ];
       microvm.devices = [];
 
-      # Disable chromium built-in PDF viewer to make it execute xdg-open
-      programs.chromium.enable = true;
-      programs.chromium.extraOpts."AlwaysOpenPdfExternally" = true;
+      ghaf.programs.chromium.enable = true;
+
       # Set default PDF XDG handler
       xdg.mime.defaultApplications."application/pdf" = "ghaf-pdf.desktop";
     }

--- a/targets/lenovo-x1/appvms/zathura.nix
+++ b/targets/lenovo-x1/appvms/zathura.nix
@@ -10,11 +10,7 @@
   extraModules = [
     {
       time.timeZone = "Asia/Dubai";
-
-      # Use regular clipboard instead of primary clipboard.
-      environment.etc."zathurarc".text = ''
-        set selection-clipboard clipboard
-      '';
+      ghaf.programs.zathura.enable = true;
     }
   ];
   borderColor = "#122263";


### PR DESCRIPTION
This creates a new option `ghaf.programs.<name>`, which allows us to configure applications across targets and whether they run inside a VM or not.

This also fixes Chromium border glitch, and Element border colour (SP-4645 & SP-4644).

## Description of changes

- Add program option for Zathura, fixes clipboard issue also on Orin.
- Add program option for Chromium
  - Fixes border glitch when unmaximising application.
  - Chromium on Orin should now behave similarly to X1 carbon.
- Fix Element border.
- Fix duplicate icons on Orin.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Chromium can still open PDFs on X1 carbon.
- Chromium unmaximise glitch fixed on X1 carbon.
- Zathura on Orin can now copy to normal clipboard (not primary).
- Element border should be fully coloured.
