### PR TITLE
increase memsize for building disko images

### DIFF
--- a/modules/disko/disko-ab-partitions.nix
+++ b/modules/disko/disko-ab-partitions.nix
@@ -34,7 +34,8 @@
     supportedFilesystems = ["zfs"];
   };
   disko = {
-    memSize = 4096;
+    # 8GB is the recommeneded minimum for ZFS, so we are using this for VMs to avoid `cp` oom errors.
+    memSize = 8192;
     extraPostVM = ''
       ${pkgs.zstd}/bin/zstd --compress $out/*raw
       rm $out/*raw


### PR DESCRIPTION
Trying to reduce the ARC didn't help to reduce the overall memory usage of the VM while building the disk images.
I see some increase of zio_buf_comb_<NUM> slabs which are also used for ARC, but maybe also in other places of zfs.
Hence I am increasing zfs to what is commonly known as the recommended memory size (also I personally used zfs with 4GB just fine on my NAS).
It could be that I am missing some other leak but I couldn't spot anything suspciously large except for zfs related allocations in /proc/slabinfo

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
