### PR TITLE
OP-TEE: Add option for PKCS11 TA (CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS)

### DIFF
--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,0 +1,9 @@
+Copyright <YEAR> <COPYRIGHT HOLDER>
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -126,3 +126,10 @@ SPDX-FileCopyrightText = "Copyright 2019-2021 Microchip Corporation."
 path = [
 	"packages/hart-software-services/0001-Workaround-for-a-compilation-issue.patch",
 ]
+
+[[annotations]]
+SPDX-License-Identifier = "BSD-2-Clause"
+SPDX-FileCopyrightText = "Copyright (c) 2017-2020, Linaro Limited"
+path = [
+	"targets/nvidia-jetson-orin/0001-ta-pkcs11-Build-time-option-for-controlling-pin-lock.patch",
+]

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/optee.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/optee.nix
@@ -43,6 +43,15 @@
         '';
       };
 
+      lockPinAfterFailedLoginAttempts = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Locks correspondingly User or SO PIN when reaching maximum
+          failed authentication attemps (continous) limit
+        '';
+      };
+
       heapSize = lib.mkOption {
         type = lib.types.int;
         default = 32768;

--- a/targets/nvidia-jetson-orin/0001-ta-pkcs11-Build-time-option-for-controlling-pin-lock.patch
+++ b/targets/nvidia-jetson-orin/0001-ta-pkcs11-Build-time-option-for-controlling-pin-lock.patch
@@ -1,0 +1,186 @@
+From 18c1ea534dba4a75848fdeea3c55de00ca11c397 Mon Sep 17 00:00:00 2001
+From: Tanel Dettenborn <tanel@ssrc.tii.ae>
+Date: Sat, 14 Sep 2024 16:45:46 +0300
+Subject: [PATCH] ta: pkcs11: Build time option for controlling pin locking
+ Adding a build time option for disabling or enabling pin locking after failed
+ authentication attempts. Option controls both, User and SO, pins. Default is
+ 'y'.
+
+Option is called:
+ CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS
+
+NOTE: Patch is backported!
+
+Signed-off-by: Tanel Dettenborn <tanel@ssrc.tii.ae>
+---
+ optee/optee_os/ta/pkcs11/src/pkcs11_token.c | 102 +++++++++++---------
+ optee/optee_os/ta/pkcs11/sub.mk             |   4 +
+ 2 files changed, 60 insertions(+), 46 deletions(-)
+
+diff --git a/optee/optee_os/ta/pkcs11/src/pkcs11_token.c b/optee/optee_os/ta/pkcs11/src/pkcs11_token.c
+index 25ba77827..9882d1cf2 100644
+--- a/optee/optee_os/ta/pkcs11/src/pkcs11_token.c
++++ b/optee/optee_os/ta/pkcs11/src/pkcs11_token.c
+@@ -884,16 +884,18 @@ enum pkcs11_rc entry_ck_token_initialize(uint32_t ptypes, TEE_Param *params)
+ 		if (rc != PKCS11_CKR_PIN_INCORRECT)
+ 			return rc;
+ 
+-		token->db_main->flags |= PKCS11_CKFT_SO_PIN_COUNT_LOW;
+-		token->db_main->so_pin_count++;
++		if (IS_ENABLED(CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS)) {
++			token->db_main->flags |= PKCS11_CKFT_SO_PIN_COUNT_LOW;
++			token->db_main->so_pin_count++;
+ 
+-		pin_count = token->db_main->so_pin_count;
+-		if (pin_count == PKCS11_TOKEN_SO_PIN_COUNT_MAX - 1)
+-			token->db_main->flags |= PKCS11_CKFT_SO_PIN_FINAL_TRY;
+-		if (pin_count == PKCS11_TOKEN_SO_PIN_COUNT_MAX)
+-			token->db_main->flags |= PKCS11_CKFT_SO_PIN_LOCKED;
++			pin_count = token->db_main->so_pin_count;
++			if (pin_count == PKCS11_TOKEN_SO_PIN_COUNT_MAX - 1)
++				token->db_main->flags |= PKCS11_CKFT_SO_PIN_FINAL_TRY;
++			if (pin_count == PKCS11_TOKEN_SO_PIN_COUNT_MAX)
++				token->db_main->flags |= PKCS11_CKFT_SO_PIN_LOCKED;
+ 
+-		update_persistent_db(token);
++			update_persistent_db(token);
++		}
+ 
+ 		return PKCS11_CKR_PIN_INCORRECT;
+ 	}
+@@ -1140,35 +1142,39 @@ static enum pkcs11_rc check_so_pin(struct pkcs11_session *session,
+ 		if (rc != PKCS11_CKR_PIN_INCORRECT)
+ 			return rc;
+ 
+-		token->db_main->flags |= PKCS11_CKFT_SO_PIN_COUNT_LOW;
+-		token->db_main->so_pin_count++;
++		if (IS_ENABLED(CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS)) {
++			token->db_main->flags |= PKCS11_CKFT_SO_PIN_COUNT_LOW;
++			token->db_main->so_pin_count++;
+ 
+-		pin_count = token->db_main->so_pin_count;
+-		if (pin_count == PKCS11_TOKEN_SO_PIN_COUNT_MAX - 1)
+-			token->db_main->flags |= PKCS11_CKFT_SO_PIN_FINAL_TRY;
+-		if (pin_count == PKCS11_TOKEN_SO_PIN_COUNT_MAX)
+-			token->db_main->flags |= PKCS11_CKFT_SO_PIN_LOCKED;
++			pin_count = token->db_main->so_pin_count;
++			if (pin_count == PKCS11_TOKEN_SO_PIN_COUNT_MAX - 1)
++				token->db_main->flags |= PKCS11_CKFT_SO_PIN_FINAL_TRY;
++			if (pin_count == PKCS11_TOKEN_SO_PIN_COUNT_MAX)
++				token->db_main->flags |= PKCS11_CKFT_SO_PIN_LOCKED;
+ 
+-		update_persistent_db(token);
++			update_persistent_db(token);
+ 
+-		if (token->db_main->flags & PKCS11_CKFT_SO_PIN_LOCKED)
+-			return PKCS11_CKR_PIN_LOCKED;
++			if (token->db_main->flags & PKCS11_CKFT_SO_PIN_LOCKED)
++				return PKCS11_CKR_PIN_LOCKED;
++		}
+ 
+ 		return PKCS11_CKR_PIN_INCORRECT;
+ 	}
+ 
+-	if (token->db_main->so_pin_count) {
+-		token->db_main->so_pin_count = 0;
++	if (IS_ENABLED(CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS)) {
++		if (token->db_main->so_pin_count) {
++			token->db_main->so_pin_count = 0;
+ 
+-		update_persistent_db(token);
+-	}
++			update_persistent_db(token);
++		}
+ 
+-	if (token->db_main->flags & (PKCS11_CKFT_SO_PIN_COUNT_LOW |
+-				     PKCS11_CKFT_SO_PIN_FINAL_TRY)) {
+-		token->db_main->flags &= ~(PKCS11_CKFT_SO_PIN_COUNT_LOW |
+-					   PKCS11_CKFT_SO_PIN_FINAL_TRY);
++		if (token->db_main->flags & (PKCS11_CKFT_SO_PIN_COUNT_LOW |
++									 PKCS11_CKFT_SO_PIN_FINAL_TRY)) {
++			token->db_main->flags &= ~(PKCS11_CKFT_SO_PIN_COUNT_LOW |
++									   PKCS11_CKFT_SO_PIN_FINAL_TRY);
+ 
+-		update_persistent_db(token);
++			update_persistent_db(token);
++		}
+ 	}
+ 
+ 	return PKCS11_CKR_OK;
+@@ -1199,35 +1205,39 @@ static enum pkcs11_rc check_user_pin(struct pkcs11_session *session,
+ 		if (rc != PKCS11_CKR_PIN_INCORRECT)
+ 			return rc;
+ 
+-		token->db_main->flags |= PKCS11_CKFT_USER_PIN_COUNT_LOW;
+-		token->db_main->user_pin_count++;
++		if (IS_ENABLED(CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS)) {
++			token->db_main->flags |= PKCS11_CKFT_USER_PIN_COUNT_LOW;
++			token->db_main->user_pin_count++;
+ 
+-		pin_count = token->db_main->user_pin_count;
+-		if (pin_count == PKCS11_TOKEN_USER_PIN_COUNT_MAX - 1)
+-			token->db_main->flags |= PKCS11_CKFT_USER_PIN_FINAL_TRY;
+-		if (pin_count == PKCS11_TOKEN_USER_PIN_COUNT_MAX)
+-			token->db_main->flags |= PKCS11_CKFT_USER_PIN_LOCKED;
++			pin_count = token->db_main->user_pin_count;
++			if (pin_count == PKCS11_TOKEN_USER_PIN_COUNT_MAX - 1)
++				token->db_main->flags |= PKCS11_CKFT_USER_PIN_FINAL_TRY;
++			if (pin_count == PKCS11_TOKEN_USER_PIN_COUNT_MAX)
++				token->db_main->flags |= PKCS11_CKFT_USER_PIN_LOCKED;
+ 
+-		update_persistent_db(token);
++			update_persistent_db(token);
+ 
+-		if (token->db_main->flags & PKCS11_CKFT_USER_PIN_LOCKED)
+-			return PKCS11_CKR_PIN_LOCKED;
++			if (token->db_main->flags & PKCS11_CKFT_USER_PIN_LOCKED)
++				return PKCS11_CKR_PIN_LOCKED;
++		}
+ 
+ 		return PKCS11_CKR_PIN_INCORRECT;
+ 	}
+ 
+-	if (token->db_main->user_pin_count) {
+-		token->db_main->user_pin_count = 0;
++	if (IS_ENABLED(CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS)) {
++		if (token->db_main->user_pin_count) {
++			token->db_main->user_pin_count = 0;
+ 
+-		update_persistent_db(token);
+-	}
++			update_persistent_db(token);
++		}
+ 
+-	if (token->db_main->flags & (PKCS11_CKFT_USER_PIN_COUNT_LOW |
+-				     PKCS11_CKFT_USER_PIN_FINAL_TRY)) {
+-		token->db_main->flags &= ~(PKCS11_CKFT_USER_PIN_COUNT_LOW |
+-					   PKCS11_CKFT_USER_PIN_FINAL_TRY);
++		if (token->db_main->flags & (PKCS11_CKFT_USER_PIN_COUNT_LOW |
++									 PKCS11_CKFT_USER_PIN_FINAL_TRY)) {
++			token->db_main->flags &= ~(PKCS11_CKFT_USER_PIN_COUNT_LOW |
++									   PKCS11_CKFT_USER_PIN_FINAL_TRY);
+ 
+-		update_persistent_db(token);
++			update_persistent_db(token);
++		}
+ 	}
+ 
+ 	return PKCS11_CKR_OK;
+diff --git a/optee/optee_os/ta/pkcs11/sub.mk b/optee/optee_os/ta/pkcs11/sub.mk
+index 30dd13cb5..c9c401879 100644
+--- a/optee/optee_os/ta/pkcs11/sub.mk
++++ b/optee/optee_os/ta/pkcs11/sub.mk
+@@ -10,6 +10,10 @@ CFG_PKCS11_TA_HEAP_SIZE ?= (32 * 1024)
+ # Defines the number of PKCS11 token implemented by the PKCS11 TA
+ CFG_PKCS11_TA_TOKEN_COUNT ?= 3
+ 
++# Locks correspondingly User or SO PIN when reaching maximum
++# failed authentication attemps (continous) limit
++CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS ?= y
++
+ global-incdirs-y += include
+ global-incdirs-y += src
+ subdirs-y += src
+-- 
+2.42.2
+

--- a/targets/nvidia-jetson-orin/optee.nix
+++ b/targets/nvidia-jetson-orin/optee.nix
@@ -16,10 +16,13 @@ _:
     inherit (pkgs.nvidia-jetpack) l4tVersion opteeClient;
     inherit (config.hardware.nvidia-jetpack.devicePkgs) taDevKit;
 
-    opteeSource = pkgs.fetchgit {
-      url = "https://nv-tegra.nvidia.com/r/tegra/optee-src/nv-optee";
-      rev = "jetson_${l4tVersion}";
-      sha256 = "sha256-jJOMig2+9FlKA9gJUCH/dva7ZtAq1typZSNGKyM7tlg=";
+    opteeSource = pkgs.applyPatches {
+      src = pkgs.fetchgit {
+        url = "https://nv-tegra.nvidia.com/r/tegra/optee-src/nv-optee";
+        rev = "jetson_${l4tVersion}";
+        sha256 = "sha256-jJOMig2+9FlKA9gJUCH/dva7ZtAq1typZSNGKyM7tlg=";
+      };
+      patches = [ ./0001-ta-pkcs11-Build-time-option-for-controlling-pin-lock.patch ];
     };
 
     opteeXtest = stdenv.mkDerivation {
@@ -58,6 +61,9 @@ _:
         "CFG_PKCS11_TA_HEAP_SIZE=${builtins.toString config.ghaf.hardware.nvidia.orin.optee.pkcs11.heapSize}"
         "CFG_PKCS11_TA_AUTH_TEE_IDENTITY=${
           if config.ghaf.hardware.nvidia.orin.optee.pkcs11.authTeeIdentity then "y" else "n"
+        }"
+        "CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS=${
+          if config.ghaf.hardware.nvidia.orin.optee.pkcs11.lockPinAfterFailedLoginAttempts then "y" else "n"
         }"
         "CFG_PKCS11_TA_ALLOW_DIGEST_KEY=y"
         "OPTEE_CLIENT_EXPORT=${opteeClient}"


### PR DESCRIPTION
Introducing a build time option for OP-TEE's PKCS11 TA: lockPinAfterFailedLoginAttempts. If lockPinAfterFailedLoginAttempts is set to true then PKCS11 TA is build with CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS=y and respectively CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS=n if option is set to false.

Default value is false.

**Note**: This is a custom feature. It is not part of the OP-TEE's upstream, but I have opened [a pull request](https://github.com/OP-TEE/optee_os/pull/7040) towards OP-TEE repository. I will updated this pull request if my OP-TEE's pull request receives any comments. 

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`
       Note: Need to remove /data/tee-directory

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: Jetson Orin NX or AGX
- [x] Is this a new feature
  - [x] List the test steps to verify:
A complete testing requires two sequence _limited_ and _unlimited_ logins. 
Common for both cases are initilization:
`alias p11="pkcs11-tool-optee --slot-index 0 --label test"`
`p11 --init-token --so-pin 1111`
`p11 --init-pin --login --so-pin 1111 --new-pin 2222`


**_Limited login attempts_**
Compile PKCS11 TA with `lockPinAfterFailedLoginAttempts = false`
!! remove secure storage `rm -rf /data/tee` !!
`p11 --login --pin 1232 --list-object`
`p11 --init-pin --login --so-pin 1234 --new-pin 2222`
--> Both returns `CKR_PIN_INCORRECT`
`p11 --login --pin 2222 --list-object`
`p11 --init-pin --login --so-pin 1111 --new-pin 2222`
--> Both are able to login (operation success)
7x: `p11 --login --pin 1232 --list-object`
7x: `p11 --init-pin --login --so-pin 1234 --new-pin 2222`
--> Both PINs are locked:  `CKR_PIN_LOCKED`
`p11 --login --pin 2222 --list-object`
`p11 --init-pin --login --so-pin 1111 --new-pin 2222`
--> Both returns `CKR_PIN_LOCKED`

**_Unlimited login attempts_**
Compile PKCS11 TA with `lockPinAfterFailedLoginAttempts = true` 
!! remove secure storage `rm -rf /data/tee` !!
`p11 --login --pin 1232 --list-object`
`p11 --init-pin --login --so-pin 1234 --new-pin 2222`
--> Both returns `CKR_PIN_INCORRECT`
`p11 --login --pin 2222 --list-object`
`p11 --init-pin --login --so-pin 1111 --new-pin 2222`
--> Both are able to login (operation success)
7x: `p11 --login --pin 1232 --list-object`
7x: `p11 --init-pin --login --so-pin 1234 --new-pin 2222`
--> Both returns `CKR_PIN_INCORRECT`
`p11 --login --pin 2222 --list-object`
`p11 --init-pin --login --so-pin 1111 --new-pin 2222`
--> Both are able to login (operation success)

- [x] If it is an improvement how does it impact existing functionality?
       Adds feature into PKCS11 TA and convenience option for fine tuning it.

