### PR TITLE
guivm: fix crash on lid close

### DIFF
--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -89,6 +89,10 @@
           hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
         };
 
+        # Suspend inside Qemu causes segfault
+        # See: https://gitlab.com/qemu-project/qemu/-/issues/2321
+        services.logind.lidSwitch = "ignore";
+
         microvm = {
           optimize.enable = false;
           vcpu = 2;
@@ -231,10 +235,10 @@ in {
     systemd.services.vsockproxy = {
       enable = true;
       description = "vsockproxy";
-      unitConfig = {
-        Type = "simple";
-      };
       serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        RestartSec = "1";
         ExecStart = "${vsockproxy}/bin/vsockproxy ${toString cfg.waypipePort} ${toString cfg.vsockCID} ${toString cfg.waypipePort}";
       };
       wantedBy = ["multi-user.target"];

--- a/packages/vsockproxy/default.nix
+++ b/packages/vsockproxy/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "tiiuae";
     repo = "vsockproxy";
-    rev = "aad625f9a27ce4c68d9996c65ece8477ace37534";
-    sha256 = "sha256-3WgpDlF8oIdlgwkvl7TPR6WAh+qk0mowzuYiPY0rwaU=";
+    rev = "851e995b4c24a776f78d56310010e4e29456921c";
+    sha256 = "sha256-fyawskwts4OIBshGDeh5ANeBCEm3h5AyHCyhwfxgP14=";
   };
 
   installPhase = ''


### PR DESCRIPTION
Disables suspend inside gui-vm, as it causes qemu to segfault.
Related to: https://gitlab.com/qemu-project/qemu/-/issues/2321

Also brings in fix in vsockproxy, which didn't used to handle signals
gracefully, causing it to crash when the host is suspended.

## Description of changes

- Configure logind not to suspend inside gui-vm.
- Update vsockproxy to [include fix](https://github.com/tiiuae/vsockproxy/commit/851e995b4c24a776f78d56310010e4e29456921c).
- Let vsockproxy systemd service restart always, so it is always available.

Fixes: SP-3466, and possibly SP-3464

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Boot the system, open any app VM window.
- Close the lid and open, as many times.
- Apps should still be running, interactive, networking available, other apps still launchable.
- Close lid, keep closed for more than 5 minutes, open lid. Apps should work (same as above).
- When the lid is closed, the system should be in suspend (pulsing red ThinkPad LED).
- If `ping` command is running, it would be paused due to suspend, and resume when lid is opened.
- Please be gentle with laptop during testing :)
