### PR TITLE
waypipe: fix border drawing when compositor has output scaling != 1

### DIFF
--- a/overlays/custom-packages/waypipe/default.nix
+++ b/overlays/custom-packages/waypipe/default.nix
@@ -3,5 +3,6 @@
 {prev, ...}:
 # Waypipe with vsock and window borders
 prev.waypipe.overrideAttrs (_prevAttrs: {
+  # Upstream pull request: https://gitlab.freedesktop.org/mstoeckl/waypipe/-/merge_requests/21
   patches = [./waypipe-window-borders.patch];
 })

--- a/overlays/custom-packages/waypipe/waypipe-window-borders.patch
+++ b/overlays/custom-packages/waypipe/waypipe-window-borders.patch
@@ -1,4 +1,4 @@
-From 3f35f181a3b5245ac3a518bb8ae40bdf2b6635f3 Mon Sep 17 00:00:00 2001
+From b993dca0e0919cf16c207026605f0fe5a61f479f Mon Sep 17 00:00:00 2001
 From: Yuri Nesterov <yuriy.nesterov@unikie.com>
 Date: Fri, 24 May 2024 11:15:41 +0200
 Subject: [PATCH] Add support for coloured window borders
@@ -6,33 +6,58 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
+This is usefor to visually distinguish between different windows when
+using waypipe. The border is drawn around the window and can be
+configured with a hex color and a border size in pixels.
+
 Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
 ---
- protocols/function_list.txt |   3 +
- src/handlers.c              | 112 ++++++++++++++++++++++++++++++++++++
+ protocols/function_list.txt |   4 ++
+ src/handlers.c              | 121 ++++++++++++++++++++++++++++++++++++
  src/main.h                  |   3 +
  src/parsing.h               |   4 ++
  src/util.c                  |  12 ++++
  src/util.h                  |   6 ++
- src/waypipe.c               |  69 +++++++++++++++++++++-
- 7 files changed, 207 insertions(+), 2 deletions(-)
+ src/waypipe.c               |  70 ++++++++++++++++++++-
+ waypipe.scd                 |   5 ++
+ 8 files changed, 223 insertions(+), 2 deletions(-)
 
 diff --git a/protocols/function_list.txt b/protocols/function_list.txt
-index 4acaec5..b15a293 100644
+index 4acaec5..4750263 100644
 --- a/protocols/function_list.txt
 +++ b/protocols/function_list.txt
-@@ -50,3 +50,6 @@ zwp_linux_dmabuf_v1_req_get_default_feedback
- zwp_linux_dmabuf_v1_req_get_surface_feedback
- zwp_primary_selection_offer_v1_req_receive
- zwp_primary_selection_source_v1_evt_send
-+xdg_wm_base_req_get_xdg_surface
-+xdg_surface_req_set_window_geometry
+@@ -16,6 +16,7 @@ wl_registry_req_bind
+ wl_shm_req_create_pool
+ wl_shm_pool_req_create_buffer
+ wl_shm_pool_req_resize
++wl_surface_evt_preferred_buffer_scale
+ wl_surface_req_attach
+ wl_surface_req_commit
+ wl_surface_req_damage
+@@ -25,7 +26,10 @@ wl_surface_req_set_buffer_scale
+ wp_presentation_evt_clock_id
+ wp_presentation_feedback_evt_presented
+ wp_presentation_req_feedback
 +xdg_surface_req_get_toplevel
++xdg_surface_req_set_window_geometry
+ xdg_toplevel_req_set_title
++xdg_wm_base_req_get_xdg_surface
+ zwlr_data_control_offer_v1_req_receive
+ zwlr_data_control_source_v1_evt_send
+ zwlr_export_dmabuf_frame_v1_evt_frame
 diff --git a/src/handlers.c b/src/handlers.c
-index 8e151b2..3bc15ff 100644
+index c82f4e0..50ff7a3 100644
 --- a/src/handlers.c
 +++ b/src/handlers.c
