### PR TITLE
HACK: hyprland testing

### DIFF
--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -194,12 +194,11 @@ let
     name = "labwc-session";
 
     runtimeInputs = [
-      #pkgs.labwc
+      pkgs.labwc
       autostart
     ];
 
-    #text = "labwc -C /etc/labwc -s labwc-autostart";
-    text = "hyprland";
+    text = "labwc -C /etc/labwc -s labwc-autostart";
   };
 in
 {

--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -194,11 +194,12 @@ let
     name = "labwc-session";
 
     runtimeInputs = [
-      pkgs.labwc
+      #pkgs.labwc
       autostart
     ];
 
-    text = "labwc -C /etc/labwc -s labwc-autostart";
+    #text = "labwc -C /etc/labwc -s labwc-autostart";
+    text = "hyprland";
   };
 in
 {

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -97,7 +97,8 @@ in
 
     environment.systemPackages =
       [
-        pkgs.labwc
+        pkgs.hyprland
+        #pkgs.labwc
         pkgs.ghaf-openbox-theme
         pkgs.adwaita-icon-theme
 

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -97,8 +97,7 @@ in
 
     environment.systemPackages =
       [
-        pkgs.hyprland
-        #pkgs.labwc
+        pkgs.labwc
         pkgs.ghaf-openbox-theme
         pkgs.adwaita-icon-theme
 

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -15,7 +15,6 @@
     kernelConfig.kernelParams = [
       "intel_iommu=on,sm_on"
       "iommu=pt"
-      "module_blacklist=i915" # Prevent i915 module from being accidentally used by host
       "acpi_backlight=vendor"
       "acpi_osi=linux"
     ];

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -15,6 +15,7 @@
     kernelConfig.kernelParams = [
       "intel_iommu=on,sm_on"
       "iommu=pt"
+      "module_blacklist=i915" # Prevent i915 module from being accidentally used by host
       "acpi_backlight=vendor"
       "acpi_osi=linux"
       "xe.force_probe='a7a1'"

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -89,7 +89,7 @@
     ];
     kernelConfig = {
       stage1.kernelModules = [ "i915" ];
-      kernelParams = [ "earlykms" ];
+      kernelParams = [ "earlykms" "xe.force_probe='a7a1'" "i915.force_probe='!a7a1'" ];
     };
   };
 

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -17,7 +17,13 @@
       "iommu=pt"
       "acpi_backlight=vendor"
       "acpi_osi=linux"
+      "xe.force_probe='a7a1'"
+      "i915.force_probe='!a7a1'"
     ];
+    # [    8.569240] xe 0000:00:02.0: Your graphics device a7a1 is not officially supported
+    # by xe driver in this kernel version. To force Xe probe,
+    # use xe.force_probe='a7a1' and i915.force_probe='!a7a1'
+    # module parameters
   };
 
   input = {

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -15,16 +15,10 @@
     kernelConfig.kernelParams = [
       "intel_iommu=on,sm_on"
       "iommu=pt"
-      "module_blacklist=i915" # Prevent i915 module from being accidentally used by host
+      "module_blacklist=i915,xe,drm_gpuvm" # Prevent modules from being accidentally used by host
       "acpi_backlight=vendor"
       "acpi_osi=linux"
-      "xe.force_probe='a7a1'"
-      "i915.force_probe='!a7a1'"
     ];
-    # [    8.569240] xe 0000:00:02.0: Your graphics device a7a1 is not officially supported
-    # by xe driver in this kernel version. To force Xe probe,
-    # use xe.force_probe='a7a1' and i915.force_probe='!a7a1'
-    # module parameters
   };
 
   input = {

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -3,7 +3,7 @@
 #
 # Modules that should be only imported to host
 #
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   networking.hostName = lib.mkDefault "ghaf-host";
 
@@ -15,4 +15,8 @@
     # To push logs to central location
     ../common/logging/client.nix
   ];
