### PR TITLE
Add Falcon LLM

### DIFF
--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -196,6 +196,13 @@ in
             }
 
             {
+              name = "Falcon AI";
+              description = "Your local large language model, developed by TII.";
+              path = "${pkgs.alpaca}/bin/alpaca";
+              icon = "${pkgs.ghaf-artwork}/icons/falcon-icon.svg";
+            }
+
+            {
               name = "Shutdown";
               description = "Shutdown System";
               path = "${pkgs.givc-cli}/bin/givc-cli ${cliArgs} poweroff";

--- a/modules/microvm/virtualization/microvm/common/storagevm.nix
+++ b/modules/microvm/virtualization/microvm/common/storagevm.nix
@@ -20,7 +20,7 @@ in
       # FIXME: Probably will lead to disgraceful error messages, as we
       # put typechecking on nix impermanence option. But other,
       # proper, ways are much harder.
-      type = types.anything;
+      type = types.listOf types.anything;
       default = [ ];
       example = [
         "/var/lib/nixos"
@@ -51,7 +51,7 @@ in
     };
 
     files = mkOption {
-      type = types.anything;
+      type = types.listOf types.anything;
       default = [ ];
       example = [ "/etc/machine-id" ];
       description = ''

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -68,6 +68,14 @@ let
             storagevm = {
               enable = true;
               name = "guivm";
+              directories = [
+                {
+                  directory = "/var/lib/private/ollama";
+                  inherit (config.ghaf.users.accounts) user;
+                  group = "ollama";
+                  mode = "u=rwx,g=,o=";
+                }
+              ];
               users.${config.ghaf.users.accounts.user}.directories = [
                 ".cache"
                 ".config"
@@ -147,7 +155,7 @@ let
           microvm = {
             optimize.enable = false;
             vcpu = 2;
-            mem = 2048;
+            mem = 12288;
             hypervisor = "qemu";
             shares = [
               {
@@ -184,7 +192,10 @@ let
           imports = [
             ../../../common
             ../../../desktop
+            ../../../reference/services
           ];
+
+          ghaf.reference.services.ollama = true;
 
           # Waypipe service runs in the GUIVM and listens for incoming connections from AppVMs
           systemd.user.services.waypipe = {

--- a/modules/reference/services/default.nix
+++ b/modules/reference/services/default.nix
@@ -11,11 +11,13 @@ in
     ./dendrite-pinecone/dendrite-pinecone.nix
     ./dendrite-pinecone/dendrite-config.nix
     ./proxy-server/3proxy-config.nix
+    ./ollama/ollama.nix
   ];
   options.ghaf.reference.services = {
-    enable = mkEnableOption "Enable the Ghaf reference services";
-    dendrite = mkEnableOption "Enable the dendrite-pinecone service";
+    enable = mkEnableOption "Ghaf reference services";
+    dendrite = mkEnableOption "dendrite-pinecone service";
     proxy-business = mkEnableOption "Enable the proxy server service";
+    ollama = mkEnableOption "ollama service";
   };
   config = mkIf cfg.enable {
     ghaf.reference.services = {

--- a/modules/reference/services/ollama/ollama.nix
+++ b/modules/reference/services/ollama/ollama.nix
@@ -1,0 +1,105 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.reference.services;
+  inherit (lib) mkIf;
+in
+{
+  config = mkIf cfg.ollama {
+    services.ollama = {
+      enable = true;
+      openFirewall = true;
+      host = "0.0.0.0";
+    };
+
+    environment.systemPackages = [
+      (pkgs.writeShellApplication {
+        name = "load-falcon";
+        runtimeInputs = with pkgs; [
+          libnotify
+          ollama
+        ];
+        text = ''
+          if [ "''${1:-}" == "--check" ]; then
+             if ollama show falcon2; then
+                echo "falcon2 model is installed"
+                exit 0
+             fi
+
+             if [ -f /tmp/falcon-download ]; then
+               if [ "$(cat /tmp/falcon-download)" == "1" ]; then
+                  echo "falcon2 model is currently being installed"
+                  exit 0
+               fi
+             fi
+
+             echo "falcon2 model is not installed"
+             exit 1
+          fi
+
+          function cleanup() {
+             echo 0 > /tmp/falcon-download
+          }
+
+          trap cleanup SIGINT
+
+          if ! ollama show falcon2; then
+             notify-send -i ${pkgs.ghaf-artwork}/icons/falcon-icon.svg 'Falcon AI' 'Downloading the latest falcon2 model. This may take a while...'
+             echo 1 > /tmp/falcon-download
+          else
+             echo "falcon2 model is already installed"
+             exit 0
+          fi
+
+          if ollama pull falcon2:latest; then
+            notify-send -i ${pkgs.ghaf-artwork}/icons/falcon-icon.svg 'Falcon AI' 'The falcon model has been downloaded successfully. You may now try it out!'
+          else
+            notify-send -i ${pkgs.ghaf-artwork}/icons/falcon-icon.svg 'Falcon AI' 'Failed to download the falcon model. Please try again later.'
+          fi
+
+          cleanup
+        '';
+      })
+    ];
+
+    # This forces Alpaca to use the systemd ollama daemon instead of spawning
+    # its own.
+    system.userActivationScripts.alpaca-configure = {
+      text = ''
+                source ${config.system.build.setEnvironment}
+                mkdir -p $HOME/.config/com.jeffser.Alpaca
+                cat <<EOF > $HOME/.config/com.jeffser.Alpaca/server.json
+        {
+              "remote_url": "http://localhost:11434",
+              "remote_bearer_token": "",
+              "run_remote": true,
+              "local_port": 11435,
+              "run_on_background": false,
+              "powersaver_warning": true,
+              "model_tweaks": {
+                    "temperature": 0.7,
+                    "seed": 0,
+                    "keep_alive": 5
+              },
+              "ollama_overrides": {},
+              "idle_timer": 0
+        }
+        EOF
+      '';
+    };
+
+    systemd.services.ollama = {
+      serviceConfig = {
+        TimeoutStartSec = "5h";
+        Restart = "always";
+        RestartSec = "5s";
+      };
+    };
+  };
+}


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

- Add ollama (AI backend) and alpaca (AI frontend).
  - ~Autoload falcon2 model whenever there is an internet connection~
  - Added load-falcon command to load the model, which shows user-friendly notification.
  - This command should be integrated with UI later, such as in system bar or widgets.
- ~Increased system partitions size until a permanent fix is available.~ fixed by #813 

This PR carries some overlays and systemd options that should be removed by ~#769~ #809

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [x] Change requires full re-installation: **YES** as per #813
- [ ] Change can be updated with `nixos-rebuild ... switch`: **NO** full reinstallation needed as per #813

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: x1 carbon only
- [x] Is this a new feature
  - [x] List the test steps to verify:
    - Fresh installation of Ghaf (rebuild is not enough)
    - Connect to Wi-Fi, open terminal in gui-vm, run `load-falcon`
      - On a 50Mb/s internet connection, it may take a bit over 20 minutes
      - You can see the progress by running `systemctl status ollama-model-loader`.  If you see messages with "blob", it is downloading. If deactivated successfully, then the model should be available.
    - Open Falcon AI application, you should see "Falcon2" on the top, you should be able to ask a basic question and it would reply.
    - Please don't test the model's accuracy or behaviour as it is out of scope :smiley: 
    - Do not untoggle the "Use Remote Connection" option in the Alpaca settings.
- [ ] If it is an improvement how does it impact existing functionality?

