### PR TITLE
gtklock: Fix screen goes black after wrong passwords

### DIFF
--- a/overlays/README.md
+++ b/overlays/README.md
@@ -37,6 +37,10 @@ The status of the integration in nixpkgs can be tracked using the [Pull Request 
 
 ## From Overlays
 
+[gtklock: Guard against race condition](https://github.com/jovanlanik/gtklock/pull/95)
+
+[gtklock: Fix black screen SP-4849](https://github.com/jovanlanik/gtklock/commit/e0e7f6d5ae7667fcc3479b6732046c67275b2f2f)
+
 
 ## carried in tiiuae/nixpkgs/nixos-unstable-proc-qemu
 

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -20,4 +20,5 @@
   tpm2-pkcs11 = import ./tpm2-pkcs11 {inherit prev;};
   waybar = import ./waybar {inherit prev;};
   mitmweb-ui = final.callPackage ../../packages/mitmweb-ui {};
+  gtklock = import ./gtklock {inherit prev;};
 })

--- a/overlays/custom-packages/gtklock/auth-guard-against-race-condition-with-messages.patch
+++ b/overlays/custom-packages/gtklock/auth-guard-against-race-condition-with-messages.patch
@@ -1,0 +1,36 @@
+From d22127f0fd61bbeba8c12378b3c5b46cc3064d63 Mon Sep 17 00:00:00 2001
+From: Zephyr Lykos <git@mochaa.ws>
+Date: Sat, 22 Jun 2024 18:48:54 +0800
+Subject: [PATCH] auth: guard against race condition with messages
+
+---
+ src/auth.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/auth.c b/src/auth.c
+index a3a99b3..a5eb33d 100644
+--- a/src/auth.c
++++ b/src/auth.c
+@@ -148,15 +148,15 @@ enum pwcheck auth_pw_check(const char *s) {
+ 	size_t len;
+ 	ssize_t nread;
+ 	nread = read(err_pipe[PIPE_PARENT], &len, sizeof(size_t));
+-	if(nread > 0) {
+-		error_string = malloc(len+1);
++	if(nread > 0 && len <= PAM_MAX_MSG_SIZE) {
++		error_string = malloc(PAM_MAX_MSG_SIZE);
+ 		nread = read(err_pipe[PIPE_PARENT], error_string, len);
+ 		error_string[nread] = '\0';
+ 		return PW_ERROR;
+ 	}
+ 	nread = read(out_pipe[PIPE_PARENT], &len, sizeof(size_t));
+-	if(nread > 0) {
+-		message_string = malloc(len+1);
++	if(nread > 0 && len <= PAM_MAX_MSG_SIZE) {
++		message_string = malloc(PAM_MAX_MSG_SIZE);
+ 		nread = read(out_pipe[PIPE_PARENT], message_string, len);
+ 		message_string[nread] = '\0';
+ 		return PW_MESSAGE;
+-- 
+2.40.1
+

--- a/overlays/custom-packages/gtklock/default.nix
+++ b/overlays/custom-packages/gtklock/default.nix
@@ -1,0 +1,15 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This overlay will apply gtklock patches which are merged in master branch
+# https://github.com/jovanlanik/gtklock/commit/d22127f0fd61bbeba8c12378b3c5b46cc3064d63
+# https://github.com/jovanlanik/gtklock/commit/e0e7f6d5ae7667fcc3479b6732046c67275b2f2f
+# TODO: Remove patches, once there new release for gtlk-lock
+#
+{prev}:
+prev.gtklock.overrideAttrs {
+  patches = [
+    ./auth-guard-against-race-condition-with-messages.patch
+    ./update.patch
+  ];
+}

--- a/overlays/custom-packages/gtklock/update.patch
+++ b/overlays/custom-packages/gtklock/update.patch
@@ -1,0 +1,116 @@
+From e0e7f6d5ae7667fcc3479b6732046c67275b2f2f Mon Sep 17 00:00:00 2001
+From: Jovan Lanik <jox969@gmail.com>
+Date: Tue, 16 Jul 2024 15:30:18 +0200
+Subject: [PATCH] update
+
+---
+ include/window.h |  2 ++
+ res/gtklock.ui   | 20 +++++++++++++++++++-
+ src/window.c     | 27 ++++++++++++++++++---------
+ 3 files changed, 39 insertions(+), 10 deletions(-)
+
+diff --git a/include/window.h b/include/window.h
+index 75b8372..77ba2c3 100644
+--- a/include/window.h
++++ b/include/window.h
+@@ -17,6 +17,8 @@ struct Window {
+ 	GtkWidget *body_grid;
+ 	GtkWidget *input_label;
+ 	GtkWidget *input_field;
++	GtkWidget *message_revealer;
++	GtkWidget *message_scrolled_window;
+ 	GtkWidget *message_box;
+ 	GtkWidget *unlock_button;
+ 	GtkWidget *error_label;
+diff --git a/res/gtklock.ui b/res/gtklock.ui
+index 150a4d2..3aab413 100644
+--- a/res/gtklock.ui
++++ b/res/gtklock.ui
+@@ -57,8 +57,26 @@
+ 							</packing>
+ 						</child>
+ 						<child>
+-							<object class="GtkBox" id="message-box">
++							<object class="GtkRevealer" id="message-revealer">
++								<property name="transition-type">none</property>
+ 								<property name="no-show-all">1</property>
++								<child>
++									<object class="GtkScrolledWindow" id="message-scrolled-window">
++										<property name="hscrollbar-policy">never</property>
++										<property name="max-content-height">256</property>
++										<property name="propagate-natural-height">1</property>
++										<child>
++											<object class="GtkViewport">
++												<child>
++													<object class="GtkBox" id="message-box">
++														<property name="orientation">vertical</property>
++														<property name="homogeneous">1</property>
++													</object>
++												</child>
++											</object>
++										</child>
++									</object>
++								</child>
+ 							</object>
+ 							<packing>
+ 								<property name="left-attach">1</property>
+diff --git a/src/window.c b/src/window.c
+index a1a268b..d73eab0 100644
+--- a/src/window.c
++++ b/src/window.c
+@@ -86,27 +86,34 @@ static GtkInfoBar *window_new_message(struct Window *ctx, char *msg) {
+ 	return GTK_INFO_BAR(bar);
+ }
+ 
++static void destroy_callback(GtkWidget* widget, gpointer _data) {
++	gtk_widget_destroy(widget);
++}
++
+ static void window_setup_messages(struct Window *ctx) {
+-	if(ctx->message_box != NULL) {
+-		gtk_widget_destroy(ctx->message_box);
+-		ctx->message_box = NULL;
+-	}
+-	ctx->message_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+-	gtk_widget_set_no_show_all(ctx->message_box, TRUE);
+-	gtk_grid_attach(GTK_GRID(ctx->body_grid), ctx->message_box, 1, 1, 2, 1);
++	gtk_container_foreach(GTK_CONTAINER(ctx->message_box), destroy_callback, NULL);
++	gtk_revealer_set_reveal_child(GTK_REVEALER(ctx->message_revealer), FALSE);
++	gtk_widget_hide(ctx->message_revealer);
+ 
+ 	for(guint idx = 0; idx < gtklock->errors->len; idx++) {
+ 		char *err = g_array_index(gtklock->errors, char *, idx);
+ 		GtkInfoBar *bar = window_new_message(ctx, err);
+ 		gtk_info_bar_set_message_type(bar, GTK_MESSAGE_WARNING);
+-		gtk_widget_show(ctx->message_box);
++
++		gtk_revealer_set_reveal_child(GTK_REVEALER(ctx->message_revealer), TRUE);
++		gtk_widget_show(ctx->message_revealer);
++		gtk_widget_show_all(ctx->message_scrolled_window);
+ 	}
+ 	for(guint idx = 0; idx < gtklock->messages->len; idx++) {
+ 		char *msg = g_array_index(gtklock->messages, char *, idx);
+ 		GtkInfoBar *bar = window_new_message(ctx, msg);
+ 		gtk_info_bar_set_message_type(bar, GTK_MESSAGE_INFO);
+-		gtk_widget_show(ctx->message_box);
++
++		gtk_revealer_set_reveal_child(GTK_REVEALER(ctx->message_revealer), TRUE);
++		gtk_widget_show(ctx->message_revealer);
++		gtk_widget_show_all(ctx->message_scrolled_window);
+ 	}
++
+ }
+ 
+ static void window_set_busy(struct Window *ctx, gboolean busy) {
+@@ -342,6 +349,8 @@ struct Window *create_window(GdkMonitor *monitor) {
+ 	w->input_field = GTK_WIDGET(gtk_builder_get_object(builder, "input-field"));
+ 	g_signal_connect(w->input_field, "button-press-event", G_CALLBACK(entry_button_press), NULL);
+ 
++	w->message_revealer = GTK_WIDGET(gtk_builder_get_object(builder, "message-revealer"));
++	w->message_scrolled_window = GTK_WIDGET(gtk_builder_get_object(builder, "message-scrolled-window"));
+ 	w->message_box = GTK_WIDGET(gtk_builder_get_object(builder, "message-box"));
+ 	w->unlock_button = GTK_WIDGET(gtk_builder_get_object(builder, "unlock-button"));
+ 	w->error_label = GTK_WIDGET(gtk_builder_get_object(builder, "error-label"));
+-- 
+2.40.1
+


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
This patch will fix SP-4849 issue.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Testing instructions in SP-4849