### PR TITLE
Proxy setup to allow/deny specific urls for BusinessVM

### DIFF
--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -11,6 +11,12 @@ let
   #TODO: Move this to a common place
   xdgPdfPort = 1200;
   name = "business";
+  tiiVpnAddr = "151.253.154.18";
+  vpnOnlyAddr = "${tiiVpnAddr},jira.tii.ae,access.tii.ae,confluence.tii.ae,i-service.tii.ae,catalyst.atrc.ae";
+  netvmEntry = builtins.filter (x: x.name == "net-vm") config.ghaf.networking.hosts.entries;
+  netvmAddress = lib.head (builtins.map (x: x.ip) netvmEntry);
+  adminvmEntry = builtins.filter (x: x.name == "admin-vm") config.ghaf.networking.hosts.entries;
+  adminvmAddress = lib.head (builtins.map (x: x.ip) adminvmEntry);
 in
 {
   name = "${name}";
@@ -38,9 +44,10 @@ in
       pkgs.globalprotect-openconnect
       pkgs.losslesscut-bin
       pkgs.openconnect
-      pkgs.nftables
       pkgs.gnome-text-editor
-    ];
+    ]
+    ++ lib.optionals config.ghaf.profiles.debug.enable [ pkgs.tcpdump ];
+
   # TODO create a repository of mac addresses to avoid conflicts
   macAddress = "02:00:00:03:10:01";
   ramMb = 6144;
@@ -74,7 +81,6 @@ in
       };
 
       ghaf.reference.programs.chromium.enable = true;
-
       # Set default PDF XDG handler
       xdg.mime.defaultApplications."application/pdf" = "ghaf-pdf.desktop";
 
