### PR TITLE
Enable setting locale and timezone

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -66,7 +66,11 @@ path = "overlays/custom-packages/gtklock/*.patch"
 [[annotations]]
 SPDX-License-Identifier = "LGPL-2.1-or-later"
 SPDX-FileCopyrightText = "systemd contributors"
-path = "modules/common/systemd/systemd-boot-double-dtb-buffer-size.patch"
+path = [
+	"modules/common/systemd/systemd-boot-double-dtb-buffer-size.patch",
+	"modules/common/systemd/systemd-localed-locale-archive.patch",
+	"modules/common/systemd/systemd-re-enable-locale-setting.patch",
+]
 
 [[annotations]]
 SPDX-License-Identifier = "MIT"

--- a/flake.lock
+++ b/flake.lock
@@ -299,17 +299,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1727957559,
-        "narHash": "sha256-X5yjuHZh7pu93xNaJlN0/H8KvA4oEs2lLQXc8u6J0yA=",
+        "lastModified": 1728498882,
+        "narHash": "sha256-S5NEtxfgC3pbglhKxHCymqhId689DzMUU2v2LUobYeA=",
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "68079deac890d19d84389becc37805310fc0107f",
+        "rev": "be24afa09e310546ea84832994e59efb0272c303",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "68079deac890d19d84389becc37805310fc0107f",
+        "rev": "be24afa09e310546ea84832994e59efb0272c303",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,7 @@
     };
 
     givc = {
-      url = "github:tiiuae/ghaf-givc/68079deac890d19d84389becc37805310fc0107f";
+      url = "github:tiiuae/ghaf-givc/be24afa09e310546ea84832994e59efb0272c303";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -24,5 +24,18 @@
     boot.enableContainers = false;
     documentation.nixos.enable = false;
     ##### Remove to here
+
+    i18n.supportedLocales = [
+      "C.UTF-8/UTF-8"
+      "en_US.UTF-8/UTF-8"
+      "ar_AE.UTF-8/UTF-8"
+    ];
+    environment.extraInit = ''
+      if [ -f /etc/locale.conf ]; then
+          . /etc/locale.conf
+          export LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION LC_ALL
+      fi
+    '';
+
   };
 }

--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -62,7 +62,11 @@ let
       }
     )).overrideAttrs
       (prevAttrs: {
-        patches = prevAttrs.patches ++ [ ./systemd-boot-double-dtb-buffer-size.patch ];
+        patches = prevAttrs.patches ++ [
+          ./systemd-boot-double-dtb-buffer-size.patch
+          ./systemd-re-enable-locale-setting.patch
+          ./systemd-localed-locale-archive.patch
+        ];
       });
 
   # Definition of suppressed system units in systemd configuration. This removes the units and has priority.

