### PR TITLE
labwc: enable audio controls, fix wifi status script

### DIFF
--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -7,6 +7,8 @@
   ...
 }: let
   cfg = config.ghaf.graphics.labwc;
+
+  audio-ctrl = pkgs.callPackage ../../../packages/audio-ctrl {};
   gtklockStyle = pkgs.writeText "gtklock.css" ''
     window {
       background: rgba(29, 29, 29, 1);
@@ -101,10 +103,19 @@
       </keybind>
     ''}
       <keybind key="XF86_MonBrightnessUp">
-        <action name="Execute" command="${pkgs.brightnessctl}/bin/brightnessctl set +10%" />
+        <action name="Execute" command="${pkgs.brightnessctl}/bin/brightnessctl set +5%" />
       </keybind>
       <keybind key="XF86_MonBrightnessDown">
-        <action name="Execute" command="${pkgs.brightnessctl}/bin/brightnessctl set 10%-" />
+        <action name="Execute" command="${pkgs.brightnessctl}/bin/brightnessctl set 5%-" />
+      </keybind>
+      <keybind key="XF86_AudioRaiseVolume">
+        <action name="Execute" command="${audio-ctrl}/bin/audio-ctrl inc" />
+      </keybind>
+      <keybind key="XF86_AudioLowerVolume">
+        <action name="Execute" command="${audio-ctrl}/bin/audio-ctrl dec" />
+      </keybind>
+      <keybind key="XF86_AudioMute">
+        <action name="Execute" command="${audio-ctrl}/bin/audio-ctrl mut" />
       </keybind>
     </keyboard>
     <mouse><default /></mouse>

--- a/packages/audio-ctrl/default.nix
+++ b/packages/audio-ctrl/default.nix
@@ -1,0 +1,43 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This is a temporary solution for volume control.
+#
+{
+  openssh,
+  writeShellApplication,
+  ...
+}:
+writeShellApplication {
+  name = "audio-ctrl";
+  runtimeInputs = [
+    openssh
+  ];
+  text = ''
+    function pamixer {
+      # Connect to audio-vm
+      output=$(ssh -q ghaf@audio-vm \
+          -i /run/waypipe-ssh/id_ed25519 \
+          -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null \
+          "pamixer $1")
+    }
+
+    case "$1" in
+      inc)
+        pamixer "-i 5"
+        ;;
+      dec)
+        pamixer "-d 5"
+        ;;
+      mut)
+        pamixer "--get-mute"
+        if [ "$output" = "false" ]; then
+          pamixer "-m"
+        else
+          pamixer "-u"
+        fi
+        ;;
+      esac
+  '';
+}

