### PR TITLE
Create testing profile for non-default features

### DIFF
--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -39,8 +39,13 @@ let
               applications.enable = false;
               graphics.enable = true;
             };
+
             # To enable screen locking set to true
-            graphics.labwc.autolock.enable = false;
+            graphics.labwc = {
+              autolock.enable = lib.mkDefault config.ghaf.graphics.labwc.autolock.enable;
+              autologinUser = lib.mkDefault config.ghaf.graphics.labwc.autologinUser;
+            };
+
             development = {
               ssh.daemon.enable = lib.mkDefault config.ghaf.development.ssh.daemon.enable;
               debug.tools.enable = lib.mkDefault config.ghaf.development.debug.tools.enable;

--- a/modules/reference/profiles/default.nix
+++ b/modules/reference/profiles/default.nix
@@ -7,5 +7,6 @@
   imports = [
     ./laptop-x86.nix
     ./mvp-user-trial.nix
+    ./mvp-user-trial-extras.nix
   ];
 }

--- a/modules/reference/profiles/mvp-user-trial-extras.nix
+++ b/modules/reference/profiles/mvp-user-trial-extras.nix
@@ -1,0 +1,53 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.reference.profiles.mvp-user-trial-extras;
+in
+{
+  imports = [ ./mvp-user-trial.nix ];
+
+  options.ghaf.reference.profiles.mvp-user-trial-extras = {
+    enable = lib.mkEnableOption "Enable the mvp configuration for apps and services";
+  };
+
+  config = lib.mkIf cfg.enable {
+    ghaf = {
+      reference = {
+        profiles = {
+          mvp-user-trial.enable = true;
+        };
+
+        programs = {
+          windows-launcher = {
+            enable = true;
+            spice = true;
+          };
+        };
+      };
+
+      profiles = {
+        # Enable below option for host hardening features
+        # Secure Boot
+        host-hardening.enable = true;
+      };
+
+      virtualization.microvm = {
+        # Enable idsvm and the MiTM features
+        idsvm = {
+          enable = lib.mkForce true;
+          mitmproxy.enable = lib.mkForce true;
+        };
+      };
+
+      # Enable below option for session lock feature
+      graphics = {
+        boot.enable = lib.mkForce true;
+        labwc = {
+          autolock.enable = lib.mkForce true;
+          autologinUser = lib.mkForce null;
+        };
+      };
+    };
+  };
+}

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -18,6 +18,8 @@ in
 
   config = lib.mkIf cfg.enable {
     ghaf = {
+      graphics.labwc.autolock.enable = false;
+
       reference = {
         appvms = {
           enable = true;
@@ -32,13 +34,6 @@ in
         services = {
           enable = true;
           dendrite = true;
-        };
-
-        programs = {
-          windows-launcher = {
-            enable = false;
-            spice = false;
-          };
         };
 
         personalize = {

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -33,6 +33,15 @@ let
         };
       }
     ])
+    (laptop-configuration "lenovo-x1-extras" "debug" [
+      self.nixosModules.disko-ab-partitions-v1
+      {
+        ghaf = {
+          hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen11.nix";
+          reference.profiles.mvp-user-trial-extras.enable = true;
+        };
+      }
+    ])
     (laptop-configuration "dell-latitude-7230" "debug" [
       self.nixosModules.disko-basic-partition-v1
       {
@@ -68,6 +77,15 @@ let
         ghaf = {
           hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen11.nix";
           reference.profiles.mvp-user-trial.enable = true;
+        };
+      }
+    ])
+    (laptop-configuration "lenovo-x1-extras" "release" [
+      self.nixosModules.disko-ab-partitions-v1
+      {
+        ghaf = {
+          hardware.definition.configFile = "/lenovo-x1/definitions/x1-gen11.nix";
+          reference.profiles.mvp-user-trial-extras.enable = true;
         };
       }
     ])

--- a/targets/laptop/laptop-configuration-builder.nix
+++ b/targets/laptop/laptop-configuration-builder.nix
@@ -33,8 +33,6 @@ let
                 # variant type, turn on debug or release
                 debug.enable = variant == "debug";
                 release.enable = variant == "release";
-                # Enable below option for host hardening features
-                host-hardening.enable = false;
               };
             };
           })


### PR DESCRIPTION
This patch enables features that are needed for testing and validation,
which are not currently enabled by defualt in the standard MVP image.

The corresponding image is intended only for the bi-weekly regression
tests at present.

-------

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to
new target created for testing the features that are not enabled by default. It is based on the default MVP-user-trial image, with a few additional features. It only applies to the lenovo X1 gen11 at the moment.

- [ ] Is this a new feature
  - [ ] List the test steps to verify
  
  `nix build .#lenovo-x1-extras-debug`
