### PR TITLE
Use cloud-hypervisor for net-vm on x86

### DIFF
--- a/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -62,7 +62,7 @@
       path = "0000:00:14.3";
       vendorId = "8086";
       productId = "51f0";
-      name = "wlp0s5f0";
+      name = "wls8";
     }
   ];
 

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -64,7 +64,7 @@
       path = "0000:00:14.3";
       vendorId = "8086";
       productId = "51f1";
-      name = "wlp0s5f0";
+      name = "wls8";
     }
   ];
 

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -62,13 +62,19 @@
 
         microvm = {
           optimize.enable = true;
-          hypervisor = "qemu";
+          hypervisor = {
+            # Use the same machine type as the host
+            x86_64-linux = "cloud-hypervisor";
+            aarch64-linux = "qemu";
+          }
+          .${configHost.nixpkgs.hostPlatform.system};
           shares =
             [
               {
                 tag = "ro-store";
                 source = "/nix/store";
                 mountPoint = "/nix/.ro-store";
+                proto = "virtiofs";
               }
             ]
             ++ lib.optionals isGuiVmEnabled [
@@ -77,6 +83,7 @@
                 tag = configHost.ghaf.security.sshKeys.waypipeSshPublicKeyName;
                 source = configHost.ghaf.security.sshKeys.waypipeSshPublicKeyDir;
                 mountPoint = configHost.ghaf.security.sshKeys.waypipeSshPublicKeyDir;
+                proto = "virtiofs";
               }
             ];
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Replace QEMU with cloud-hypervisor for net-vm guest on x86 hardware.

cloud-hypervisor makes a differently connected virtual device, so the permanent name of the interface changes.

Move smcroute startup to NetworkManager dispatcher script to allow the guest to reach multi-user.target before host timeout reboots the VM.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Verify that network connectivity works after configuring it.

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
