### PR TITLE
fix: ghaf-host rootfs out-of-space fails to boot

### DIFF
--- a/modules/common/development/nix.nix
+++ b/modules/common/development/nix.nix
@@ -31,6 +31,15 @@ in
         keep-derivations = true;
       };
 
+      # avoid scenario where the host rootfs gets filled
+      # with nixos-rebuild ... switch generated excess
+      # generations and becomes unbootable
+      gc = {
+        automatic = true;
+        dates = "daily";
+        options = "--delete-older-than 3d";
+      };
+
       # Set the path and registry so that e.g. nix-shell and repl work
       nixPath = lib.mkIf (cfg.nixpkgs != null) [ "nixpkgs=${cfg.nixpkgs}" ];
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

* Too many nixos-rebuild ... switch fills the ghaf-host rootfs and the system fails to boot, including access to prev generations.
* The fix ~~limits the generations to 5.~~ removes generations over 3 days old. Without limiting the amount of generations, the practical recovery was clean ghaf install.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

* Run `nixos-rebuild ... switch` with changes to the configuration. 
* Wait three days until the automatic garbage collections runs. 
* Reboot and verify that the stale ghaf configuration generations have been removed. 