-@@ -357,6 +357,13 @@ struct wp_object *create_wp_object(uint32_t id, const struct wp_interface *type)
+@@ -98,6 +98,7 @@ struct obj_wl_surface {
+ 	uint32_t attached_buffer_id; /* protocol object id */
+ 	int32_t scale;
+ 	int32_t transform;
++	int32_t preferred_buffer_scale;
+ };
+ 
+ struct obj_wlr_screencopy_frame {
+@@ -357,6 +358,13 @@ struct wp_object *create_wp_object(uint32_t id, const struct wp_interface *type)
  	} else if (type == &intf_wl_surface) {
  		((struct obj_wl_surface *)new_obj)->scale = 1;
  	}
@@ -46,7 +71,7 @@ index 8e151b2..3bc15ff 100644
  	return new_obj;
  }
  
-@@ -742,6 +749,87 @@ static void rotate_damage_lists(struct obj_wl_surface *surface)
+@@ -743,6 +751,88 @@ static void rotate_damage_lists(struct obj_wl_surface *surface)
  			(SURFACE_DAMAGE_BACKLOG - 1) * sizeof(uint64_t));
  	surface->attached_buffer_uids[0] = 0;
  }
@@ -112,16 +137,17 @@ index 8e151b2..3bc15ff 100644
 +
 +	if ((buf->shm_format != WL_SHM_FORMAT_ARGB8888) && (buf->shm_format != WL_SHM_FORMAT_XRGB8888)) {
 +		wp_debug("Unable to draw the border, SHM format %d is not supported", buf->shm_format);
-+	}
-+	else {
++	} else {
 +		if (ctx->obj->xdg_surface_id) {
 +			struct wp_object *xdg_surface = tracker_get(ctx->tracker, ctx->obj->xdg_surface_id);
 +			if (xdg_surface && xdg_surface->is_window) {
-+				int32_t x1 = xdg_surface->window_x;
-+				int32_t y1 = xdg_surface->window_y;
-+				int32_t x2 = min(buf->shm_width, xdg_surface->window_x + xdg_surface->window_width);
-+				int32_t y2 = min(buf->shm_height, xdg_surface->window_y + xdg_surface->window_height);
++			  int32_t scale = surface->preferred_buffer_scale > 0 ? surface->preferred_buffer_scale : 1;
++				int32_t x1 = xdg_surface->window_x * scale;
++				int32_t y1 = xdg_surface->window_y * scale;
++				int32_t x2 = min(buf->shm_width, (xdg_surface->window_x + xdg_surface->window_width) * scale);
++				int32_t y2 = min(buf->shm_height, (xdg_surface->window_y + xdg_surface->window_height) * scale);
 +				int32_t border_size = min(min(ctx->g->config->border_size, x2 - x1), y2 - y1);
++
 +				draw_rect(buf, x1, y1, x2, y1 + border_size, &ctx->g->config->border_color); // top
 +				draw_rect(buf, x1, y1 + border_size, x1 + border_size, y2, &ctx->g->config->border_color); // left
 +				draw_rect(buf, x1 + border_size, y2 - border_size, x2, y2, &ctx->g->config->border_color); // bottom
@@ -134,7 +160,7 @@ index 8e151b2..3bc15ff 100644
  void do_wl_surface_req_commit(struct context *ctx)
  {
  	struct obj_wl_surface *surface = (struct obj_wl_surface *)ctx->obj;
-@@ -759,6 +847,10 @@ void do_wl_surface_req_commit(struct context *ctx)
+@@ -760,6 +850,10 @@ void do_wl_surface_req_commit(struct context *ctx)
  		/* commit signifies a client-side update only */
  		return;
  	}
@@ -145,7 +171,21 @@ index 8e151b2..3bc15ff 100644
  	struct wp_object *obj =
  			tracker_get(ctx->tracker, surface->attached_buffer_id);
  	if (!obj) {
-@@ -2020,3 +2112,23 @@ void do_xdg_toplevel_req_set_title(struct context *ctx, const char *str)
+@@ -921,6 +1015,13 @@ static void append_damage_record(struct obj_wl_surface *surface, int32_t x,
+ 	damage->width = width;
+ 	damage->height = height;
+ }
++
++void do_wl_surface_evt_preferred_buffer_scale(struct context *ctx, int32_t scale)
++{
++	struct obj_wl_surface *surface = (struct obj_wl_surface *)ctx->obj;
++	surface->preferred_buffer_scale = scale;
++}
++
+ void do_wl_surface_req_damage(struct context *ctx, int32_t x, int32_t y,
+ 		int32_t width, int32_t height)
+ {
+@@ -2021,3 +2122,23 @@ void do_xdg_toplevel_req_set_title(struct context *ctx, const char *str)
  }
  
  const struct wp_interface *the_display_interface = &intf_wl_display;
@@ -199,10 +239,10 @@ index f3580b0..5739001 100644
  struct message_tracker {
  	/* Tree containing all objects that are currently alive or zombie */
 diff --git a/src/util.c b/src/util.c
-index 88948ee..6f0a5ca 100644
+index 8b4bce9..c4ff390 100644
 --- a/src/util.c
 +++ b/src/util.c
-@@ -800,3 +800,15 @@ int listen_on_vsock(uint32_t port, int nmaxclients, int *socket_fd_out)
+@@ -794,3 +794,15 @@ int listen_on_vsock(uint32_t port, int nmaxclients, int *socket_fd_out)
  	return 0;
  }
  #endif
@@ -234,7 +274,7 @@ index 9970840..8e5cec1 100644
 +
  #endif // WAYPIPE_UTIL_H
 diff --git a/src/waypipe.c b/src/waypipe.c
-index c66a971..a572ae8 100644
+index c66a971..0dbec96 100644
 --- a/src/waypipe.c
 +++ b/src/waypipe.c
 @@ -86,6 +86,7 @@ static const char usage_string[] =
@@ -342,19 +382,36 @@ index c66a971..a572ae8 100644
  	};
  
  	/* We do not parse any getopt arguments happening after the mode choice
-@@ -724,6 +783,12 @@ int main(int argc, char **argv)
+@@ -724,6 +783,13 @@ int main(int argc, char **argv)
  			}
  			config.title_prefix = optarg;
  			break;
 +		case ARG_BORDER:
 +			config.border = true;
 +			if (parse_border(optarg, &config) == -1) {
-+				fail = true;
++				fprintf(stderr, "Invalid border argument: %s\n", optarg);
++				return EXIT_FAILURE;
 +			}
 +			break;
  		default:
  			fail = true;
  			break;
+diff --git a/waypipe.scd b/waypipe.scd
+index d0b300d..f555b30 100644
+--- a/waypipe.scd
++++ b/waypipe.scd
+@@ -111,6 +111,11 @@ compressible as images containing pictures.
+ 	absolute path, the socket will be created in the folder given by the
+ 	environment variable _XDG_RUNTIME_DIR_.)
+ 
++*--border C,S*
++	For server: add a border with hex color C and border size S in hex around the
++	window. The hex color should be in the format #RRGGBB or #RRGGBBAA and
++	the border size is in pixels.
++
+ *--drm-node R*
+ 	Specify the path *R* to the drm device that this instance of waypipe should
+ 	use and (in server mode) notify connecting applications about.
 -- 
-2.44.0
+2.45.1
 


### PR DESCRIPTION
The old version did break if a screen used output scaling (i.e. on 200% scaling on 4k screens) by making the border only a quarter of the needed size.
This was fixed by requesting the compositor output scaling.

I found this bug when I tested this patch prior to upstreaming the patch to https://gitlab.freedesktop.org/mstoeckl/waypipe/-/merge_requests/21

I also updated the manpage

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
