### PR TITLE
graphics: add ghaf-open command to launch applications

### DIFF
--- a/modules/desktop/graphics/window-manager.nix
+++ b/modules/desktop/graphics/window-manager.nix
@@ -7,6 +7,7 @@
   ...
 }: let
   cfg = config.ghaf.graphics.window-manager-common;
+  ghaf-open = pkgs.callPackage ../../../packages/ghaf-open {};
 in {
   options.ghaf.graphics.window-manager-common = {
     enable = lib.mkOption {
@@ -25,10 +26,14 @@ in {
 
     environment.noXlibs = false;
 
-    environment.systemPackages = [
-      # Seatd is needed to manage log-in process for wayland sessions
-      pkgs.seatd
-    ];
+    environment.systemPackages =
+      [
+        # Seatd is needed to manage log-in process for wayland sessions
+        pkgs.seatd
+      ]
+      ++ lib.optionals config.ghaf.profiles.debug.enable [
+        ghaf-open
+      ];
 
     # Next services/targets are taken from official weston documentation:
     # https://wayland.pages.freedesktop.org/weston/toc/running-weston.html

--- a/packages/ghaf-open/default.nix
+++ b/packages/ghaf-open/default.nix
@@ -1,0 +1,42 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# A debug script that allows executing applications from the command line.
+{
+  writeShellApplication,
+  gawk,
+  ...
+}:
+writeShellApplication {
+  name = "ghaf-open";
+  runtimeInputs = [gawk];
+  text = ''
+    APPS=/run/current-system/sw/share/applications
+
+    function list_apps() {
+      for e in "$APPS"/*.desktop; do
+        [[ -e "$e" ]] || continue  # in case of no entries
+
+        basename "$e" .desktop
+      done
+    }
+
+    if [ $# -eq 0 ]; then
+      echo -e "Usage: ghaf-open <-l|application> [args...]\n"
+      echo -e "\t-l\tList available applications"
+      exit 1
+    fi
+
+    if [ "$1" = "-l" ]; then
+      list_apps
+      exit 0
+    fi
+
+    if [ ! -e "$APPS/$1.desktop" ]; then
+      echo "No launcher entry for $1"
+      exit 1
+    fi
+
+    eval "$(awk '/^Exec=/{sub(/^Exec=/, ""); print}' "$APPS/$1.desktop") ''${*:2}"
+  '';
+}


### PR DESCRIPTION
This allows the user/tester to view and launch applications from the terminal, locally or remotely. It will also show the output of the launched application.

This works with applications inside or outside app VMs.

## Description of changes

- Add `ghaf-open` command
- Command lists available applications (launchers) when no or invalid argument is given
- Arguments can be passed to the application

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Run the command with no argument, should list applications.
- Run the command with a valid application, should launch.
  - Applications should all be launchable just like clicking on it.
  - Any application that has an output, will be displayed in standard output.
  - Arguments are passed to the application (typically works well only for local applications).
  - Command should work remotely over ssh, GUIs should appear properly on the device.
- Should work on both X1 carbon and Orin.
  - On X1 carbon the command is available in `gui-vm`.
  - On Orin the command is available in `ghaf-host`.

This can be used in ci-automations, the command will exit code 1 if application name is not available on the system.
