### PR TITLE
Lock the screen when Yubikey hardware is plugged out

### DIFF
--- a/modules/common/services/yubikey.nix
+++ b/modules/common/services/yubikey.nix
@@ -41,9 +41,10 @@ in {
       cue = true;
     };
 
-    # Below rule is needed for screen locker (gtklock) to work
+    # Below rules are needed for screen locker (gtklock) to work
     services.udev.extraRules = ''
       KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0407", TAG+="uaccess", GROUP="kvm", MODE="0666"
+      ACTION=="remove", ENV{ID_BUS}=="usb", ENV{ID_VENDOR_ID}=="1050", ENV{ID_MODEL_ID}=="0407", RUN+="${pkgs.systemd}/bin/loginctl lock-sessions"
     '';
   };
 }

--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -70,6 +70,9 @@
           swayidle -w timeout ${builtins.toString cfg.autolock.duration} \
           'chayang && ${lockCmd}' &
         ''}
+
+        # Register lockCmd with swayidle, so that when lock signal is received system can be locked automatically
+        ${pkgs.swayidle}/bin/swayidle lock "${lockCmd}" &
       ''
       + cfg.extraAutostart;
   };


### PR DESCRIPTION
* Add udev rule for Yubikey hardware such that once Yubikey is plugged out of system, screen should lock automatically.
* Starting swayidle lock in labwc autostart.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Prerequisite 
Yubikey hardware, more details [here](https://www.yubico.com/products/yubikey-5-overview/)

**Steps:**
1) Plugin the Yubikey Hardware
2) Plugout the Yubikey Hardware
3) After plugout screen locker will appear automatically. 