--- a/packages/nm-launcher/default.nix
+++ b/packages/nm-launcher/default.nix
@@ -21,6 +21,7 @@ writeShellApplication {
         -f -N -q ghaf@net-vm \
         -i /run/waypipe-ssh/id_ed25519 \
         -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
         -o StreamLocalBindUnlink=yes \
         -o ExitOnForwardFailure=yes \
         -L /tmp/ssh_session_dbus.sock:/run/user/1000/bus \

--- a/packages/wifi-signal-strength/default.nix
+++ b/packages/wifi-signal-strength/default.nix
@@ -1,71 +1,65 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  stdenvNoCC,
-  pkgs,
+  networkmanager,
+  openssh,
+  util-linux,
+  gawk,
+  coreutils-full,
+  writeShellApplication,
   wifiDevice,
   ...
-}: let
-  wifiSignalStrength =
-    pkgs.writeShellScript
-    "wifi-signal-strength"
-    ''
-      NETWORK_STATUS_FILE=/tmp/network-status
+}:
+writeShellApplication {
+  name = "wifi-signal-strength";
+  runtimeInputs = [
+    networkmanager
+    openssh
+    gawk
+    util-linux
+    coreutils-full
+  ];
+  text = ''
+    NETWORK_STATUS_FILE=/tmp/network-status
 
-      export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
-      export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/ssh_system_dbus.sock
+    export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
+    export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/ssh_system_dbus.sock
 
-      # Lock the script to reuse
-      LOCK_FILE=/tmp/wifi-signal.lock
-      exec 99>"$LOCK_FILE"
-      ${pkgs.util-linux}/bin/flock -w 60 -x 99 || exit 1
+    # Lock the script to reuse
+    LOCK_FILE=/tmp/wifi-signal.lock
+    exec 99>"$LOCK_FILE"
+    flock -w 60 -x 99 || exit 1
 
-      # Return the result as json format for waybar and use the control socket to close the ssh tunnel.
-      trap "${pkgs.openssh}/bin/ssh -q -S /tmp/nmcli_socket -O exit ghaf@net-vm && ${pkgs.coreutils-full}/bin/cat $NETWORK_STATUS_FILE" EXIT
+    # Return the result as json format for waybar and use the control socket to close the ssh tunnel.
+    trap 'ssh -q -S /tmp/nmcli_socket -O exit ghaf@net-vm && cat "$NETWORK_STATUS_FILE"' EXIT
 
-      # Connect to netvm
-      ${pkgs.openssh}/bin/ssh -M -S /tmp/nmcli_socket \
-          -f -N -q ghaf@net-vm \
-          -i /run/waypipe-ssh/id_ed25519 \
-          -o StrictHostKeyChecking=no \
-          -o StreamLocalBindUnlink=yes \
-          -o ExitOnForwardFailure=yes \
-          -L /tmp/ssh_session_dbus.sock:/run/user/1000/bus \
-          -L /tmp/ssh_system_dbus.sock:/run/dbus/system_bus_socket
-      signal0=󰤟
-      signal1=󰤢
-      signal2=󰤥
-      signal3=󰤨
-      no_signal=󰤭
-      # Get IP address of netvm
-      address=$(${pkgs.networkmanager}/bin/nmcli device show ${wifiDevice} | ${pkgs.gawk}/bin/awk '{ if ($1=="IP4.ADDRESS[1]:") {print $2}}')
-      # Get signal strength and ssid
-      connection=($(${pkgs.networkmanager}/bin/nmcli -f IN-USE,SIGNAL,SSID dev wifi | ${pkgs.gawk}/bin/awk '/^\*/{if (NR!=1) {print $2; print $3}}'))
-      connection[0]=$(if [ -z ''${connection[0]} ]; then echo "-1"; else echo ''${connection[0]}; fi)
-      # Set the icon of signal level
-      signal_level=$(if [ ''${connection[0]} -gt 80 ]; then echo $signal3; elif [ ''${connection[0]} -gt 60 ]; then echo $signal2; elif [ ''${connection[0]} -gt 30 ]; then echo $signal1; elif [ ''${connection[0]} -gt 0 ]; then echo signal0; else echo $no_signal; fi)
-      tooltip=$(if [ -z $address ]; then echo ''${connection[0]}%; else echo $address ''${connection[0]}%; fi)
-      text=$(if [ -z ''${connection[1]} ]; then echo "No connection"; else echo ''${connection[1]} $signal_level; fi)
-      # Save the result in json format
-      RESULT="{\"percentage\":\""''${connection[0]}"\", \"text\":\""$text"\", \"tooltip\":\""$tooltip"\", \"class\":\"1\"}"
-      echo $RESULT>/tmp/network-status
-      ${pkgs.util-linux}/bin/flock -u 99
-    '';
-in
-  stdenvNoCC.mkDerivation {
-    name = "wifi-signal-strength";
-
-    phases = ["installPhase"];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      cp ${wifiSignalStrength} $out/bin/wifi-signal-strength
-    '';
-
-    meta = {
-      description = "Script to get wifi data from nmcli to show network of netvm using D-Bus over SSH on Waybar.";
-      platforms = [
-        "x86_64-linux"
-      ];
-    };
-  }
+    # Connect to netvm
+    ssh -M -S /tmp/nmcli_socket \
+        -f -N -q ghaf@net-vm \
+        -i /run/waypipe-ssh/id_ed25519 \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -o StreamLocalBindUnlink=yes \
+        -o ExitOnForwardFailure=yes \
+        -L /tmp/ssh_session_dbus.sock:/run/user/1000/bus \
+        -L /tmp/ssh_system_dbus.sock:/run/dbus/system_bus_socket
+    signal0="\UF091F"
+    signal1="\UF0922"
+    signal2="\UF0925"
+    signal3="\UF0928"
+    no_signal="\UF092D"
+    # Get IP address of netvm
+    address=$(nmcli device show ${wifiDevice} | awk '{ if ($1=="IP4.ADDRESS[1]:") {print $2}}')
+    # Get signal strength and ssi
+    mapfile -t connection < <(nmcli -f IN-USE,SIGNAL,SSID dev wifi | awk '/^\*/{if (NR!=1) {print $2; print $3}}')
+    connection[0]=$(if [ -z "''${connection[0]}" ]; then echo "-1"; else echo "''${connection[0]}"; fi)
+    # Set the icon of signal level
+    signal_level=$(if [ "''${connection[0]}" -gt 80 ]; then echo "''${signal3}"; elif [ "''${connection[0]}" -gt 60 ]; then echo "''${signal2}"; elif [ "''${connection[0]}" -gt 30 ]; then echo "''${signal1}"; elif [ "''${connection[0]}" -gt 0 ]; then echo "''${signal0};" else echo "''${no_signal}"; fi)
+    tooltip=$(if [ -z "''${address}" ]; then echo "''${connection[0]}%"; else echo "''${address} ''${connection[0]}%"; fi)
+    text=$(if [ -z "''${connection[1]}" ]; then echo "No connection"; else echo "''${connection[1]} $signal_level"; fi)
+    # Save the result in json format
+    RESULT="{\"percentage\":\"''${connection[0]}\", \"text\":\"''${text}\", \"tooltip\":\"''${tooltip}\", \"class\":\"1\"}"
+    echo -e "$RESULT">/tmp/network-status
+    flock -u 99
+  '';
+}


### PR DESCRIPTION
Enables the media keys for volume up, down, and mute toggling.

Also now the wifi-signal-strength script is checked by shellcheck, all shellcheck issues are fixed, including bugs when netvm is rebooted and signal strength 0 not showing properly.

## Description of changes

- Media keys now work for volume up, volume down, and mute.
  - Volume step is 5%.
- Brightness step is now 5% instead of 10%.
- wifi-signal-strength script fixes
  - When net-vm reboots, host key check used to fail (even with it set to no). This is now fixed, so status should continue to update after net-vm reboots.
  - When signal strength was <30, it used to print "signal0" instead of icon. Now proper icon should be shown.
  - Script uses `writeShellApplication` which means it is run through shellcheck.
  - Shellcheck issues are fixed.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Test volume keys (volume up, down, mute).
  - There might be small delay for these key presses, unlike brightness which is instant.
- Reboot net-vm, the status for wifi should continue to update properly after it is back up.