### PR TITLE
Change the riscv target to have -from-x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,8 @@ jobs:
             target: nvidia-jetson-orin-agx-debug-from-x86_64
           - arch: x86_64-linux
             target: nvidia-jetson-orin-nx-debug-from-x86_64
-          - arch: riscv64-linux
-            target: microchip-icicle-kit-debug
+          - arch: x86_64-linux
+            target: microchip-icicle-kit-debug-from-x86_64
           - arch: x86_64-linux
             target: doc
           - arch: aarch64-linux

--- a/hydrajobs/flake-module.nix
+++ b/hydrajobs/flake-module.nix
@@ -30,12 +30,13 @@ in
     nxp-imx8mp-evk-debug.x86_64-linux = self.packages.aarch64-linux.nxp-imx8mp-evk-debug;
     docs.x86_64-linux = self.packages.x86_64-linux.doc;
     docs.aarch64-linux = self.packages.aarch64-linux.doc;
-    microchip-icicle-kit-debug.x86_64-linux = self.packages.riscv64-linux.microchip-icicle-kit-debug;
-    # Build cross-copmiled images
+    # Build cross-compiled images
     nvidia-jetson-orin-agx-debug-from-x86_64.x86_64-linux =
       self.packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64;
     nvidia-jetson-orin-nx-debug-from-x86_64.x86_64-linux =
       self.packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64;
+    microchip-icicle-kit-debug-from-x86_64.x86_64-linux =
+      self.packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64;
 
     # Build also cross-compiled images without demo apps
     nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64.x86_64-linux =

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 { self, ... }:
 {
-  flake.packages.riscv64-linux.hart-software-services =
-    self.nixosConfigurations.microchip-icicle-kit-debug.pkgs.callPackage ./hart-software-services
+  flake.packages.x86_64-linux.hart-software-services =
+    self.nixosConfigurations.microchip-icicle-kit-debug-from-x86_64.pkgs.callPackage
+      ./hart-software-services
       { };
   perSystem =
     {

--- a/targets/microchip-icicle-kit/flake-module.nix
+++ b/targets/microchip-icicle-kit/flake-module.nix
@@ -61,7 +61,7 @@ let
     in
     {
       inherit hostConfiguration;
-      name = "${name}-${variant}";
+      name = "${name}-${variant}-from-x86_64";
       package = hostConfiguration.config.system.build.sdImage;
     };
 
@@ -76,7 +76,7 @@ in
       map (t: lib.nameValuePair t.name t.hostConfiguration) targets
     );
     packages = {
-      riscv64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+      x86_64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
     };
   };
 }


### PR DESCRIPTION
This is to be consistent with the naming conventions as this package is a xcompiled package we should follow the same convention and list it as a package that is built on x86 and not claim that it is a package that is built on riscv directly

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