@@ -92,183 +98,45 @@ in
       #Firewall Settings
       networking = {
         firewall.enable = true;
+        proxy = {
+          default = "http://${netvmAddress}:${toString config.ghaf.reference.services.proxy-server.bindPort}";
+          noProxy = "192.168.101.10,${adminvmAddress},127.0.0.1,localhost,${vpnOnlyAddr}";
+        };
         firewall.extraCommands = ''
 
-          iptables -F
-            add_rule() {
-              local ip=$1
-              iptables -I OUTPUT -p tcp -d $ip --dport 80 -j ACCEPT
-              iptables -I OUTPUT -p tcp -d $ip --dport 443 -j ACCEPT
-              iptables -I INPUT -p tcp -s $ip --sport 80 -j ACCEPT
-              iptables -I INPUT -p tcp -s $ip --sport 443 -j ACCEPT
-            }
-           # Urls can be found from Source: https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges
-           # Allow microsoft365.com
-           add_rule 13.107.6.156
-           add_rule 13.107.9.156
+          add_rule() {
+                local ip=$1
+                iptables -I OUTPUT -p tcp -d $ip --dport 80 -j ACCEPT
+                iptables -I OUTPUT -p tcp -d $ip --dport 443 -j ACCEPT
+                iptables -I INPUT -p tcp -s $ip --sport 80 -j ACCEPT
+                iptables -I INPUT -p tcp -s $ip --sport 443 -j ACCEPT
+              }
+          # Default policy 
+          iptables -P INPUT DROP
 
-           # Exchange
-           add_rule 13.107.6.152/31
-           add_rule 13.107.18.10/31
-           add_rule 13.107.128.0/22
-           add_rule 23.103.160.0/20
-           add_rule 40.96.0.0/13
-           add_rule 40.104.0.0/15
-           add_rule 52.96.0.0/14
-           add_rule 131.253.33.215/32
-           add_rule 132.245.0.0/16
-           add_rule 150.171.32.0/22
-           add_rule 204.79.197.215/32
+          # Block any other unwanted traffic (optional)
+          iptables -N logreject
+          iptables -A logreject -j LOG
+          iptables -A logreject -j REJECT
 
+          # allow everything for local VPN traffic
+          iptables -A INPUT -i tun0 -j ACCEPT
+          iptables -A FORWARD -i tun0 -j ACCEPT
+          iptables -A FORWARD -o tun0 -j ACCEPT
+          iptables -A OUTPUT -o tun0 -j ACCEPT
 
-           # Exchange Online
-           add_rule 40.92.0.0/15
-           add_rule 40.107.0.0/16
-           add_rule 52.100.0.0/14
-           add_rule 52.238.78.88/32
-           add_rule 104.47.0.0/17
+          # WARN: if all the traffic including VPN flowing through proxy is intended,
+          # remove "add_rule 151.253.154.18" rule and pass "--proxy-server=http://192.168.100.1:3128" to openconnect(VPN) app.
+          # also remove "151.253.154.18,tii.ae,.tii.ae,sapsf.com,.sapsf.com" addresses from noProxy option and add
+          # them to allow acl list in modules/reference/appvms/3proxy-config.nix file.
+          # Allow VPN access.tii.ae 
+          add_rule ${tiiVpnAddr}
 
-
-           # Sharepoint
-           add_rule 13.107.136.0/22
-           add_rule 40.108.128.0/17
-           add_rule 52.104.0.0/14
-           add_rule 104.146.128.0/17
-           add_rule 150.171.40.0/22
-
-
-           # Common
-           add_rule 13.107.6.171/32
-           add_rule 13.107.18.15/32
-           add_rule 13.107.140.6/32
-           add_rule 52.108.0.0/14
-           add_rule 52.244.37.168/32
-           add_rule 20.20.32.0/19
-           add_rule 20.190.128.0/18
-           add_rule 20.231.128.0/19
-           add_rule 40.126.0.0/18
-           add_rule 13.107.6.192/32
-           add_rule 13.107.9.192/32
-           add_rule 52.108.0.0/14
-
-           # Teams
-           add_rule 13.107.64.0/18
-           add_rule 52.112.0.0/14
-           add_rule 52.122.0.0/15
-           add_rule 52.108.0.0/14
-           add_rule 52.238.119.141/32
-           add_rule 52.244.160.207/32
-           add_rule 2.16.234.57
-           add_rule 23.56.21.152
-           add_rule 23.33.233.129
-           add_rule 52.123.0.0/16
-
-
-           # Allow VPN access.tii.ae and iservice
-           add_rule 151.253.154.18
-           add_rule 10.161.10.120
-
-           # To be checked
-           # Allow res.cdn.office.net
-           add_rule 152.199.21.175
-           add_rule 152.199.39.108
-           add_rule 2.21.231.0/24
-           add_rule 2.20.249.0/24
-           add_rule 152.199.0.0/16
-
-
-           # Allow js.monitor.azure.com
-           add_rule 13.107.246.0/24
-
-           # Allow c.s-microsoft.com
-           add_rule 23.207.193.242
-           add_rule 23.208.213.121
-           add_rule 23.208.173.122
-           add_rule 23.44.1.243
-           add_rule 104.65.229.0/24
-           add_rule 23.53.113.0/24
-           add_rule 2.19.105.47
-
-           # Allow microsoft.com
-           add_rule 20.70.246.20
-           add_rule 20.236.44.162
-           add_rule 20.76.201.171
-           add_rule 20.231.239.246
-           add_rule 20.112.250.133
-           add_rule 184.25.221.172
-
-           # statics.teams.cdn.office.net
-           add_rule 95.101.0.0/16
-           add_rule 184.87.193.0/24
-           add_rule 23.44.0.0/14
-           add_rule 96.16.53.0/24
-           add_rule 23.59.80.0/24
-           add_rule 23.202.33.0/24
-           add_rule 104.73.172.0/24
-           add_rule 184.27.123.0/24
-           add_rule 2.16.56.0/24
-           add_rule 23.219.73.130
-           add_rule 104.93.18.174
-           add_rule 2.21.225.158
-           add_rule 23.45.137.145
-           add_rule 23.48.121.167
-           add_rule 23.46.197.94
-           add_rule 104.80.21.47
-           add_rule 23.195.154.8
-           add_rule 193.229.113.0/24
-
-           # edge.skype.com for teams
-           add_rule 13.107.254.0/24
-           add_rule 13.107.3.0/24
-
-           # api.flightproxy.skype.com for teams
-           add_rule 98.66.0.0/16
-           add_rule 4.208.0.0/16
-           add_rule 4.225.208.0/24
-           add_rule 4.210.0.0/16
-           add_rule 108.141.240.0/24
-           add_rule 74.241.0.0/16
-           add_rule 20.216.0.0/16
-           add_rule 172.211.0.0/16
-           add_rule 20.50.217.0/24
-           add_rule 68.219.14.0/24
-           add_rule 20.107.136.0/24
-           add_rule 4.175.191.0/24
-           add_rule 98.64.0.0/16
-
-           # Allow tiiuae.sharepoint.com
-           add_rule 52.104.7.53
-           add_rule 52.105.255.39
-           add_rule 13.107.138.10
-           add_rule 13.107.136.10
-           add_rule 118.215.84.0/24
-           add_rule 104.69.171.0/24
-           add_rule 13.107.136.10
-           add_rule 23.15.111.0/24
-           # Allow shell.cdn.office.net
-           add_rule 23.50.92.176
-           add_rule 23.15.30.57
-           add_rule 23.50.187.58
-           add_rule 104.73.234.244
-           add_rule 104.83.143.131
-           # Allow res-1.cdn.office.net
-           add_rule 23.52.40.0/24
-           add_rule 23.64.122.0/24
-           add_rule 2.16.106.0/24
-           # Allow publiccdn.sharepointonline.com
-           add_rule 23.50.86.117
-           add_rule 104.69.168.125
-           add_rule 2.16.43.238
-           add_rule 23.34.79.0/24
-           add_rule 23.39.68.0/24
-           # r4.res.office365.com
-           add_rule 2.19.97.32
-           add_rule 2.22.61.139
-
-
-           # Block all other HTTP and HTTPS traffic
-           iptables -A OUTPUT -p tcp --dport 80 -j REJECT
-           iptables -A OUTPUT -p tcp --dport 443 -j REJECT
+          # Block all other HTTP and HTTPS traffic
+          iptables -A OUTPUT -p tcp --dport 80 -j logreject
+          iptables -A OUTPUT -p tcp --dport 443 -j logreject
+          iptables -A OUTPUT -p udp --dport 80 -j logreject
+          iptables -A OUTPUT -p udp --dport 443 -j logreject
 
         '';
       };

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -34,6 +34,7 @@ in
         services = {
           enable = true;
           dendrite = true;
+          proxy-business = lib.mkForce config.ghaf.reference.appvms.business-vm;
         };
 
         personalize = {

--- a/modules/reference/services/default.nix
+++ b/modules/reference/services/default.nix
@@ -10,14 +10,17 @@ in
   imports = [
     ./dendrite-pinecone/dendrite-pinecone.nix
     ./dendrite-pinecone/dendrite-config.nix
+    ./proxy-server/3proxy-config.nix
   ];
   options.ghaf.reference.services = {
     enable = mkEnableOption "Enable the Ghaf reference services";
     dendrite = mkEnableOption "Enable the dendrite-pinecone service";
+    proxy-business = mkEnableOption "Enable the proxy server service";
   };
   config = mkIf cfg.enable {
     ghaf.reference.services = {
       dendrite-pinecone.enable = mkForce (cfg.dendrite && isNetVM);
+      proxy-server.enable = mkForce (cfg.proxy-business && isNetVM);
     };
   };
 }

