### PR TITLE
[X1] Turn off the display when system is suspended

### DIFF
--- a/modules/hardware/common/qemu.nix
+++ b/modules/hardware/common/qemu.nix
@@ -24,9 +24,6 @@ in
     ghaf.qemu.guivm = optionalAttrs (hasAttr "hardware" config.ghaf) {
       microvm.qemu.extraArgs =
         [
-          # Button
-          "-device"
-          "button"
           # Battery
           "-device"
           "battery"


### PR DESCRIPTION
* Addresses SP-4844 - Display turns on in sleep mode when the lid is closed.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `nix flake check --accept-flake-config` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

- Display will get turn off automatically when lid is closed.
- Display will get turn off automatically when we run `sudo systsemctl suspend` on `ghaf-host` 

### Known issues with Qemu
1. As persistent Storage is enabled in `gui-vm` due to which `gui-vm` fails to suspend as virtio filesystem doesn't support suspend, details [here](https://github.com/torvalds/linux/blob/v6.10/fs/fuse/virtio_fs.c#L1058-L1063).
```
gui-vm kernel: virtio-fs: suspend/resume not yet supported
gui-vm kernel: virtio-pci 0000:00:04.0: PM: pci_pm_suspend(): virtio_pci_freeze+0x0/0x50 [virtio_pci] returns -95
gui-vm kernel: virtio-pci 0000:00:04.0: PM: dpm_run_callback(): pci_pm_suspend+0x0/0x170 returns -95
gui-vm kernel: virtio-pci 0000:00:04.0: PM: failed to suspend async: error -95
```

2. If someway we can managed to solve problem 1, then `gui-vm` cannot be resume on keyboard press, way to resume is from qemu monitor socket.

3. If someway we can managed to solve problem 2, then qemu freezes after resume, more details [here](https://gitlab.com/qemu-project/qemu/-/issues/2520)
 
So considering above qemu issues, I think better to turn off display.

### Power improvements

|Check |With PR  | Without PR |
| -------------| ------------- | ------------- |
Battery Drainage | ~2 % per hour  | ~8 % per hour |

Approx 4 times improvement in battery life when lid is closed.

### Next Steps
Try to replicate with `givc` service if feasible. 