### PR TITLE
Add ydotool and grim to debug tools

### DIFF
--- a/modules/common/development/debug-tools.nix
+++ b/modules/common/development/debug-tools.nix
@@ -48,6 +48,10 @@ in
           evtest
           # For deleting Linux Boot Manager entries in automated testing
 
+          # Tools for automated GUI-testing
+          ydotool
+          grim
+
           efibootmgr
           # Performance testing
 

--- a/modules/common/development/debug-tools.nix
+++ b/modules/common/development/debug-tools.nix
@@ -48,10 +48,6 @@ in
           evtest
           # For deleting Linux Boot Manager entries in automated testing
 
-          # Tools for automated GUI-testing
-          ydotool
-          grim
-
           efibootmgr
           # Performance testing
 
@@ -83,7 +79,12 @@ in
         config.nixpkgs.hostPlatform.system != "aarch64-linux"
       ) config.boot.kernelPackages.perf
       # LuaJIT (which is sysbench dependency) not available on RISC-V
-      ++ lib.optional (config.nixpkgs.hostPlatform.system != "riscv64-linux") pkgs.sysbench
+      # ydotool and grim are tools for automated GUI-testing, useless on riscv
+      ++ lib.optionals (config.nixpkgs.hostPlatform.system != "riscv64-linux") [
+        pkgs.sysbench
+        ydotool
+        grim
+        ]
       # Icicle Kit performance test script available on RISC-V
       ++ lib.optional (config.nixpkgs.hostPlatform.system == "riscv64-linux") perf-test-script-icicle
       # runtimeShell (unixbench dependency) not available on RISC-V nor on cross-compiled Orin AGX/NX

--- a/modules/common/development/debug-tools.nix
+++ b/modules/common/development/debug-tools.nix
@@ -82,9 +82,9 @@ in
       # ydotool and grim are tools for automated GUI-testing, useless on riscv
       ++ lib.optionals (config.nixpkgs.hostPlatform.system != "riscv64-linux") [
         pkgs.sysbench
-        ydotool
-        grim
-        ]
+        pkgs.ydotool
+        pkgs.grim
+      ]
       # Icicle Kit performance test script available on RISC-V
       ++ lib.optional (config.nixpkgs.hostPlatform.system == "riscv64-linux") perf-test-script-icicle
       # runtimeShell (unixbench dependency) not available on RISC-V nor on cross-compiled Orin AGX/NX


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

These tools are necessary in running automated GUI tests:
https://github.com/tiiuae/ci-test-automation/pull/140

- grim can be used in taking screenshots
- with ydotool mouse and keyboard can be operated from command line

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
Lenovo X1
Orin AGX
Orin NX
NUC
- [x] Is this a new feature
  - [x] List the test steps to verify:

To check the tools are available run in gui-vm for Lenovo-X1 and in ghaf-host for other targets:
  ydotool
  grim

Usage of the tools can be demonstrated by running ci-test-atutomation test case SP-T97 on Lenovo-X1 with https://github.com/tiiuae/ci-test-automation/pull/140
robot -v DEVICE:Lenovo-X1 -v BUILD_ID:X1 -v LOGIN:ghaf -v PASSWORD:ghaf -i SP-T97 ./

- [ ] If it is an improvement how does it impact existing functionality?

