### PR TITLE
lenovo-x1: compress image using zstd

### DIFF
--- a/modules/disko/lenovo-x1-disko-basic.nix
+++ b/modules/disko/lenovo-x1-disko-basic.nix
@@ -3,7 +3,7 @@
 # Example to create a bios compatible gpt partition
 # To use this example, you will need to specify a device i.e.
 #   { disko.devices.disk1.device = "/dev/sda"; }
-{
+{pkgs, ...}: {
   disko.devices = {
     disk.disk1 = {
       type = "disk";
@@ -59,5 +59,11 @@
       };
     };
   };
-  disko.memSize = 2048;
+  disko = {
+    memSize = 2048;
+    extraPostVM = ''
+      ${pkgs.zstd}/bin/zstd --compress $out/*raw
+      rm $out/*raw
+    '';
+  };
 }

--- a/packages/installer/ghaf-installer.sh
+++ b/packages/installer/ghaf-installer.sh
@@ -28,7 +28,7 @@ read -r -p "Device name [e.g. /dev/nvme0n1]: " DEVICE_NAME
 read -r -p 'WARNING: Next command will destroy all previous data from your device, press Enter to proceed. '
 
 echo "Installing..."
-dd if=@imagePath@ of="${DEVICE_NAME}" bs=32M status=progress
+zstdcat @imagePath@ | dd of="${DEVICE_NAME}" bs=32M status=progress
 
 echo ""
 echo "Installation done. Please remove the installation media and reboot"

--- a/targets/lenovo-x1-installer/flake-module.nix
+++ b/targets/lenovo-x1-installer/flake-module.nix
@@ -10,7 +10,7 @@
   name = "lenovo-x1-carbon";
   system = "x86_64-linux";
   installer = generation: variant: let
-    imagePath = self.packages.x86_64-linux."${name}-${generation}-${variant}" + "/disk1.raw";
+    imagePath = self.packages.x86_64-linux."${name}-${generation}-${variant}" + "/disk1.raw.zst";
     hostConfiguration = lib.nixosSystem {
       inherit system;
       modules = [
@@ -38,6 +38,8 @@
           environment.systemPackages = [
             installScript
           ];
+
+          isoImage.squashfsCompression = "zstd -Xcompression-level 3";
 
           # NOTE: Stop nixos complains about "warning:
           # mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash."


### PR DESCRIPTION
This avoids having images on the builders and cache take too much storage.

## Description of changes

The goal of this change is to compress all build artefacts to a reasonable size, in a reasonable amount of time. This is so that:

- Disko image files takes less space in the binary cache and builders.
- Downloading disko images files would be much faster from the binary cache, reducing bandwidth and time required to build a system.
- Building the ISO image would be much faster.

These are results as tested on my Lenovo P1 Gen3 laptop. This table is similar to Fedora's [comparison of compression levels and algorithms](https://fedoraproject.org/wiki/Changes/Switch_RPMs_to_zstd_compression#Comparison_of_compression_algorithms_and_levels), so we can compare easily.

| Target | Compression | Level | Size | Comp. time | Decomp. time | Comments |
| --- | --- | --- | --- | --- | --- | --- |
| `lenovo-x1-carbon-gen11-debug` (disko image) | None | - | 16G | - | - | Default before this patch |
| `lenovo-x1-carbon-gen11-debug` (disko image) | zstd | 3 | 3.8G |  36s | 12s | This patch |
| `lenovo-x1-carbon-gen11-debug` (disko image) | zstd | 8 | 3.32G |  2min | 15s |  |
| `lenovo-x1-carbon-gen11-debug-installer` (iso) | disko: none <br> squashfs: xz <br> iso: none | [See default](https://github.com/NixOS/nixpkgs/blob/nixos-24.05/nixos/modules/installer/cd-dvd/iso-image.nix#L509) | 6.3G | 25min | - | Default before this patch |
| `lenovo-x1-carbon-gen11-debug-installer` (iso) | disko: none <br> squashfs: zstd <br> iso: none | 3 | 7.6G | 1min | - | |
| `lenovo-x1-carbon-gen11-debug-installer` (iso) | disko: zstd <br> squashfs: zstd <br> iso: none | 3 | 7.5G | 50s | - | This patch |


> [!IMPORTANT]  
> With the installer target, compression time is the build time for the last item in dependency chart (iso build), not including disko image build time/compression. The decompression time for installer is only for the iso, as squashfs is decompressed during boot.

Using zstandard as a compression algorithm makes sense for our use case, especially with the speed improvement. This improves development speed, and we can still use this compression for production builds.
Distributions such as Fedora, Ubuntu, and Arch have switched to using zstd for compressing packages.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Build disko image
  - Flash using: `zstdcat result/disk1.raw.zst | sudo dd of=/dev/<DEVICE> bs=32M status=progress`
- Create an installer, flash on USB. Test with `sudo ghaf-installer.sh`

For disko image, expect the build to take slightly longer, and to a less extent also decompression. But image should take significantly less disk space.

For iso installer image, expect the build to be significantly faster, but the result would be larger by about 1.3GB.