### PR TITLE
logging: Update the mac address retrieval

### DIFF
--- a/modules/common/logging/hw-mac-retrieve.nix
+++ b/modules/common/logging/hw-mac-retrieve.nix
@@ -8,7 +8,7 @@
 }: let
   # TODO: replace sshCommand and MacCommand with givc rpc to retrieve Mac Address
   sshCommand = "${pkgs.sshpass}/bin/sshpass -p ghaf ${pkgs.openssh}/bin/ssh -o StrictHostKeyChecking=no ghaf@net-vm";
-  macCommand = "cat /sys/class/net/wlp0s5f0/address";
+  macCommand = "${pkgs.hwinfo}/bin/hwinfo --network --only /class/net/wlp0s5f0 |  ${pkgs.gawk}/bin/awk '/Permanent HW Address/ {print $4}'";
   macAddressPath = config.ghaf.logging.identifierFilePath;
 in {
   options.ghaf.logging.identifierFilePath = lib.mkOption {
@@ -36,6 +36,8 @@ in {
         ExecStart = ''
           ${pkgs.bash}/bin/bash -c "echo -n $(${sshCommand} ${macCommand}) > ${macAddressPath}"
         '';
+        Restart = "on-failure";
+        RestartSec = "1";
       };
     };
   };


### PR DESCRIPTION
With this patch will be calling hwinfo utility to retrieve Permanent HW Address / MAC Address for wlp0s5f0 network interface. As we cannot rely on the sys interface for mac retrieval possibly due to MAC randomization.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
In `admin-vm` run following command
```
[ghaf@admin-vm:~]$ sudo cat /var/lib/private/alloy/MACAddress
```
Its should match exactly **Permanent HW Address** of `net-vm`
```
[ghaf@net-vm:~]$ hwinfo --network --only /class/net/wlp0s5f0 | grep "Permanent HW Address"
```

