### PR TITLE
Add bluetooth support

### DIFF
--- a/modules/common/services/bluetooth.nix
+++ b/modules/common/services/bluetooth.nix
@@ -1,36 +1,76 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.ghaf.services.bluetooth;
   inherit (lib) mkIf mkEnableOption;
+  bluetoothUser = "bluetooth";
 in
 {
   options.ghaf.services.bluetooth = {
     enable = mkEnableOption "Bluetooth configurations";
   };
   config = mkIf cfg.enable {
+
+    # Enable bluetooth
     hardware.bluetooth = {
       enable = true;
     };
 
-    # Polkit rules for blueman
-    ghaf.systemd.withPolkit = true;
-    security.polkit = {
-      enable = true;
-      extraConfig = ''
-        polkit.addRule(function(action, subject) {
-          if ((action.id == "org.blueman.network.setup" ||
-              action.id == "org.blueman.dhcp.client" ||
-              action.id == "org.blueman.rfkill.setstate" ||
-              action.id == "org.blueman.pppd.pppconnect") &&
-              subject.user == "ghaf") {
-              return polkit.Result.YES;
-          }
-        });
-      '';
+    # Setup bluetooth user and group
+    users = {
+      users."${bluetoothUser}" = {
+        isSystemUser = true;
+        group = "${bluetoothUser}";
+      };
+      groups."${bluetoothUser}" = { };
     };
 
-    systemd.tmpfiles.rules = [ "f /var/lib/systemd/linger/${config.ghaf.users.accounts.user}" ];
+    # Uinput kernel module
+    boot.kernelModules = [ "uinput" ];
+
+    # Rfkill udev rule
+    services.udev.extraRules = ''
+      KERNEL=="rfkill", SUBSYSTEM=="misc", GROUP="${bluetoothUser}"
+      KERNEL=="uinput", SUBSYSTEM=="misc", GROUP="${bluetoothUser}"
+    '';
+
+    # Dbus policy updates
+    services.dbus.packages = [
+      (pkgs.writeTextFile {
+        name = "bluez-dbus-policy";
+        text = ''
+          <!DOCTYPE busconfig PUBLIC
+            "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+            "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+          <busconfig>
+            <policy user="${bluetoothUser}">
+              <allow own="org.bluez"/>
+              <allow send_destination="org.bluez.*"/>
+              <allow send_interface="org.bluez.*"/>
+              <allow send_type="method_call"/>
+              <allow send_interface="org.freedesktop.DBus.Introspectable"/>
+              <allow send_interface="org.freedesktop.DBus.Properties"/>
+              <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
+            </policy>
+            <policy user="pipewire">
+              <allow send_destination="org.bluez"/>
+            </policy>
+          </busconfig>
+        '';
+        destination = "/share/dbus-1/system.d/bluez.conf";
+      })
+    ];
+
+    # Configure bluetooth service
+    systemd.services.bluetooth.serviceConfig = {
+      User = "${bluetoothUser}";
+      Group = "${bluetoothUser}";
+    };
   };
 }

--- a/modules/common/services/bluetooth.nix
+++ b/modules/common/services/bluetooth.nix
@@ -1,0 +1,36 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.services.bluetooth;
+  inherit (lib) mkIf mkEnableOption;
+in
+{
+  options.ghaf.services.bluetooth = {
+    enable = mkEnableOption "Bluetooth configurations";
+  };
+  config = mkIf cfg.enable {
+    hardware.bluetooth = {
+      enable = true;
+    };
+
+    # Polkit rules for blueman
+    ghaf.systemd.withPolkit = true;
+    security.polkit = {
+      enable = true;
+      extraConfig = ''
+        polkit.addRule(function(action, subject) {
+          if ((action.id == "org.blueman.network.setup" ||
+              action.id == "org.blueman.dhcp.client" ||
+              action.id == "org.blueman.rfkill.setstate" ||
+              action.id == "org.blueman.pppd.pppconnect") &&
+              subject.user == "ghaf") {
+              return polkit.Result.YES;
+          }
+        });
+      '';
+    };
+
+    systemd.tmpfiles.rules = [ "f /var/lib/systemd/linger/${config.ghaf.users.accounts.user}" ];
+  };
+}

--- a/modules/common/services/default.nix
+++ b/modules/common/services/default.nix
@@ -10,5 +10,6 @@
     ./pdfopen.nix
     ./namespaces.nix
     ./yubikey.nix
+    ./bluetooth.nix
   ];
 }

