### PR TITLE
Add support for USB removable media

### DIFF
--- a/modules/common/services/default.nix
+++ b/modules/common/services/default.nix
@@ -11,5 +11,6 @@
     ./namespaces.nix
     ./yubikey.nix
     ./bluetooth.nix
+    ./disks.nix
   ];
 }

--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -155,6 +155,13 @@ in
             }
 
             {
+              name = "File Manager";
+              description = "File manager application";
+              path = "${pkgs.pcmanfm}/bin/pcmanfm";
+              icon = "${pkgs.icon-pack}/system-file-manager.svg";
+            }
+
+            {
               name = "Network Settings";
               description = "Manage Network & Wi-Fi Settings";
               path = "${pkgs.nm-launcher}/bin/nm-launcher";

--- a/modules/common/services/disks.nix
+++ b/modules/common/services/disks.nix
@@ -1,0 +1,52 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.services.disks;
+  yaml = pkgs.formats.yaml { };
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
+in
+{
+  options.ghaf.services.disks = {
+    enable = mkEnableOption "Enable disk mount daemon";
+
+    fileManager = mkOption {
+      type = types.str;
+      default = "xdg-open";
+      description = "The program to open mounted directories";
+    };
+  };
+  config = mkIf cfg.enable {
+
+    services.udisks2.enable = true;
+
+    environment.etc."udiskie.yml".source = yaml.generate "udiskie.yml" {
+      program_options = {
+        automount = true;
+        tray = "auto";
+        notify = true;
+      };
+    };
+
+    systemd.user.services.udiskie = {
+      enable = true;
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.udiskie}/bin/udiskie -c /etc/udiskie.yml -f ${cfg.fileManager} --appindicator";
+      };
+      after = [ "ghaf-session.target" ];
+      partOf = [ "ghaf-session.target" ];
+      wantedBy = [ "ghaf-session.target" ];
+    };
+  };
+}

--- a/modules/desktop/graphics/ghaf-launcher.nix
+++ b/modules/desktop/graphics/ghaf-launcher.nix
@@ -52,6 +52,7 @@ pkgs.writeShellApplication {
   runtimeInputs = [
     pkgs.coreutils
     pkgs.nwg-drawer
+    pkgs.util-linux
   ];
   bashOptions = [ ];
   text = ''

--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -44,11 +44,9 @@ let
           disable = true;
         }
         {
-          # Currently disabled to leave USB drives connected to the host
           class = 8;
           sublass = 6;
           description = "Mass Storage - SCSI (USB drives)";
-          disable = true;
         }
       ];
       evdevPassthrough = {

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -82,6 +82,8 @@ let
                 "Videos"
               ];
             };
+            services.disks.enable = true;
+            services.disks.fileManager = "${pkgs.pcmanfm}/bin/pcmanfm";
           };
 
           systemd.services."waypipe-ssh-keygen" =

--- a/packages/icon-pack/default.nix
+++ b/packages/icon-pack/default.nix
@@ -31,6 +31,7 @@ let
     "thorium-browser.svg"
     "utilities-terminal.svg"
     "yast-vpn.svg"
+    "system-file-manager.svg"
   ];
 in
 runCommand "icon-pack"


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

- Enable passthrough of USB drives to the GUIVM.
- Add a new service to enable auto-mounting.
- Add a simple file manager to the GUIVM.

Note: A reboot or a restart of the vhotplug service is required to enable USB drive passthrough if the system is updated with nixos-rebuild.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- Reboot the device or restart the vhotplug service on the host if the system was updated with nixos-rebuild.
- Connect a USB drive to the Lenovo X1.
- Make sure an auto-mount notification appears.
- Click on the disk icon at the bottom panel and browse the files.
- The file manager should also be accessible from the launcher panel.
- Also, it would be nice to test a use case when the system is booted from a USB drive. In this case it shouldn't be attached to the GUIVM.

