### PR TITLE
Workaround for hss compilation issue

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -117,3 +117,11 @@ SPDX-FileCopyrightText = "Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIAT
 path = [
 	"modules/jetpack/nvidia-jetson-orin/tegra2-mb2-bct-scr.patch",
 ]
+
+
+[[annotations]]
+SPDX-License-Identifier = "MIT"
+SPDX-FileCopyrightText = "Copyright 2019-2021 Microchip Corporation."
+path = [
+	"packages/hart-software-services/0001-Workaround-for-a-compilation-issue.patch",
+]

--- a/packages/hart-software-services/0001-Workaround-for-a-compilation-issue.patch
+++ b/packages/hart-software-services/0001-Workaround-for-a-compilation-issue.patch
@@ -1,0 +1,16 @@
+diff --git a/application/rules.mk b/application/rules.mk
+index ff3905e..f663089 100644
+--- a/application/rules.mk
++++ b/application/rules.mk
+@@ -113,7 +113,7 @@ ifdef CONFIG_CC_STACKPROTECTOR_STRONG
+   # CORE_CFLAGS+=-fstack-clash-protection  # currently does nothing on RISC-V
+ else
+   $(info INFO: NOTICE: enabling -flto (which means stack protection is disabled))
+-  OPT-y+=-flto=auto -ffat-lto-objects -fcompare-debug -fno-stack-protector
++  OPT-y+=-flto=auto -ffat-lto-objects -fno-stack-protector
+ endif
+ 
+ ##############################################################################
+-- 
+2.42.0
+

--- a/packages/hart-software-services/default.nix
+++ b/packages/hart-software-services/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation (
       sha256 = "sha256-j/nda7//CjJW09zt/YrBy6h+q+VKE5t/ueXxDzwVWQ0=";
     };
 
+    patches = [ ./0001-Workaround-for-a-compilation-issue.patch ];
     depsBuildBuild = [ python3 ];
 
     configurePhase = ''


### PR DESCRIPTION
<!--
    Copyright 2024 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Workaround for hss compilation issue
- Patched hss package to removed `-fcompare-debug` flag from make rules
- Downgrading compiler didn't work, Compiler build fails for  gcc11 and gcc12

GCC Bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104180

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
