### PR TITLE
lenovo-x1: temporary fix build errors of release and release installer targets to build only

### DIFF
--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -41,7 +41,9 @@ in
       graphics = {
         launchers =
           let
-            hostEntry = filter (x: x.name == "ghaf-host-debug") config.ghaf.networking.hosts.entries;
+            hostEntry = filter (
+              x: x.name == "audio-vm" + lib.optionalString config.ghaf.profiles.debug.enable "-debug"
+            ) config.ghaf.networking.hosts.entries;
             hostAddress = head (map (x: x.ip) hostEntry);
             powerControl = pkgs.callPackage ../../../packages/powercontrol { };
             privateSshKeyPath = config.ghaf.security.sshKeys.sshKeyPath;

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -121,7 +121,7 @@ let
           systemd.network.networks."10-ethint0".addresses =
             let
               getAudioVmEntry = builtins.filter (
-                x: x.name == "audio-vm-debug"
+                x: x.name == "audio-vm" + lib.optionalString config.ghaf.profiles.debug.enable "-debug"
               ) config.ghaf.networking.hosts.entries;
               ip = lib.head (builtins.map (x: x.ip) getAudioVmEntry);
             in

--- a/modules/reference/profiles/laptop-x86.nix
+++ b/modules/reference/profiles/laptop-x86.nix
@@ -121,7 +121,8 @@ in
       # Logging configuration
       logging.client.enable = true;
       logging.client.endpoint = "http://${listenerAddress}:${listenerPort}/loki/api/v1/push";
-      logging.listener.address = "admin-vm-debug";
+      logging.listener.address =
+        "admin-vm" + lib.optionalString config.ghaf.profiles.debug.enable "-debug";
       logging.listener.port = 9999;
     };
   };


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
The call of the vm by name fails because has "debug" suffix. The call has been modified to use the correct option, following the Lenovo X1 targets. 

However it doesn't solve the functional issue and doesn't work on release targets because of connections are restricted. GIVC will fix it in the future.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

Build the targets:
#packages.x86_64-linux.lenovo-x1-carbon-gen11-release
#packages.x86_64-linux.lenovo-x1-carbon-gen11-release-installer

You can also check with "#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug" target to be sure does it work.
Run the image and run one of the applications or scripts in the launcher; for example "shutdown".
Observe that the script or application works.