### PR TITLE
logging: Collect journal logs from admin-vm

### DIFF
--- a/modules/common/logging/logs-aggregator.nix
+++ b/modules/common/logging/logs-aggregator.nix
@@ -27,6 +27,19 @@ in {
           // Alloy service can read file in this specific location
           filename = "${macAddressPath}"
         }
+        discovery.relabel "adminJournal" {
+          targets = []
+          rule {
+            source_labels = ["__journal__hostname"]
+            target_label  = "nodename"
+          }
+        }
+
+        loki.source.journal "journal" {
+          path          = "/var/log/journal"
+          relabel_rules = discovery.relabel.adminJournal.rules
+          forward_to    = [loki.write.remote.receiver]
+        }
 
         loki.write "remote" {
           endpoint {


### PR DESCRIPTION
This patch will start logging journal logs collected from admin-vm to grafana server in the cloud.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

In Grafana server now we can view logs from `admin-vm` as well which is not there previously. 

![image](https://github.com/user-attachments/assets/20a736ce-b7d4-4c91-8991-461b4f15b21a)

