### PR TITLE
Enable AppArmor 

### DIFF
--- a/modules/common/security/apparmor/default.nix
+++ b/modules/common/security/apparmor/default.nix
@@ -1,0 +1,29 @@
+# Copyright 2024-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.security.apparmor;
+in
+{
+  ## Option to enable Apparmor security
+  options.ghaf.security.apparmor = {
+    enable = lib.mkOption {
+      description = ''
+        Enable Apparmor security.
+      '';
+      type = lib.types.bool;
+      default = false;
+    };
+  };
+
+  imports = [
+    ./profiles/google-chrome.nix
+    ./profiles/ping.nix
+  ];
+
+  config = lib.mkIf cfg.enable {
+    security.apparmor.enable = true;
+    security.apparmor.killUnconfinedConfinables = lib.mkDefault true;
+    services.dbus.apparmor = "enabled";
+  };
+}

--- a/modules/common/security/apparmor/profiles/google-chrome.nix
+++ b/modules/common/security/apparmor/profiles/google-chrome.nix
@@ -1,0 +1,199 @@
+# Copyright 2024-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  ## Apparmor profile for Chromium
+  config.security.apparmor.policies."bin.chrome" = lib.mkIf config.ghaf.security.apparmor.enable {
+    enforce = lib.mkForce true;
+    profile = ''
+      abi <abi/3.0>,
+      include <tunables/global>
+
+      @{INTEGER}=[0-9]{[0-9],}{[0-9],}{[0-9],}{[0-9],}{[0-9],}{[0-9],}{[0-9],}{[0-9],}{[0-9],}
+      @{ETC}=/etc
+      @{NIX}=/nix
+
+      ${pkgs.google-chrome}/share/google/chrome/google-chrome {
+        include <abstractions/base>
+        include <abstractions/dbus-session>
+        include <abstractions/fonts>
+        include <abstractions/ibus>
+
+        ${config.environment.etc."os-release".source}                   r,
+        ${config.environment.etc."lsb-release".source}                  r,
+
+        capability sys_admin,
+        capability sys_chroot,
+        capability sys_ptrace,
+
+        deny @{ETC}/nixos/**                                            r,
+        deny @{ETC}@{NIX}/**                                            r,
+        @{NIX}/store/                                                   mr,
+        @{NIX}/store/**                                                 mr,
+
+        ptrace (read, readby),
+
+        ${pkgs.xdg-utils}/bin/*                                         ixr,
+        ${pkgs.coreutils}/bin/*                                         ixr,
+        ${pkgs.coreutils-full}/bin/*                                    ixr,
+        ${pkgs.procps}/bin/ps                                           ixr,
+        ${pkgs.gnugrep}/bin/grep                                        ixr,
+        ${pkgs.gnused}/bin/sed                                          ixr,
+        ${pkgs.which}/bin/which                                         ixr,
+        ${pkgs.gawk}/bin/*                                              ixr,
+        ${pkgs.google-chrome}/bin/*                                     ixr,
+        ${pkgs.google-chrome}/share/google/chrome/*                     ixr,
+        ${pkgs.chromium}-sandbox/bin/*                                  ixr,
+        ${pkgs.givc-cli}/bin/givc-cli                                   ixr,
+        ${pkgs.open-normal-extension}/*                                 ixr,
+        ${config.ghaf.services.xdghandlers.handlerPath}/bin/*           ixr,
+        ${pkgs.systemd}/bin/*                                           ixr,
+        ${pkgs.bashInteractive}/bin/*                                   ixr,
+        ${pkgs.libressl.nc}/bin/*                                       ixr,
+        ${pkgs.openssh}/bin/*                                           ixr,
+        ${pkgs.perlPackages.FileMimeInfo}/bin/mimetype                  ixr,
+
+        @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size            r,
+        @{sys}/module/                                                  r,
+        @{sys}/module/**                                                r,
+        @{sys}/bus/                                                     r,
+        @{sys}/bus/**                                                   r,
+        @{sys}/class/                                                   r,
+        @{sys}/class/**                                                 r,
+        @{sys}/devices/                                                 r,
+        @{sys}/devices/**                                               r,
+        @{sys}/fs/                                                      r,
+        @{sys}/fs/**                                                    r,
+        @{sys}/dev/                                                     rw,
+        @{sys}/dev/**                                                   rw,
+        @{sys}/devices/pci*/**                                          rw,
+
+              @{PROC}                                                   r,
+              @{PROC}/[0-9]*/net/ipv6_route                             r,
+              @{PROC}/[0-9]*/net/arp                                    r,
+              @{PROC}/[0-9]*/net/if_inet6                               r,
+              @{PROC}/[0-9]*/net/route                                  r,
+              @{PROC}/[0-9]*/net/ipv6_route                             r,
+              @{PROC}/[0-9]*/stat                                       rix,
+              @{PROC}/[0-9]*/task/@{tid}/comm                           rw,
+              @{PROC}/[0-9]*/task/@{tid}/status                         rix,
+        owner @{PROC}/[0-9]*/cgroup                                     r,
+        owner @{PROC}/[0-9]*/fd/                                        r,
+        owner @{PROC}/[0-9]*/io                                         r,
+        owner @{PROC}/[0-9]*/mountinfo                                  r,
+        owner @{PROC}/[0-9]*/mounts                                     r,
+        owner @{PROC}/[0-9]*/oom_score_adj                              w,
+        owner @{PROC}/[0-9]*/gid_map                                    w,
+        owner @{PROC}/[0-9]*/setgroups                                  w,
+        owner @{PROC}/[0-9]*/uid_map                                    w,
+        owner @{PROC}/[0-9]*/smaps                                      rix,
+        owner @{PROC}/[0-9]*/statm                                      rix,
+        owner @{PROC}/[0-9]*/task/                                      r,
+        owner @{PROC}/[0-9]*/cmdline                                    rix,
+        owner @{PROC}/[0-9]*/environ                                    rix,
+        owner @{PROC}/[0-9]*/clear_refs                                 rw,
+        owner @{PROC}/[0-9]*/comm                                       rw,
+        owner @{PROC}/self/*                                            r,
+        owner @{PROC}/self/exe                                          rix,
+        owner @{PROC}/self/fd/*                                         rw,
+              @{PROC}/sys/kernel/yama/ptrace_scope                      rw,
+              @{PROC}/sys/fs/inotify/max_user_watches                   r,
+              @{PROC}/ati/major                                         r,
+
+              /dev/**                                                   rw,
+              /dev/fb0                                                  rw,
+              /dev/hidraw@{INTEGER}                                     rw,
+              /dev/shm/**                                               rw,
+              /dev/tty                                                  rw,
+              /dev/video@{INTEGER}                                      rw,
+        owner /dev/shm/pulse-shm*                                       m,
+        owner /dev/tty@{INTEGER}                                        rw,
+              /dev/v4l/**                                               rw,
+              /dev/snd/**                                               rw,
+              /dev/null                                                 rw,
+
+              /run/udev/                                                ixr,
+              /run/udev/**                                              ixr,
+              /run/mount/                                               ixr,
+              /run/mount/**                                             ixr,
+              /run/current-system/sw/bin/*                              lr,
+
+              @{ETC}/static/                                            r,
+              @{ETC}/static/**                                          r,
+              @{ETC}/chromium/**                                        r,
+              @{ETC}/host/                                              r,
+              @{ETC}/host/**                                            r,
+
+         @{ETC}/opt/                                                    rix,
+         @{ETC}/opt/**                                                  rix,
+         @{ETC}/static/opt/                                             rix,
+         @{ETC}/static/opt/**                                           rix,
+         @{ETC}/xdg/mimeapps.list                                       lr,
+         @{ETC}/static/xdg/mimeapps.list                                lr,
+
+        owner @{HOME}                                                   r,
+        owner @{HOME}/.DCOPserver_*                                     r,
+        owner @{HOME}/.ICEauthority                                     r,
+        owner @{HOME}/.nix-profile/                                     r,
+        owner @{HOME}/.nix-profile/**                                   r,
+        owner @{HOME}/.fonts.*                                          lrw,
+        owner @{HOME}/.cache/                                           wrk,
+        owner @{HOME}/.cache/**                                         wrk,
+        owner @{HOME}/.config/google-chrome                             rwkm,
+        owner @{HOME}/.config/google-chrome/**                          rwkm,
+        owner @{HOME}/.config/**                                        rw,
+        owner @{HOME}/.config                                           rw,
+
+        owner @{HOME}/.local/                                           rw,
+        owner @{HOME}/.local/**                                         rw,
+        owner @{HOME}/.local/share/mime/mime.cache                      rw,
+        owner @{HOME}/.local/share/applications/mimeapps.list           rw,
+        owner @{HOME}/.pki/                                             rwkm,
+        owner @{HOME}/.pki/**                                           rwkm,
+        owner @{HOME}/Downloads/                                        rw,
+        owner @{HOME}/Downloads/**                                      rw,
+
+        owner @{HOME}/Unsafe\ share/                                    rw,
+        owner @{HOME}/Unsafe\ share/**                                  rw,
+        owner @{HOME}/tmp/**                                            rwkl,
+        owner @{HOME}/tmp/                                              rw,
+
+
+        @{ETC}/profiles                                                 r,
+        @{ETC}/profiles/**                                              r,
+        @{NIX}/var                                                      r,
+        @{NIX}/var/**                                                   r,
+
+        owner @{run}/user/[0-9]*/                                       rw,
+        owner @{run}/user/[0-9]*/**                                     rw,
+              @{run}/user/[0-9]*/                                       r,
+              @{run}/user/[0-9]*/**                                     r,
+
+              /var/tmp/                                                 rw,
+        owner /var/tmp/**                                               rwkl,
+
+              /tmp/                                                     rw,
+        owner /tmp/**                                                   rwkl,
+              /tmp/.X[0-9]*-lock                                        r,
+
+        deny /boot/EFI/systemd/**                                       r,
+        deny /boot/EFI/nixos/**                                         r,
+        deny /boot/loader/**                                            r,
+        deny /boot/vmlinuz*                                             r,
+        deny /var/cache/fontconfig/                                     w,
+
+        ### Networking ###
+        network inet     stream,
+        network inet6    stream,
+        network inet     dgram,
+        network inet6    dgram,
+        network netlink  raw,
+      }
+    '';
+  };
+}

--- a/modules/common/security/apparmor/profiles/ping.nix
+++ b/modules/common/security/apparmor/profiles/ping.nix
@@ -1,0 +1,31 @@
+# Copyright 2024-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  ## Apparmor profile for ping
+  config.security.apparmor.policies."bin.ping" = lib.mkIf config.ghaf.security.apparmor.enable {
+    profile = ''
+      #include <tunables/global>
+      ${pkgs.iputils}/bin/ping {
+        #include <abstractions/base>
+        #include <abstractions/consoles>
+        #include <abstractions/nameservice>
+
+        include "${pkgs.apparmorRulesFromClosure { name = "ping"; } [ pkgs.iputils ]}"
+
+        capability net_raw,
+        capability setuid,
+        network inet raw,
+
+        ${pkgs.iputils}/bin/ping mixr,
+        /etc/modules.conf r,
+      }
+
+    '';
+  };
+}

--- a/modules/common/security/default.nix
+++ b/modules/common/security/default.nix
@@ -1,3 +1,8 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ imports = [ ./sshkeys.nix ]; }
+{
+  imports = [
+    ./sshkeys.nix
+    ./apparmor
+  ];
+}

--- a/modules/common/services/xdghandlers.nix
+++ b/modules/common/services/xdghandlers.nix
@@ -60,8 +60,13 @@ in
 {
   options.ghaf.services.xdghandlers = {
     enable = mkEnableOption "Enable Ghaf XDG handlers";
+    handlerPath = lib.mkOption {
+      description = "Path of xdgHandler script.";
+      type = lib.types.str;
+    };
   };
   config = mkIf cfg.enable {
+    ghaf.services.xdghandlers.handlerPath = xdgOpenFile.outPath;
     environment.systemPackages = [
       pkgs.xdg-utils
       xdgPdfItem

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -43,6 +43,7 @@
             ghaf.reference.programs.google-chrome.enable = true;
             ghaf.reference.programs.google-chrome.openInNormalExtension = true;
             ghaf.services.xdghandlers.enable = true;
+            ghaf.security.apparmor.enable = true;
           }
         ];
       }

--- a/modules/reference/appvms/google-chrome.nix
+++ b/modules/reference/appvms/google-chrome.nix
@@ -36,6 +36,7 @@
           imports = [ ../programs/google-chrome.nix ];
           ghaf.reference.programs.google-chrome.enable = true;
           ghaf.services.xdghandlers.enable = true;
+          ghaf.security.apparmor.enable = true;
         }
       ];
     }

--- a/modules/reference/personalize/authorizedSshKeys.nix
+++ b/modules/reference/personalize/authorizedSshKeys.nix
@@ -25,6 +25,7 @@
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICwsW+YJw6ukhoWPEBLN93EFiGhN7H2VJn5yZcKId56W mb@mmm"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKbBp2dH2X3dcU1zh+xW3ZsdYROKpJd3n13ssOP092qE joerg@turingmachine"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIstCgKDX1vVWI8MgdVwsEMhju6DQJubi3V0ziLcU/2h vunny.sodhi@unikie.com"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINfyjcPGIRHEtXZgoF7wImA5gEY6ytIfkBeipz4lwnj6 Ganga.Ram@tii.ae"
 
     # For ghaf-installer automated testing:
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAolaKCuIUBQSBFGFZI1taNX+JTAr8edqUts7A6k2Kv7"


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
- Enabled AppArmor 
- AppArmor profiles for google-chrome and ping
- AppArmor enabled in chrome-vm and business-vm


## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
Verify if chromium profile is active inside chromium-vm.
`$> sudo aa-status`

Do audio and video recording/playback, Google spread sheet editing using Chromium browser.

A brief documentation and test report are available in confluence.

https://ssrc.atlassian.net/wiki/spaces/GA/pages/1187708968/Security#1.-AppArmor%3A
