### PR TITLE
x1-installer: add checks in installer script, other improvements

### DIFF
--- a/packages/installer/default.nix
+++ b/packages/installer/default.nix
@@ -1,23 +1,17 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  bash,
-  imagePath,
-  substituteAll,
+  coreutils,
+  hwinfo,
+  writeShellApplication,
+  zstd,
 }:
-substituteAll {
-  dir = "bin";
-  isExecutable = true;
-
-  pname = "ghaf-installer";
-  src = ./ghaf-installer.sh;
-  inherit imagePath;
-
-  buildInputs = [
-    bash
+writeShellApplication {
+  name = "ghaf-installer";
+  runtimeInputs = [
+    coreutils
+    zstd
+    hwinfo
   ];
-
-  postInstall = ''
-    patchShebangs $out/bin/ghaf-installer.sh
-  '';
+  text = builtins.readFile ./ghaf-installer.sh;
 }

--- a/packages/installer/ghaf-installer.sh
+++ b/packages/installer/ghaf-installer.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+
+if [ "$EUID" -ne 0 ]; then
+	echo "Please run as root"
+  exit
+fi
+
+# Make sure $IMG_PATH env is set
+if [ -z "$IMG_PATH" ]; then
+	echo "IMG_PATH is not set!"
+	exit
+fi
+
 clear
+
 cat <<"EOF"
   ,----..     ,---,
  /   /   \  ,--.' |                 .--.,
@@ -22,13 +35,44 @@ echo "Welcome to Ghaf installer!"
 
 echo "To install image choose path to the device on which image will be installed."
 
-lsblk
-read -r -p "Device name [e.g. /dev/nvme0n1]: " DEVICE_NAME
+hwinfo --disk --short
 
-read -r -p 'WARNING: Next command will destroy all previous data from your device, press Enter to proceed. '
+while true; do
+	read -r -p "Device name [e.g. /dev/nvme0n1]: " DEVICE_NAME
+
+	if [ ! -d "/sys/block/$(basename "$DEVICE_NAME")" ]; then
+		echo "Device not found!"
+		continue
+	fi
+
+	# Check if removable
+	if [ "$(cat "/sys/block/$(basename "$DEVICE_NAME")/removable")" != "0" ]; then
+		read -r -p "Device provided is removable, do you want to continue? [y/N] " response
+		case "$response" in
+			[yY][eE][sS]|[yY])
+				break
+				;;
+			*)
+				continue
+				;;
+		esac
+	fi
+
+	break
+done
+
+echo "Installing Ghaf on $DEVICE_NAME"
+read -r -p 'Do you want to continue? [y/N] ' response
+
+case "$response" in
+	[yY][eE][sS]|[yY]);;
+	*)
+		echo "Exiting..."
+		exit
+		;;
+esac
 
 echo "Installing..."
-zstdcat @imagePath@ | dd of="${DEVICE_NAME}" bs=32M status=progress
+zstdcat "$IMG_PATH" | dd of="${DEVICE_NAME}" bs=32M status=progress
 
-echo ""
 echo "Installation done. Please remove the installation media and reboot"


### PR DESCRIPTION
The image path is now set as an environment variable, so the script derivation could be reused. Also the installer derivation is created using `writeShellApplication` which will test against shellcheck.

Also added message on running the installer. The installer now only shows devices and the vendor/name, and doesn't include the partitions.

The installer also has proper confirmation prompts, and also warn the user if they are trying to install Ghaf on a removable device.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

- Use `writeShellApplication` for installer, specify runtimeInputs. Now script is always checked against shellcheck.
- Installer improvements
  - Lists only actual devices, while partitions and loop devices are not shown. This uses `hwinfo` package.
  - Includes vendor and disk name of each drive (e.g. Sandisk Cruzer Force).
  - Installer verifies device user input, whether the device actually is valid.
  - Additionally confirms if the user is trying to install Ghaf on removable media.
  - Proper `[y/N]` prompts for each of the confirmations.
  - Shows error if not executed as root.
  - Image path given as environment variable, means the shell script doesn't have to always be rebuilt with disko image.
- Changed hostname to be `ghaf-installer`.
- Added getty help message on running `ghaf-installer`.

## Checklist for things done


- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Build the installer image
- Boot the live cd
  - There should be a message on boot with instructions to run the installer.
  - Run installer, should get list of actual devices (no partitions).
  - Input invalid device name, or specify a device partition, should give an error device doesn't exist and prompt again.
  - Input valid device, confirm, should install properly.