### PR TITLE
Enable Yubikey Authentication

### DIFF
--- a/modules/common/services/default.nix
+++ b/modules/common/services/default.nix
@@ -9,5 +9,6 @@
     ./desktop.nix
     ./pdfopen.nix
     ./namespaces.nix
+    ./yubikey.nix
   ];
 }

--- a/modules/common/services/yubikey.nix
+++ b/modules/common/services/yubikey.nix
@@ -1,0 +1,49 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkIf mkOption types concatStrings;
+  cfg = config.ghaf.services.yubikey;
+  u2f_file = pkgs.writeText "u2f_mapping" config.ghaf.services.yubikey.u2fKeys;
+in {
+  options.ghaf.services.yubikey = {
+    enable = mkEnableOption "Enable yubikey support which provide 2FA";
+
+    u2fKeys = mkOption {
+      type = types.str;
+      default = [];
+      example = concatStrings [
+        ##  Key should in following format <username>:<KeyHandle1>,<UserKey1>,<CoseType1>,<Options1>:<KeyHandle2>,<UserKey2>,<CoseType2>,<Options2>:...
+        "ghaf:SZ2CwN7EAE4Ujfxhm+CediUaT9ngoaMOqsKRDrOC+wUkTriKlc1cVtsxkOSav2r9ztaNKn/OwoHiN3BmsBYdZA==,oIdGgoGmkVrVis1kdzpvX3kXrOmBe2noFrpHqh4VKlq/WxrFk+Du670BL7DzLas+GxIPNjgdDCHo9daVzthIwQ==,es256,+presence"
+        ":9CEdjOg0YGpvNeisK5OW1hjjg0nRvJDBpr7X8Q4QPtxJP4iC5C6dShTxEpxmLAkqAi8x/jKCDwpt146AYAXfFg==,q8ddSEI2tIyRwB2MhRlrGZRv6ZDkEC2RYn/n33fdmK1KjBkcMy6ELUMQQDVGtsvsiQFbRS3v4qxjsgXF5BVD0A==,es256,+presence+pin"
+      ];
+      description = "It will contain U2F Keys / public keys reterived from Yubikey hardware";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Enable service and package for Yubikey
+    services.pcscd.enable = true;
+    environment.systemPackages = [pkgs.pam_u2f];
+
+    security.pam.services = {
+      sudo.u2fAuth = true;
+      gtklock.u2fAuth = true;
+    };
+
+    security.pam.u2f = {
+      authFile = "${u2f_file}";
+      control = "sufficient";
+      cue = true;
+    };
+
+    # Below rule is needed for screen locker (gtklock) to work
+    services.udev.extraRules = ''
+      KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0407", TAG+="uaccess", GROUP="kvm", MODE="0666"
+    '';
+  };
+}

--- a/modules/hardware/common/qemu.nix
+++ b/modules/hardware/common/qemu.nix
@@ -32,7 +32,9 @@ in {
           "acad"
         ]
         ++ optionals (hasAttr "fprint-reader" config.ghaf.hardware.usb.internal.qemuExtraArgs)
-        config.ghaf.hardware.usb.internal.qemuExtraArgs.fprint-reader;
+        config.ghaf.hardware.usb.internal.qemuExtraArgs.fprint-reader
+        ++ optionals (hasAttr "yubikey" config.ghaf.hardware.usb.external.qemuExtraArgs)
+        config.ghaf.hardware.usb.external.qemuExtraArgs.yubikey;
     };
   };
 }

--- a/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -136,6 +136,11 @@
         vendorId = "067b";
         productId = "23a3";
       }
+      {
+        name = "yubikey";
+        vendorId = "1050";
+        productId = "0407";
+      }
     ];
   };
 }

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -138,6 +138,11 @@
         vendorId = "067b";
         productId = "23a3";
       }
+      {
+        name = "yubikey";
+        vendorId = "1050";
+        productId = "0407";
+      }
     ];
   };
 }

--- a/modules/microvm/virtualization/microvm/modules.nix
+++ b/modules/microvm/virtualization/microvm/modules.nix
@@ -7,7 +7,7 @@
   ...
 }: let
   inherit (builtins) hasAttr;
-  inherit (lib) mkOption types optionals optionalAttrs;
+  inherit (lib) mkOption types optionals optionalAttrs concatStrings;
 
   cfg = config.ghaf.virtualization.microvm;
 
@@ -75,6 +75,15 @@
       config.ghaf.services.pdfopener.enable = true;
     };
 
+    # Yubikey module
+    yubikey = optionalAttrs cfg.guivm.yubikey {
+      config.ghaf.services.yubikey.enable = true;
+      config.ghaf.services.yubikey.u2fKeys = concatStrings [
+        # Add your Yubikey U2F Keys / public Keys here
+        ""
+      ];
+    };
+
     # Common namespace to share (built-time) between host and VMs
     commonNamespace = {
       config.ghaf.namespaces = config.ghaf.namespaces;
@@ -121,6 +130,13 @@ in {
         Enable Fingerprint module configuration.
       '';
     };
+    guivm.yubikey = mkOption {
+      type = types.bool;
+      default = cfg.guivm.enable;
+      description = ''
+        Enable Yubikey module configuration.
+      '';
+    };
   };
 
   config = {
@@ -148,6 +164,7 @@ in {
         qemuModules.guivm
         serviceModules.desktop
         serviceModules.fprint
+        serviceModules.yubikey
         serviceModules.pdfOpener
         serviceModules.commonNamespace
         referenceProgramsModule


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
This patch enables Yubikey authentication for ghaf gui-vm. We are doing Yubikey passthrough from ghaf-host to gui-vm. Currently Yubikey Authentication supported with screen locker (gtklock) and sudo command in pam sufficient mode means either password or tap on device is enough for authentication.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

**Prerequisite:**
1) Yubikey hardware, more details [here](https://www.yubico.com/products/yubikey-5-overview/)
2) Generate Yubikey public key using following command
``
pamu2fcfg  -u ghaf -o pam://gui-vm
``
3) Make sure you have Yubikey public key added [here](https://github.com/tiiuae/ghaf/pull/689/files#diff-d7de64aaf9be5d66f157884b4f27b3a245eb0c8dd830d8a845e6ed90dadeac70R82) ([example](https://github.com/tiiuae/ghaf/pull/689/files#diff-b295efaff3c4d69acf6d0f2eea743b20a9c4234a64bb4b34bbaeb60f6ca37455R19-R23))


Now plug the Yubikey hardware to Ghaf system. 

**To verify Yubikey device is detected in `gui-vm`**
[ghaf@gui-vm:~]$ lsusb | grep YubiKey
Bus 003 Device 003: ID 1050:0407 Yubico YubiKey OTP+FIDO+CCID

**To verify `sudo` command is working** 
[ghaf@gui-vm:~]$ sudo su
Please touch the device.

[root@gui-vm:/home/ghaf]# 

**To verify `screen lock` is working** 
1) Press `Windows + l` to lock the screen
2) Press Enter and tap on Yubikey device to unlock the system.
![image](https://github.com/user-attachments/assets/82eeb405-a67c-4114-b964-a2fa90d13909)
