### PR TITLE
Add common directory

### DIFF
--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -34,6 +34,12 @@ let
           })
 
           ./common/storagevm.nix
+          (
+            with configHost.ghaf.virtualization.microvm-host;
+            lib.optionalAttrs (sharedVmDirectory.enable && builtins.elem vmName sharedVmDirectory.vms) (
+              import ./common/shared-directory.nix vmName
+            )
+          )
 
           # To push logs to central location
           ../../../common/logging/client.nix

--- a/modules/microvm/virtualization/microvm/common/shared-directory.nix
+++ b/modules/microvm/virtualization/microvm/common/shared-directory.nix
@@ -1,0 +1,41 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+name:
+{ lib, config, ... }:
+let
+  cfg = config.ghaf.storagevm;
+  shared-mountPath = "/tmp/shared/shares";
+  inherit (config.ghaf.users.accounts) user;
+  isGuiVm = builtins.stringLength name == 0;
+  userDir = "/home/${user}" + (if isGuiVm then "/Shares" else "/Unsafe\ share");
+in
+{
+  config = lib.mkIf cfg.enable {
+    fileSystems.${shared-mountPath}.neededForBoot = true;
+
+    microvm.shares = [
+      {
+        tag = "shared-directory";
+        proto = "virtiofs";
+        securityModel = "passthrough";
+        # We want double dir to keep root permission for `shared` directory and `shares` will be allowed to view and change by user.
+        source = "/storagevm/shared/shares" + (if !isGuiVm then "/Unsafe\ ${name}\ share/" else "");
+        mountPoint = shared-mountPath;
+      }
+    ];
+
+    # https://github.com/nix-community/impermanence/blob/master/nixos.nix#L61-L70
+    fileSystems.${userDir} = {
+      depends = [ shared-mountPath ];
+      device = shared-mountPath;
+      noCheck = true;
+      mountPoint = userDir;
+      fsType = "none";
+      options = [
+        "bind"
+        "X-fstrim.notrim"
+        "x-gvfs-hide"
+      ];
+    };
+  };
+}

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -18,44 +18,78 @@ in
   options.ghaf.virtualization.microvm-host = {
     enable = lib.mkEnableOption "MicroVM Host";
     networkSupport = lib.mkEnableOption "Network support services to run host applications.";
-  };
+    sharedVmDirectory = {
+      enable = lib.mkEnableOption "shared directory" // {
+        default = true;
+      };
 
-  config = lib.mkIf cfg.enable {
-    microvm.host.enable = true;
-    ghaf.systemd = {
-      withName = "host-systemd";
-      enable = true;
-      boot.enable = true;
-      withAudit = config.ghaf.profiles.debug.enable;
-      withPolkit = true;
-      withTpm2Tss = pkgs.stdenv.hostPlatform.isx86;
-      withRepart = true;
-      withFido2 = true;
-      withCryptsetup = true;
-      withTimesyncd = cfg.networkSupport;
-      withNss = cfg.networkSupport;
-      withResolved = cfg.networkSupport;
-      withSerial = config.ghaf.profiles.debug.enable;
-      withDebug = config.ghaf.profiles.debug.enable;
-      withHardenedConfigs = true;
+      vms = lib.mkOption {
+        description = ''
+          List of names of virtual machines for which unsafe shared folder will be enabled.
+        '';
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
     };
-    ghaf.givc.host.enable = true;
-
-    # TODO: remove hardcoded paths
-    systemd.services."microvm@audio-vm".serviceConfig =
-      lib.optionalAttrs config.ghaf.virtualization.microvm.audiovm.enable
-        {
-          # The + here is a systemd feature to make the script run as root.
-          ExecStopPost = [
-            "+${pkgs.writeShellScript "reload-audio" ''
-              # The script makes audio device internal state to reset
-              # This fixes issue of audio device getting into some unexpected
-              # state when the VM is being shutdown during audio mic recording
-              echo "1" > /sys/bus/pci/devices/0000:00:1f.3/remove
-              sleep 0.1
-              echo "1" > /sys/bus/pci/devices/0000:00:1f.0/rescan
-            ''}"
-          ];
-        };
   };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      microvm.host.enable = true;