--- a/modules/common/systemd/systemd-localed-locale-archive.patch
+++ b/modules/common/systemd/systemd-localed-locale-archive.patch
@@ -1,0 +1,41 @@
+From 01aec4230eec5f1ce97ab6edbb81a478ce4462f0 Mon Sep 17 00:00:00 2001
+From: Santtu Lakkala <santtu.lakkala@unikie.com>
+Date: Fri, 19 Jul 2024 14:46:29 +0300
+Subject: [PATCH] localed: use LOCALE_ARCHIVE
+
+Signed-off-by: Santtu Lakkala <santtu.lakkala@unikie.com>
+---
+ src/basic/locale-util.c | 6 +++++-
+ units/systemd-localed.service.in | 1 +
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/basic/locale-util.c b/src/basic/locale-util.c
+index 23565273dd..cb61387d1c 100644
+--- a/src/basic/locale-util.c
++++ b/src/basic/locale-util.c
+@@ -101,7 +101,11 @@ static int add_locales_from_archive(Set *locales) {
+         struct stat st;
+         int r;
+ 
+-        fd = open("/usr/lib/locale/locale-archive", O_RDONLY|O_NOCTTY|O_CLOEXEC);
++        const char *archive = secure_getenv("LOCALE_ARCHIVE");
++        if (!archive)
++                archive = "/usr/lib/locale/locale-archive";
++
++        fd = open(archive, O_RDONLY|O_NOCTTY|O_CLOEXEC);
+         if (fd < 0)
+                 return errno == ENOENT ? 0 : -errno;
+ 
+diff --git a/units/systemd-localed.service.in b/units/systemd-localed.service.in
+index 4de89aa8dd..1e72b18edc 100644
+--- a/units/systemd-localed.service.in
++++ b/units/systemd-localed.service.in
+@@ -45,4 +45,5 @@ RestrictSUIDSGID=yes
+ SystemCallArchitectures=native
+ SystemCallErrorNumber=EPERM
+ SystemCallFilter=@system-service
++Environment=LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive
+ {{SERVICE_WATCHDOG}}
+-- 
+2.42.0
+

--- a/modules/common/systemd/systemd-re-enable-locale-setting.patch
+++ b/modules/common/systemd/systemd-re-enable-locale-setting.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gabriel Ebner <gebner@gebner.org>
+Date: Sun, 6 Dec 2015 14:26:36 +0100
+Subject: [PATCH] hostnamed, localed, timedated: disable methods that change
+ system settings.
+
+Signed-off-by: Santtu Lakkala <santtu.lakkala@unikie.com>
+---
+ src/locale/localed.c     |  9 +++++++++
+ 3 files changed, 25 insertions(+)
+
+diff --git a/src/locale/localed.c b/src/locale/localed.c
+index 5d96237fae..9af35cd29c 100644
+--- a/src/locale/localed.c
++++ b/src/locale/localed.c
+@@ -229,9 +229,6 @@ static int method_set_locale(sd_bus_message *m, void *userdata, sd_bus_error *er
+ 
+         use_localegen = locale_gen_check_available();
+ 
+-        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+-            "Changing system settings via systemd is not supported on NixOS.");
+-
+         /* If single locale without variable name is provided, then we assume it is LANG=. */
+         if (strv_length(l) == 1 && !strchr(l[0], '=')) {
+                 if (!locale_is_valid(l[0]))
+@@ -350,9 +347,6 @@ static int method_set_vc_keyboard(sd_bus_message *m, void *userdata, sd_bus_erro
+         if (r < 0)
+                 return bus_log_parse_error(r);
+ 
+-        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+-            "Changing system settings via systemd is not supported on NixOS.");
+-
+         vc_context_empty_to_null(&in);
+ 
+         r = vc_context_verify_and_warn(&in, LOG_ERR, error);
+@@ -471,9 +465,6 @@ static int method_set_x11_keyboard(sd_bus_message *m, void *userdata, sd_bus_err
+         if (r < 0)
+                 return bus_log_parse_error(r);
+ 
+-        return sd_bus_error_setf(error, SD_BUS_ERROR_NOT_SUPPORTED,
+-            "Changing system settings via systemd is not supported on NixOS.");
+-
+         x11_context_empty_to_null(&in);
+ 
+         r = x11_context_verify_and_warn(&in, LOG_ERR, error);

--- a/modules/desktop/graphics/waybar.config.nix
+++ b/modules/desktop/graphics/waybar.config.nix
@@ -19,7 +19,6 @@ let
   wifi-signal-strength = pkgs.callPackage ../../../packages/wifi-signal-strength {
     wifiDevice = wifiDevice.name;
   };
-  timeZone = if config.time.timeZone != null then config.time.timeZone else "UTC";
 in
 {
   config = lib.mkIf cfg.enable {
@@ -62,7 +61,6 @@ in
                 "spacing": 10
             },
             "clock": {
-                "timezone": "${timeZone}",
                 "tooltip-format": "<big>{:%d %b %Y}</big>\n<tt><small>{calendar}</small></tt>",
                 "format": "{:%a %d %b   %H:%M}"
             },

--- a/modules/microvm/virtualization/microvm/adminvm.nix
+++ b/modules/microvm/virtualization/microvm/adminvm.nix
@@ -10,6 +10,7 @@ let
 
   adminvmBaseConfiguration = {
     imports = [
+      inputs.impermanence.nixosModules.impermanence
       inputs.self.nixosModules.givc-adminvm
       (import ./common/vm-networking.nix {
         inherit
@@ -23,6 +24,7 @@ let
       # We need to retrieve mac address and start log aggregator
       ../../../common/logging/hw-mac-retrieve.nix
       ../../../common/logging/logs-aggregator.nix
+      ./common/storagevm.nix
       (
         { lib, ... }:
         {
@@ -46,6 +48,14 @@ let
               withTimesyncd = true;
               withDebug = configHost.ghaf.profiles.debug.enable;
               withHardenedConfigs = true;
+            };
+            storagevm = {
+              enable = true;
+              name = "adminvm";
+              files = [
+                "/etc/locale-givc.conf"
+                "/etc/timezone.conf"
+              ];
             };
 
             givc.adminvm.enable = true;

--- a/modules/microvm/virtualization/microvm/adminvm.nix
+++ b/modules/microvm/virtualization/microvm/adminvm.nix
@@ -92,7 +92,7 @@ let
           };
 
           microvm = {
-            optimize.enable = true;
+            optimize.enable = false;
             #TODO: Add back support cloud-hypervisor
             #the system fails to switch root to the stage2 with cloud-hypervisor
             hypervisor = "qemu";

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -72,6 +72,7 @@ let
                   enable = true;
                   withName = "appvm-systemd";
                   withAudit = configHost.ghaf.profiles.debug.enable;
+                  withLocaled = true;
                   withNss = true;
                   withResolved = true;
                   withTimesyncd = true;

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -55,6 +55,7 @@ let
               enable = true;
               withName = "guivm-systemd";
               withAudit = config.ghaf.profiles.debug.enable;
+              withLocaled = true;
               withNss = true;
               withResolved = true;
               withTimesyncd = true;

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -46,6 +46,7 @@ in
         withRepart = true;
         withFido2 = true;
         withCryptsetup = true;
+        withLocaled = true;
         withTimesyncd = cfg.networkSupport;
         withNss = cfg.networkSupport;
         withResolved = cfg.networkSupport;

--- a/targets/laptop/laptop-configuration-builder.nix
+++ b/targets/laptop/laptop-configuration-builder.nix
@@ -26,8 +26,6 @@ let
           #TODO see the twisted dependencies in common/desktop
 
           (_: {
-            time.timeZone = "Asia/Dubai";
-
             ghaf = {
               profiles = {
                 # variant type, turn on debug or release


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Re-enables locale setting in systemd-localed, with added support for LOCALE_ARCHIVE.

Removed hardcoded timezone setting to allow timedatectl set-timezone to work.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Run: `/nix/store/*-cli/bin/givc-cli --addr admin-vm-debug --name admin-vm-debug --port 9001 --notls set-locale ar_AE.UTF-8` and start chromium; observe UI language in Arabic. Run again with `set-timezone Europe/Helsinki`, observe UI time change. Reboot device, and changes should persist.
<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
