### PR TITLE
Refactor hardware dependencies and audiovm

### DIFF
--- a/modules/common/services/default.nix
+++ b/modules/common/services/default.nix
@@ -4,5 +4,6 @@
   imports = [
     ./dendrite-pinecone.nix
     ./fprint.nix
+    ./audio.nix
   ];
 }

--- a/modules/hardware/common/passthru.nix
+++ b/modules/hardware/common/passthru.nix
@@ -52,6 +52,13 @@ in {
         Extra arguments to pass to qemu when enabling the guivm.
       '';
     };
+    audiovmKernelParams = mkOption {
+      type = types.attrsOf types.anything;
+      default = {};
+      description = ''
+        Sound hardware specific kernel parameters to configure audiovm.
+      '';
+    };
   };
 
   config = {
@@ -109,6 +116,12 @@ in {
         "-device"
         "acad"
       ];
+
+      audiovmKernelParams = {
+        microvm = {
+          inherit (config.ghaf.hardware.definition.audio) kernelParams;
+        };
+      };
     };
 
     # Enable VFIO for PCI devices

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -109,6 +109,23 @@ in {
       default = "";
     };
 
+    generic = {
+      kernelParams = mkOption {
+        description = "Hardware specific kernel parameters for the host";
+        type = types.listOf types.str;
+        default = [];
+        example = literalExpression ''
+          [
+            "intel_iommu=on,sm_on"
+            "iommu=pt"
+            "module_blacklist=i915"
+            "acpi_backlight=vendor"
+            "acpi_osi=linux"
+          ]
+        '';
+      };
+    };
+
     input = {
       keyboard = mkOption {
         description = "Name of the keyboard device(s)";

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -234,6 +234,17 @@ in {
           ]
         '';
       };
+      kernelParams = mkOption {
+        description = "Hardware specific kernel parameters for audio devices";
+        type = types.listOf types.str;
+        default = [];
+        example = literalExpression ''
+          [
+            "snd_intel_dspcfg.dsp_driver=3"
+            "snd_sof_intel_hda_common.dmic_num=4"
+          ]
+        '';
+      };
     };
 
     usb = {

--- a/modules/hardware/lenovo-x1/default.nix
+++ b/modules/hardware/lenovo-x1/default.nix
@@ -19,6 +19,7 @@ in {
   };
 
   config = {
+    # Hardware definition
     ghaf.hardware.definition = {
       inherit (hwDefinition) input;
       inherit (hwDefinition) disks;
@@ -28,8 +29,22 @@ in {
       inherit (hwDefinition) usb;
     };
 
+    # Disk configuration
     disko.devices.disk = hwDefinition.disks;
 
+    # Hardware specific kernel parameters
+    boot = {
+      kernelParams = [
+        "intel_iommu=on,sm_on"
+        "iommu=pt"
+        # Prevent i915 module from being accidentally used by host
+        "module_blacklist=i915"
+        "acpi_backlight=vendor"
+        "acpi_osi=linux"
+      ];
+    };
+
+    # Host udev rules
     services.udev.extraRules = ''
       # Keyboard
       ${lib.strings.concatMapStringsSep "\n" (d: ''SUBSYSTEM=="input", ATTRS{name}=="${d}", GROUP="kvm"'') hwDefinition.input.keyboard.name}

--- a/modules/hardware/lenovo-x1/default.nix
+++ b/modules/hardware/lenovo-x1/default.nix
@@ -7,20 +7,22 @@
   ...
 }: let
   hwDefinition = import (./. + "/definitions/x1-${config.ghaf.hardware.generation}.nix");
+  inherit (lib) mkOption types;
 in {
   imports = [
     ../definition.nix
   ];
 
-  options.ghaf.hardware.generation = lib.mkOption {
+  options.ghaf.hardware.generation = mkOption {
     description = "Generation of the hardware configuration";
-    type = lib.types.str;
-    default = "gen11";
+    type = types.nullOr types.str;
+    default = null;
   };
 
   config = {
     # Hardware definition
     ghaf.hardware.definition = {
+      inherit (hwDefinition) generic;
       inherit (hwDefinition) input;
       inherit (hwDefinition) disks;
       inherit (hwDefinition) network;
@@ -34,14 +36,7 @@ in {
 
     # Hardware specific kernel parameters
     boot = {
-      kernelParams = [
-        "intel_iommu=on,sm_on"
-        "iommu=pt"
-        # Prevent i915 module from being accidentally used by host
-        "module_blacklist=i915"
-        "acpi_backlight=vendor"
-        "acpi_osi=linux"
-      ];
+      inherit (hwDefinition.generic) kernelParams;
     };
 
     # Host udev rules

--- a/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -68,32 +68,38 @@
   # With the current implementation, the whole PCI IOMMU group 13:
   #   00:1f.x in the Lenovo X1 Carbon 10 gen
   #   must be defined for passthrough to AudioVM
-  audio.pciDevices = [
-    {
-      # ISA bridge: Intel Corporation Alder Lake PCH eSPI Controller(rev 01)
-      path = "0000:00:1f.0";
-      vendorId = "8086";
-      productId = "5182";
-    }
-    {
-      # Audio device: Intel Corporation Alder Lake PCH-P High Definition Audio Controller (rev 01)
-      path = "0000:00:1f.3";
-      vendorId = "8086";
-      productId = "51c8";
-    }
-    {
-      # SMBus: Intel Corporation Alder Lake PCH-P SMBus Host Controller (rev 01)
-      path = "0000:00:1f.4";
-      vendorId = "8086";
-      productId = "51a3";
-    }
-    {
-      # Serial bus controller: Intel Corporation Alder Lake-P PCH SPI Controller (rev 01)
-      path = "0000:00:1f.5";
-      vendorId = "8086";
-      productId = "51a4";
-    }
-  ];
+  audio = {
+    pciDevices = [
+      {
+        # ISA bridge: Intel Corporation Alder Lake PCH eSPI Controller(rev 01)
+        path = "0000:00:1f.0";
+        vendorId = "8086";
+        productId = "5182";
+      }
+      {
+        # Audio device: Intel Corporation Alder Lake PCH-P High Definition Audio Controller (rev 01)
+        path = "0000:00:1f.3";
+        vendorId = "8086";
+        productId = "51c8";
+      }
+      {
+        # SMBus: Intel Corporation Alder Lake PCH-P SMBus Host Controller (rev 01)
+        path = "0000:00:1f.4";
+        vendorId = "8086";
+        productId = "51a3";
+      }
+      {
+        # Serial bus controller: Intel Corporation Alder Lake-P PCH SPI Controller (rev 01)
+        path = "0000:00:1f.5";
+        vendorId = "8086";
+        productId = "51a4";
+      }
+    ];
+    kernelParams = [
+      "snd_intel_dspcfg.dsp_driver=3"
+      "snd_sof_intel_hda_common.dmic_num=4"
+    ];
+  };
 
   usb = {
     internal = [

--- a/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -4,6 +4,16 @@
 {
   name = "Lenovo X1 Carbon Gen 10";
 
+  generic = {
+    kernelParams = [
+      "intel_iommu=on,sm_on"
+      "iommu=pt"
+      "module_blacklist=i915" # Prevent i915 module from being accidentally used by host
+      "acpi_backlight=vendor"
+      "acpi_osi=linux"
+    ];
+  };
+
   input = {
     keyboard = {
       name = ["AT Translated Set 2 keyboard"];

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -4,6 +4,16 @@
 {
   name = "Lenovo X1 Carbon Gen 11";
 
+  generic = {
+    kernelParams = [
+      "intel_iommu=on,sm_on"
+      "iommu=pt"
+      "module_blacklist=i915" # Prevent i915 module from being accidentally used by host
+      "acpi_backlight=vendor"
+      "acpi_osi=linux"
+    ];
+  };
+
   input = {
     keyboard = {
       name = ["AT Translated Set 2 keyboard"];

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -70,32 +70,38 @@
   # With the current implementation, the whole PCI IOMMU group 14:
   #   00:1f.x in the example from Lenovo X1 Carbon
   #   must be defined for passthrough to AudioVM
-  audio.pciDevices = [
-    {
-      # ISA bridge: Intel Corporation Raptor Lake LPC/eSPI Controller (rev 01)
-      path = "0000:00:1f.0";
-      vendorId = "8086";
-      productId = "519d";
-    }
-    {
-      # Audio device: Intel Corporation Raptor Lake-P/U/H cAVS (rev 01)
-      path = "0000:00:1f.3";
-      vendorId = "8086";
-      productId = "51ca";
-    }
-    {
-      # SMBus: Intel Corporation Alder Lake PCH-P SMBus Host Controller (rev 01)
-      path = "0000:00:1f.4";
-      vendorId = "8086";
-      productId = "51a3";
-    }
-    {
-      # Serial bus controller: Intel Corporation Alder Lake-P PCH SPI Controller (rev 01)
-      path = "0000:00:1f.5";
-      vendorId = "8086";
-      productId = "51a4";
-    }
-  ];
+  audio = {
+    pciDevices = [
+      {
+        # ISA bridge: Intel Corporation Raptor Lake LPC/eSPI Controller (rev 01)
+        path = "0000:00:1f.0";
+        vendorId = "8086";
+        productId = "519d";
+      }
+      {
+        # Audio device: Intel Corporation Raptor Lake-P/U/H cAVS (rev 01)
+        path = "0000:00:1f.3";
+        vendorId = "8086";
+        productId = "51ca";
+      }
+      {
+        # SMBus: Intel Corporation Alder Lake PCH-P SMBus Host Controller (rev 01)
+        path = "0000:00:1f.4";
+        vendorId = "8086";
+        productId = "51a3";
+      }
+      {
+        # Serial bus controller: Intel Corporation Alder Lake-P PCH SPI Controller (rev 01)
+        path = "0000:00:1f.5";
+        vendorId = "8086";
+        productId = "51a4";
+      }
+    ];
+    kernelParams = [
+      "snd_intel_dspcfg.dsp_driver=3"
+      "snd_sof_intel_hda_common.dmic_num=4"
+    ];
+  };
 
   usb = {
     internal = [

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -68,13 +68,6 @@
             }
           ];
           writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
-
-          # TODO: Move this to a hardware specific place
-          kernelParams = [
-            "snd_intel_dspcfg.dsp_driver=3"
-            "snd_sof_intel_hda_common.dmic_num=4"
-          ];
-          ###########################
           qemu = {
             machine =
               {

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -19,6 +19,7 @@
         pkgs,
         ...
       }: {
+        time.timeZone = "Asia/Dubai";
         ghaf = {
           users.accounts.enable = lib.mkDefault configHost.ghaf.users.accounts.enable;
           profiles.debug.enable = lib.mkDefault configHost.ghaf.profiles.debug.enable;
@@ -36,6 +37,7 @@
             withTimesyncd = true;
             withDebug = configHost.ghaf.profiles.debug.enable;
           };
+          services.audio.enable = true;
         };
 
         environment = {
@@ -66,6 +68,13 @@
             }
           ];
           writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";
+
+          # TODO: Move this to a hardware specific place
+          kernelParams = [
+            "snd_intel_dspcfg.dsp_driver=3"
+            "snd_sof_intel_hda_common.dmic_num=4"
+          ];
+          ###########################
           qemu = {
             machine =
               {

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -31,5 +31,20 @@ in {
       withDebug = config.ghaf.profiles.debug.enable;
       withHardenedConfigs = true;
     };
+
+    # TODO: remove hardcoded paths
+    systemd.services."microvm@audio-vm".serviceConfig = lib.optionalAttrs config.ghaf.virtualization.microvm.audiovm.enable {
+      # The + here is a systemd feature to make the script run as root.
+      ExecStopPost = [
+        "+${pkgs.writeShellScript "reload-audio" ''
+          # The script makes audio device internal state to reset
+          # This fixes issue of audio device getting into some unexpected
+          # state when the VM is being shutdown during audio mic recording
+          echo "1" > /sys/bus/pci/devices/0000:00:1f.3/remove
+          sleep 0.1
+          echo "1" > /sys/bus/pci/devices/0000:00:1f.0/rescan
+        ''}"
+      ];
+    };
   };
 }

--- a/targets/lenovo-x1/everything.nix
+++ b/targets/lenovo-x1/everything.nix
@@ -106,7 +106,10 @@
 
                   audiovm = {
                     enable = true;
-                    extraModules = [config.ghaf.hardware.passthrough.audiovmPCIPassthroughModule];
+                    extraModules = [
+                      config.ghaf.hardware.passthrough.audiovmPCIPassthroughModule
+                      config.ghaf.hardware.passthrough.audiovmKernelParams
+                    ];
                   };
 
                   appvm = {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Refactoring to separate hardware dependencies. Goal is to allow easy creation of targets other than x1, with clear(er) hardware interface. Ultimately, generating a hardware definition should be enough for a new target.

### Commit 1: Refactoring audiovm and generic x1 kernel params
- remove audiovmExtraModules file
- move audio configuration into module
- move audio shutdown fix to microvm-host
- move vfio kernel params generation to hw passthrough
- move x1 specific kernel params to hardware definition

### Commit 2: Move hw specific kernel parameters
- move audiovm (intel specfic) kernel parameters to audio device definition

General idea here is to move hardware specific kernel configurations to the hardware definition. This allows to change hardware through a single configuration file while the rest of the system can be defined hardware independent.

### Commit 3: Move host kernel parameters
- create option and move host kernel parameters to hw definition

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->

Required testing:
1. Standard build and run test for x1
2. Verify audiovm and respective functionality