### PR TITLE
widgets: eww

### DIFF
--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -84,6 +84,7 @@ let
               (rmDesktopEntries [
                 pkgs.waypipe
                 pkgs.networkmanagerapplet
+                pkgs.eww
               ])
               ++ [
                 pkgs.nm-launcher


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

* testing wacky widgets

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

The [Vertical Bar by Rxyhn](https://github.com/rxyhn/bspdots) example configuration does not load. Both bar and dashboard have errors which `eww` can't handle. 

The example bar loads on Ghaf desktop as follows:

```
# in gui-vm shell
eww daemon --logs # fails to load with no .config/eww
mkdir -p .config/eww
git clone https://github.com/elkowar/eww.git
cd .config/eww/
mv ../../eww/examples/eww-bar/* .
eww reload
eww reload --force-wayland # not sure if required
eww list-windows
eww open bar
```

![Screenshot 2024-08-22 at 11 51 39](https://github.com/user-attachments/assets/70175e67-9f2e-4756-84b5-862cc3f1c6cc)


<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
