### PR TITLE
gui-vm: Change kernel to linux latest and fix path issue

### DIFF
--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -40,6 +40,7 @@ let
     runtimeInputs = [
       pkgs.systemd
       pkgs.dbus
+      pkgs.brightnessctl
     ];
 
     text =
@@ -52,6 +53,8 @@ let
         systemctl --user reset-failed
         systemctl --user stop ghaf-session.target
         systemctl --user start ghaf-session.target
+        # By default set system brightness to 100% which can be configured later
+        brightnessctl set 100%
       ''
       + cfg.extraAutostart;
   };

--- a/modules/desktop/profiles/graphics.nix
+++ b/modules/desktop/profiles/graphics.nix
@@ -85,8 +85,6 @@ in
       WLR_NO_HARDWARE_CURSORS = if (cfg.renderer == "pixman") then 1 else 0;
       # 24 is default value set in labwc
       XCURSOR_SIZE = 24;
-      # To Fix "Fontconfig error : No writable cache directories" during new session login
-      XDG_CACHE_HOME = "$(mktemp -d)";
       XKB_DEFAULT_LAYOUT = "us,ara,fi";
       XKB_DEFAULT_OPTIONS = "grp:alt_shift_toggle";
       # Set by default in labwc, but possibly not in other compositors

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -245,11 +245,7 @@ in
           if config.ghaf.guest.kernel.hardening.graphics.enable then
             pkgs.linuxPackagesFor guest_graphics_hardened_kernel
           else
-            # TODO: with pkgs.linuxPackages_latest (6.10.2) default brightness
-            # value of ghaf system will change from 96000 (max brightness) to
-            # 4800 (5% of max brightness) which need to be debugged
-            # so, currently align Kernel version which is used by ghaf-host
-            config.boot.zfs.package.latestCompatibleLinuxPackages;
+            pkgs.linuxPackages_latest;
 
         # We need this patch to avoid reserving Intel graphics stolen memory for vm
         # https://gitlab.freedesktop.org/drm/i915/kernel/-/issues/12103


### PR DESCRIPTION
* Change kernel version to linuxPackages_latest which is 6.10.2
* Addresses SP-4919 - Temporary folder in gui-vm / host home directory

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [x] If it is an improvement how does it impact existing functionality?  Kernel version is upgraded from 6.8.12 to 6.10.2 and brightness related changes

**Note:** Test specifically more on brightness test cases.

**Reason:** As default behaviour of `intel_backlight` driver from `max_brightness` to `min_brightness` is changed from kernel 6.10.1 onwards.  More details in this [patch](https://github.com/torvalds/linux/commit/92714006eb4d10ddfaa0eca41c81e6b483e02f93) 

#### Known Issues
1) If we reduce brightness and then logout and later try to login then brightness will be back to maximum because now we are setting brightness to max for every `labwc` session launch. 
Can be resolved later, once we have store for those brightness values. 

2) Fontconfig errors expected when login after logout.