### PR TITLE
Hardware detection scanner

### DIFF
--- a/modules/disko/disko-basic-partition-v1.nix
+++ b/modules/disko/disko-basic-partition-v1.nix
@@ -60,7 +60,7 @@
     };
   };
   disko = {
-    memSize = 2048;
+    memSize = 4096;
     extraPostVM = ''
       ${pkgs.zstd}/bin/zstd --compress $out/*raw
       rm $out/*raw

--- a/modules/hardware/common/qemu.nix
+++ b/modules/hardware/common/qemu.nix
@@ -31,10 +31,10 @@ in {
           "-device"
           "acad"
         ]
-        ++ optionals (hasAttr "fprint-reader" config.ghaf.hardware.usb.internal.qemuExtraArgs)
-        config.ghaf.hardware.usb.internal.qemuExtraArgs.fprint-reader
         ++ optionals (hasAttr "yubikey" config.ghaf.hardware.usb.external.qemuExtraArgs)
-        config.ghaf.hardware.usb.external.qemuExtraArgs.yubikey;
+        config.ghaf.hardware.usb.external.qemuExtraArgs.yubikey
+        ++ optionals (hasAttr "fpr0" config.ghaf.hardware.usb.internal.qemuExtraArgs)
+        config.ghaf.hardware.usb.internal.qemuExtraArgs.fpr0;
     };
   };
 }

--- a/modules/hardware/definitions/dell-latitude/dell-latitude-7230.nix
+++ b/modules/hardware/definitions/dell-latitude/dell-latitude-7230.nix
@@ -1,0 +1,155 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  # System name
+  name = "Dell Latitude 7230 Rugged";
+
+  # List of system SKUs covered by this configuration
+  skus = [
+    "0BB7 Latitude 7230 Rugged Extreme Tablet"
+  ];
+
+  # Host configuration
+  host = {
+    kernelConfig.kernelParams = [
+      "intel_iommu=on,sm_on"
+      "iommu=pt"
+      "acpi_backlight=vendor"
+      "acpi_osi=linux"
+      "module_blacklist=i915,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl"
+    ];
+  };
+
+  # Input devices
+  input = {
+    keyboard = {
+      name = ["AT Translated Set 2 keyboard"];
+      evdev = ["/dev/keyboard0"];
+    };
+
+    mouse = {
+      name = ["PS/2 Generic Mouse" "SYNAPTICS Synaptics HIDUSB TouchPad V1.05 Mouse"];
+      evdev = ["/dev/mouse0" "/dev/mouse1"];
+    };
+
+    touchpad = {
+      name = ["SYNAPTICS Synaptics HIDUSB TouchPad V1.05 Touchpad" "EETI8082:00 0EEF:C004" "EETI8082:00 0EEF:C004 Stylus"];
+      evdev = ["/dev/touchpad0" "/dev/touchpad1" "/dev/touchpad2"];
+    };
+
+    misc = {
+      name = [
+        # "Intel HID events" "Dell WMI hotkeys" "Video Bus" "HDA Intel PCH Headphone Mic" "HDA Intel PCH HDMI/DP,pcm=3" "HDA Intel PCH HDMI/DP,pcm=7" "HDA Intel PCH HDMI/DP,pcm=8" "HDA Intel PCH HDMI/DP,pcm=9" "Intel HID 5 button array" "Lid Switch" "Power Button" "Sleep Button"
+      ];
+      evdev = [
+        # /dev/input/by-path/platform-INTC1070:00-event /dev/input/by-path/platform-PNP0C14:02-event
+      ];
+    };
+  };
+
+  # Main disk device
+  disks = {
+    disk1.device = "/dev/nvme0n1";
+  };
+
+  # Network devices for passthrough to netvm
+  network = {
+    pciDevices = [
+      {
+        # Network controller: Intel Corporation Alder Lake-P PCH CNVi WiFi (rev 01)
+        name = "wlp0s5f0";
+        path = "0000:00:14.3";
+        vendorId = "8086";
+        productId = "51f0";
+        # Detected kernel driver: iwlwifi
+        # Detected kernel modules: iwlwifi
+      }
+    ];
+    kernelConfig = {
+      stage1.kernelModules = [];
+      stage2.kernelModules = ["iwlwifi"];
+      kernelParams = [];
+    };
+  };
+
+  # GPU devices for passthrough to guivm
+  gpu = {
+    pciDevices = [
+      {
+        # VGA compatible controller: Intel Corporation Alder Lake-UP4 GT2 [Iris Xe Graphics] (rev 0c)
+        name = "gpu0";
+        path = "0000:00:02.0";
+        vendorId = "8086";
+        productId = "46aa";
+        # Detected kernel driver: i915
+        # Detected kernel modules: i915
+      }
+    ];
+    kernelConfig = {
+      stage1.kernelModules = ["i915"];
+      stage2.kernelModules = [];
+      kernelParams = ["earlykms"];
+    };
+  };
+
+  # Audio device for passthrough to audiovm
+  audio = {
+    pciDevices = [
+      {
+        # ISA bridge: Intel Corporation Alder Lake LPC Controller (rev 01)
+        name = "snd0-0";
+        path = "0000:00:1f.0";
+        vendorId = "8086";
+        productId = "5187";
+        # Detected kernel driver:
+        # Detected kernel modules:
+      }
+      {
+        # Serial bus controller: Intel Corporation Alder Lake-P PCH SPI Controller (rev 01)
+        name = "snd0-1";
+        path = "0000:00:1f.5";
+        vendorId = "8086";
+        productId = "51a4";
+        # Detected kernel driver: intel-spi
+        # Detected kernel modules: spi_intel_pci
+      }
+      {
+        # Audio device: Intel Corporation Alder Lake Smart Sound Technology Audio Controller (rev 01)
+        name = "snd0-2";
+        path = "0000:00:1f.3";
+        vendorId = "8086";
+        productId = "51cc";
+        # Detected kernel driver: snd_hda_intel
+        # Detected kernel modules: snd_hda_intel,snd_sof_pci_intel_tgl
+      }
+      {
+        # SMBus: Intel Corporation Alder Lake PCH-P SMBus Host Controller (rev 01)
+        name = "snd0-3";
+        path = "0000:00:1f.4";
+        vendorId = "8086";
+        productId = "51a3";
+        # Detected kernel driver: i801_smbus
+        # Detected kernel modules: i2c_i801
+      }
+    ];
+    kernelConfig = {
+      stage1.kernelModules = [];
+      stage2.kernelModules = ["i2c_i801" "snd_hda_intel" "snd_sof_pci_intel_tgl" "spi_intel_pci"];
+      kernelParams = [];
+    };
+  };
+
+  # USB devices for passthrough
+  usb = {
+    internal = [
+      {
+        name = "gps0";
+        hostbus = "3";
+        hostport = "7";
+      }
+    ];
+    external = [
+      # Add external USB devices here
+    ];
+  };
+}

--- a/modules/hardware/definitions/dell-latitude/dell-latitude-7330.nix
+++ b/modules/hardware/definitions/dell-latitude/dell-latitude-7330.nix
@@ -1,0 +1,197 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  # System name
+  name = "Dell Inc. Not Specified";
+
+  # List of system SKUs covered by this configuration
+  skus = [
+    "0A9E Latitude 7330 Rugged Extreme"
+  ];
+
+  # Host configuration
+  host = {
+    kernelConfig.kernelParams = [
+      "intel_iommu=on,sm_on"
+      "iommu=pt"
+      "acpi_backlight=vendor"
+      "acpi_osi=linux"
+      #"module_blacklist=e1000e,i2c_i801,i915,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,spi_intel_pci"
+    ];
+  };
+
+  # Input devices
+  input = {
+    keyboard = {
+      name = [
+        "AT Translated Set 2 keyboard"
+        "DELL0A9E:00 214A:0028 Keyboard"
+      ];
+      evdev = [
+        "/dev/keyboard0"
+        "/dev/keyboard1"
+      ];
+    };
+
+    mouse = {
+      name = [
+        "DELL0A9E:00 214A:0028 Mouse"
+        "PS/2 Generic Mouse"
+      ];
+      evdev = [
+        "/dev/mouse0"
+        "/dev/mouse1"
+      ];
+    };
+
+    touchpad = {
+      name = [
+        "CUST0000:00 0EEF:C003"
+      ];
+      evdev = [
+        "/dev/touchpad0"
+      ];
+    };
+
+    misc = {
+      name = [
+        # "Lid Switch" "Video Bus" "HDA Intel PCH Headphone Mic" "HDA Intel PCH HDMI/DP,pcm=3" "HDA Intel PCH HDMI/DP,pcm=7" "HDA Intel PCH HDMI/DP,pcm=8" "HDA Intel PCH HDMI/DP,pcm=9" "Power Button" "Sleep Button" "Intel HID events" "Intel HID 5 button array" "Dell WMI hotkeys"
+      ];
+      evdev = [
+        # /dev/input/by-path/platform-INTC1051:00-event /dev/input/by-path/platform-PNP0C14:02-event
+      ];
+    };
+  };
+
+  # Main disk device
+  disks = {
+    disk1.device = "/dev/nvme0n1";
+  };
+
+  # Network devices for passthrough to netvm
+  network = {
+    #TODO Add the Ethernet device
+    pciDevices = [
+      {
+        # Network controller: Intel Corporation Wi-Fi 6E(802.11ax) AX210/AX1675* 2x2 [Typhoon Peak] (rev 1a)
+        name = "wlp0s5f0";
+        path = "0000:72:00.0";
+        vendorId = "8086";
+        productId = "2725";
+        # Detected kernel driver: iwlwifi
+        # Detected kernel modules: iwlwifi
+      }
+    ];
+    kernelConfig = {
+      # Kernel modules are indicative only, please investigate with lsmod/modinfo
+      stage1.kernelModules = [];
+      stage2.kernelModules = [
+        "iwlwifi"
+      ];
+      kernelParams = [];
+    };
+  };
+
+  # GPU devices for passthrough to guivm
+  gpu = {
+    pciDevices = [
+      {
+        # VGA compatible controller: Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] (rev 01)
+        name = "gpu0";
+        path = "0000:00:02.0";
+        vendorId = "8086";
+        productId = "9a49";
+        # Detected kernel driver: i915
+        # Detected kernel modules: i915
+      }
+    ];
+    kernelConfig = {
+      # Kernel modules are indicative only, please investigate with lsmod/modinfo
+      stage1.kernelModules = [
+        "i915"
+      ];
+      stage2.kernelModules = [];
+      kernelParams = [
+        "earlykms"
+      ];
+    };
+  };
+
+  # Audio device for passthrough to audiovm
+  audio = {
+    #TODO: Fix splitting the Ethernet from the Audio iommu
+    pciDevices = [
+      {
+        # ISA bridge: Intel Corporation Tiger Lake-LP LPC Controller (rev 20)
+        name = "snd0-0";
+        path = "0000:00:1f.0";
+        vendorId = "8086";
+        productId = "a082";
+        # Detected kernel driver:
+        # Detected kernel modules:
+      }
+      {
+        # Serial bus controller: Intel Corporation Tiger Lake-LP SPI Controller (rev 20)
+        name = "snd0-1";
+        path = "0000:00:1f.5";
+        vendorId = "8086";
+        productId = "a0a4";
+        # Detected kernel driver: intel-spi
+        # Detected kernel modules: spi_intel_pci
+      }
+      {
+        # Audio device: Intel Corporation Tiger Lake-LP Smart Sound Technology Audio Controller (rev 20)
+        name = "snd0-2";
+        path = "0000:00:1f.3";
+        vendorId = "8086";
+        productId = "a0c8";
+        # Detected kernel driver: snd_hda_intel
+        # Detected kernel modules: snd_hda_intel,snd_sof_pci_intel_tgl
+      }
+      {
+        # Ethernet controller: Intel Corporation Ethernet Connection (13) I219-LM (rev 20)
+        name = "snd0-3";
+        path = "0000:00:1f.6";
+        vendorId = "8086";
+        productId = "15fb";
+        # Detected kernel driver: e1000e
+        # Detected kernel modules: e1000e
+      }
+      {
+        # SMBus: Intel Corporation Tiger Lake-LP SMBus Controller (rev 20)
+        name = "snd0-4";
+        path = "0000:00:1f.4";
+        vendorId = "8086";
+        productId = "a0a3";
+        # Detected kernel driver: i801_smbus
+        # Detected kernel modules: i2c_i801
+      }
+    ];
+    kernelConfig = {
+      # Kernel modules are indicative only, please investigate with lsmod/modinfo
+      stage1.kernelModules = [];
+      stage2.kernelModules = [
+        "e1000e"
+        "i2c_i801"
+        "snd_hda_intel"
+        "snd_sof_pci_intel_tgl"
+        "spi_intel_pci"
+      ];
+      kernelParams = [];
+    };
+  };
+
+  # USB devices for passthrough
+  usb = {
+    internal = [
+      {
+        name = "cam0";
+        hostbus = "3";
+        hostport = "6";
+      }
+    ];
+    external = [
+      # Add external USB devices here
+    ];
+  };
+}

--- a/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 {
+  # System name
   name = "Lenovo X1 Carbon Gen 10";
+
+  # List of system SKUs covered by this configuration
+  skus = [
+    # TODO Add SKUs
+  ];
 
   host = {
     kernelConfig.kernelParams = [
@@ -22,31 +28,35 @@
 
     mouse = {
       name = [
-        "ELAN067B:00 04F3:31F8 Mouse"
-        "SYNA8016:00 06CB:CEB3 Mouse"
+        [
+          "ELAN067B:00 04F3:31F8 Mouse"
+          "SYNA8016:00 06CB:CEB3 Mouse"
+        ]
+        "TPPS/2 Elan TrackPoint"
       ];
       evdev = [
-        "/dev/mouse"
+        "/dev/mouse0"
+        "/dev/mouse1"
       ];
     };
 
     touchpad = {
       name = [
-        "ELAN067B:00 04F3:31F8 Touchpad"
-        "SYNA8016:00 06CB:CEB3 Touchpad"
+        [
+          "ELAN067B:00 04F3:31F8 Touchpad"
+          "SYNA8016:00 06CB:CEB3 Touchpad"
+        ]
       ];
       evdev = [
-        "/dev/touchpad"
+        "/dev/touchpad0"
       ];
     };
 
     misc = {
       name = [
         "ThinkPad Extra Buttons"
-        "TPPS/2 Elan TrackPoint"
       ];
       evdev = [
-        "/dev/input/by-path/platform-i8042-serio-1-event-mouse"
         "/dev/input/by-path/platform-thinkpad_acpi-event"
       ];
     };
@@ -120,19 +130,19 @@
   usb = {
     internal = [
       {
-        name = "webcam";
+        name = "cam0";
         hostbus = "3";
         hostport = "8";
       }
       {
-        name = "fprint-reader";
+        name = "fpr0";
         hostbus = "3";
         hostport = "6";
       }
     ];
     external = [
       {
-        name = "gps-device";
+        name = "gps0";
         vendorId = "067b";
         productId = "23a3";
       }

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -2,7 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 {
+  # System name
   name = "Lenovo X1 Carbon Gen 11";
+
+  # List of system SKUs covered by this configuration
+  skus = [
+    "LENOVO_MT_21HM_BU_Think_FM_ThinkPad X1 Carbon Gen 11 21HM006EGR"
+    # TODO Add more SKUs
+  ];
 
   host = {
     kernelConfig.kernelParams = [
@@ -22,33 +29,37 @@
 
     mouse = {
       name = [
-        "ELAN067C:00 04F3:31F9 Mouse"
-        "SYNA8016:00 06CB:CEB3 Mouse"
-        "ELAN067B:00 04F3:31F8 Mouse"
+        [
+          "ELAN067C:00 04F3:31F9 Mouse"
+          "SYNA8016:00 06CB:CEB3 Mouse"
+          "ELAN067B:00 04F3:31F8 Mouse"
+        ]
+        "TPPS/2 Elan TrackPoint"
       ];
       evdev = [
-        "/dev/mouse"
+        "/dev/mouse0"
+        "/dev/mouse1"
       ];
     };
 
     touchpad = {
       name = [
-        "ELAN067C:00 04F3:31F9 Touchpad"
-        "SYNA8016:00 06CB:CEB3 Touchpad"
-        "ELAN067B:00 04F3:31F8 Touchpad"
+        [
+          "ELAN067C:00 04F3:31F9 Touchpad"
+          "SYNA8016:00 06CB:CEB3 Touchpad"
+          "ELAN067B:00 04F3:31F8 Touchpad"
+        ]
       ];
       evdev = [
-        "/dev/touchpad"
+        "/dev/touchpad0"
       ];
     };
 
     misc = {
       name = [
         "ThinkPad Extra Buttons"
-        "TPPS/2 Elan TrackPoint"
       ];
       evdev = [
-        "/dev/input/by-path/platform-i8042-serio-1-event-mouse"
         "/dev/input/by-path/platform-thinkpad_acpi-event"
       ];
     };
@@ -122,19 +133,19 @@
   usb = {
     internal = [
       {
-        name = "webcam";
+        name = "cam0";
         hostbus = "3";
         hostport = "8";
       }
       {
-        name = "fprint-reader";
+        name = "fpr0";
         hostbus = "3";
         hostport = "6";
       }
     ];
     external = [
       {
-        name = "gps-device";
+        name = "gps0";
         vendorId = "067b";
         productId = "23a3";
       }

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -3,8 +3,8 @@
 #
 {
   pkgs,
-  lib,
   config,
+  lib,
   ...
 }: let
   #TODO: Move this to a common place
@@ -62,7 +62,9 @@ in {
       time.timeZone = config.time.timeZone;
 
       microvm = {
-        qemu.extraArgs = lib.optionals config.ghaf.hardware.usb.internal.enable config.ghaf.hardware.usb.internal.qemuExtraArgs.webcam;
+        qemu.extraArgs = lib.optionals (config.ghaf.hardware.usb.internal.enable
+          && (lib.hasAttr "cam0" config.ghaf.hardware.usb.internal.qemuExtraArgs))
+        config.ghaf.hardware.usb.internal.qemuExtraArgs.cam0;
         devices = [];
       };
 

--- a/modules/reference/appvms/chromium.nix
+++ b/modules/reference/appvms/chromium.nix
@@ -7,6 +7,7 @@
   config,
   ...
 }: let
+  inherit (lib) hasAttr optionals;
   xdgPdfPort = 1200;
 in {
   name = "chromium";
@@ -57,7 +58,9 @@ in {
 
       time.timeZone = config.time.timeZone;
 
-      microvm.qemu.extraArgs = lib.optionals config.ghaf.hardware.usb.internal.enable config.ghaf.hardware.usb.internal.qemuExtraArgs.webcam;
+      microvm.qemu.extraArgs = optionals (config.ghaf.hardware.usb.internal.enable
+        && (hasAttr "cam0" config.ghaf.hardware.usb.internal.qemuExtraArgs))
+      config.ghaf.hardware.usb.internal.qemuExtraArgs.cam0;
       microvm.devices = [];
 
       ghaf.reference.programs.chromium.enable = true;

--- a/modules/reference/appvms/element.nix
+++ b/modules/reference/appvms/element.nix
@@ -7,7 +7,7 @@
   config,
   ...
 }: let
-  inherit (lib) hasAttr;
+  inherit (lib) hasAttr optionals;
   dendrite-pinecone = pkgs.callPackage ../../../packages/dendrite-pinecone {};
   isDendritePineconeEnabled =
     if (hasAttr "services" config.ghaf.reference)
@@ -91,7 +91,9 @@ in {
         extraArgs = ["-n"]; # Do not wait for a client to connect before polling
       };
 
-      microvm.qemu.extraArgs = lib.optionals config.ghaf.hardware.usb.external.enable config.ghaf.hardware.usb.external.qemuExtraArgs.gps-device;
+      microvm.qemu.extraArgs = optionals (config.ghaf.hardware.usb.external.enable
+        && (hasAttr "gps0" config.ghaf.hardware.usb.external.qemuExtraArgs))
+      config.ghaf.hardware.usb.external.qemuExtraArgs.gps0;
     }
   ];
   borderColor = "#337aff";

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -21,4 +21,5 @@
   waybar = import ./waybar {inherit prev;};
   mitmweb-ui = final.callPackage ../../packages/mitmweb-ui {};
   gtklock = import ./gtklock {inherit prev;};
+  hardware-scan = final.callPackage ../../packages/hardware-scan {};
 })

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -16,6 +16,7 @@
       kernel-hardening-checker = callPackage ./kernel-hardening-checker {};
       windows-launcher = callPackage ./windows-launcher {enableSpice = false;};
       windows-launcher-spice = callPackage ./windows-launcher {enableSpice = true;};
+      hardware-scan = callPackage ./hardware-scan {};
       doc = callPackage ../docs {
         revision = lib.strings.fileContents ../.version;
         # options = ;

--- a/packages/hardware-scan/default.nix
+++ b/packages/hardware-scan/default.nix
@@ -1,0 +1,30 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This is a temporary solution for hardware detection.
+#
+{
+  writeShellApplication,
+  util-linux,
+  pciutils,
+  usbutils,
+  dmidecode,
+  alejandra,
+}:
+writeShellApplication {
+  name = "hardware-scan";
+  runtimeInputs = [
+    util-linux
+    pciutils
+    usbutils
+    dmidecode
+    alejandra
+  ];
+  text = builtins.readFile ./hardware-scan.sh;
+  meta = {
+    description = "Helper script for hardware discovery and configuration file generation";
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
+}

--- a/packages/hardware-scan/hardware-scan.sh
+++ b/packages/hardware-scan/hardware-scan.sh
@@ -1,0 +1,631 @@
+#! /usr/bin/env bash
+# shellcheck shell=bash
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Notes:
+#     1. This script needs to run on a nix-enabled system, with either internet access or packages installed
+#     2. The script uses lspci and dmidecode to detect system information and hardware devices, using simple key words
+#     3. The host this script runs on needs to be able to detect all hardware, e.g., no passthrough should be enabled
+#     4. Do not attach external devices when running this script
+#     5. The script generates commented-out sections for some input devices, which need to be manually selected as many of them need to stay in the host
+#     6. Do NOT rely fully on the output of this script; especially for kernel modules and parameters!
+#     7. Use the hardware dump generated with the '-e' option to inspect the hardware and manually adjust the configuration file
+#     8. If you copied this script, include the following:
+#         #! /usr/bin/env nix-shell
+#         #! nix-shell -i bash -p pciutils dmidecode usbutils alejandra
+
+usage() {
+cat <<EOF
+A simple shell script (bash) to detect hardware parameters and write the results to a nix configuration file.
+This file can be used to build a Ghaf-based platform.
+
+Usage: hardware-scan [OPTIONS]
+
+Options:
+  -s | --sys           Detect system name, sku, and auto-generate a configuration file name
+  -p | --pci           Detect PCI devices with a search pattern (grep -i)
+  -n | --net           Detect network devices for passthrough usage with auto-search
+  -g | --gpu           Detect GPU devices for passthrough usage with auto-search
+  -a | --audio         Detect sound devices for passthrough usage with auto-search
+  -u | --usb           Detect USB devices for passthrough usage
+  -d | --disk          Detect disks to use
+  -i | --input         Detect input devices for passthrough usage
+  -e | --ext           Dump hardware info for later review (lspci, lsusb, dmidecode, etc.) into hwinfo/. Overwrites existing files.
+  -h | --help          This help message
+
+By default, the script runs [ -s -n -g -a -i -u -d -e ] and writes the configuration file.
+Running the script with options, you can pipe the output into a desired file (e.g., hardware-scan -p > pci_info.txt).
+EOF
+}
+
+set +xo pipefail
+
+# Global Variables
+CONFIG_FILE="" # name is auto-generated from system information (-y, -a)
+system_name=""
+system_sku=""
+declare -A pci_devices=()
+declare -A kernel_modules=()
+keyboard_attr_names=()
+mouse_attr_names=()
+touchpad_attr_names=()
+misc_devlinks=()
+misc_attr_names=()
+usb_devices=()
+disk=""
+host_blacklist=""
+
+# Default device groups
+NET_ID_1="wlp0s5f"
+NET_ID_2="eth"
+GPU_ID="gpu"
+SND_ID="snd"
+
+# Default entries
+pci_devices[$NET_ID_1]=""
+pci_devices[$NET_ID_2]=""
+pci_devices[$GPU_ID]=""
+pci_devices[$SND_ID]=""
+kernel_modules[$NET_ID_1]=""
+kernel_modules[$NET_ID_2]=""
+kernel_modules[$GPU_ID]=""
+kernel_modules[$SND_ID]=""
+
+# Detecting system information via dmidecode
+detect_system_info() {
+    system_manufacturer=$(sudo dmidecode -s system-manufacturer)
+    system_version=$(sudo dmidecode -s system-version)
+    system_product_name=$(sudo dmidecode -s system-product-name)
+    system_sku_number=$(sudo dmidecode -s system-sku-number)
+    system_name="$system_manufacturer $system_version"
+    system_sku="$system_sku_number $system_product_name"
+    CONFIG_FILE="$system_name.nix"
+    CONFIG_FILE=${CONFIG_FILE// /-}
+    CONFIG_FILE=${CONFIG_FILE,,}
+    if $verbose; then
+        echo "System: $system_name"
+        echo "SKU: $system_sku"
+    fi
+}
+
+### PCI DEVICE DETECTION ###
+
+add_pci_device () {
+
+    # Parse input params
+    local pci_device="$1"
+    local device_group_name="$2"
+    local group_num="$3"
+    local devices=()
+    local drivers=""
+    local modules=""
+
+    # Find all devices in the IOMMU group
+    pci_address=$(echo "$pci_device" | awk '{print $1}')
+    iommu_group=$(lspci -vns "$pci_address" | grep "IOMMU group" | awk -F "IOMMU group " '{print $2}')
+    iommu_path="/sys/kernel/iommu_groups/$iommu_group"
+    readarray -t iommu_devices <<< "$(find "$iommu_path" -type l | awk -F "$iommu_path/devices/" '{print $2}')"
+
+    # Add entries for each device in the IOMMU group
+    for i in "${!iommu_devices[@]}"; do
+
+        # Fetch info
+        address=${iommu_devices[$i]}
+        name=$(lspci -s "$address" | cut -d " " -f 2-)
+        vendor_id=$(lspci -mmns "$address" | awk '{print $3}')
+        product_id=$(lspci -mmns "$address" | awk '{print $4}')
+        drv=$(lspci -nnks "$address" | grep "Kernel driver in use:" | awk -F ": " '{print $2}' | tr -d '[:space:]')
+        mods=$(lspci -nnks "$address" | grep "Kernel modules:" | awk -F ": " '{print $2}' | tr -d '[:space:]')
+
+        # Check if device is already passed through
+        if echo "${pci_devices[*]}" | grep -q "$address"; then
+            echo -e "\n# Error: Cannot add $pci_address to $device_group_name$group_num: already passed through."
+            echo "# Device $pci_address and $address are in the same IOMMU group $iommu_group:"
+            for j in "${!iommu_devices[@]}"; do echo -n "# "; lspci -s "${iommu_devices[$j]}"; done
+            echo -e "# Skipping passthrough of device $pci_address\n"
+            return 0
+        fi
+
+        # Create device name and entry
+        local n=""; if [ "${#iommu_devices[@]}" -gt 1 ]; then n="-$i"; fi
+        device_name="$device_group_name$group_num$n"
+        devices+=("$(cat << EOF
+{
+    # $name
+    name = "$device_name";
+    path = "$address";
+    vendorId = $vendor_id;
+    productId = $product_id;
+    # Detected kernel driver: $drv
+    # Detected kernel modules: $mods
+}
+EOF
+)")
+        drivers="$drivers,$drv"
+        modules="$modules,$mods"
+    done
+
+    if $verbose; then
+        echo -e "Device entry: \n${devices[*]}"
+    fi
+
+    modules=${modules#','}
+    modules=$(echo "$modules" | tr ',' '\n' | sort -u | tr '\n' ',')
+    modules=${modules%','}
+
+    local modules_to_load=()
+    IFS=','
+    for elem in $modules; do
+        if [ -n "$elem" ]; then modules_to_load+=("\"$elem\""); fi
+    done
+    IFS=
+
+    # Add detected devices and kernel modules to global arrays
+    pci_devices["$device_group_name"]="${devices[*]}"
+    kernel_modules["$device_group_name"]="${modules_to_load[*]}"
+
+    # Add kernel modules to host blacklist
+    if [ "${modules}" != "" ]; then
+        host_blacklist="$host_blacklist,$modules"
+    fi
+    host_blacklist=$(echo "$host_blacklist" | tr ',' '\n' | sort -u | tr '\n' ',')
+    host_blacklist=${host_blacklist%','}
+    host_blacklist=${host_blacklist#','}
+}
+
+detect_pci_devices() {
+
+    # Check if IOMMU is enabled
+    if [ -z "$(ls -A /sys/kernel/iommu_groups)" ]; then
+        echo "# It seems that the IOMMU groups are not setup (ls /sys/kernel/iommu_groups). Please enable virtualization in the BIOS, and/or pass the respective kernel parameters."
+    fi
+
+    # Parse params
+    if [ "$#" -eq 0 ]; then
+        read -r -p "Enter search pattern for PCI devices: " search_pattern
+        read -r -p "Enter group id PCI devices: " group_id
+        group_id=${group_id:-"pci"}
+    else
+        local search_pattern="$1"
+        local group_id="$2"
+    fi
+
+    # Search for PCI devices
+    readarray -t pci_devs <<< "$(lspci -nn | grep -i "$search_pattern")"
+
+    # Select PCI devices
+    if [ ${#pci_devs[@]} -ge 1 ] && [ -n "${pci_devs[0]}" ]; then
+        local n=0
+        for i in "${!pci_devs[@]}"; do
+            read -r -p "Select '${pci_devs[$i]}' for passthrough? [Y/n] " answer
+            answer=${answer:-Y}
+            case $answer in
+                [Yy]* ) add_pci_device "${pci_devs[$i]}" "$group_id" "$n"; n=$((n+1)); continue;;
+                [Nn]* ) continue;;
+                * ) echo "Please answer yY or nN.";;
+            esac
+        done
+    else
+        echo "No device found searching for '$search_pattern'."
+        return
+    fi
+}
+
+### INPUT DEVICE DETECTION ###
+
+# Search for input devices using /dev/input/event*
+detect_input_devices() {
+
+    local input_events=()
+    local keyboard_devices=()
+    local mouse_devices=()
+    local touchpad_devices=()
+
+    while IFS= read -r line; do
+        input_events+=("$line")
+    done <<< "$(ls /dev/input/event*)"
+
+    # Use udevadm to iterate through input_events and determine devices
+    for event in "${input_events[@]}"; do
+        device_info=$(udevadm info --query=all --name="$event")
+        if [[ $device_info =~ ID_INPUT_KEYBOARD=1 ]]; then
+            keyboard_devices+=("$event")
+        elif [[ $device_info =~ ID_INPUT_KEY=1 ]] || [[ $device_info =~ ID_INPUT_SWITCH=1 ]]; then
+            misc_devices+=("$event")
+        fi
+        if [[ $device_info =~ ID_INPUT_MOUSE=1 ]] && ! [[ $device_info =~ ID_INPUT_TOUCHPAD=1 ]]; then
+            mouse_devices+=("$event")
+        elif [[ $device_info =~ ID_INPUT_TOUCHPAD=1 ]]; then
+            touchpad_devices+=("$event")
+        fi
+        if [[ $device_info =~ ID_INPUT_TOUCHSCREEN=1 ]] || [[ $device_info =~ ID_INPUT_TABLET=1 ]]; then
+            touchpad_devices+=("$event")
+        fi
+    done
+    # Check if any keyboard device found
+    if [ ${#keyboard_devices[@]} -eq 0 ]; then
+        echo "# No keyboard device found."
+    fi
+    # Check if any mouse device found
+    if [ ${#mouse_devices[@]} -eq 0 ]; then
+        echo "# No mouse device found."
+    fi
+
+    # Use udevadm to query keyboard info
+    tmp_names=()
+    for event in "${keyboard_devices[@]}"; do
+        keyboard_attr_name=$(udevadm info -a "$event" | grep "ATTRS{name}" | head -1 | awk -F "==" '{print $2}' | tr -d '\n')
+        tmp_names+=("$keyboard_attr_name")
+    done
+    # Remove duplicates
+    for elem in "${tmp_names[@]}"; do
+        if [[ ! " ${keyboard_attr_names[*]} " =~ $elem ]]; then
+            keyboard_attr_names+=("$elem")
+        fi
+    done
+
+    # Use udevadm to query mouse info
+    tmp_names=()
+    for event in "${mouse_devices[@]}"; do
+        mouse_attr_name=$(udevadm info -a "$event" | grep "ATTRS{name}" | head -1 | awk -F "==" '{print $2}' | tr -d '\n')
+        tmp_names+=("$mouse_attr_name")
+    done
+
+    # Remove duplicates
+    for elem in "${tmp_names[@]}"; do
+        if [[ ! " ${mouse_attr_names[*]} " =~ $elem ]]; then
+            mouse_attr_names+=("$elem")
+        fi
+    done
+
+    # Use udevadm to query touchpad info
+    tmp_names=()
+    for event in "${touchpad_devices[@]}"; do
+        touchpad_attr_name=$(udevadm info -a "$event" | grep "ATTRS{name}" | head -1 | awk -F "==" '{print $2}' | tr -d '\n')
+        tmp_names+=("$touchpad_attr_name")
+    done
+
+    # Remove duplicates
+    for elem in "${tmp_names[@]}"; do
+        if [[ ! " ${touchpad_attr_names[*]} " =~ $elem ]]; then
+            touchpad_attr_names+=("$elem")
+        fi
+    done
+
+    # Create evdev entries
+    for i in "${!keyboard_attr_names[@]}"; do keyboard_devlinks+=("\"/dev/keyboard$i\""); done
+    for i in "${!mouse_attr_names[@]}"; do mouse_devlinks+=("\"/dev/mouse$i\""); done
+    for i in "${!touchpad_attr_names[@]}"; do touchpad_devlinks+=("\"/dev/touchpad$i\""); done
+
+    # Use udevadm to query misc info (INPUT_KEY, INPUT_SWITCH)
+    tmp_devs=()
+    tmp_names=()
+    for event in "${misc_devices[@]}"; do
+        read -r -a devlinks <<< "$(udevadm info "$event" | grep "DEVLINKS" | awk -F "=" '{print $2}')"
+        misc_attr_name=$(udevadm info -a "$event" | grep "ATTRS{name}" | awk -F "==" '{print $2}' | tr -d '\n')
+        tmp_names+=("$misc_attr_name");
+        for dev in "${devlinks[@]}"; do tmp_devs+=("$dev"); done;
+    done
+
+    # Remove duplicates
+    for elem in "${tmp_names[@]}"; do
+        if [[ ! " ${misc_attr_names[*]} " =~ $elem ]]; then
+            misc_attr_names+=("$elem")
+        fi
+    done
+    for elem in "${tmp_devs[@]}"; do
+        if [[ ! " ${misc_devlinks[*]} " =~ $elem ]]; then
+            misc_devlinks+=("$elem")
+        fi
+    done
+
+    if $verbose; then
+        echo -e "Detected keyboard device names:\n${keyboard_attr_names[*]}\n"
+        echo -e "Detected mouse device names:\n${mouse_attr_names[*]}\n"
+        echo -e "Detected touchpad device names:\n${touchpad_attr_names[*]}\n"
+        echo -e "Miscellaneous device names:\n${misc_attr_names[*]}\n"
+        echo -e "Miscellaneous device links:\n${misc_devlinks[*]}\n"
+    fi
+}
+
+### USB DEVICE DETECTION ###
+
+# Function to create USB device entry
+add_usb() {
+    usb_device="$1"
+    name="$2"
+
+    # Get USB device info
+    bus=$(echo "$usb_device" | awk '{print $2}')
+    dev=$(echo "$usb_device" | awk '{print $4}' | tr -d ':')
+    hostport=$(udevadm info "/dev/bus/usb/$bus/$dev" | grep R: | awk -F "R: " '{print $2}')
+    hostbus=${bus//00/}
+
+    # Write USB device entry
+    usb_entry=$(cat << EOF
+{
+    name="$name";
+    hostbus="$hostbus";
+    hostport="$hostport";
+}
+EOF
+)
+    usb_devices+=("$usb_entry")
+    if $verbose; then
+        echo "USB device: $usb_entry"
+    fi
+}
+# Search for USB devices using lsusb
+detect_usb_devices() {
+    search_pattern="$1"
+    group_id="$2"
+
+    # Detect USB devices
+    usb_devs=()
+    while IFS= read -r line; do
+        usb_devs+=("$line")
+    done <<< "$(lsusb | grep -i "$search_pattern")"
+    if [ ${#usb_devs[@]} -ge 1 ] && [ "${usb_devs[0]}" != "" ]; then
+        local n=0
+        for i in "${!usb_devs[@]}"; do
+            read -r -p "Select '${usb_devs[$i]}'? [Y/n] " answer
+            answer=${answer:-Y}
+            case $answer in
+                [Yy]* ) add_usb "${usb_devs[$i]}" "$group_id$n"; n=$((n+1)); continue;;
+                [Nn]* ) continue;;
+                * ) echo "Please answer yY or nN.";;
+            esac
+        done
+    fi
+}
+
+### DISK DETECTION ###
+
+# Detect disks
+detect_disks() {
+    echo ""
+    lsblk -o NAME,TYPE,SIZE,MODEL -d
+    read -r -p "Enter the disk device name (default: nvme0n1): " disk_name
+    disk_name=${disk_name:-nvme0n1}
+    disk="/dev/$disk_name"
+    if $verbose; then
+      echo "disks.disk1.device = { $disk }"
+    fi
+}
+
+### HW INFO & CONFIG FILE ###
+
+# Generate extended hardware info
+ext_output() {
+    if [ ! -d hwinfo/ ]; then mkdir -p hwinfo/; fi
+    lspci -nn >> hwinfo/lspci.txt
+    lspci_long=$(sudo lspci -nnvvv)
+    echo "$lspci_long" >> hwinfo/lspci-long.txt
+    lsusb >> hwinfo/lsusb.txt
+    lsusb_v=$(sudo lsusb -v)
+    echo "$lsusb_v" >> hwinfo/lsusb-v.txt
+    lsusb -t >> hwinfo/lsusb-t.txt
+    dmi_info=$(sudo dmidecode)
+    echo "$dmi_info" >> hwinfo/dmidecode.txt
+    lsblk -o NAME,TYPE,SIZE,MODEL -d > hwinfo/lsblk.txt
+    udev_db=$(udevadm info --export-db)
+    echo "$udev_db" >> hwinfo/udevadm.txt
+    dmesg > hwinfo/dmesg.txt
+    if [ -f "$CONFIG_FILE" ]; then
+        cp "$CONFIG_FILE" hwinfo/
+    fi
+    tar -czf hwinfo.tar.gz hwinfo/
+    echo "> Extended output files written to hwinfo/ directory."
+}
+
+# Write the hardware configuration file
+write_file() {
+    echo "> Writing hardware configuration file..."
+    cat << EOF > "$CONFIG_FILE"
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+# System name
+name = "$system_name";
+
+# List of system SKUs covered by this configuration
+skus = [
+    "$system_sku"
+];
+
+# Host configuration
+host = {
+    kernelConfig.kernelParams = [
+        "intel_iommu=on,sm_on"
+        "iommu=pt"
+        "acpi_backlight=vendor"
+        "acpi_osi=linux"
+        #"module_blacklist=$host_blacklist"
+    ];
+};
+
+# Input devices
+input = {
+    keyboard = {
+        name = [
+            ${keyboard_attr_names[@]}
+        ];
+        evdev = [
+            ${keyboard_devlinks[@]}
+        ];
+    };
+
+    mouse = {
+        name = [
+            ${mouse_attr_names[@]}
+        ];
+        evdev = [
+            ${mouse_devlinks[@]}
+        ];
+    };
+
+    touchpad = {
+        name = [
+            ${touchpad_attr_names[@]}
+        ];
+        evdev = [
+            ${touchpad_devlinks[@]}
+        ];
+    };
+
+    misc = {
+        name = [
+            # ${misc_attr_names[@]}
+        ];
+        evdev = [
+            # ${misc_devlinks[@]}
+        ];
+    };
+};
+
+# Main disk device
+disks = {
+    disk1.device = "$disk";
+};
+
+# Network devices for passthrough to netvm
+network = {
+    pciDevices = [
+        ${pci_devices[$NET_ID_1]}
+        ${pci_devices[$NET_ID_2]}
+    ];
+    kernelConfig = {
+        # Kernel modules are indicative only, please investigate with lsmod/modinfo
+        stage1.kernelModules = [];
+        stage2.kernelModules = [
+            ${kernel_modules[$NET_ID_1]}
+            ${kernel_modules[$NET_ID_2]}
+        ];
+        kernelParams = [];
+    };
+};
+
+# GPU devices for passthrough to guivm
+gpu = {
+    pciDevices = [${pci_devices[$GPU_ID]}];
+    kernelConfig = {
+        # Kernel modules are indicative only, please investigate with lsmod/modinfo
+        stage1.kernelModules = [
+            ${kernel_modules[$GPU_ID]}
+        ];
+        stage2.kernelModules = [];
+        kernelParams = [
+            "earlykms"
+        ];
+    };
+};
+
+# Audio device for passthrough to audiovm
+audio = {
+    pciDevices = [
+        ${pci_devices["$SND_ID"]}
+    ];
+    kernelConfig = {
+        # Kernel modules are indicative only, please investigate with lsmod/modinfo
+        stage1.kernelModules = [];
+        stage2.kernelModules = [
+            ${kernel_modules[$SND_ID]}
+        ];
+        kernelParams = [];
+    };
+};
+
+# USB devices for passthrough
+usb = {
+    internal = [${usb_devices[@]}];
+    external = [
+        # Add external USB devices here
+    ];
+};
+}
+EOF
+
+    # Format the output file
+    alejandra --quiet "$CONFIG_FILE"
+    echo "> File written: $CONFIG_FILE"
+}
+
+### MAIN ###
+echo "> Running hardware detection tool..."
+
+# Default options
+verbose=true
+if [ $# -eq 0 ]; then
+    set -- "-s" "-n" "-g" "-a" "-i" "-u" "-d"
+    verbose=false
+fi
+
+# Run commands
+for cmd in "$@"; do
+	case $cmd in
+    -s | --sys)
+        echo "> Scanning system information..."
+        detect_system_info
+        continue
+        ;;
+    -n | --network)
+        echo "> Scanning network PCI devices..."
+        detect_pci_devices "network" $NET_ID_1
+        detect_pci_devices "ethernet" $NET_ID_2
+        continue
+        ;;
+    -g | --gpu)
+        echo "> Scanning GPU PCI devices..."
+        detect_pci_devices "vga" $GPU_ID
+        continue
+        ;;
+    -a | --audio)
+        echo "> Scanning audio PCI devices..."
+        detect_pci_devices "audio" $SND_ID
+        continue
+        ;;
+    -p | --pci)
+        echo "> Scanning PCI devices..."
+        detect_pci_devices
+        continue
+        ;;
+    -i | --input)
+        echo "> Scanning input devices..."
+        detect_input_devices
+        continue
+        ;;
+    -u | --usb)
+        echo "> Scanning USB devices..."
+        detect_usb_devices "cam" "cam"
+        detect_usb_devices "fingerprint\|fprint\|biometric" "fpr"
+        detect_usb_devices "gps\|gnss" "gps"
+        continue
+        ;;
+    -d | --disk)
+        echo "> Scanning disk devices..."
+        detect_disks
+        continue
+        ;;
+    -e | --ext)
+        echo "> Searching for more hardware info..."
+        ext_output
+        continue
+        ;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+        usage
+		exit 1
+		;;
+	esac
+done
+
+if ! $verbose; then
+    write_file
+    echo "> Searching for more hardware info..."
+    ext_output
+    exit 0
+fi

--- a/targets/flake-module.nix
+++ b/targets/flake-module.nix
@@ -9,6 +9,7 @@
     ./imx8mp-evk/flake-module.nix
     ./lenovo-x1-installer/flake-module.nix
     ./laptop/flake-module.nix
+    ./laptop-hw-scan/flake-module.nix
     ./microchip-icicle-kit/flake-module.nix
     ./nvidia-jetson-orin/flake-module.nix
     ./vm/flake-module.nix

--- a/targets/laptop-hw-scan/flake-module.nix
+++ b/targets/laptop-hw-scan/flake-module.nix
@@ -1,0 +1,49 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Laptop image to run hardware scan and generate config files
+{
+  lib,
+  self,
+  ...
+}: let
+  name = "laptop-hw-scan";
+  system = "x86_64-linux";
+  hw-scan = let
+    hostConfiguration = lib.nixosSystem {
+      inherit system;
+      modules = [
+        ({modulesPath, ...}: {
+          imports = [
+            "${toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
+          ];
+          users.users.nixos.openssh.authorizedKeys.keys = (import ../../modules/common/development/authorized_ssh_keys.nix).authorizedKeys;
+          systemd.services.wpa_supplicant.wantedBy = lib.mkForce ["multi-user.target"];
+          systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];
+          isoImage.isoBaseName = "ghaf";
+          isoImage.squashfsCompression = "zstd -Xcompression-level 3";
+          environment.systemPackages = [
+            self.packages.x86_64-linux.hardware-scan
+          ];
+          boot.kernelParams = [
+            # TODO AMD support
+            "intel_iommu=on,sm_on"
+            "iommu=pt"
+          ];
+        })
+      ];
+    };
+  in {
+    inherit hostConfiguration;
+    inherit name;
+    package = hostConfiguration.config.system.build.isoImage;
+  };
+  targets = [hw-scan];
+in {
+  flake = {
+    nixosConfigurations =
+      builtins.listToAttrs (map (t: lib.nameValuePair t.name t.hostConfiguration) targets);
+    packages.${system} =
+      builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+  };
+}

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -57,6 +57,15 @@
         };
       }
     ])
+    (laptop-configuration "dell-latitude-7330" "debug" [
+      self.nixosModules.disko-basic-partition-v1
+      {
+        ghaf = {
+          hardware.definition.configFile = "/definitions/dell-latitude/dell-latitude-7330.nix";
+          profiles.mvp-user-trial.enable = true;
+        };
+      }
+    ])
   ];
 in {
   flake = {

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -48,6 +48,15 @@
         };
       }
     ])
+    (laptop-configuration "dell-latitude-7230" "debug" [
+      self.nixosModules.disko-basic-partition-v1
+      {
+        ghaf = {
+          hardware.definition.configFile = "/definitions/dell-latitude/dell-latitude-7230.nix";
+          profiles.mvp-user-trial.enable = true;
+        };
+      }
+    ])
   ];
 in {
   flake = {

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -12,6 +12,7 @@
   laptop-configuration = import ./laptop-configuration-builder.nix {inherit lib self;};
 
   targets = [
+    # Laptop Debug configurations
     (laptop-configuration "lenovo-x1-carbon-gen10" "debug" [
       self.nixosModules.disko-basic-partition-v1
       {
@@ -30,6 +31,26 @@
         };
       }
     ])
+    (laptop-configuration "dell-latitude-7230" "debug" [
+      self.nixosModules.disko-basic-partition-v1
+      {
+        ghaf = {
+          hardware.definition.configFile = "/definitions/dell-latitude/dell-latitude-7230.nix";
+          profiles.mvp-user-trial.enable = true;
+        };
+      }
+    ])
+    (laptop-configuration "dell-latitude-7330" "debug" [
+      self.nixosModules.disko-basic-partition-v1
+      {
+        ghaf = {
+          hardware.definition.configFile = "/definitions/dell-latitude/dell-latitude-7330.nix";
+          profiles.mvp-user-trial.enable = true;
+        };
+      }
+    ])
+
+    # Laptop Release configurations
     (laptop-configuration "lenovo-x1-carbon-gen10" "release" [
       self.nixosModules.disko-basic-partition-v1
       {
@@ -48,7 +69,7 @@
         };
       }
     ])
-    (laptop-configuration "dell-latitude-7230" "debug" [
+    (laptop-configuration "dell-latitude-7230" "release" [
       self.nixosModules.disko-basic-partition-v1
       {
         ghaf = {
@@ -57,7 +78,7 @@
         };
       }
     ])
-    (laptop-configuration "dell-latitude-7330" "debug" [
+    (laptop-configuration "dell-latitude-7330" "release" [
       self.nixosModules.disko-basic-partition-v1
       {
         ghaf = {

--- a/targets/lenovo-x1-installer/flake-module.nix
+++ b/targets/lenovo-x1-installer/flake-module.nix
@@ -40,6 +40,7 @@
 
           environment.systemPackages = [
             installScript
+            self.packages.x86_64-linux.hardware-scan
           ];
 
           services.getty = {

--- a/templates/boilerplate/modules/hardware/default.nix
+++ b/templates/boilerplate/modules/hardware/default.nix
@@ -31,23 +31,27 @@
 
     mouse = {
       name = [
-        "ELAN067C:00 04F3:31F9 Mouse"
-        "SYNA8016:00 06CB:CEB3 Mouse"
-        "ELAN067B:00 04F3:31F8 Mouse"
+        [
+          "ELAN067C:00 04F3:31F9 Mouse"
+          "SYNA8016:00 06CB:CEB3 Mouse"
+          "ELAN067B:00 04F3:31F8 Mouse"
+        ]
       ];
       evdev = [
-        "/dev/mouse"
+        "/dev/mouse0"
       ];
     };
 
     touchpad = {
       name = [
-        "ELAN067C:00 04F3:31F9 Touchpad"
-        "SYNA8016:00 06CB:CEB3 Touchpad"
-        "ELAN067B:00 04F3:31F8 Touchpad"
+        [
+          "ELAN067C:00 04F3:31F9 Touchpad"
+          "SYNA8016:00 06CB:CEB3 Touchpad"
+          "ELAN067B:00 04F3:31F8 Touchpad"
+        ]
       ];
       evdev = [
-        "/dev/touchpad"
+        "/dev/touchpad0"
       ];
     };
 
@@ -131,19 +135,19 @@
   usb = {
     internal = [
       {
-        name = "webcam";
+        name = "cam0";
         hostbus = "3";
         hostport = "8";
       }
       {
-        name = "fprint-reader";
+        name = "fpr0";
         hostbus = "3";
         hostport = "6";
       }
     ];
     external = [
       {
-        name = "gps-device";
+        name = "gps0";
         vendorId = "067b";
         productId = "23a3";
       }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Adding a (temporary) hardware detection script to generate hardware definition files for different laptop hardware.
The script can generate a Ghaf laptop target compatible hardware definition file (details below).
 
Main changes:
- Add `hardware-scan` shell script to generate a hardware definition file
- Add a laptop hardware scan target, minimal image without having to generate an image to flash
- Change the udev rule generation for input devices. This is necessary to allow more input devices and rule auto-generation 
- Add a hardware definition for the Dell Latitude 7230 laptop

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions

### Generate the hardware-scan package
```
nix build .#packages.x86_64-linux.hardware-scan
./result/bin/hardware-scan
```
or run directly with
`nix run github:tiiuae/ghaf/<commit>#hardware-scan`
### Generate and run hardware-scan on a laptop
1. Add your ssh key
2. Build target 
`nix build .#laptop-hw-scan`
3. Flash 
`dd if=/result/iso/ghaf-... of=/dev/sdX bs=32M status=progress; sync`
4. Boot, then type `hardware-scan`
5. The script should ask you if you want to select various devices for passthrough. If selected, the respective entries are generated. Note that there may be errors caused by IOMMU group dependencies.
6. Move the generated files to your development machine (e.g., `scp -r nixos@<your-ip>:~/* local-dir/`)
7. The script should generate a hardware definition profile, as well as a `hwinfo/` folder with dumps from udevadm, lspci, etc.
8. Use the generated `.nix` as basis for your hardware definition

Few words of caution:
- Don't fully rely on the generated output file, walk through all options that are being set 
- Currently, the host kernel module blacklist is commented out by default. Select the suggested modules carefully, and/or try without blacklisting
- Uncomment required `misc` input devices, e.g., for `acpi` 

## Testing
- Test builds of all lenovo-x1-carbon targets 
- Verify that input devices are working as before (although errors should result in not being able see GUI)
- Perhaps run `udevadm verify`

(Optional) Feel free to run the `hardware-scan` on various targets and report any findings
(Optional) Report any SKU identifiers to be added to the x1 definitions

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
