### PR TITLE
Disable the windows-vm launcher for MVP trial

### DIFF
--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -147,7 +147,7 @@ in {
             #   icon = "${pkgs.icon-pack}/system-suspend-hibernate.svg";
             # }
           ]
-          ++ optionals (hasAttr "spice-host" winConfig) [
+          ++ optionals config.ghaf.reference.programs.windows-launcher.enable [
             {
               name = "Windows";
               path = "${pkgs.virt-viewer}/bin/remote-viewer -f spice://${winConfig.spice-host}:${toString winConfig.spice-port}";

--- a/modules/profiles/mvp-user-trial.nix
+++ b/modules/profiles/mvp-user-trial.nix
@@ -37,8 +37,8 @@ in {
 
         programs = {
           windows-launcher = {
-            enable = true;
-            spice = true;
+            enable = false;
+            spice = false;
           };
         };
       };


### PR DESCRIPTION
The windows VM is not PoR for this configuration so remove it in order that it does not cause confusion.

The functionality is still available and can be enabled in different profiles as needed.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
The windowns launcher should not be visable in the app launcher.