--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -125,6 +125,12 @@ in
             }
 
             {
+              name = "Bluetooth Settings";
+              path = "${pkgs.bt-launcher}/bin/bt-launcher";
+              icon = "${pkgs.icon-pack}/bluetooth-48.svg";
+            }
+
+            {
               name = "Shutdown";
               path = "${pkgs.givc-cli}/bin/givc-cli ${cliArgs} poweroff";
               icon = "${pkgs.icon-pack}/system-shutdown.svg";

--- a/modules/common/systemd/hardened-configs/common/bluetooth.nix
+++ b/modules/common/systemd/hardened-configs/common/bluetooth.nix
@@ -1,0 +1,80 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  ProtectProc = "noaccess";
+  ProcSubset = "pid";
+  ProtectHome = true;
+  ProtectSystem = "full";
+  PrivateTmp = true;
+  PrivateMounts = true;
+  UMask = 77;
+  ProtectKernelTunables = true;
+  ProtectKernelModules = true;
+  ProtectKernelLogs = true;
+  KeyringMode = "private";
+  ProtectHostname = true;
+  ProtectClock = true;
+  ProtectControlGroups = true;
+  RestrictRealtime = true;
+  RemoveIPC = true;
+  NotifyAccess = "all";
+  NoNewPrivileges = true;
+  RestrictSUIDSGID = true;
+  LockPersonality = true;
+  MemoryDenyWriteExecute = true;
+  IPAddressDeny = "any";
+  RestrictAddressFamilies = [
+    "AF_BLUETOOTH"
+    "AF_ALG"
+    "AF_UNIX"
+  ];
+  ReadWritePaths = [ "/var/lib/bluetooth" ];
+  DeviceAllow = [
+    "/dev/rfkill"
+    "/dev/uinput"
+  ];
+  RestrictNamespaces = [
+    "~user"
+    "~pid"
+    "~net"
+    "~uts"
+    "~mnt"
+    "~cgroup"
+    "~ipc"
+  ];
+  AmbientCapabilities = [
+    "CAP_NET_BIND_SERVICE"
+    "CAP_NET_ADMIN"
+    "CAP_NET_RAW"
+    "CAP_SYS_RESOURCE"
+    "CAP_AUDIT_WRITE"
+  ];
+  CapabilityBoundingSet = [
+    "CAP_NET_BIND_SERVICE"
+    "CAP_NET_ADMIN"
+    "CAP_NET_RAW"
+    "CAP_SYS_RESOURCE"
+    "CAP_AUDIT_WRITE"
+  ];
+  SystemCallArchitectures = "native";
+  SystemCallFilter = [
+    "~@swap"
+    "~@timer"
+    "~@pkey"
+    "~@debug"
+    "~@cpu_emulation"
+    "~@mount"
+    "~@ipc"
+    "~@resources"
+    "~@memlock"
+    "~@keyring"
+    "~@raw_io"
+    "~@clock"
+    "~@aio"
+    "~@setuid"
+    "~@module"
+    "~@reboot"
+    "~@sandbox"
+    "~@chown"
+  ];
+}

--- a/modules/common/users/accounts.nix
+++ b/modules/common/users/accounts.nix
@@ -34,7 +34,7 @@ in
 
   config = mkIf cfg.enable {
     users = {
-      mutableUsers = true;
+      mutableUsers = false;
       users."${cfg.user}" = {
         isNormalUser = true;
         inherit (cfg) password;
@@ -50,6 +50,7 @@ in
         members = [ cfg.user ];
       };
     };
+
     # to build ghaf as ghaf-user with caches
     nix.settings.trusted-users = mkIf config.ghaf.profiles.debug.enable [ cfg.user ];
   };

--- a/modules/hardware/common/qemu.nix
+++ b/modules/hardware/common/qemu.nix
@@ -18,6 +18,11 @@ in
       default = { };
       description = "Extra qemu arguments for GuiVM";
     };
