### PR TITLE
Disable hardening kernel checks as unmaintained

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -17,12 +17,12 @@
             reuse lint
             touch $out
           '';
-        module-test-hardened-generic-host-kernel =
-          pkgs.callPackage ../modules/hardware/x86_64-generic/kernel/host/test {inherit pkgs;};
-        module-test-hardened-lenovo-x1-guest-guivm-kernel =
-          pkgs.callPackage ../modules/hardware/lenovo-x1/kernel/guest/test {inherit pkgs;};
-        module-test-hardened-pkvm-kernel =
-          pkgs.callPackage ../modules/hardware/x86_64-generic/kernel/host/pkvm/test {inherit pkgs;};
+        # module-test-hardened-generic-host-kernel =
+        #   pkgs.callPackage ../modules/hardware/x86_64-generic/kernel/host/test {inherit pkgs;};
+        # module-test-hardened-lenovo-x1-guest-guivm-kernel =
+        #   pkgs.callPackage ../modules/hardware/lenovo-x1/kernel/guest/test {inherit pkgs;};
+        # module-test-hardened-pkvm-kernel =
+        #   pkgs.callPackage ../modules/hardware/x86_64-generic/kernel/host/pkvm/test {inherit pkgs;};
       }
       // (lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages);
   };


### PR DESCRIPTION
Temp disable this until there is a process to ensure that the hardening
checks are applicable to the current kernels.

-------

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Disable the hardening checks from the `nix flake check` so that `nix-fast-build`` will know state for iterative builds`

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing
Run `nix-fast-build` on consecutive times and see that there is nothing to be built after the first iteration.