### PR TITLE
orin demo-apps: configure zathura & chromium properly

### DIFF
--- a/modules/desktop/graphics/demo-apps.nix
+++ b/modules/desktop/graphics/demo-apps.nix
@@ -62,5 +62,11 @@ in {
         path = "${pkgs.appflowy}/bin/appflowy";
         icon = "${pkgs.appflowy}/opt/data/flutter_assets/assets/images/flowy_logo.svg";
       };
+
+    ghaf.programs.chromium.enable = cfg.chromium;
+    ghaf.programs.zathura.enable = cfg.zathura;
+
+    # Set default PDF XDG handler
+    xdg.mime.defaultApplications."application/pdf" = lib.mkIf cfg.zathura "PDF Viewer.desktop";
   };
 }

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -68,6 +68,10 @@ in {
           colour = "#630505";
         }
         {
+          identifier = "Firefox";
+          colour = "#630505";
+        }
+        {
           identifier = "org.pwmt.zathura";
           colour = "#122263";
         }

--- a/modules/reference/programs/chromium.nix
+++ b/modules/reference/programs/chromium.nix
@@ -9,7 +9,6 @@
 in {
   options.ghaf.programs.chromium = {
     enable = lib.mkEnableOption "Enable Chromium program settings";
-    useZathuraVM = lib.mkEnableOption "Open PDFs in Zathura VM";
   };
   config = lib.mkIf cfg.enable {
     programs.chromium.enable = true;

--- a/modules/reference/programs/default.nix
+++ b/modules/reference/programs/default.nix
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   imports = [
-    ./zathura.nix
     ./chromium.nix
     ./windows-launcher.nix
+    ./zathura.nix
   ];
 }


### PR DESCRIPTION
## Description of changes

Configures Zathura and Chromium on Orin if enabled. Assuming Chromium is enabled:

- Chromium border should behave properly
- Opening PDFs in chromium now opens in zathura

Also border for Firefox is added.

Fixes: SP-4724, SP-4710.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

If you previously used Chromium on the Orin installation, you may need to remove old chromium configuration (`rm -rf ~/.config/chromium`). This is for it to load the correct default (initial) preferences for window bordering.