+    audiovm = mkOption {
+      type = types.attrs;
+      default = { };
+      description = "Extra qemu arguments for AudioVM";
+    };
   };
 
   config = {
@@ -40,6 +45,9 @@ in
           "-device"
           "pcie-root-port,bus=pcie.0,id=${config.ghaf.hardware.usb.vhotplug.pcieBusPrefix}${toString n},chassis=${toString n}"
         ]) (lib.range 1 config.ghaf.hardware.usb.vhotplug.pciePortCount);
+    };
+    ghaf.qemu.audiovm = optionalAttrs (hasAttr "hardware" config.ghaf) {
+      microvm.qemu.extraArgs = optionals (hasAttr "bt0" config.ghaf.hardware.usb.internal.qemuExtraArgs) config.ghaf.hardware.usb.internal.qemuExtraArgs.bt0;
     };
   };
 }

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -117,7 +117,6 @@ let
             ${config.ghaf.security.sshKeys.waypipeSshPublicKeyDir}.options = [ "ro" ];
           };
 
-          # Fixed IP-address for debugging subnet
           # SSH is very picky about to file permissions and ownership and will
           # accept neither direct path inside /nix/store or symlink that points
           # there. Therefore we copy the file to /etc/ssh/get-auth-keys (by
@@ -125,15 +124,6 @@ let
           environment.etc = lib.mkIf isGuiVmEnabled {
             ${config.ghaf.security.sshKeys.getAuthKeysFilePathInEtc} = sshKeysHelper.getAuthKeysSource;
           };
