### PR TITLE
AGX nmcli for netvm

### DIFF
--- a/modules/reference/hardware/jetpack-microvm/agx-netvm-wlan-pci-passthrough.nix
+++ b/modules/reference/hardware/jetpack-microvm/agx-netvm-wlan-pci-passthrough.nix
@@ -1,6 +1,11 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ lib, config, ... }:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
 let
   cfg = config.ghaf.hardware.nvidia.orin.agx;
 in
@@ -10,14 +15,22 @@ in
     # Orin AGX WLAN card PCI passthrough
     ghaf.hardware.nvidia.orin.enablePCIPassthroughCommon = true;
 
+    # Common Wifi Service set
+
+    # Passthrough devices
     ghaf.virtualization.microvm.netvm.extraModules = [
       {
+        ghaf.services.wifi.enable = true;
         microvm.devices = [
           {
             bus = "pci";
             path = "0001:01:00.0";
           }
         ];
+        # Network Manager is defined for netvm of Orin Devices
+        environment.systemPackages = [ pkgs.networkmanager ];
+        # Network Manager package defines a gnome plugin with build failure on Orin
+        networking.networkmanager.plugins = lib.mkForce [ ];
       }
     ];
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Changes in NetVm for Lenovo left the state of NetVm in NVIDIA AGX behind where there was no NetworkManager tool to create a connection. The passthrough for Wifi device was active but there were no means of creating a wireless connection. NX had no problems as the netvm utilizes the ethernet device. Here this PR adds NetworkManager and nmcli to the netvm on NVIDIA AGX devices to allow networkmanager to connect to wireless network. 

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [X] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [X] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [X] List all targets that this applies to: Jetson Orin AGX - aarch64
- [X] Is this a new feature
  - [X] List the test steps to verify:

1. Run `nmcli` to check the connections listing wlp0s5f0 (wifi device) disconnected.
2. Run `nmcli` con to ensure there is no wifi connection but only loopback.
```
NAME  UUID                                  TYPE      DEVICE 
lo    9fe4bd21-f68d-4df6-8537-ab2edba3d9ed  loopback  lo  
```
3. Run `nmcli d wifi list` to get a list of Wireless Access Points 
```
IN-USE  BSSID              SSID                        MODE   CHAN  RATE        SIGNAL  BARS  SECURITY 
        AA:BB:CC:DD:EE:11  SomeSSID_unknwn 2,4GHz      Infra  11    195 Mbit/s  79      ▂▄▆_  WPA2    
```
4. Run `nmcli dev wifi con "SomeSSID_unknwn" --ask` to start Wifi connection and being asked its Wireless password.
```
Password: ***********
Device 'wlp0s5f0' successfully activated with 'c15e0916-bde5-44e8-fbfb-4860dd0b89da'.
```
5. Run `nmcli con` again to verify connection.
```
NAME               UUID                                  TYPE      DEVICE 
SomeSSID_unknwn    c15e0916-bde5-44e8-fbfb-4860dd0b89da  wifi      wlp0s5f0
lo                 9fe4bd21-f68d-4df6-8537-ab2edba3d9ed  loopback  lo  
```
6. Run `ping 8.8.8.8` to check ip connectivity
```
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=59 time=9.65 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=59 time=8.58 ms
^C
--- 8.8.8.8 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 8.575/9.113/9.652/0.538 ms
```

- [X] If it is an improvement how does it impact existing functionality?
Without this PR the netvm on AGX had no wireless connection capability.
Unfortunately the NetworkManager caused cross compile failure. 
