### PR TITLE
Fix postboot command for ZFS installation.

### DIFF
--- a/modules/disko/disko-zfs-postboot.nix
+++ b/modules/disko/disko-zfs-postboot.nix
@@ -15,7 +15,7 @@ let
     # Extract the partition number using regex
     if [[ "$P_DEVPATH" =~ [0-9]+$ ]]; then
       PARTNUM=$(echo "$P_DEVPATH" | ${pkgs.gnugrep}/bin/grep -o '[0-9]*$')
-      PARENT_DISK=$(echo "$P_DEVPATH" | ${pkgs.gnused}/bin/sed 's/[0-9]*$//')
+      PARENT_DISK=/dev/$(${pkgs.util-linux}/bin/lsblk -no pkname "$P_DEVPATH")
     else
       echo "No partition number found in device path: $P_DEVPATH"
     fi
@@ -34,5 +34,8 @@ let
   '';
 in
 {
+  # To debug postBootCommands, one may run
+  # journalctl -u initrd-nixos-activation.service
+  # inside the running Ghaf host.
   boot.postBootCommands = postBootCmds;
 }


### PR DESCRIPTION
This fix resolves SSRCSP-5296.
Previously, zfspool has not been expanded for the system, installed on nvme drive. The issue was so that a partition's parent disk name is not resolved correctly for `/dev/nvme0n1` device.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [x] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

Install the system and check ZFS pool size with `zpool status` or `zpool list`. It must occupy all the free space available on the disk.

- [x] List all targets that this applies to: Lenovo-X1
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?


