### PR TITLE
Centralized network config for virtual machines

### DIFF
--- a/modules/network/common/common.nix
+++ b/modules/network/common/common.nix
@@ -1,0 +1,2 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/modules/network/common/default.nix
+++ b/modules/network/common/default.nix
@@ -1,0 +1,7 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  imports = [
+    ./common.nix
+  ];
+}

--- a/modules/network/definition.nix
+++ b/modules/network/definition.nix
@@ -1,0 +1,60 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Module for Network Definitions
+#
+# The point of this module is to only store information about the network
+# configuration, and the logic that uses this information should be elsewhere.
+{lib, ...}: let
+  inherit (lib) mkOption types literalExpression;
+in {
+  options.ghaf.network.definition = let
+    networkSubmodule = types.submodule {
+      options = {
+        hostName = mkOption {
+          type = types.str;
+          description = ''
+            Hostname
+          '';
+        };
+        macAddress = mkOption {
+          type = types.str;
+          description = ''
+            MAC address
+          '';
+        };
+        ipAddressId = mkOption {
+          type = types.int;
+          description = ''
+            IP Address ID, the last octet of internal/debug network IP address
+          '';
+        };
+      };
+    };
+  in {
+    internalNetwork = mkOption {
+      description = "Internal network address";
+      type = types.str;
+      default = "192.168.100.0";
+    };
+
+    debugNetwork = mkOption {
+      description = "Debug network address";
+      type = types.str;
+      default = "192.168.101.0";
+    };
+
+    virtualMachines = mkOption {
+      description = "Virtual Machines";
+      type = types.listOf networkSubmodule;
+      default = [];
+      example = literalExpression ''
+        [{
+          hostName = "net-vm";
+          macAddress = "02:00:00:01:01:01";
+          ipAddressId = 1;
+        }]
+      '';
+    };
+  };
+}

--- a/modules/network/flake-module.nix
+++ b/modules/network/flake-module.nix
@@ -1,0 +1,10 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+_: {
+  flake.nixosModules = {
+    network-common.imports = [
+      ./definition.nix
+      ./common
+    ];
+  };
+}


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Have all of the network configuration (MACs, IPs and hostnames) for virtual machines in one place instead of configuration being scattered around in several files and having excessive redundancy.

This is work in progress.
There might be some overlaps with other work, those will be sorted out soon.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
