### PR TITLE
GPU acceleration in gui-vm

### DIFF
--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -104,6 +104,8 @@ let
               ++ [
                 pkgs.nm-launcher
                 pkgs.pamixer
+                pkgs.glxinfo
+                pkgs.mesa-demos
               ]
               ++ (lib.optional (
                 config.ghaf.profiles.debug.enable && config.ghaf.virtualization.microvm.idsvm.mitmproxy.enable
@@ -227,9 +229,7 @@ in
     microvm.vms."${vmName}" = {
       autostart = true;
       config = guivmBaseConfiguration // {
-        boot.kernelPackages = lib.mkIf config.ghaf.guest.kernel.hardening.graphics.enable (
-          pkgs.linuxPackagesFor guest_graphics_hardened_kernel
-        );
+        boot.kernelPackages = pkgs.linuxPackages_latest;
 
         imports = guivmBaseConfiguration.imports ++ cfg.extraModules;
       };


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

* tested with `glxgears` and `gloss` (mesa-demos) - courtesy of dev/testing by @vunnyso 's from  [#754](https://github.com/tiiuae/ghaf/pull/754#issuecomment-2311779637)

![Screenshot 2024-08-27 at 15 54 40](https://github.com/user-attachments/assets/8fd9f984-1beb-4efe-a884-502555e8d8f8)

![Screenshot 2024-08-27 at 15 56 48](https://github.com/user-attachments/assets/7d0be33e-ac3c-457e-a412-291d17f3d48a)

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: X1
- [x] Is this a new feature
  - [x] List the test steps to verify
```
[ghaf@gui-vm:~]$ DISPLAY=:0.0 glxgears
16604 frames in 5.0 seconds = 3320.791 FPS
17441 frames in 5.0 seconds = 3488.048 FPS
18489 frames in 5.0 seconds = 3697.665 FPS
18446 frames in 5.0 seconds = 3689.172 FPS
19340 frames in 5.0 seconds = 3867.940 FPS
^C

[ghaf@gui-vm:~]$ DISPLAY=:0.0 gloss
3672 frames in 5.001 seconds = 734.253 FPS
3953 frames in 5 seconds = 790.6 FPS
3955 frames in 5.001 seconds = 790.842 FPS
3913 frames in 5 seconds = 782.6 FPS
4027 frames in 5.001 seconds = 805.239 FPS
```

- [x] If it is an improvement how does it impact existing functionality? LFS-enabled kernel features have not been aligned/tested with gui-vm running the linuxLatest.

