### PR TITLE
[Lenovo X1]: Created host-hardening profile & updated lanzaboote

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,29 +2,17 @@
   "nodes": {
     "crane": {
       "inputs": {
-        "flake-compat": [
-          "lanzaboote",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "lanzaboote",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "lanzaboote",
           "nixpkgs"
-        ],
-        "rust-overlay": [
-          "lanzaboote",
-          "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1681177078,
-        "narHash": "sha256-ZNIjBDou2GOabcpctiQykEQVkI8BDwk7TyvlWlI4myE=",
+        "lastModified": 1717535930,
+        "narHash": "sha256-1hZ/txnbd/RmiBPNUs7i8UQw2N89uAK3UzrGAWdnFfU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0c9f468ff00576577d83f5019a66c557ede5acf6",
+        "rev": "55e7754ec31dac78980c8be45f8a28e80e370946",
         "type": "github"
       },
       "original": {
@@ -226,16 +214,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1682802423,
-        "narHash": "sha256-Fb5TeRTdvUlo/5Yi2d+FC8a6KoRLk2h1VE0/peMhWPs=",
+        "lastModified": 1718178907,
+        "narHash": "sha256-eSZyrQ9uoPB9iPQ8Y5H7gAmAgAvCw3InStmU3oEjqsE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "64b903ca87d18cef2752c19c098af275c6e51d63",
+        "rev": "b627ccd97d0159214cee5c7db1412b75e4be6086",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "v0.3.0",
+        "ref": "v0.4.1",
         "repo": "lanzaboote",
         "type": "github"
       }
@@ -416,11 +404,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682129965,
-        "narHash": "sha256-1KRPIorEL6pLpJR04FwAqqnt4Tzcm4MqD84yhlD+XSk=",
+        "lastModified": 1717813066,
+        "narHash": "sha256-wqbRwq3i7g5EHIui0bIi84mdqZ/It1AXBSLJ5tafD28=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2c417c0460b788328220120c698630947547ee83",
+        "rev": "6dc3e45fe4aee36efeed24d64fc68b1f989d5465",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -116,7 +116,7 @@
     # Security
     #
     lanzaboote = {
-      url = "github:nix-community/lanzaboote/v0.3.0";
+      url = "github:nix-community/lanzaboote/v0.4.1";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";

--- a/modules/common/profiles/default.nix
+++ b/modules/common/profiles/default.nix
@@ -4,5 +4,6 @@
   imports = [
     ./debug.nix
     ./release.nix
+    ./host-hardening.nix
   ];
 }

--- a/modules/common/profiles/host-hardening.nix
+++ b/modules/common/profiles/host-hardening.nix
@@ -1,0 +1,27 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.ghaf.profiles.host-hardening;
+  has_host = builtins.hasAttr "host" config.ghaf;
+  has_secureBoot = builtins.hasAttr "secureboot" config.ghaf.host;
+in {
+  options.ghaf.profiles.host-hardening = {
+    enable = lib.mkEnableOption "Host hardening profile";
+  };
+
+  config = lib.mkIf cfg.enable {
+    ghaf =
+      {}
+      // lib.optionalAttrs (has_host && has_secureBoot) {
+        host = {
+          # Enable secure boot in the host configuration
+          secureboot.enable = true;
+        };
+      };
+  };
+}

--- a/modules/common/profiles/kernel-hardening.nix
+++ b/modules/common/profiles/kernel-hardening.nix
@@ -8,16 +8,13 @@
 }: let
   cfg = config.ghaf.profiles.hardening;
 in {
-  options.ghaf.profiles.hardening = {
+  options.ghaf.profiles.kernel-hardening = {
     enable = lib.mkEnableOption "hardened profile";
   };
 
   config = lib.mkIf cfg.enable {
     ghaf = {
       host = {
-        # Enable some security features in the host configuration
-        secureboot.enable = true;
-
         # Kernel hardening
         kernel.hardening = {
           enable = true;

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -21,6 +21,7 @@ in {
     ../hardware/x86_64-generic
     ../hardware/common
     ../hardware/definition.nix
+    ../lanzaboote
   ];
 
   options.ghaf.profiles.laptop-x86 = {

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -5,11 +5,12 @@
 {
   lib,
   self,
+  inputs,
   ...
 }: let
   system = "x86_64-linux";
 
-  laptop-configuration = import ./laptop-configuration-builder.nix {inherit lib self;};
+  laptop-configuration = import ./laptop-configuration-builder.nix {inherit lib self inputs;};
 
   targets = [
     # Laptop Debug configurations

--- a/targets/laptop/laptop-configuration-builder.nix
+++ b/targets/laptop/laptop-configuration-builder.nix
@@ -3,6 +3,7 @@
 {
   lib,
   self,
+  inputs,
   ...
 }: let
   system = "x86_64-linux";
@@ -16,6 +17,7 @@
         [
           self.nixosModules.profiles
           self.nixosModules.laptop
+          inputs.lanzaboote.nixosModules.lanzaboote
 
           #TODO can we move microvm to the profile/laptop-x86?
           self.nixosModules.microvm
@@ -29,6 +31,8 @@
                 # variant type, turn on debug or release
                 debug.enable = variant == "debug";
                 release.enable = variant == "release";
+                # Enable below option for host hardening features
+                host-hardening.enable = false;
               };
             };
           })


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

-  Created host-hardening profile which holds hardening configuration needed for the host. 
   Also added secure boot configuration under host. By default host-hardening profile is disabled.
-  Updated lanzaboote package version to v0.4.1.
-  Addresses SP-4919
    


## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

1) To test secure boot working change  [here](https://github.com/tiiuae/ghaf/pull/708/files#diff-0a25818675b9140f2f3d2007e018a9194d588053fe36654b7e6a484f69d14080R35) `host-hardening.enable = true;`
2) You may need to flash image as some of lanzaboote file may not install with `nixos-rebuild ... switch`
3) Enable secure boot from BIOS.
4) Enroll keys `sudo sbctl enroll-keys --microsoft` and reboot
5) Run below command to verify functionality  
```
[ghaf@ghaf-host:~]$ sbctl status | grep Secure
Secure Boot:    ✓ Enabled
```
6. Also can verify lanzaboote version 
```
[ghaf@ghaf-host:~]$ sudo bootctl status | grep lanza
         Stub: lanzastub 0.4.1
```