--- a/modules/reference/services/proxy-server/3proxy-config.nix
+++ b/modules/reference/services/proxy-server/3proxy-config.nix
@@ -1,0 +1,107 @@
+# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.reference.services.proxy-server;
+  inherit (lib) mkEnableOption mkIf;
+  # use nix-prefetch-url to calculate sha256 checksum
+  # TODO The urls should be fetched during boot. The script should be implemented in netvm or adminvm
+  #pkgs.fetchurl {
+  #  url = "https://endpoints.office.com/endpoints/worldwide?clientrequestid=b10c5ed1-bad1-445f-b386-b919946339a7";
+  #  sha256 = "1zly0g23vray4wg6fjxxdys6zzksbymlzggbg75jxqcf8g9j6xnw";
+  #};
+  msEndpointsFile = ./ms_urls.json;
+  # Read and parse the JSON file
+  msEndpointsData = builtins.fromJSON (builtins.readFile msEndpointsFile);
+
+  # Extract URLs from the JSON data based on categories
+  msExtractUrls = map (x: x.urls or [ ]) (
+    lib.filter (
+      x: x.category == "Optimize" || x.category == "Allow" || x.category == "Default"
+    ) msEndpointsData
+  );
+
+  msUrlsFlattened = builtins.concatLists msExtractUrls ++ [ "microsoft365.com" ];
+
+  tiiUrls = [
+    #for jira avatars
+    "*.gravatar.com"
+    # for confluence icons
+    "*.atlassian.com"
+    "*tii.ae"
+    "*tii.org"
+    "hcm22.sapsf.com"
+    "aderp.addigital.gov.ae"
+    "s1.mn1.ariba.com"
+    "tii.sourcing.mn1.ariba.com"
+    "a1c7ohabl.accounts.ondemand.com"
+    "flpnwc-ojffapwnic.dispatcher.ae1.hana.ondemand.com"
+    "*.docusign.com"
+    "access.clarivate.com"
+  ];
+
+  ssrcUrls = [
+    "*.cachix.org"
+    "cache.vedenemo.dev"
+    "vedenemo.dev"
+    "loki.ghaflogs.vedenemo.dev"
+    "ghaflogs.vedenemo.dev"
+    "himalia.vedenemo.dev"
+  ];
+  netvmEntry = builtins.filter (x: x.name == "net-vm") config.ghaf.networking.hosts.entries;
+  netvmAddr = lib.head (builtins.map (x: x.ip) netvmEntry);
+in
+{
+  options.ghaf.reference.services.proxy-server = {
+    enable = mkEnableOption "Enable proxy server module";
+    bindPort = lib.mkOption {
+      type = lib.types.int;
+      default = 3128;
+      description = "Bind port for proxy server";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+
+    ];
+
+    #Firewall Settings
+    networking = {
+      firewall.enable = true;
+      firewall.extraCommands = ''
+         # Allow incoming connections to 3proxy on port ${toString cfg.bindPort} from the client's IP
+        iptables -I INPUT -p tcp -s 192.168.100.0/24 --dport ${toString cfg.bindPort} -j ACCEPT
+        iptables -I INPUT -p udp -s 192.168.100.0/24 --dport ${toString cfg.bindPort} -j ACCEPT
+      '';
+    };
+    services._3proxy = {
+      enable = true;
+      services = [
+        {
+          type = "proxy";
+          bindAddress = "${netvmAddr}";
+          inherit (cfg) bindPort;
+          maxConnections = 200;
+          auth = [ "iponly" ];
+          acl = [
+            {
+              rule = "allow";
+              targets = msUrlsFlattened;
+            }
+            {
+              rule = "allow";
+              targets = tiiUrls;
+            }
+            {
+              rule = "allow";
+              targets = ssrcUrls;
+            }
+            { rule = "deny"; }
+          ];
+        }
+      ];
+    };
+
+  };
+}

