### PR TITLE
Add ghaf-infra dev cache to Ghaf flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,18 +5,21 @@
 
   nixConfig = {
     substituters = [
+      "https://dev-cache.vedenemo.dev"
       "https://cache.vedenemo.dev"
       "https://cache.ssrcdevops.tii.ae"
       "https://ghaf-dev.cachix.org"
       "https://cache.nixos.org/"
     ];
     extra-trusted-substituters = [
+      "https://dev-cache.vedenemo.dev"
       "https://cache.vedenemo.dev"
       "https://cache.ssrcdevops.tii.ae"
       "https://ghaf-dev.cachix.org"
       "https://cache.nixos.org/"
     ];
     extra-trusted-public-keys = [
+      "ghaf-infra-dev:EdgcUJsErufZitluMOYmoJDMQE+HFyveI/D270Cr84I="
       "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
       "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
       "ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY="


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Add https://dev-cache.vedenemo.dev nix binary cache to Ghaf flake.

https://dev-cache.vedenemo.dev is the ['dev' deployment](https://github.com/henrirosten/ghaf-infra/blob/d0ec199a3c9dc08dfd0e9e56dc3a3843e58ac582/terraform/main.tf#L117) of https://github.com/tiiuae/ghaf-infra/tree/main/terraform, with its jenkins instance running in https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/. The cache content is pushed e.g. from [pre-merge pipeline](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-pre-merge-pipeline/) and the [main pipeline](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-main-pipeline/) as outlined in [Confluence](https://ssrc.atlassian.net/wiki/spaces/SP/pages/1127023251/Ghaf-infra+Binary+Cache+Usage#Jenkins-pipelines).

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