+  virtualisation.libvirtd = {
+    enable = true;
+    qemu.ovmf.packages = [ pkgs.OVMFFull ];
+  };
 }

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -11,6 +11,7 @@ let
   macAddress = "02:00:00:02:02:02";
   inherit (import ../../../../lib/launcher.nix { inherit pkgs lib; }) rmDesktopEntries;
   guivmBaseConfiguration = {
+
     imports = [
       (import ./common/vm-networking.nix {
         inherit
@@ -211,9 +212,7 @@ in
     microvm.vms."${vmName}" = {
       autostart = true;
       config = guivmBaseConfiguration // {
-        boot.kernelPackages = lib.mkIf config.ghaf.guest.kernel.hardening.graphics.enable (
-          pkgs.linuxPackagesFor guest_graphics_hardened_kernel
-        );
+        boot.kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
 
         imports = guivmBaseConfiguration.imports ++ cfg.extraModules;
       };


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

* starts hyprland instead of labwc but fails due to i915 driver crash in gui-vm - reproducible every time
dmesg
```
[    0.720628] i915 0000:00:05.0: [drm] VT-d active for gfx access
[    0.720667] i915 0000:00:05.0: vgaarb: deactivate vga console
[    0.721200] Console: switching to colour dummy device 80x25
[    0.721285] i915 0000:00:05.0: [drm] Using Transparent Hugepages
[    0.725549] i915 0000:00:05.0: Invalid PCI ROM data signature: expecting 0x52494350, got 0xcb03aa55
[    0.725558] i915 0000:00:05.0: [drm] Failed to find VBIOS tables (VBT)
[    0.726028] i915 0000:00:05.0: vgaarb: VGA decodes changed: olddecodes=io+mem,decodes=io+mem:owns=io+mem
[    0.729146] i915 0000:00:05.0: [drm] Finished loading DMC firmware i915/adlp_dmc.bin (v2.20)
[    0.959741] ------------[ cut here ]------------
[    0.959750] i915 0000:00:05.0: Platform does not support port C
[    0.959838] WARNING: CPU: 0 PID: 87 at drivers/gpu/drm/i915/display/intel_display.c:7426 assert_port_valid+0x60/0x80 [i915]
[    0.960067] Modules linked in: i915(+) i2c_algo_bit drm_buddy video wmi backlight ttm intel_gtt drm_display_helper cec
[    0.960081] CPU: 0 PID: 87 Comm: modprobe Not tainted 6.6.43 #1-NixOS
[    0.960087] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS rel-1.16.3-0-ga6ed6b701f0a-prebuilt.qemu.org 04/01/2014
[    0.960088] RIP: 0010:assert_port_valid+0x60/0x80 [i915]
[    0.960262] Code: 7f 08 8d 6e 41 4c 8b 67 50 4d 85 e4 75 03 4c 8b 27 e8 44 22 94 fc 89 e9 4c 89 e2 48 c7 c7 40 df 7a c0 48 89 c6 e8 60 d1 13 fc <0f> 0b 89 d8 5b 5d 83 e0 01 41 5c 31 d2 31 c9 31 f6 31 ff c3 cc cc
[    0.960264] RSP: 0018:ffff95fa8026bac8 EFLAGS: 00010246
[    0.960269] RAX: 0000000000000000 RBX: 000000000000001e RCX: 0000000000000000
[    0.960271] RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000000
[    0.960272] RBP: 0000000000000043 R08: 0000000000000000 R09: 0000000000000000
[    0.960273] R10: 0000000000000000 R11: 0000000000000000 R12: ffff8cab418e3ba0
[    0.960274] R13: ffff8cab43141aa8 R14: 0000000000000002 R15: ffff8cab419ac000
[    0.960275] FS:  00007f4830823200(0000) GS:ffff8cabbd000000(0000) knlGS:0000000000000000
[    0.960277] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[    0.960279] CR2: 00007f7e8fd995c0 CR3: 0000000003100000 CR4: 0000000000750ef0
[    0.960283] PKRU: 55555554
[    0.960284] Call Trace:
[    0.960286]  <TASK>
[    0.960288]  ? assert_port_valid+0x60/0x80 [i915]
[    0.960454]  ? __warn+0x81/0x130
[    0.960481]  ? assert_port_valid+0x60/0x80 [i915]
[    0.960645]  ? report_bug+0x182/0x1b0
[    0.960667]  ? handle_bug+0x42/0x90
[    0.960682]  ? exc_invalid_op+0x17/0x80
[    0.960685]  ? asm_exc_invalid_op+0x1a/0x20
[    0.960705]  ? assert_port_valid+0x60/0x80 [i915]
[    0.960865]  ? assert_port_valid+0x60/0x80 [i915]
[    0.961030]  ? __pfx_intel_ddi_init+0x10/0x10 [i915]
[    0.961195]  intel_ddi_init+0x67/0x1040 [i915]
[    0.961353]  ? __pfx_intel_ddi_init+0x10/0x10 [i915]
[    0.961505]  intel_bios_for_each_encoder+0x35/0x60 [i915]
[    0.961686]  intel_setup_outputs+0x380/0x8c0 [i915]
[    0.961863]  intel_display_driver_probe_nogem+0x15a/0x230 [i915]
[    0.962032]  i915_driver_probe+0x6e3/0xb90 [i915]
[    0.962171]  local_pci_probe+0x3f/0xa0
[    0.962190]  pci_device_probe+0xc3/0x250
[    0.962197]  ? sysfs_do_create_link_sd+0x6e/0xf0
[    0.962214]  really_probe+0x1a9/0x3f0
[    0.962228]  ? __pfx___driver_attach+0x10/0x10
[    0.962230]  __driver_probe_device+0x78/0x170
[    0.962236]  driver_probe_device+0x1f/0xa0
[    0.962238]  __driver_attach+0xea/0x1e0
[    0.962239]  bus_for_each_dev+0x89/0xe0
[    0.962243]  bus_add_driver+0x14d/0x280
[    0.962246]  driver_register+0x5d/0x120
[    0.962252]  i915_init+0x22/0xc0 [i915]
[    0.962387]  ? __pfx_i915_init+0x10/0x10 [i915]
[    0.962519]  do_one_initcall+0x5a/0x330
[    0.962535]  do_init_module+0x90/0x270
[    0.962549]  __do_sys_init_module+0x18a/0x1c0
[    0.962552]  do_syscall_64+0x39/0x90
[    0.962555]  entry_SYSCALL_64_after_hwframe+0x78/0xe2
[    0.962558] RIP: 0033:0x7f483093b61e
[    0.962563] Code: 48 8b 0d 0d 68 0d 00 f7 d8 64 89 01 48 83 c8 ff c3 66 2e 0f 1f 84 00 00 00 00 00 90 f3 0f 1e fa 49 89 ca b8 af 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d da 67 0d 00 f7 d8 64 89 01 48
[    0.962565] RSP: 002b:00007ffffddc2728 EFLAGS: 00000246 ORIG_RAX: 00000000000000af
[    0.962567] RAX: ffffffffffffffda RBX: 0000000001b21b80 RCX: 00007f483093b61e
[    0.962568] RDX: 000000000041e1e1 RSI: 000000000089aa28 RDI: 00007f482fae9010
[    0.962570] RBP: 00007f482fae9010 R08: 0000000000000000 R09: 0000000000000000
[    0.962571] R10: 0000000000000000 R11: 0000000000000246 R12: 000000000041e1e1
[    0.962572] R13: 0000000000040000 R14: 0000000001b21c90 R15: 0000000000000000
[    0.962574]  </TASK>
[    0.962575] ---[ end trace 0000000000000000 ]---
[    0.962723] i915 0000:00:05.0: [drm] [ENCODER:235:DDI A/PHY A] is disabled/in DSI mode with an ungated DDI clock, gate it
[    0.983659] i915 0000:00:05.0: [drm] GT0: GuC firmware i915/adlp_guc_70.bin version 70.20.0
[    0.983667] i915 0000:00:05.0: [drm] GT0: HuC firmware i915/tgl_huc.bin version 7.9.3
[    0.998879] i915 0000:00:05.0: [drm] GT0: HuC: authenticated for all workloads
[    0.999621] i915 0000:00:05.0: [drm] GT0: GUC: submission enabled
[    0.999624] i915 0000:00:05.0: [drm] GT0: GUC: SLPC enabled
[    1.000130] i915 0000:00:05.0: [drm] GT0: GUC: RC enabled
[    1.003075] [drm] Initialized i915 1.6.0 20201103 for 0000:00:05.0 on minor 0
...
[  509.964188] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
[  509.964596] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
[  509.965012] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
[  509.967988] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
[  509.968445] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
[  509.968881] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
[  509.969296] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
[  509.969708] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
[  509.970130] i915 0000:00:05.0: [drm] *ERROR* Fault errors on pipe A: 0x00000080
# endless stream
```

Related: https://gitlab.freedesktop.org/drm/i915/kernel/-/issues/10261

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing

<!--
How this was tested by the author? How is this supposed to be tested
by people doing system testing?
-->
