### PR TITLE
Enable permanent storage for user common files

### DIFF
--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -10,6 +10,7 @@ let
   cfg = config.ghaf.graphics.labwc;
 
   audio-ctrl = pkgs.callPackage ../../../packages/audio-ctrl { };
+  ghaf-screenshot = pkgs.callPackage ../../../packages/ghaf-screenshot { };
   gtklockStyle = pkgs.writeText "gtklock.css" ''
     window {
       background: rgba(18, 18, 18, 1);
@@ -91,7 +92,7 @@ let
       </keybind>
       ${lib.optionalString config.ghaf.profiles.debug.enable ''
         <keybind key="Print">
-          <action name="Execute" command="${pkgs.grim}/bin/grim" />
+          <action name="Execute" command="${ghaf-screenshot}/bin/ghaf-screenshot" />
         </keybind>
       ''}
       <keybind key="XF86_MonBrightnessUp">

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -104,7 +104,13 @@ in
         (import ./launchers.nix { inherit pkgs config; })
       ]
       # Grim screenshot tool is used for labwc debug-builds
-      ++ lib.optionals config.ghaf.profiles.debug.enable [ pkgs.grim ];
+      # satty and slurp add some functionality to bring it
+      # a more modern selection tool
+      ++ lib.optionals config.ghaf.profiles.debug.enable [
+        pkgs.grim
+        pkgs.satty
+        pkgs.slurp
+      ];
 
     # It will create a /etc/pam.d/ file for authentication
     security.pam.services.gtklock = { };

