### PR TITLE
Add support for USB hot plugging

### DIFF
--- a/modules/hardware/common/default.nix
+++ b/modules/hardware/common/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./usb/internal.nix
     ./usb/external.nix
+    ./usb/vhotplug.nix
     ./devices.nix
     ./kernel.nix
     ./qemu.nix

--- a/modules/hardware/common/qemu.nix
+++ b/modules/hardware/common/qemu.nix
@@ -35,7 +35,11 @@ in
           "acad"
         ]
         ++ optionals (hasAttr "yubikey" config.ghaf.hardware.usb.external.qemuExtraArgs) config.ghaf.hardware.usb.external.qemuExtraArgs.yubikey
-        ++ optionals (hasAttr "fpr0" config.ghaf.hardware.usb.internal.qemuExtraArgs) config.ghaf.hardware.usb.internal.qemuExtraArgs.fpr0;
+        ++ optionals (hasAttr "fpr0" config.ghaf.hardware.usb.internal.qemuExtraArgs) config.ghaf.hardware.usb.internal.qemuExtraArgs.fpr0
+        ++ optionals config.ghaf.hardware.usb.vhotplug.enableEvdevPassthrough builtins.concatMap (n: [
+          "-device"
+          "pcie-root-port,bus=pcie.0,id=${config.ghaf.hardware.usb.vhotplug.pcieBusPrefix}${toString n},chassis=${toString n}"
+        ]) (lib.range 1 config.ghaf.hardware.usb.vhotplug.pciePortCount);
     };
   };
 }

--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -1,0 +1,192 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.hardware.usb.vhotplug;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    types
+    mkIf
+    literalExpression
+    ;
+
+  vhotplug = pkgs.callPackage ../../../../packages/vhotplug { };
+  defaultRules = [
+    {
+      name = "GUIVM";
+      qmpSocket = "/var/lib/microvms/gui-vm/gui-vm.sock";
+      usbPassthrough = [
+        {
+          class = 3;
+          protocol = 1;
+          description = "HID Keyboard";
+        }
+        {
+          class = 3;
+          protocol = 2;
+          description = "HID Mouse";
+        }
+        {
+          class = 11;
+          description = "Chip/SmartCard (e.g. YubiKey)";
+        }
+        {
+          class = 224;
+          subclass = 1;
+          protocol = 1;
+          description = "Bluetooth";
+          disable = true;
+        }
+        {
+          # Currently disabled to leave USB drives connected to the host
+          class = 8;
+          sublass = 6;
+          description = "Mass Storage - SCSI (USB drives)";
+          disable = true;
+        }
+      ];
+      evdevPassthrough = {
+        enable = cfg.enableEvdevPassthrough;
+        inherit (cfg) pcieBusPrefix;
+      };
+    }
+    {
+      name = "NetVM";
+      qmpSocket = "/var/lib/microvms/net-vm/net-vm.sock";
+      usbPassthrough = [
+        {
+          # Currently disabled to avoid breaking remote nixos-rebuild,
+          # which requires an Ethernet adapter connected to the host
+          class = 2;
+          sublass = 6;
+          description = "Communications - Ethernet Networking";
+          disable = true;
+        }
+      ];
+    }
+    {
+      name = "ChromiumVM";
+      qmpSocket = "/var/lib/microvms/chromium-vm/chromium-vm.sock";
+      usbPassthrough = [
+        {
+          class = 14;
+          description = "Video (USB Webcams)";
+        }
+      ];
+    }
+    {
+      name = "AudioVM";
+      qmpSocket = "/var/lib/microvms/audio-vm/audio-vm.sock";
+      usbPassthrough = [
+        {
+          class = 1;
+          description = "Audio";
+        }
+      ];
+    }
+  ];
+in
+{
+  options.ghaf.hardware.usb.vhotplug = {
+    enable = mkEnableOption "Enable hot plugging of USB devices";
+
+    rules = mkOption {
+      type = types.listOf types.attrs;
+      default = defaultRules;
+      description = ''
+        List of virtual machines with USB hot plugging rules.
+      '';
+      example = literalExpression ''
+        [
+         {
+            name = "GUIVM";
+            qmpSocket = "/var/lib/microvms/gui-vm/gui-vm.sock";
+            usbPassthrough = [
+              {
+                class = 3;
+                protocol = 1;
+                description = "HID Keyboard";
+                ignore = [
+                  {
+                    vendorId = "046d";
+                    productId = "c52b";
+                    description = "Logitech, Inc. Unifying Receiver";
+                  }
+                ];
+              }
+              {
+                vendorId = "067b";
+                productId = "23a3";
+                description = "Prolific Technology, Inc. USB-Serial Controller";
+                disable = true;
+              }
+            ];
+          }
+          {
+            name = "NetVM";
+            qmpSocket = "/var/lib/microvms/net-vm/net-vm.sock";
+            usbPassthrough = [
+              {
+                productName = ".*ethernet.*";
+                description = "Ethernet devices";
+              }
+            ];
+          }
+        ];
+      '';
+    };
+
+    enableEvdevPassthrough = mkOption {
+      description = ''
+        Enable passthrough of non-USB input devices on startup using QEMU virtio-input-host-pci device.
+      '';
+      type = types.bool;
+      default = true;
+    };
+
+    pcieBusPrefix = mkOption {
+      type = types.nullOr types.str;
+      default = "rp";
+      description = ''
+        PCIe bus prefix used for the pcie-root-port QEMU device when evdev passthrough is enabled.
+      '';
+    };
+
+    pciePortCount = lib.mkOption {
+      type = lib.types.int;
+      default = 5;
+      description = ''
+        The number of PCIe ports used for hot-plugging virtio-input-host-pci devices.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.extraRules = ''
+      SUBSYSTEM=="usb", GROUP="kvm"
+      KERNEL=="event*", GROUP="kvm"
+    '';
+
+    environment.etc."vhotplug.conf".text = builtins.toJSON { vms = cfg.rules; };
+
+    systemd.services.vhotplug = {
+      enable = true;
+      description = "vhotplug";
+      wantedBy = [ "microvms.target" ];
+      after = [ "microvms.target" ];
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        RestartSec = "1";
+        ExecStart = "${vhotplug}/bin/vhotplug -a -c /etc/vhotplug.conf";
+      };
+      startLimitIntervalSec = 0;
+    };
+  };
+}

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -59,7 +59,7 @@ let
               pkgs.pulseaudio
               pkgs.pamixer
               pkgs.pipewire
