### PR TITLE
treefmt: replace black with ruff

### DIFF
--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -22,15 +22,9 @@
         statix.enable = true; # prevents use of nix anti-patterns https://github.com/nerdypepper/statix
 
         # Python
-        # It was found out that the best outcome comes from running mulitple
-        # formatters.
-        black.enable = true; # The Classic Python formatter
-        isort.enable = true; # Python import sorter
-        # Ruff, a Python formatter written in Rust (30x faster than Black).
-        # Also provides additional linting.
-        # Do not enable ruff.format = true; because then it won't complaing
-        # about linting errors. The default mode is the check mode.
+        # Ruff, a Python formatter and linter written in Rust (30x faster than Black).
         ruff.check = true;
+        ruff.format = true;
 
         # Bash
         shellcheck.enable = true; # lints shell scripts https://github.com/koalaman/shellcheck

--- a/packages/element-gps/main.py
+++ b/packages/element-gps/main.py
@@ -14,7 +14,7 @@ import websockets
 
 class GpsProcessState:
     def __init__(self):
-        self._gps_data = str()
+        self._gps_data = ""
         self.data_lock = asyncio.Lock()
         self.condition = asyncio.Condition()
         self.abort_websockets = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+lint.select = [ "E", "F", "I", "U", "N", "RUF", "A" ]
+lint.ignore = [ "E501", "A003"]


### PR DESCRIPTION
One tool less to download.
Ruff's formatting tries to stay close to 100% compatible with black while being faster.
Having one tool for everything also should in theory cause less compatibility issues.                                                

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