-
-          systemd.network.networks."10-ethint0".addresses =
-            let
-              getAudioVmEntry = builtins.filter (
-                x: x.name == "audio-vm" + lib.optionalString config.ghaf.profiles.debug.enable "-debug"
-              ) config.ghaf.networking.hosts.entries;
-              ip = lib.head (builtins.map (x: x.ip) getAudioVmEntry);
-            in
-            [ { Address = "${ip}/24"; } ];
         }
       )
     ];

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -21,6 +21,7 @@ let
   audiovmBaseConfiguration = {
     imports = [
       inputs.self.nixosModules.givc-audiovm
+      inputs.impermanence.nixosModules.impermanence
       (import ./common/vm-networking.nix {
         inherit
           config
@@ -30,6 +31,7 @@ let
           ;
         internalIP = 5;
       })
+      ./common/storagevm.nix
       (
         { lib, pkgs, ... }:
         {
@@ -52,9 +54,22 @@ let
               withResolved = true;
               withTimesyncd = true;
               withDebug = configHost.ghaf.profiles.debug.enable;
+              withHardenedConfigs = true;
             };
             givc.audiovm.enable = true;
             services.audio.enable = true;
+            storagevm = {
+              enable = true;
+              name = "audiovm";
+              directories = [
+                {
+                  directory = "/var/lib/bluetooth";
+                  user = "bluetooth";
+                  group = "bluetooth";
+                  mode = "u=rwx,g=,o=";
+                }
+              ];
+            };
           };
 
           environment = {

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -111,6 +111,7 @@ let
               ])
               ++ [
                 pkgs.nm-launcher
+                pkgs.bt-launcher
                 pkgs.pamixer
               ]
               ++ (lib.optional (

--- a/modules/microvm/virtualization/microvm/modules.nix
+++ b/modules/microvm/virtualization/microvm/modules.nix
@@ -43,6 +43,7 @@ let
   # Qemu configuration modules
   qemuModules = {
     inherit (config.ghaf.qemu) guivm;
+    inherit (config.ghaf.qemu) audiovm;
   };
 
   # Service modules
@@ -54,6 +55,9 @@ let
 
     # Audio module
     audio = optionalAttrs cfg.audiovm.audio { config.ghaf.services.audio.enable = true; };
+
+    # Bluetooth module
+    bluetooth = optionalAttrs cfg.audiovm.audio { config.ghaf.services.bluetooth.enable = true; };
 
     # Wifi module
     wifi = optionalAttrs cfg.netvm.wifi { config.ghaf.services.wifi.enable = true; };
@@ -145,8 +149,11 @@ in
       audiovm.extraModules = optionals cfg.audiovm.enable [
         deviceModules.audiovmPCIPassthroughModule
         kernelConfigs.audiovm
+        firmwareModule
+        qemuModules.audiovm
         serviceModules.audio
         serviceModules.givc
+        serviceModules.bluetooth
       ];
       # Guivm modules
       guivm.extraModules = optionals cfg.guivm.enable [

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -57,13 +57,10 @@ in
       hardware.pulseaudio = {
         enable = true;
         extraConfig = ''
-          load-module module-tunnel-sink sink_name=chromium-speaker server=audio-vm:4713 format=s16le channels=2 rate=48000
-          load-module module-tunnel-source source_name=chromium-mic server=audio-vm:4713 format=s16le channels=1 rate=48000
-
-          # Set sink and source default max volume to about 90% (0-65536)
-          set-sink-volume chromium-speaker 60000
-          set-source-volume chromium-mic 60000
+          load-module module-tunnel-sink-new sink_name=business-speaker server=audio-vm:4713 reconnect_interval_ms=1000
+          load-module module-tunnel-source-new source_name=business-mic server=audio-vm:4713 reconnect_interval_ms=1000
         '';
+        package = pkgs.pulseaudio-ghaf;
       };
 
       time.timeZone = config.time.timeZone;

--- a/modules/reference/appvms/chromium.nix
+++ b/modules/reference/appvms/chromium.nix
@@ -32,11 +32,11 @@ in
     in
     [
       pkgs.chromium
-      pkgs.pulseaudio
       pkgs.xdg-utils
       xdgPdfItem
       xdgOpenPdf
-    ];
+    ]
+    ++ lib.optional config.ghaf.development.debug.tools.enable pkgs.alsa-utils;
   # TODO create a repository of mac addresses to avoid conflicts
   macAddress = "02:00:00:03:05:01";
   ramMb = 3072;
@@ -54,13 +54,10 @@ in
       hardware.pulseaudio = {
         enable = true;
         extraConfig = ''
-          load-module module-tunnel-sink sink_name=chromium-speaker server=audio-vm:4713 format=s16le channels=2 rate=48000
-          load-module module-tunnel-source source_name=chromium-mic server=audio-vm:4713 format=s16le channels=1 rate=48000
-
-          # Set sink and source default max volume to about 90% (0-65536)
-          set-sink-volume chromium-speaker 60000
-          set-source-volume chromium-mic 60000
+          load-module module-tunnel-sink-new sink_name=chromium-speaker server=audio-vm:4713 reconnect_interval_ms=1000
+          load-module module-tunnel-source-new source_name=chromium-mic server=audio-vm:4713 reconnect_interval_ms=1000
         '';
+        package = pkgs.pulseaudio-ghaf;
       };
 
       time.timeZone = config.time.timeZone;

--- a/modules/reference/appvms/comms.nix
+++ b/modules/reference/appvms/comms.nix
@@ -43,13 +43,10 @@ in
       hardware.pulseaudio = {
         enable = true;
         extraConfig = ''
-          load-module module-tunnel-sink sink_name=element-speaker server=audio-vm:4713 format=s16le channels=2 rate=48000
-          load-module module-tunnel-source source_name=element-mic server=audio-vm:4713 format=s16le channels=1 rate=48000
-
-          # Set sink and source default max volume to about 90% (0-65536)
-          set-sink-volume element-speaker 60000
-          set-source-volume element-mic 60000
+          load-module module-tunnel-sink-new sink_name=comms-speaker server=audio-vm:4713 reconnect_interval_ms=1000
+          load-module module-tunnel-source-new source_name=comms-mic server=audio-vm:4713 reconnect_interval_ms=1000
         '';
+        package = pkgs.pulseaudio-ghaf;
       };
 
       systemd = {

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -133,6 +133,11 @@
         hostbus = "3";
         hostport = "6";
       }
+      {
+        name = "bt0";
+        hostbus = "3";
+        hostport = "10";
+      }
     ];
     external = [
       {

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -136,6 +136,11 @@
         hostbus = "3";
         hostport = "6";
       }
+      {
+        name = "bt0";
+        hostbus = "3";
+        hostport = "10";
+      }
     ];
     external = [
       {

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -20,4 +20,5 @@
   mitmweb-ui = final.callPackage ../../packages/mitmweb-ui { };
   gtklock = import ./gtklock { inherit prev; };
   hardware-scan = final.callPackage ../../packages/hardware-scan { };
+  pulseaudio-ghaf = import ./pulseaudio { inherit prev; };
 })

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -12,6 +12,7 @@
   waypipe = import ./waypipe { inherit final prev; };
   qemu_kvm = import ./qemu { inherit final prev; };
   nm-launcher = final.callPackage ../../packages/nm-launcher { };
+  bt-launcher = final.callPackage ../../packages/bt-launcher { };
   icon-pack = final.callPackage ../../packages/icon-pack { };
   labwc = import ./labwc { inherit prev; };
   tpm2-pkcs11 = import ./tpm2-pkcs11 { inherit prev; };

--- a/overlays/custom-packages/pulseaudio/default.nix
+++ b/overlays/custom-packages/pulseaudio/default.nix
@@ -1,0 +1,7 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ prev, ... }:
+prev.pulseaudio.overrideAttrs (_prevAttrs: {
+  # This patch enables the live switching of pulse tunnels to different sinks
+  patches = _prevAttrs.patches ++ [ ./pulseaudio-remove-dont-move.patch ];
+})

--- a/overlays/custom-packages/pulseaudio/pulseaudio-remove-dont-move.patch
+++ b/overlays/custom-packages/pulseaudio/pulseaudio-remove-dont-move.patch
@@ -1,3 +1,5 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
 diff --git a/src/modules/module-tunnel-sink-new.c b/src/modules/module-tunnel-sink-new.c
 index 0b91ce266..ea41c50e2 100644
 --- a/src/modules/module-tunnel-sink-new.c

--- a/overlays/custom-packages/pulseaudio/pulseaudio-remove-dont-move.patch
+++ b/overlays/custom-packages/pulseaudio/pulseaudio-remove-dont-move.patch
@@ -1,0 +1,26 @@
+diff --git a/src/modules/module-tunnel-sink-new.c b/src/modules/module-tunnel-sink-new.c
+index 0b91ce266..ea41c50e2 100644
+--- a/src/modules/module-tunnel-sink-new.c
++++ b/src/modules/module-tunnel-sink-new.c
+@@ -417,7 +417,7 @@ static void on_sink_created(struct userdata *u) {
+     if (pa_stream_connect_playback(u->stream,
+                                    u->remote_sink_name,
+                                    &bufferattr,
+-                                   PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_DONT_MOVE | PA_STREAM_START_CORKED | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY,
++                                   PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_START_CORKED | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY,
+                                    NULL,
+                                    NULL) < 0) {
+         pa_log_error("Could not connect stream.");
+diff --git a/src/modules/module-tunnel-source-new.c b/src/modules/module-tunnel-source-new.c
+index d75fe9e6b..510d0c1aa 100644
+--- a/src/modules/module-tunnel-source-new.c
++++ b/src/modules/module-tunnel-source-new.c
+@@ -397,7 +397,7 @@ static void on_source_created(struct userdata *u) {
+     if (pa_stream_connect_record(u->stream,
+                                  u->remote_source_name,
+                                  &bufferattr,
+-                                 PA_STREAM_INTERPOLATE_TIMING|PA_STREAM_DONT_MOVE|PA_STREAM_AUTO_TIMING_UPDATE|PA_STREAM_START_CORKED|PA_STREAM_ADJUST_LATENCY) < 0) {
++                                 PA_STREAM_INTERPOLATE_TIMING|PA_STREAM_AUTO_TIMING_UPDATE|PA_STREAM_START_CORKED|PA_STREAM_ADJUST_LATENCY) < 0) {
+         pa_log_debug("Could not create stream: %s", pa_strerror(pa_context_errno(u->context)));
+         u->thread_mainloop_api->quit(u->thread_mainloop_api, TUNNEL_THREAD_FAILED_MAINLOOP);
+     }

--- a/packages/bt-launcher/default.nix
+++ b/packages/bt-launcher/default.nix
@@ -11,6 +11,7 @@ writeShellApplication {
   name = "bt-launcher";
 
   text = ''
+    export PULSE_SERVER=audio-vm:4713
     export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
     export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/ssh_system_dbus.sock
     ${openssh}/bin/ssh -M -S /tmp/control_socket \

--- a/packages/bt-launcher/default.nix
+++ b/packages/bt-launcher/default.nix
@@ -1,0 +1,35 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  blueman,
+  openssh,
+  writeShellApplication,
+  lib,
+  ...
+}:
+writeShellApplication {
+  name = "bt-launcher";
+
+  text = ''
+    export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
+    export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/ssh_system_dbus.sock
+    ${openssh}/bin/ssh -M -S /tmp/control_socket \
+        -f -N -q ghaf@audio-vm \
+        -i /run/waypipe-ssh/id_ed25519 \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -o StreamLocalBindUnlink=yes \
+        -o ExitOnForwardFailure=yes \
+        -L /tmp/ssh_session_dbus.sock:/run/user/1000/bus \
+        -L /tmp/ssh_system_dbus.sock:/run/dbus/system_bus_socket
+    ${blueman}/bin/blueman-applet &
+    ${blueman}/bin/blueman-manager
+    # Use the control socket to close the ssh tunnel.
+    ${openssh}/bin/ssh -q -S /tmp/control_socket -O exit ghaf@audio-vm
+  '';
+
+  meta = {
+    description = "Script to launch blueman to configure bluetooth of audiovm using D-Bus over SSH.";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/packages/bt-launcher/default.nix
+++ b/packages/bt-launcher/default.nix
@@ -14,7 +14,7 @@ writeShellApplication {
     export PULSE_SERVER=audio-vm:4713
     export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
     export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/ssh_system_dbus.sock
-    ${openssh}/bin/ssh -M -S /tmp/control_socket \
+    ${openssh}/bin/ssh -M -S /tmp/control_socket_bt \
         -f -N -q ghaf@audio-vm \
         -i /run/waypipe-ssh/id_ed25519 \
         -o StrictHostKeyChecking=no \
@@ -26,7 +26,7 @@ writeShellApplication {
     ${blueman}/bin/blueman-applet &
     ${blueman}/bin/blueman-manager
     # Use the control socket to close the ssh tunnel.
-    ${openssh}/bin/ssh -q -S /tmp/control_socket -O exit ghaf@audio-vm
+    ${openssh}/bin/ssh -q -S /tmp/control_socket_bt -O exit ghaf@audio-vm
   '';
 
   meta = {

--- a/packages/icon-pack/default.nix
+++ b/packages/icon-pack/default.nix
@@ -10,6 +10,7 @@
 }:
 let
   icons = [
+    "bluetooth-48.svg"
     "chromium.svg"
     "distributor-logo-android.svg"
     "distributor-logo-windows.svg"


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Adds initial bluetooth support to audiovm, for the use of bluetooth headsets.

Global changes:
- set `mutableUsers` to false
- enable hardened systemd configurations in audiovm

Bluetooth module:
- add bluetooth service config, service system user, dbus config, hardened config, system user, etc.
- add (temporary) bluetooth manager (blueman), connecting to audiovm dbus via ssh 
- add persistent storage for bluetooth device configs

Functionality added:
- search, add/connect, disconnect, and use bluetooth headsets
- use bluetooth headset (and mic) in chromium

Known issues:
- to use mic in chromium, headset profile needs to be manually switched to an HSP/HFP profile (lower quality)
- (irregular) once in a while a new connection will fail, then after a while pop-up an authorization request 
- annoying blueman connect/disconnect pop-ups that need to be manually closed (ESC) 
- bluetooth headset needs to be (re)enabled after reboot, no autoconnect 

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to
Lenovo x1

- [x] Is this a new feature

### Testing Checklist
- [x] List the test steps to verify
  - [ ] Regular audio works as before (note: laptop mic does not work in chromium atm)
  - [ ] Bluetooth manager starts
  - [ ] Bluetooth devices can be searched
  - [ ] Bluetooth devices can be added + connected
  - [ ] Device connection switches sound automatically to headset (high-def sound profile) 
  - [ ] Sound with headset works in chromium/business/comms VMs (+mic after switching to HSP/HFP profile)
  - [ ] Bluetooth devices can be disconnected
  - [ ] Bluetooth devices can be removed
  - [ ] Bluetooth device profiles are kept across system re-boots

- [x] If it is an improvement how does it impact existing functionality?
- search, add/connect, disconnect, and use bluetooth headsets
- use bluetooth headset (and mic) in chromium