-            ];
+            ] ++ lib.optional config.ghaf.development.debug.tools.enable pkgs.alsa-utils;
           };
 
           time.timeZone = config.time.timeZone;
@@ -73,7 +73,8 @@ let
           services.openssh = config.ghaf.security.sshKeys.sshAuthorizedKeysCommand;
 
           microvm = {
-            optimize.enable = true;
+            # Optimize is disabled because when it is enabled, qemu is built without libusb
+            optimize.enable = false;
             vcpu = 1;
             mem = 256;
             hypervisor = "qemu";
@@ -102,6 +103,10 @@ let
                   aarch64-linux = "virt";
                 }
                 .${configHost.nixpkgs.hostPlatform.system};
+              extraArgs = [
+                "-device"
+                "qemu-xhci"
+              ];
             };
           };
 

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -77,7 +77,8 @@ let
           services.openssh = config.ghaf.security.sshKeys.sshAuthorizedKeysCommand;
 
           microvm = {
-            optimize.enable = true;
+            # Optimize is disabled because when it is enabled, qemu is built without libusb
+            optimize.enable = false;
             hypervisor = "qemu";
             shares =
               [
@@ -105,6 +106,10 @@ let
                   aarch64-linux = "virt";
                 }
                 .${config.nixpkgs.hostPlatform.system};
+              extraArgs = [
+                "-device"
+                "qemu-xhci"
+              ];
             };
           };
 

--- a/modules/reference/profiles/laptop-x86.nix
+++ b/modules/reference/profiles/laptop-x86.nix
@@ -65,6 +65,7 @@ in
         tpm2.enable = true;
         usb.internal.enable = true;
         usb.external.enable = true;
+        usb.vhotplug.enable = true;
       };
 
       # Virtualization options

--- a/packages/qemuqmp/default.nix
+++ b/packages/qemuqmp/default.nix
@@ -1,0 +1,26 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  python3Packages,
+  fetchPypi,
+  lib,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "qemu.qmp";
+  version = "0.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-y8iPvMEV7pQ9hER9FyxkLaEgIgRRQWwvYhrPM98eEBA=";
+  };
+
+  pyproject = true;
+
+  nativeBuildInputs = [ python3Packages.setuptools-scm ];
+
+  meta = {
+    homepage = "https://www.qemu.org/";
+    description = "QEMU Monitor Protocol library";
+    license = lib.licenses.lgpl2Plus;
+  };
+}

--- a/packages/vhotplug/default.nix
+++ b/packages/vhotplug/default.nix
@@ -1,0 +1,29 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  python3Packages,
+  pkgs,
+  fetchFromGitHub,
+}:
+let
+  qemuqmp = pkgs.callPackage ../qemuqmp { };
+in
+python3Packages.buildPythonApplication rec {
+  pname = "vhotplug";
+  version = "0.1";
+
+  propagatedBuildInputs = [
+    python3Packages.pyudev
+    python3Packages.psutil
+    qemuqmp
+  ];
+
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "tiiuae";
+    repo = "vhotplug";
+    rev = "fd05361ed893d06cdb5ac4a538c171e4a86b6f5a";
+    hash = "sha256-6fl5xeSpcIIBKn3dZUAEHiNRRpn9LbYC4Imap5KBH2M=";
+  };
+}


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This adds a service that runs on the host and listens for device add and remove events using libudev. When a new USB device is attached, it is automatically assigned to the designated virtual machine using the official qemu.qmp library."

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Input Devices:
- Connect a USB keyboard or mouse to the Lenovo X1 and verify that it is working in the GUI VM.

Audio Devices:
- Connect a USB headset to the Lenovo X1 and ssh into the audio-vm.
- Run `aplay -l` and find the headset in the list. It should be listed as either card 0 or card 1.
- To test the sound, execute `speaker-test -D hw:1,0 -c 2 -t sine`. If the headset appears as card 0, change hw:1,0 to hw:0,0.

If a bug is found or if something is not working as expected, please collect the vhotplug service logs from journalctl on the host.
