### PR TITLE
Move ZFS-related config pieces to one place

### DIFF
--- a/modules/disko/disko-ab-partitions.nix
+++ b/modules/disko/disko-ab-partitions.nix
@@ -23,9 +23,16 @@
 # - recovery : (no quota) Recovery factory image is stored here
 # - storagevm: (no quota) Dataset is meant to be used for StorageVM
 {pkgs, ...}: {
-  #TODO Probably the 'networking.hostId' should be set
-  # somewhere else instead.
+  # TODO Keep ZFS-related parts of the configuration here for now.
+  # This allows to have all config dependencies in one place and cleans
+  # other targets' configs from unnecessary components.
   networking.hostId = "8425e349";
+  boot = {
+    initrd.availableKernelModules = [
+      "zfs"
+    ];
+    supportedFilesystems = ["zfs"];
+  };
   disko = {
     memSize = 4096;
     extraPostVM = ''

--- a/modules/hardware/x86_64-generic/x86_64-linux.nix
+++ b/modules/hardware/x86_64-generic/x86_64-linux.nix
@@ -32,13 +32,14 @@ in {
       initrd.availableKernelModules = [
         "nvme"
         "uas"
-        "zfs"
       ];
       loader = {
         efi.canTouchEfiVariables = true;
         systemd-boot.enable = true;
       };
-      supportedFilesystems = ["zfs"];
+      # ZFS-compatible kernel is used for every applicable target since for certain
+      # targets ZFS support is required, and having the same kernel version for
+      # different targets simplifies and hardens the resulting configuration.
       kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
     };
   };


### PR DESCRIPTION
These changes clean up other configurations that do not use ZFS

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This PR fixes the build error for x86-generic target.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

All x86-based configuration should build without issues, no matter if they use ZFS or not. The kernel version is `Linux ghaf-host 6.8.12`

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