--- a/modules/reference/services/proxy-server/ms_urls.json
+++ b/modules/reference/services/proxy-server/ms_urls.json
@@ -1,0 +1,1132 @@
+[
+    {
+        "_comment": [
+            "Copyright 2024 TII (SSRC) and the Ghaf contributors",
+            "SPDX-License-Identifier: Apache-2.0"
+        ],
+        "id": 1,
+        "serviceArea": "Exchange",
+        "serviceAreaDisplayName": "Exchange Online",
+        "urls": [
+            "outlook.cloud.microsoft",
+            "outlook.office.com",
+            "outlook.office365.com"
+        ],
+        "ips": [
+            "13.107.6.152/31",
+            "13.107.18.10/31",
+            "13.107.128.0/22",
+            "23.103.160.0/20",
+            "40.96.0.0/13",
+            "40.104.0.0/15",
+            "52.96.0.0/14",
+            "131.253.33.215/32",
+            "132.245.0.0/16",
+            "150.171.32.0/22",
+            "204.79.197.215/32",
+            "2603:1006::/40",
+            "2603:1016::/36",
+            "2603:1026::/36",
+            "2603:1036::/36",
+            "2603:1046::/36",
+            "2603:1056::/36",
+            "2620:1ec:4::152/128",
+            "2620:1ec:4::153/128",
+            "2620:1ec:c::10/128",
+            "2620:1ec:c::11/128",
+            "2620:1ec:d::10/128",
+            "2620:1ec:d::11/128",
+            "2620:1ec:8f0::/46",
+            "2620:1ec:900::/46",
+            "2620:1ec:a92::152/128",
+            "2620:1ec:a92::153/128"
+        ],
+        "tcpPorts": "80,443",
+        "udpPorts": "443",
+        "expressRoute": true,
+        "category": "Optimize",
+        "required": true
+    },
+    {
+        "id": 2,
+        "serviceArea": "Exchange",
+        "serviceAreaDisplayName": "Exchange Online",
+        "urls": [
+            "outlook.office365.com",
+            "smtp.office365.com"
+        ],
+        "ips": [
+            "13.107.6.152/31",
+            "13.107.18.10/31",
+            "13.107.128.0/22",
+            "23.103.160.0/20",
+            "40.96.0.0/13",
+            "40.104.0.0/15",
+            "52.96.0.0/14",
+            "131.253.33.215/32",
+            "132.245.0.0/16",
+            "150.171.32.0/22",
+            "204.79.197.215/32",
+            "2603:1006::/40",
+            "2603:1016::/36",
+            "2603:1026::/36",
+            "2603:1036::/36",
+            "2603:1046::/36",
+            "2603:1056::/36",
+            "2620:1ec:4::152/128",
+            "2620:1ec:4::153/128",
+            "2620:1ec:c::10/128",
+            "2620:1ec:c::11/128",
+            "2620:1ec:d::10/128",
+            "2620:1ec:d::11/128",
+            "2620:1ec:8f0::/46",
+            "2620:1ec:900::/46",
+            "2620:1ec:a92::152/128",
+            "2620:1ec:a92::153/128"
+        ],
+        "tcpPorts": "143, 587, 993, 995",
+        "expressRoute": true,
+        "category": "Allow",
+        "required": false,
+        "notes": "POP3, IMAP4, SMTP Client traffic"
+    },
+    {
+        "id": 8,
+        "serviceArea": "Exchange",
+        "serviceAreaDisplayName": "Exchange Online",
+        "urls": [
+            "*.outlook.com",
+            "autodiscover.*.onmicrosoft.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 9,
+        "serviceArea": "Exchange",
+        "serviceAreaDisplayName": "Exchange Online",
+        "urls": [
+            "*.protection.outlook.com"
+        ],
+        "ips": [
+            "40.92.0.0/15",
+            "40.107.0.0/16",
+            "52.100.0.0/14",
+            "52.238.78.88/32",
+            "104.47.0.0/17",
+            "2a01:111:f400::/48",
+            "2a01:111:f403::/48"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": true,
+        "category": "Allow",
+        "required": true
+    },
+    {
+        "id": 10,
+        "serviceArea": "Exchange",
+        "serviceAreaDisplayName": "Exchange Online",
+        "urls": [
+            "*.mail.protection.outlook.com",
+            "*.mx.microsoft"
+        ],
+        "ips": [
+            "40.92.0.0/15",
+            "40.107.0.0/16",
+            "52.100.0.0/14",
+            "104.47.0.0/17",
+            "2a01:111:f400::/48",
+            "2a01:111:f403::/48"
+        ],
+        "tcpPorts": "25",
+        "expressRoute": true,
+        "category": "Allow",
+        "required": true
+    },
+    {
+        "id": 11,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "ips": [
+            "52.112.0.0/14",
+            "52.122.0.0/15",
+            "2603:1063::/38"
+        ],
+        "udpPorts": "3478,3479,3480,3481",
+        "expressRoute": true,
+        "category": "Optimize",
+        "required": true
+    },
+    {
+        "id": 12,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "urls": [
+            "*.lync.com",
+            "*.teams.cloud.microsoft",
+            "*.teams.microsoft.com",
+            "teams.cloud.microsoft",
+            "teams.microsoft.com"
+        ],
+        "ips": [
+            "52.112.0.0/14",
+            "52.122.0.0/15",
+            "52.238.119.141/32",
+            "52.244.160.207/32",
+            "2603:1027::/48",
+            "2603:1037::/48",
+            "2603:1047::/48",
+            "2603:1057::/48",
+            "2603:1063::/38",
+            "2620:1ec:6::/48",
+            "2620:1ec:40::/42"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": true,
+        "category": "Allow",
+        "required": true
+    },
+    {
+        "id": 16,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "urls": [
+            "*.keydelivery.mediaservices.windows.net",
+            "*.streaming.mediaservices.windows.net",
+            "mlccdn.blob.core.windows.net"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 17,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "urls": [
+            "aka.ms"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 18,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "urls": [
+            "*.users.storage.live.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Federation with Skype and public IM connectivity: Contact picture retrieval"
+    },
+    {
+        "id": 19,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "urls": [
+            "adl.windows.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Applies only to those who deploy the Conference Room Systems"
+    },
+    {
+        "id": 27,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "urls": [
+            "*.secure.skypeassets.com",
+            "mlccdnprod.azureedge.net"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 31,
+        "serviceArea": "SharePoint",
+        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+        "urls": [
+            "*.sharepoint.com"
+        ],
+        "ips": [
+            "13.107.136.0/22",
+            "40.108.128.0/17",
+            "52.104.0.0/14",
+            "104.146.128.0/17",
+            "150.171.40.0/22",
+            "2603:1061:1300::/40",
+            "2620:1ec:8f8::/46",
+            "2620:1ec:908::/46",
+            "2a01:111:f402::/48"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": true,
+        "category": "Optimize",
+        "required": true
+    },
+    {
+        "id": 32,
+        "serviceArea": "SharePoint",
+        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+        "urls": [
+            "ssw.live.com",
+            "storage.live.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "OneDrive for Business: supportability, telemetry, APIs, and embedded email links"
+    },
+    {
+        "id": 33,
+        "serviceArea": "SharePoint",
+        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+        "urls": [
+            "*.search.production.apac.trafficmanager.net",
+            "*.search.production.emea.trafficmanager.net",
+            "*.search.production.us.trafficmanager.net"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "SharePoint Hybrid Search - Endpoint to SearchContentService where the hybrid crawler feeds documents"
+    },
+    {
+        "id": 35,
+        "serviceArea": "SharePoint",
+        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+        "urls": [
+            "*.wns.windows.com",
+            "admin.onedrive.com",
+            "officeclient.microsoft.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 36,
+        "serviceArea": "SharePoint",
+        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+        "urls": [
+            "g.live.com",
+            "oneclient.sfx.ms"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 37,
+        "serviceArea": "SharePoint",
+        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+        "urls": [
+            "*.sharepointonline.com",
+            "spoprod-a.akamaihd.net"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 39,
+        "serviceArea": "SharePoint",
+        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+        "urls": [
+            "*.svc.ms"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 46,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.officeapps.live.com",
+            "*.online.office.com",
+            "office.live.com"
+        ],
+        "ips": [
+            "13.107.6.171/32",
+            "13.107.18.15/32",
+            "13.107.140.6/32",
+            "52.108.0.0/14",
+            "52.244.37.168/32",
+            "2603:1006:1400::/40",
+            "2603:1016:2400::/40",
+            "2603:1026:2400::/40",
+            "2603:1036:2400::/40",
+            "2603:1046:1400::/40",
+            "2603:1056:1400::/40",
+            "2603:1063:2000::/38",
+            "2620:1ec:c::15/128",
+            "2620:1ec:8fc::6/128",
+            "2620:1ec:a92::171/128",
+            "2a01:111:f100:2000::a83e:3019/128",
+            "2a01:111:f100:2002::8975:2d79/128",
+            "2a01:111:f100:2002::8975:2da8/128",
+            "2a01:111:f100:7000::6fdd:6cd5/128",
+            "2a01:111:f100:a004::bfeb:88cf/128"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": true,
+        "category": "Allow",
+        "required": true
+    },
+    {
+        "id": 47,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.office.net"
+        ],
+        "tcpPorts": "443,80",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 49,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.onenote.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 50,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.microsoft.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "OneNote notebooks (wildcards)"
+    },
+    {
+        "id": 51,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*cdn.onenote.net"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 53,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "ajax.aspnetcdn.com",
+            "apis.live.net",
+            "officeapps.live.com",
+            "www.onedrive.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 56,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.auth.microsoft.com",
+            "*.msftidentity.com",
+            "*.msidentity.com",
+            "account.activedirectory.windowsazure.com",
+            "accounts.accesscontrol.windows.net",
+            "adminwebservice.microsoftonline.com",
+            "api.passwordreset.microsoftonline.com",
+            "autologon.microsoftazuread-sso.com",
+            "becws.microsoftonline.com",
+            "ccs.login.microsoftonline.com",
+            "clientconfig.microsoftonline-p.net",
+            "companymanager.microsoftonline.com",
+            "device.login.microsoftonline.com",
+            "graph.microsoft.com",
+            "graph.windows.net",
+            "login.microsoft.com",
+            "login.microsoftonline.com",
+            "login.microsoftonline-p.com",
+            "login.windows.net",
+            "logincert.microsoftonline.com",
+            "loginex.microsoftonline.com",
+            "login-us.microsoftonline.com",
+            "nexus.microsoftonline-p.com",
+            "passwordreset.microsoftonline.com",
+            "provisioningapi.microsoftonline.com"
+        ],
+        "ips": [
+            "20.20.32.0/19",
+            "20.190.128.0/18",
+            "20.231.128.0/19",
+            "40.126.0.0/18",
+            "2603:1006:2000::/48",
+            "2603:1007:200::/48",
+            "2603:1016:1400::/48",
+            "2603:1017::/48",
+            "2603:1026:3000::/48",
+            "2603:1027:1::/48",
+            "2603:1036:3000::/48",
+            "2603:1037:1::/48",
+            "2603:1046:2000::/48",
+            "2603:1047:1::/48",
+            "2603:1056:2000::/48",
+            "2603:1057:2::/48"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": true,
+        "category": "Allow",
+        "required": true
+    },
+    {
+        "id": 59,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.hip.live.com",
+            "*.microsoftonline.com",
+            "*.microsoftonline-p.com",
+            "*.msauth.net",
+            "*.msauthimages.net",
+            "*.msecnd.net",
+            "*.msftauth.net",
+            "*.msftauthimages.net",
+            "*.phonefactor.net",
+            "enterpriseregistration.windows.net",
+            "policykeyservice.dc.ad.msft.net"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 64,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.protection.office.com",
+            "*.security.microsoft.com",
+            "compliance.microsoft.com",
+            "defender.microsoft.com",
+            "protection.office.com",
+            "purview.microsoft.com",
+            "security.microsoft.com"
+        ],
+        "ips": [
+            "13.107.6.192/32",
+            "13.107.9.192/32",
+            "2620:1ec:4::192/128",
+            "2620:1ec:a92::192/128"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": true,
+        "category": "Allow",
+        "required": true
+    },
+    {
+        "id": 66,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.portal.cloudappsecurity.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 68,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "firstpartyapps.oaspapps.com",
+            "prod.firstpartyapps.oaspapps.com.akadns.net",
+            "telemetryservice.firstpartyapps.oaspapps.com",
+            "wus-firstpartyapps.oaspapps.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Portal and shared: 3rd party office integration. (including CDNs)"
+    },
+    {
+        "id": 69,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.aria.microsoft.com",
+            "*.events.data.microsoft.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 70,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.o365weve.com",
+            "amp.azure.net",
+            "appsforoffice.microsoft.com",
+            "assets.onestore.ms",
+            "auth.gfx.ms",
+            "c1.microsoft.com",
+            "dgps.support.microsoft.com",
+            "docs.microsoft.com",
+            "msdn.microsoft.com",
+            "platform.linkedin.com",
+            "prod.msocdn.com",
+            "shellprod.msocdn.com",
+            "support.microsoft.com",
+            "technet.microsoft.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 71,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.office365.com"
+        ],
+        "tcpPorts": "443,80",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 73,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.aadrm.com",
+            "*.azurerms.com",
+            "*.informationprotection.azure.com",
+            "ecn.dev.virtualearth.net",
+            "informationprotection.hosting.portal.azure.net"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 75,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.sharepointonline.com",
+            "dc.services.visualstudio.com",
+            "mem.gfx.ms",
+            "staffhub.ms",
+            "staffhubweb.azureedge.net"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Graph.windows.net, Office 365 Management Pack for Operations Manager, SecureScore, Azure AD Device Registration, Forms, StaffHub, Application Insights, captcha services"
+    },
+    {
+        "id": 78,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.microsoft.com",
+            "*.msocdn.com",
+            "*.onmicrosoft.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Some Office 365 features require endpoints within these domains (including CDNs). Many specific FQDNs within these wildcards have been published recently as we work to either remove or better explain our guidance relating to these wildcards."
+    },
+    {
+        "id": 79,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "o15.officeredir.microsoft.com",
+            "officepreviewredir.microsoft.com",
+            "officeredir.microsoft.com",
+            "r.office.microsoft.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 83,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "activation.sls.microsoft.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 84,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "crl.microsoft.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 86,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "office15client.microsoft.com",
+            "officeclient.microsoft.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 89,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "go.microsoft.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 91,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "ajax.aspnetcdn.com",
+            "cdn.odc.officeapps.live.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 92,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "officecdn.microsoft.com",
+            "officecdn.microsoft.com.edgesuite.net",
+            "otelrules.azureedge.net"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 93,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.virtualearth.net",
+            "c.bing.net",
+            "ocos-office365-s2s.msedge.net",
+            "tse1.mm.bing.net",
+            "www.bing.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "ProPlus: auxiliary URLs"
+    },
+    {
+        "id": 95,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.acompli.net",
+            "*.outlookmobile.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Outlook for Android and iOS"
+    },
+    {
+        "id": 96,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "login.windows-ppe.net"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Outlook for Android and iOS: Authentication"
+    },
+    {
+        "id": 97,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "account.live.com",
+            "login.live.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Outlook for Android and iOS: Consumer Outlook.com and OneDrive integration"
+    },
+    {
+        "id": 105,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "www.acompli.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Outlook for Android and iOS: Outlook Privacy"
+    },
+    {
+        "id": 114,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.appex.bing.com",
+            "*.appex-rf.msn.com",
+            "c.bing.com",
+            "c.live.com",
+            "d.docs.live.net",
+            "docs.live.net",
+            "partnerservices.getmicrosoftkey.com",
+            "signup.live.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Office Mobile URLs"
+    },
+    {
+        "id": 116,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "account.live.com",
+            "auth.gfx.ms",
+            "login.live.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Office for iPad URLs"
+    },
+    {
+        "id": 117,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.yammer.com",
+            "*.yammerusercontent.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Yammer"
+    },
+    {
+        "id": 118,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.assets-yammer.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Yammer CDN"
+    },
+    {
+        "id": 121,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "www.outlook.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Planner: auxiliary URLs"
+    },
+    {
+        "id": 122,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "eus-www.sway-cdn.com",
+            "eus-www.sway-extensions.com",
+            "wus-www.sway-cdn.com",
+            "wus-www.sway-extensions.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Sway CDNs"
+    },
+    {
+        "id": 124,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "sway.com",
+            "www.sway.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Sway"
+    },
+    {
+        "id": 125,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.entrust.net",
+            "*.geotrust.com",
+            "*.omniroot.com",
+            "*.public-trust.com",
+            "*.symcb.com",
+            "*.symcd.com",
+            "*.verisign.com",
+            "*.verisign.net",
+            "apps.identrust.com",
+            "cacerts.digicert.com",
+            "cert.int-x3.letsencrypt.org",
+            "crl.globalsign.com",
+            "crl.globalsign.net",
+            "crl.identrust.com",
+            "crl3.digicert.com",
+            "crl4.digicert.com",
+            "isrg.trustid.ocsp.identrust.com",
+            "mscrl.microsoft.com",
+            "ocsp.digicert.com",
+            "ocsp.globalsign.com",
+            "ocsp.msocsp.com",
+            "ocsp2.globalsign.com",
+            "ocspx.digicert.com",
+            "secure.globalsign.com",
+            "www.digicert.com",
+            "www.microsoft.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 126,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "officespeech.platform.bing.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "Connection to the speech service is required for Office Dictation features. If connectivity is not allowed, Dictation will be disabled."
+    },
+    {
+        "id": 127,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "urls": [
+            "*.skype.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 147,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.office.com",
+            "www.microsoft365.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 152,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.microsoftusercontent.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": false,
+        "notes": "These endpoints enable the Office Scripts functionality in Office clients available through the Automate tab and the Python in Excel functionality available through the Formulas tab. The Office Scripts feature can also be disabled through the Office 365 Admin portal. For admin controls related to Python in Excel, see [Data security and Python in Excel](https://support.microsoft.com/office/data-security-and-python-in-excel-33cc88a4-4a87-485e-9ff9-f35958278327)."
+    },
+    {
+        "id": 153,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.azure-apim.net",
+            "*.flow.microsoft.com",
+            "*.powerapps.com",
+            "*.powerautomate.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 156,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.activity.windows.com",
+            "activity.windows.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 158,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.cortana.ai"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 159,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "admin.microsoft.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 160,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "cdn.odc.officeapps.live.com",
+            "cdn.uci.officeapps.live.com"
+        ],
+        "tcpPorts": "80,443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 180,
+        "serviceArea": "Skype",
+        "serviceAreaDisplayName": "Microsoft Teams",
+        "urls": [
+            "compass-ssl.microsoft.com"
+        ],
+        "tcpPorts": "443",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    },
+    {
+        "id": 184,
+        "serviceArea": "Common",
+        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+        "urls": [
+            "*.cloud.microsoft",
+            "*.static.microsoft",
+            "*.usercontent.microsoft"
+        ],
+        "tcpPorts": "443,80",
+        "expressRoute": false,
+        "category": "Default",
+        "required": true
+    }
+]


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
![Screenshot from 2024-10-01 14-39-28](https://github.com/user-attachments/assets/9b82f67d-c78b-4a02-8366-abf4e1a9e0b2)
The proxy solution, which can allow or deny specific URLs, has been implemented as shown in the picture above. The HTTP/HTTPs packets from the business-vm will be redirected through the proxy server in netvm.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [x] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
    - The targets include business-vm 
- [ ] Is this a new feature
  - [ ] List the test steps to verify:    
- [x] If it is an improvement how does it impact existing functionality?
   - ms365 URLs fetched from [the link](https://endpoints.office.com/endpoints/worldwide?clientrequestid=b10c5ed1-bad1-445f-b386-b919946339a7) instead of static firewall policy configuration. [URLs](https://endpoints.office.com/endpoints/worldwide?clientrequestid=b10c5ed1-bad1-445f-b386-b919946339a7) should be accessible through proxy. In other words Teams, Outlook, and Microsoft 365 apps should work flawlessly
   - URLs with tii domain can be only accessible through VPN.
