### PR TITLE
Fix ids-vm

### DIFF
--- a/modules/microvm/virtualization/microvm/idsvm/idsvm.nix
+++ b/modules/microvm/virtualization/microvm/idsvm/idsvm.nix
@@ -45,7 +45,7 @@ let
           nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
           nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
 
-          microvm.hypervisor = "cloud-hypervisor";
+          microvm.hypervisor = "qemu";
 
           environment.systemPackages = [
             pkgs.snort # TODO: put into separate module

--- a/modules/microvm/virtualization/microvm/netvm.nix
+++ b/modules/microvm/virtualization/microvm/netvm.nix
@@ -27,7 +27,7 @@ let
           macAddress
           ;
         internalIP = 1;
-        gateway = [ ];
+        isGateway = true;
       })
       # To push logs to central location
       ../../../common/logging/client.nix


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
IDS VM is not working in current configuration.

Changes:
- change idsvm `microvm.hypervisor` from 'cloud-hypervisor' to 'qemu'
- fix gateway settings

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to
lenovo x1

- [x] List the test steps to verify

### Reproduce problem (optional)

- enable idsvm in `modules/profiles/laptop-x86.nix`:
```
idsvm = {
  enable = true;
  mitmproxy.enable = true;
};
```
- run `mitmweb-ui` in guivm terminal

### Verify configuration

Check config with nix repl
```
:lf .
vms = nixosConfigurations.lenovo-x1-carbon-gen11-debug.config.microvm.vms
:p builtins.map (vm: {"${vm}-gateway" = vms."${vm}".config.config.systemd.network.networks."10-ethint0".gateway;}) (builtins.attrNames vms)
```
- Output with idsvm disabled 
```
[
  { admin-vm-gateway = [ "192.168.100.1" ]; }
  { appflowy-vm-gateway = [ "192.168.100.1" ]; }
  { audio-vm-gateway = [ "192.168.100.1" ]; }
  { business-vm-gateway = [ "192.168.100.1" ]; }
  { chromium-vm-gateway = [ "192.168.100.1" ]; }
  { element-vm-gateway = [ "192.168.100.1" ]; }
  { gala-vm-gateway = [ "192.168.100.1" ]; }
  { gui-vm-gateway = [ "192.168.100.1" ]; }
  { net-vm-gateway = [ ]; }
  { zathura-vm-gateway = [ "192.168.100.1" ]; }
]
```
- Output with idsvm enabled
```
[
  { admin-vm-gateway = [ "192.168.100.4" ]; }
  { appflowy-vm-gateway = [ "192.168.100.4" ]; }
  { audio-vm-gateway = [ "192.168.100.4" ]; }
  { business-vm-gateway = [ "192.168.100.4" ]; }
  { chromium-vm-gateway = [ "192.168.100.4" ]; }
  { element-vm-gateway = [ "192.168.100.4" ]; }
  { gala-vm-gateway = [ "192.168.100.4" ]; }
  { gui-vm-gateway = [ "192.168.100.4" ]; }
  { ids-vm-gateway = [ "192.168.100.1" ]; }
  { net-vm-gateway = [ ]; }
  { zathura-vm-gateway = [ "192.168.100.4" ]; }
]
```

### Tests

Without idsvm:
1. Verify network functionality works for all VMs 
2. (Optional) Check gateways on running system (`ip route`)

With idsvm:
1. Run `mitmweb-ui`, start chromium to verify traffic gets recorded
2. (Optional) Check gateways on running system (`ip route`)

Note that with idsvm enabled, business vm apps (except chromium itself) don't work, will be addressed with GIVC.  

- [ ] Is this a new feature
- [ ] If it is an improvement how does it impact existing functionality?