### PR TITLE
Storage (VM) phase 0.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,6 +223,21 @@
         "type": "github"
       }
     },
+    "impermanence": {
+      "locked": {
+        "lastModified": 1717932370,
+        "narHash": "sha256-7C5lCpiWiyPoIACOcu2mukn/1JRtz6HC/1aEMhUdcw0=",
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "rev": "27979f1c3a0d3b9617a3563e2839114ba7d48d3f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "impermanence",
+        "type": "github"
+      }
+    },
     "jetpack-nixos": {
       "inputs": {
         "nixpkgs": [
@@ -433,6 +448,7 @@
         "flake-root": "flake-root",
         "flake-utils": "flake-utils",
         "ghafpkgs": "ghafpkgs",
+        "impermanence": "impermanence",
         "jetpack-nixos": "jetpack-nixos",
         "lanzaboote": "lanzaboote",
         "microvm": "microvm",

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,10 @@
         flake-compat.follows = "flake-compat";
       };
     };
+
+    impermanence = {
+      url = "github:nix-community/impermanence";
+    };
   };
 
   outputs =

--- a/modules/flake-module.nix
+++ b/modules/flake-module.nix
@@ -25,6 +25,7 @@
     jetpack.imports = [ ./jetpack ];
     jetpack-microvm.imports = [ ./jetpack-microvm ];
     lanzaboote.imports = [ ./lanzaboote ];
+    microvm.imports = [ (import ./microvm { inherit inputs; }) ];
     polarfire.imports = [ ./polarfire ];
     reference-appvms.imports = [ ./reference/appvms ];
     reference-personalize.imports = [ ./reference/personalize ];

--- a/modules/flake-module.nix
+++ b/modules/flake-module.nix
@@ -25,7 +25,7 @@
     jetpack.imports = [ ./jetpack ];
     jetpack-microvm.imports = [ ./jetpack-microvm ];
     lanzaboote.imports = [ ./lanzaboote ];
