### PR TITLE
OP-TEE: Add option for PKCS11 TA (CFG_PKCS11_TA_AUTH_TEE_IDENTITY)

### DIFF
--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/optee.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/optee.nix
@@ -35,6 +35,14 @@
         '';
       };
 
+      authTeeIdentity = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Enable PKCS#11 TA's TEE Identity based authentication support
+        '';
+      };
+
       heapSize = lib.mkOption {
         type = lib.types.int;
         default = 32768;

--- a/targets/nvidia-jetson-orin/optee.nix
+++ b/targets/nvidia-jetson-orin/optee.nix
@@ -56,7 +56,9 @@ _:
         "TA_DEV_KIT_DIR=${taDevKit}/export-ta_arm64"
         "CFG_PKCS11_TA_TOKEN_COUNT=${builtins.toString config.ghaf.hardware.nvidia.orin.optee.pkcs11.tokenCount}"
         "CFG_PKCS11_TA_HEAP_SIZE=${builtins.toString config.ghaf.hardware.nvidia.orin.optee.pkcs11.heapSize}"
-        "CFG_PKCS11_TA_AUTH_TEE_IDENTITY=y"
+        "CFG_PKCS11_TA_AUTH_TEE_IDENTITY=${
+          if config.ghaf.hardware.nvidia.orin.optee.pkcs11.authTeeIdentity then "y" else "n"
+        }"
         "CFG_PKCS11_TA_ALLOW_DIGEST_KEY=y"
         "OPTEE_CLIENT_EXPORT=${opteeClient}"
         "O=$(PWD)/out"


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Introducing a build time option for OP-TEE's PKCS11 TA: `authTeeIdentity`. If `authTeeIdentity` is set to true then PKCS11 TA is build with  `CFG_PKCS11_TA_AUTH_TEE_IDENTITY=y` and respectively `CFG_PKCS11_TA_AUTH_TEE_IDENTITY=n` if option is set to false.

Default value is true. Default is same as it is currently in [OP-TEE's repository](https://github.com/OP-TEE/optee_os/blob/master/ta/pkcs11/sub.mk#L5). 
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`
Note: Need to remove `/data/tee`-directory
<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: Jetson Orin NX or AGX
- [ ] Is this a new feature
  - [x] List the test steps to verify:
Unfortunately OpenSC's pkcs11-tool from nixpkgs does not support Null-parameter and therefore runtime testing is not possible. But as a completeness then steps would be:
1. Compile PKCS11 TA with `authTeeIdentity = true`
2. Initialize pin with Null: `pkcs11-tool --init-token --so-pin ""`
3. --> `Token successfully initialized`
4. Re-compile PKCS11 TA with  `authTeeIdentity = false`
5. Initialize pin with Null: `pkcs11-tool --init-token --so-pin ""`
6. --> `error: PKCS11 function C_InitToken failed: rv = CKR_ARGUMENTS_BAD (0x7)`

Currently the best option is observe build time logs:
1. `authTeeIdentity = true` ->  `CFG_PKCS11_TA_AUTH_TEE_IDENTITY=y` 
2. `authTeeIdentity = false` -> `CFG_PKCS11_TA_AUTH_TEE_IDENTITY=n`
- [x] If it is an improvement how does it impact existing functionality?
 Adds a convenience option for fine tuning PKCS11 TA.

