### PR TITLE
Chnage vm-target renderer to software renderer pixman

### DIFF
--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -45,6 +45,7 @@ let
                 applications.enable = true;
                 release.enable = variant == "release";
                 debug.enable = variant == "debug";
+                graphics.renderer = "pixman";
               };
             };
           }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

The virtual machine target  `packages.x86_64-linux.vm-debug` wouldn't boot after we have integrated hardware rendering. Changed this setting to software renderer "pixman" for now so that we get a clean boot from running this target.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X ] Summary of the proposed changes in the PR description
- [ X] More detailed description in the commit message(s)
- [X ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ X] Test procedure described (or includes tests). Select one or more:
  - [X ] Tested on Lenovo X1 `x86_64`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

Run Ghaf in vm according to instructions at https://tiiuae.github.io/ghaf/ref_impl/build_and_run.html#running-ghaf-image-for-x86-vm-ghaf-host