+      ghaf.systemd = {
+        withName = "host-systemd";
+        enable = true;
+        boot.enable = true;
+        withAudit = config.ghaf.profiles.debug.enable;
+        withPolkit = true;
+        withTpm2Tss = pkgs.stdenv.hostPlatform.isx86;
+        withRepart = true;
+        withFido2 = true;
+        withCryptsetup = true;
+        withTimesyncd = cfg.networkSupport;
+        withNss = cfg.networkSupport;
+        withResolved = cfg.networkSupport;
+        withSerial = config.ghaf.profiles.debug.enable;
+        withDebug = config.ghaf.profiles.debug.enable;
+        withHardenedConfigs = true;
+      };
+      ghaf.givc.host.enable = true;
+
+      # TODO: remove hardcoded paths
+      systemd.services."microvm@audio-vm".serviceConfig =
+        lib.optionalAttrs config.ghaf.virtualization.microvm.audiovm.enable
+          {
+            # The + here is a systemd feature to make the script run as root.
+            ExecStopPost = [
+              "+${pkgs.writeShellScript "reload-audio" ''
+                # The script makes audio device internal state to reset
+                # This fixes issue of audio device getting into some unexpected
+                # state when the VM is being shutdown during audio mic recording
+                echo "1" > /sys/bus/pci/devices/0000:00:1f.3/remove
+                sleep 0.1
+                echo "1" > /sys/bus/pci/devices/0000:00:1f.0/rescan
+              ''}"
+            ];
+          };
+
+    })
+    (lib.mkIf cfg.sharedVmDirectory.enable {
+      ghaf.virtualization.microvm.guivm.extraModules = [ (import ./common/shared-directory.nix "") ];
+
+      # Create directories required for sharing files with correct permissions.
+      systemd.tmpfiles.rules =
+        let
+          vmDirs = map (
+            n:
+            "d /storagevm/shared/shares/Unsafe\\x20${n}\\x20share/ 0700 ${config.ghaf.users.accounts.user} users"
+          ) cfg.sharedVmDirectory.vms;
+        in
+        [
+          "d /storagevm/shared 0755 root root"
+          "d /storagevm/shared/shares 0700 ${config.ghaf.users.accounts.user} users"
+        ]
+        ++ vmDirs;
+
+    })
+  ];
 }

--- a/modules/reference/profiles/laptop-x86.nix
+++ b/modules/reference/profiles/laptop-x86.nix
@@ -63,6 +63,14 @@ in
         microvm-host = {
           enable = true;
           networkSupport = true;
+          sharedVmDirectory = {
+            enable = true;
+            vms = [
+              "business-vm"
+              "chromium-vm"
+              "comms-vm"
+            ];
+          };
         };
 
         microvm = {

--- a/modules/reference/programs/chromium.nix
+++ b/modules/reference/programs/chromium.nix
@@ -13,8 +13,11 @@ in
     programs.chromium = {
       enable = true;
 
-      # Fix border glitch when going maximised->minimised.
-      initialPrefs.browser.custom_chrome_frame = false;
+      initialPrefs = {
+        # Fix border glitch when going maximised->minimised.
+        browser.custom_chrome_frame = false;
+        download.prompt_for_download = true;
+      };
 
       # Don't use pdf.js, open externally.
       extraOpts."AlwaysOpenPdfExternally" = true;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Add directory that allow user to share files between appvms and guivm easily.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [x] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: every target.
- [x] Is this a new feature
  - [x] List the test steps to verify:
    1. Connect to chromium-vm and create file in `/home/ghaf/Unsafe share` directory.
    2. Go back to guivm and move file from `/home/ghaf/Shares/Unsafe chromium-vm share` to `/home/ghaf/Shares/Unsafe business-vm share`.
    3. Connect to business vm and check that file appears in `/home/ghaf/Unsafe share` directory.
    4. Check that file stays in place after reboot.
- [ ] If it is an improvement how does it impact existing functionality?

