### PR TITLE
Add common Ghaf audio configuration for app-vms

### DIFF
--- a/modules/common/services/audio.nix
+++ b/modules/common/services/audio.nix
@@ -44,7 +44,7 @@ in
                 # Enable TCP socket for VMs pulseaudio clients
                 "server.address" = [
                   {
-                    address = "tcp:${toString cfg.pulseaudioTcpPort}";
+                    address = "tcp:0.0.0.0:${toString cfg.pulseaudioTcpPort}";
                     "client.access" = "unrestricted";
                   }
                 ];

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -33,6 +33,7 @@ let
             internalIP = index + 100;
           })
 
+          ./common/ghaf-audio.nix
           ./common/storagevm.nix
 
           # To push logs to central location
@@ -71,6 +72,11 @@ let
                   withPolkit = true;
                   withDebug = configHost.ghaf.profiles.debug.enable;
                   withHardenedConfigs = true;
+                };
+
+                ghaf-audio = {
+                  inherit (vm.ghafAudio) enable;
+                  name = "${vm.name}";
                 };
 
                 storagevm = {
@@ -253,6 +259,7 @@ in
               type = types.nullOr types.str;
               default = null;
             };
+            ghafAudio.enable = lib.mkEnableOption "Ghaf application audio support";
             vtpm.enable = lib.mkEnableOption "vTPM support in the virtual machine";
           };
         }

--- a/modules/microvm/virtualization/microvm/common/ghaf-audio.nix
+++ b/modules/microvm/virtualization/microvm/common/ghaf-audio.nix
@@ -1,0 +1,44 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.ghaf-audio;
+  audiovmHost = "audio-vm";
+  audiovmPort = config.ghaf.services.audio.pulseaudioTcpPort;
+  address = "tcp:${audiovmHost}:${toString audiovmPort}";
+  reconnectMs = 1000;
+in
+{
+  options.ghaf.ghaf-audio = with lib; {
+    enable = mkEnableOption "Ghaf audio support for application virtual machine.";
+
+    name = mkOption {
+      description = ''
+        Basename of corresponding virtual machine audio channel.
+      '';
+      type = types.str;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.rtkit.enable = true;
+    users.extraUsers.ghaf.extraGroups = [
+      "audio"
+      "video"
+    ];
+
+    hardware.pulseaudio = {
+      enable = true;
+      extraConfig = ''
+        load-module module-tunnel-sink-new sink_name=${cfg.name}.speaker server=${address} reconnect_interval_ms=${toString reconnectMs}
+        load-module module-tunnel-source-new source_name=${cfg.name}.mic server=${address} reconnect_interval_ms=${toString reconnectMs}
+      '';
+      package = pkgs.pulseaudio-ghaf;
+    };
+  };
+}

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -32,7 +32,6 @@ in
     in
     [
       pkgs.chromium
-      pkgs.pulseaudio
       pkgs.xdg-utils
       xdgPdfItem
       xdgOpenPdf
@@ -47,22 +46,6 @@ in
   extraModules = [
     {
       imports = [ ../programs/chromium.nix ];
-      # Enable pulseaudio for Chromium VM
-      security.rtkit.enable = true;
-      users.extraUsers.ghaf.extraGroups = [
-        "audio"
-        "video"
-      ];
-
-      hardware.pulseaudio = {
-        enable = true;
-        extraConfig = ''
-          load-module module-tunnel-sink-new sink_name=business-speaker server=audio-vm:4713 reconnect_interval_ms=1000
-          load-module module-tunnel-source-new source_name=business-mic server=audio-vm:4713 reconnect_interval_ms=1000
-        '';
-        package = pkgs.pulseaudio-ghaf;
-      };
-
       time.timeZone = config.time.timeZone;
 
       microvm = {
@@ -284,5 +267,6 @@ in
     }
   ];
   borderColor = "#00FF00";
+  ghafAudio.enable = true;
   vtpm.enable = true;
 }

--- a/modules/reference/appvms/chromium.nix
+++ b/modules/reference/appvms/chromium.nix
@@ -44,21 +44,6 @@ in
   extraModules = [
     {
       imports = [ ../programs/chromium.nix ];
-      # Enable pulseaudio for Chromium VM
-      security.rtkit.enable = true;
-      users.extraUsers.ghaf.extraGroups = [
-        "audio"
-        "video"
-      ];
-
-      hardware.pulseaudio = {
-        enable = true;
-        extraConfig = ''
-          load-module module-tunnel-sink-new sink_name=chromium-speaker server=audio-vm:4713 reconnect_interval_ms=1000
-          load-module module-tunnel-source-new source_name=chromium-mic server=audio-vm:4713 reconnect_interval_ms=1000
-        '';
-        package = pkgs.pulseaudio-ghaf;
-      };
 
       time.timeZone = config.time.timeZone;
 
@@ -84,5 +69,6 @@ in
     }
   ];
   borderColor = "#630505";
+  ghafAudio.enable = true;
   vtpm.enable = true;
 }

--- a/modules/reference/appvms/comms.nix
+++ b/modules/reference/appvms/comms.nix
@@ -26,29 +26,12 @@ in
     pkgs.element-gps
     pkgs.gpsd
     pkgs.tcpdump
-    pkgs.pulseaudio
   ] ++ pkgs.lib.optionals isDendritePineconeEnabled [ dendrite-pinecone ];
   macAddress = "02:00:00:03:09:01";
   ramMb = 4096;
   cores = 4;
   extraModules = [
     {
-      # Enable pulseaudio for user ghaf to access mic
-      security.rtkit.enable = true;
-      users.extraUsers.ghaf.extraGroups = [
-        "audio"
-        "video"
-      ];
-
-      hardware.pulseaudio = {
-        enable = true;
-        extraConfig = ''
-          load-module module-tunnel-sink-new sink_name=comms-speaker server=audio-vm:4713 reconnect_interval_ms=1000
-          load-module module-tunnel-source-new source_name=comms-mic server=audio-vm:4713 reconnect_interval_ms=1000
-        '';
-        package = pkgs.pulseaudio-ghaf;
-      };
-
       systemd = {
         services = {
           element-gps = {
@@ -110,4 +93,5 @@ in
     }
   ];
   borderColor = "#337aff";
+  ghafAudio.enable = true;
 }


### PR DESCRIPTION
Fix issue with getting no audio when changing sound IO port

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Add common Ghaf audio setting and configuration for App-vns
Also fixes issue for changing audio IO port

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [X] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [X] If it is an improvement how does it impact existing functionality?

Fixes a bug when playing/recording audio and user unplugs 3.5mm (or usb etc) headset
Audio should re-route automatically to integrated speakers/mic.
There is 1 second delay in the switchin of audio port
Verify recording with shell tool parecord / paplay since some mic recording web pages seemed to cause buggy noise