--- a/modules/disko/disko-ab-partitions.nix
+++ b/modules/disko/disko-ab-partitions.nix
@@ -34,7 +34,7 @@
   };
   disko = {
     # 8GB is the recommeneded minimum for ZFS, so we are using this for VMs to avoid `cp` oom errors.
-    memSize = 8192;
+    memSize = 16384;
     extraPostVM = ''
       ${pkgs.zstd}/bin/zstd --compress $out/*raw
       rm $out/*raw

--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -72,6 +72,20 @@ let
                   withDebug = configHost.ghaf.profiles.debug.enable;
                   withHardenedConfigs = true;
                 };
+
+                storagevm = {
+                  enable = true;
+                  name = "${vm.name}";
+                  users.${config.ghaf.users.accounts.user}.directories = [
+                    ".config/"
+                    "Downloads"
+                    "Music"
+                    "Pictures"
+                    "Documents"
+                    "Videos"
+                  ];
+                };
+
                 # Logging client configuration
                 logging.client.enable = configHost.ghaf.logging.client.enable;
                 logging.client.endpoint = configHost.ghaf.logging.client.endpoint;

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -76,6 +76,11 @@ let
                   mode = "u=rwx,g=,o=";
                 }
               ];
+              users.${config.ghaf.users.accounts.user}.directories = [
+                ".config/"
+                "Pictures"
+                "Videos"
+              ];
             };
           };
 
@@ -122,6 +127,10 @@ let
                 pkgs.glxinfo
                 pkgs.libva-utils
               ];
+            sessionVariables = {
+              XDG_PICTURES_DIR = "$HOME/Pictures";
+              XDG_VIDEOS_DIR = "$HOME/Videos";
+            };
           };
 
           time.timeZone = config.time.timeZone;

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -87,11 +87,6 @@ in
       };
 
       ghaf.reference.programs.chromium.enable = true;
-      ghaf.storagevm = {
-        enable = true;
-        name = "${name}";
-        users.${config.ghaf.users.accounts.user}.directories = [ ".config" ];
-      };
 
       # Set default PDF XDG handler
       xdg.mime.defaultApplications."application/pdf" = "ghaf-pdf.desktop";

--- a/modules/reference/appvms/chromium.nix
+++ b/modules/reference/appvms/chromium.nix
@@ -78,11 +78,6 @@ in
       };
 
       ghaf.reference.programs.chromium.enable = true;
-      ghaf.storagevm = {
-        enable = true;
-        name = "${name}";
-        users.${config.ghaf.users.accounts.user}.directories = [ ".config" ];
-      };
 
       # Set default PDF XDG handler
       xdg.mime.defaultApplications."application/pdf" = "ghaf-pdf.desktop";

--- a/modules/reference/appvms/comms.nix
+++ b/modules/reference/appvms/comms.nix
@@ -107,11 +107,6 @@ in
           "slack":   "${config.ghaf.givc.appPrefix}/run-waypipe ${config.ghaf.givc.appPrefix}/chromium --enable-features=UseOzonePlatform --ozone-platform=wayland --app=https://app.slack.com/client ${config.ghaf.givc.idsExtraArgs}"
           }'';
       };
-      ghaf.storagevm = {
-        enable = true;
-        name = "${name}";
-        users.${config.ghaf.users.accounts.user}.directories = [ ".config/" ];
-      };
     }
   ];
   borderColor = "#337aff";

--- a/modules/reference/appvms/zathura.nix
+++ b/modules/reference/appvms/zathura.nix
@@ -17,11 +17,17 @@
     {
       imports = [ ../programs/zathura.nix ];
       time.timeZone = config.time.timeZone;
-      ghaf.reference.programs.zathura.enable = true;
-      ghaf.givc.appvm = {
-        enable = true;
-        name = lib.mkForce "zathura-vm";
-        applications = lib.mkForce ''{"zathura": "${config.ghaf.givc.appPrefix}/run-waypipe ${config.ghaf.givc.appPrefix}/zathura"}'';
+      ghaf = {
+        reference.programs.zathura.enable = true;
+
+        givc.appvm = {
+          enable = true;
+          name = lib.mkForce "zathura-vm";
+          applications = lib.mkForce ''{"zathura": "${config.ghaf.givc.appPrefix}/run-waypipe ${config.ghaf.givc.appPrefix}/zathura"}'';
+        };
+
+        #this vm should be stateless so nothing stored between boots.
+        storagevm.enable = lib.mkForce false;
       };
     }
   ];

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -24,6 +24,7 @@
         windows-launcher = callPackage ./windows-launcher { enableSpice = false; };
         windows-launcher-spice = callPackage ./windows-launcher { enableSpice = true; };
         hardware-scan = callPackage ./hardware-scan { };
+        ghaf-screenshot = callPackage ./ghaf-screenshot { };
         doc = callPackage ../docs {
           revision = lib.strings.fileContents ../.version;
           options =

--- a/packages/ghaf-screenshot/default.nix
+++ b/packages/ghaf-screenshot/default.nix
@@ -1,0 +1,40 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  satty,
+  slurp,
+  grim,
+  writeShellApplication,
+  ...
+}:
+
+#write a writeShellApplication to take screenshots using grim sluro and satty
+writeShellApplication {
+  name = "ghaf-screenshot";
+  runtimeInputs = [
+    grim
+    satty
+    slurp
+  ];
+  text = ''
+    dirname="$XDG_PICTURES_DIR/Screenshots"
+
+    # Check if directory exists and create it if it doesn't
+    if [ ! -d "$dirname" ]; then
+        mkdir -p "$dirname"
+    fi
+
+    # Take a screenshot and allow the user to process it before either copying it to the clipboard or saving it to the directory
+    # defined some opinionated defaults and this can be reviewed later if we continue to use this after the reselection of the new desktop environment.
+
+    grim -g "$(slurp -c '#ff0000ff' -b '#ffffff80' -w 4)" - | satty --filename - --output-filename "$dirname/screenshot-$(date '+%Y%m%d-%H-%M-%S').png" --save-after-copy
+  '';
+
+  meta = {
+    description = "ghaf-screenshot";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
This is for storing some of the user common directories that are under the users home directory.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This makes some of the directories persist across the reboots.

In addition this patch adds the ability to select the capture area that
is used for the screenshots. When the screenshot is selected there is
Satty functionality that allows for some basic post capture editing in
the form of an overlay to add annotations such as, arrows, boxes, and
text.

The user can the save the file, or copy it to the clipboard. Once in the
clipboard it can be pasted into any of the other vms where there is an
app that will accept those images. This is the case for e.g. slack and
outlook.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [X] List all targets that this applies to:
  lenovo-x1 MVP target

- [X] If it is an improvement how does it impact existing functionality?
-   this adds some of the appvm user directories to the permanent storage.
```
ssh chromium-vm or business-vm
echo "hello downloads" > Downloads/downloads.txt
echo "hello documents" > Documents/documents.txt

reboot

ssh chromium-vm or business-vm
cat Downloads/downloads.txt
cat Documents/documents.txt
```

Share a screenshot across vms

```
PtrSc
select the area that you wish to share
add some annotations from the menu item
copy to clipboard
paste into e.g. an email body in outlook
```
