### PR TITLE
labwc: add magnification (zooming)

### DIFF
--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -120,6 +120,15 @@
       <keybind key="XF86_AudioMute">
         <action name="Execute" command="${audio-ctrl}/bin/audio-ctrl mut" />
       </keybind>
+      <keybind key="W-z">
+        <action name="ToggleMagnify" />
+      </keybind>
+      <keybind key="W--">
+        <action name="ZoomOut" />
+      </keybind>
+      <keybind key="W-=">
+        <action name="ZoomIn" />
+      </keybind>
     </keyboard>
     <mouse><default /></mouse>
     <windowRules>


### PR DESCRIPTION
Adds magnification in labwc, which can be used for accessibility, development, and demo purposes.

Requires labwc 0.7.3+, depends on #703.

## Description of changes

- Add keybindings for magnification.
  - Super+z for toggling magnification.
  - Super+- for zoom out.
  - Super++ (without pressing Shift) for zoom in.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Test keybindings on desktop.
- If greetd is merged, this should work on login screen too.
