### PR TITLE
[Lenovo X1] gui-vm: Enable GPU acceleration

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -104,6 +104,7 @@ path = [
 	"modules/jetpack-microvm/*.patch",
 	"modules/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/patches/net_vm_dtb_with_uarti.patch",
 	"modules/common/virtualization/pkvm/0001-pkvm-enable-pkvm-on-intel-x86-6.1-lts.patch",
+	"modules/microvm/virtualization/microvm/0001-x86-gpu-Don-t-reserve-stolen-memory-for-GPU-passthro.patch",
 ]
 
 [[annotations]]

--- a/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -15,7 +15,7 @@
     kernelConfig.kernelParams = [
       "intel_iommu=on,sm_on"
       "iommu=pt"
-      "module_blacklist=i915" # Prevent i915 module from being accidentally used by host
+      "module_blacklist=i915,xe" # Prevent i915,xe modules from being accidentally used by host
       "acpi_backlight=vendor"
       "acpi_osi=linux"
     ];

--- a/modules/microvm/virtualization/microvm/0001-x86-gpu-Don-t-reserve-stolen-memory-for-GPU-passthro.patch
+++ b/modules/microvm/virtualization/microvm/0001-x86-gpu-Don-t-reserve-stolen-memory-for-GPU-passthro.patch
@@ -1,0 +1,27 @@
+From 13c0345fc3e5ed8b6c28d1f272bb2630881d4714 Mon Sep 17 00:00:00 2001
+From: Vunny Sodhi <vunny.sodhi@unikie.com>
+Date: Thu, 29 Aug 2024 19:46:24 +0300
+Subject: [PATCH] x86/gpu: Don't reserve stolen memory for GPU passthrough
+
+Signed-off-by: Vunny Sodhi <vunny.sodhi@unikie.com>
+---
+ arch/x86/kernel/early-quirks.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/x86/kernel/early-quirks.c b/arch/x86/kernel/early-quirks.c
+index 59f4aefc6..3b735eea9 100644
+--- a/arch/x86/kernel/early-quirks.c
++++ b/arch/x86/kernel/early-quirks.c
+@@ -596,6 +596,9 @@ static void __init intel_graphics_quirks(int num, int slot, int func)
+ 	u16 device;
+ 	int i;
+ 
++	// Nothing to do for GPU passthrough case
++	return;
++
+ 	/*
+ 	 * Reserve "stolen memory" for an integrated GPU.  If we've already
+ 	 * found one, there's nothing to do for other (discrete) GPUs.
+-- 
+2.40.1
+


### PR DESCRIPTION
This patch will enable hardware accelerated display for renderering along with media hardware codecs.
Also we are patching Intel i915 driver in gui-vm to avoid reserving Intel graphics memory during boot
time which in turn fixes DMA Fault errors on the ghaf-host.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
- [x] Is this a new feature
  - [x] List the test steps to verify:
- [x] If it is an improvement how does it impact existing functionality? Kernel version is upgraded from `6.6.43` to `6.8.12` and GPU acceleration is enabled. 

**Its would be nice if we can get results across different GEN of Lenovo X1 Carbon devices.** 

1) Check hardware acceleration in  `gui-vm`  using following command --> **Accelerated** should be `yes`
```
[ghaf@gui-vm:~]$ DISPLAY=:0.0 glxinfo -B
name of display: :0.0
display: :0  screen: 0
direct rendering: Yes
Extended renderer info (GLX_MESA_query_renderer):
    Vendor: Intel (0x8086)
    Device: Mesa Intel(R) Graphics (RPL-U) (0xa7a1)
    Version: 24.1.4
    Accelerated: yes
    ..........................

```
2) Run `glxgears` in `gui-vm` and check performance --> Frame rate should match monitor refresh rate ~60FPS.
```
[ghaf@gui-vm:~]$ DISPLAY=:0.0  glxgears
Running synchronized to the vertical refresh.  The framerate should be
approximately the same as the monitor refresh rate.
304 frames in 5.0 seconds = 60.717 FPS
301 frames in 5.0 seconds = 60.014 FPS
300 frames in 5.0 seconds = 59.993 FPS
300 frames in 5.0 seconds = 59.996 FPS
300 frames in 5.0 seconds = 59.994 FPS
```

3) Hardware accelerated Media Encoders and decoders should be listed
```
[ghaf@gui-vm:~]$ vainfo 
Trying display: wayland
libva info: VA-API version 1.22.0
libva info: Trying to open /run/opengl-driver/lib/dri/iHD_drv_video.so
libva info: Found init function __vaDriverInit_1_22
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 24.2.5 ()
vainfo: Supported profile and entrypoints
      VAProfileNone                   : VAEntrypointVideoProc
      VAProfileNone                   : VAEntrypointStats
      VAProfileMPEG2Simple            : VAEntrypointVLD
      VAProfileMPEG2Simple            : VAEntrypointEncSlice
      ..........................
```

**Note:** Do not expect GPU acceleration in `chromium-vm` or other VMs, also `chrome://gpu` reports SW rendering  as expected. The GPU is isolated/available to the gui-vm only as of now.