-    microvm.imports = [ (import ./microvm { inherit inputs; }) ];
+    microvm.imports = [ ./microvm ];
     polarfire.imports = [ ./polarfire ];
     reference-appvms.imports = [ ./reference/appvms ];
     reference-personalize.imports = [ ./reference/personalize ];

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -6,12 +6,12 @@
     microvm.imports = [
       inputs.microvm.nixosModules.host
       ./virtualization/microvm/microvm-host.nix
-      ./virtualization/microvm/netvm.nix
+      (import ./virtualization/microvm/netvm.nix { inherit (inputs) impermanence; })
       ./virtualization/microvm/adminvm.nix
       ./virtualization/microvm/idsvm/idsvm.nix
       ./virtualization/microvm/idsvm/mitmproxy
-      ./virtualization/microvm/appvm.nix
-      ./virtualization/microvm/guivm.nix
+      (import ./virtualization/microvm/appvm.nix { inherit (inputs) impermanence; })
+      (import ./virtualization/microvm/guivm.nix { inherit (inputs) impermanence; })
       ./virtualization/microvm/audiovm.nix
       ./virtualization/microvm/modules.nix
       ./networking.nix

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -1,5 +1,6 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+{ impermanence }:
 {
   config,
   lib,
@@ -24,6 +25,7 @@ let
       cid = if vm.cid > 0 then vm.cid else cfg.vsockBaseCID + index;
       appvmConfiguration = {
         imports = [
+          impermanence.nixosModules.impermanence
           (import ./common/vm-networking.nix {
             inherit config lib vmName;
             inherit (vm) macAddress;

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -25,12 +25,14 @@ let
       cid = if vm.cid > 0 then vm.cid else cfg.vsockBaseCID + index;
       appvmConfiguration = {
         imports = [
-          impermanence.nixosModules.impermanence
           (import ./common/vm-networking.nix {
             inherit config lib vmName;
             inherit (vm) macAddress;
             internalIP = index + 100;
           })
+
+          (import ./common/storagevm.nix { inherit impermanence; })
+
           # To push logs to central location
           ../../../common/logging/client.nix
           (

--- a/modules/microvm/virtualization/microvm/common/storagevm.nix
+++ b/modules/microvm/virtualization/microvm/common/storagevm.nix
@@ -1,0 +1,60 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ impermanence }:
+{ lib, config, ... }:
+let
+  cfg = config.ghaf.storagevm;
+  mountPath = "/tmp/storagevm";
+in
+{
+  imports = [ impermanence.nixosModules.impermanence ];
+
+  options.ghaf.storagevm = with lib; {
+    enable = mkEnableOption "StorageVM support";
+
+    name = mkOption {
+      description = ''
+        Name of the corresponding directory on the storage virtual machine.
+      '';
+      type = types.str;
+    };
+
+    directories = mkOption {
+      # FIXME: Probably will lead to disgraceful error messages, as we
+      # put typechecking on nix impermanence option. But other,
+      # proper, ways are much harder.
+      type = types.anything;
+      default = [ ];
+      example = [
+        "Downloads"
+        "Music"
+        "Pictures"
+        "Documents"
+        "Videos"
+      ];
+      description = ''
+        Directories to bind mount to persistent storage.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    fileSystems.${mountPath}.neededForBoot = true;
+
+    microvm.shares = [
+      {
+        tag = "hostshare";
+        proto = "virtiofs";
+        securityModel = "passthrough";
+        source = "/storagevm/${cfg.name}";
+        mountPoint = mountPath;
+      }
+    ];
+
+    environment.persistence.${mountPath} = {
+      hideMounts = true;
+      inherit (cfg) directories;
+      # inherit (cfg) directories;
+    };
+  };
+}

--- a/modules/microvm/virtualization/microvm/common/storagevm.nix
+++ b/modules/microvm/virtualization/microvm/common/storagevm.nix
@@ -36,6 +36,32 @@ in
         Directories to bind mount to persistent storage.
       '';
     };
+
+    users = mkOption {
+      type = types.anything;
+      default = { };
+      example = {
+        "user".directories = [
+          "Downloads"
+          "Music"
+          "Pictures"
+          "Documents"
+          "Videos"
+        ];
+      };
+      description = ''
+        User-specific directories to bind mount to persistent storage.
+      '';
+    };
+
+    files = mkOption {
+      type = types.anything;
+      default = [ ];
+      example = [ "/etc/machine-id" ];
+      description = ''
+        Files to bind mount to persistent storage.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -51,10 +77,15 @@ in
       }
     ];
 
-    environment.persistence.${mountPath} = {
-      hideMounts = true;
-      inherit (cfg) directories;
-      # inherit (cfg) directories;
-    };
+    environment.persistence.${mountPath} = lib.mkMerge [
+      {
+        hideMounts = true;
+        files = [
+          "/etc/ssh/ssh_host_ed25519_key.pub"
+          "/etc/ssh/ssh_host_ed25519_key"
+        ];
+      }
+      { inherit (cfg) directories users files; }
+    ];
   };
 }

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -62,9 +62,9 @@ let
               name = "guivm";
               directories = [
                 {
-                  directory = "/home/ghaf/";
-                  user = "ghaf";
-                  group = "users";
+                  directory = "/home/${config.ghaf.users.accounts.user}/";
+                  inherit (config.ghaf.users.accounts) user;
+                  group = config.ghaf.users.accounts.user;
                   mode = "u=rwx,g=,o=";
                 }
               ];

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -85,8 +85,11 @@ let
 
           services.openssh = config.ghaf.security.sshKeys.sshAuthorizedKeysCommand;
 
-          # WORKAROUND: Create a rule to temporary hardcode device name for Wi-Fi adapter
-          services.udev.extraRules = ''
+          # WORKAROUND: Create a rule to temporary hardcode device name for Wi-Fi adapter on x86
+          # TODO this is a dirty hack to guard against adding this to Nvidia/vm targets which
+          # dont have that definition structure yet defined. FIXME.
+          # TODO the hardware.definition should not even be exposed in targets that do not consume it
+          services.udev.extraRules = lib.mkIf (config.ghaf.hardware.definition.network.pciDevices != [ ]) ''
             SUBSYSTEM=="net", ACTION=="add", ATTRS{vendor}=="0x${(lib.head config.ghaf.hardware.definition.network.pciDevices).vendorId}", ATTRS{device}=="0x${(lib.head config.ghaf.hardware.definition.network.pciDevices).productId}", NAME="${(lib.head config.ghaf.hardware.definition.network.pciDevices).name}"
           '';
 

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -85,6 +85,11 @@ let
 
           services.openssh = config.ghaf.security.sshKeys.sshAuthorizedKeysCommand;
 
+          # WORKAROUND: Create a rule to temporary hardcode device name for Wi-Fi adapter
+          services.udev.extraRules = ''
+            SUBSYSTEM=="net", ACTION=="add", ATTRS{vendor}=="0x${(lib.head config.ghaf.hardware.definition.network.pciDevices).vendorId}", ATTRS{device}=="0x${(lib.head config.ghaf.hardware.definition.network.pciDevices).productId}", NAME="${(lib.head config.ghaf.hardware.definition.network.pciDevices).name}"
+          '';
+
           microvm = {
             optimize.enable = true;
             hypervisor = "qemu";

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -73,29 +73,14 @@ in
           && (lib.hasAttr "cam0" config.ghaf.hardware.usb.internal.qemuExtraArgs)
         ) config.ghaf.hardware.usb.internal.qemuExtraArgs.cam0;
         devices = [ ];
-        shares = [
-          {
-            tag = "hostshare";
-            proto = "virtiofs";
-            securityModel = "passthrough";
-            source = "/storagevm/business";
-            mountPoint = "/tmp/storagevm";
-          }
-        ];
-      };
-
-      fileSystems = {
-        "/tmp/storagevm".neededForBoot = true;
-      };
-
-      environment.persistence."/tmp/storagevm" = {
-        hideMounts = true;
-        users.ghaf = {
-          directories = [ ".config" ];
-        };
       };
 
       ghaf.reference.programs.chromium.enable = true;
+      ghaf.storagevm = {
+        enable = true;
+        name = "business";
+        directories = [ "/home/${config.ghaf.users.accounts.user}/.config" ];
+      };
 
       # Set default PDF XDG handler
       xdg.mime.defaultApplications."application/pdf" = "ghaf-pdf.desktop";

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -73,6 +73,26 @@ in
           && (lib.hasAttr "cam0" config.ghaf.hardware.usb.internal.qemuExtraArgs)
         ) config.ghaf.hardware.usb.internal.qemuExtraArgs.cam0;
         devices = [ ];
+        shares = [
+          {
+            tag = "hostshare";
+            proto = "virtiofs";
+            securityModel = "passthrough";
+            source = "/storagevm/business";
+            mountPoint = "/tmp/storagevm";
+          }
+        ];
+      };
+
+      fileSystems = {
+        "/tmp/storagevm".neededForBoot = true;
+      };
+
+      environment.persistence."/tmp/storagevm" = {
+        hideMounts = true;
+        users.ghaf = {
+          directories = [ ".config" ];
+        };
       };
 
       ghaf.reference.programs.chromium.enable = true;

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -10,9 +10,10 @@
 let
   #TODO: Move this to a common place
   xdgPdfPort = 1200;
+  name = "business";
 in
 {
-  name = "business";
+  name = "${name}";
   packages =
     let
       # PDF XDG handler is executed when the user opens a PDF file in the browser
@@ -78,8 +79,8 @@ in
       ghaf.reference.programs.chromium.enable = true;
       ghaf.storagevm = {
         enable = true;
-        name = "business";
-        directories = [ "/home/${config.ghaf.users.accounts.user}/.config" ];
+        name = "${name}";
+        users.${config.ghaf.users.accounts.user}.directories = [ ".config" ];
       };
 
       # Set default PDF XDG handler

--- a/modules/reference/appvms/chromium.nix
+++ b/modules/reference/appvms/chromium.nix
@@ -69,6 +69,26 @@ in
         && (hasAttr "cam0" config.ghaf.hardware.usb.internal.qemuExtraArgs)
       ) config.ghaf.hardware.usb.internal.qemuExtraArgs.cam0;
       microvm.devices = [ ];
+      microvm.shares = [
+        {
+          tag = "hostshare";
+          proto = "virtiofs";
+          securityModel = "passthrough";
+          source = "/storagevm/chromium";
+          mountPoint = "/tmp/storagevm";
+        }
+      ];
+
+      fileSystems = {
+        "/tmp/storagevm".neededForBoot = true;
+      };
+
+      environment.persistence."/tmp/storagevm" = {
+        hideMounts = true;
+        users.ghaf = {
+          directories = [ ".config" ];
+        };
+      };
 
       ghaf.reference.programs.chromium.enable = true;
 

--- a/modules/reference/appvms/chromium.nix
+++ b/modules/reference/appvms/chromium.nix
@@ -10,9 +10,10 @@
 let
   inherit (lib) hasAttr optionals;
   xdgPdfPort = 1200;
+  name = "chromium";
 in
 {
-  name = "chromium";
+  name = "${name}";
   packages =
     let
       # PDF XDG handler is executed when the user opens a PDF file in the browser
@@ -73,8 +74,8 @@ in
       ghaf.reference.programs.chromium.enable = true;
       ghaf.storagevm = {
         enable = true;
-        name = "business";
-        directories = [ "/home/${config.ghaf.users.accounts.user}/.config" ];
+        name = "${name}";
+        users.${config.ghaf.users.accounts.user}.directories = [ ".config" ];
       };
 
       # Set default PDF XDG handler

--- a/modules/reference/appvms/chromium.nix
+++ b/modules/reference/appvms/chromium.nix
@@ -69,28 +69,13 @@ in
         && (hasAttr "cam0" config.ghaf.hardware.usb.internal.qemuExtraArgs)
       ) config.ghaf.hardware.usb.internal.qemuExtraArgs.cam0;
       microvm.devices = [ ];
-      microvm.shares = [
-        {
-          tag = "hostshare";
-          proto = "virtiofs";
-          securityModel = "passthrough";
-          source = "/storagevm/chromium";
-          mountPoint = "/tmp/storagevm";
-        }
-      ];
-
-      fileSystems = {
-        "/tmp/storagevm".neededForBoot = true;
-      };
-
-      environment.persistence."/tmp/storagevm" = {
-        hideMounts = true;
-        users.ghaf = {
-          directories = [ ".config" ];
-        };
-      };
 
       ghaf.reference.programs.chromium.enable = true;
+      ghaf.storagevm = {
+        enable = true;
+        name = "business";
+        directories = [ "/home/${config.ghaf.users.accounts.user}/.config" ];
+      };
 
       # Set default PDF XDG handler
       xdg.mime.defaultApplications."application/pdf" = "ghaf-pdf.desktop";

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -26,6 +26,7 @@ let
     ])
     (laptop-configuration "lenovo-x1-carbon-gen11" "debug" [
       self.nixosModules.disko-ab-partitions-v1
+      inputs.impermanence.nixosModules.impermanence
       {
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen11.nix";


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This is the initial implementation of the Storage solution. It uses `impermanence` framework along with virtiofs shares to make needed files/directories persistent.

Currently it allows to store WiFi configuration, user data from GUI-vm user home directory and common-purpose browser configuration and user sessions/data.

Each VM has an access to it's only data and does not know anything about other stored entities. The host system has an access to all the data stored.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->

1. Boot the system. Connect to Wi-Fi network through GUI-VM.
2. Open Chromium browser, go to any website and add it's address as a bookmark. Close browser window.
3. Open Business-VM browser (MS365), log in to the Outlook. Close the browser window.
4. Create any file in user's home directory in GUI-VM: `touch ~/testfile`
5. Reboot the computer.
6. Check that results of 1.-4. are survived the reboot. The Wi-Fi should connect automatically and all bookmarks/sessions/files are in place.

It is possible to restart a microvm without rebooting:
`systemctl restart microvm@<vm name>.service`