### PR TITLE
alloy.service hardening

### DIFF
--- a/modules/common/systemd/hardened-configs/common/alloy.nix
+++ b/modules/common/systemd/hardened-configs/common/alloy.nix
@@ -1,0 +1,59 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{
+  IPAccounting = true;
+  IPAddressAllow = [
+    "192.168.100.0/24"
+    "192.168.101.0/24"
+  ];
+  RestrictAddressFamilies = [ "~AF_INET6" ];
+
+  ProtectHome = true;
+  ProtectSystem = "full";
+  ProtectProc = true;
+  PrivateUsers = true;
+  DynamicUser = true;
+  PrivateDevices = true;
+  ProtectKernelTunables = true;
+  ProtectKernelModules = true;
+  ProtectKernelLogs = true;
+  NoNewPrivileges = true;
+  UMask = 27;
+  ProtectHostname = true;
+  ProtectClock = true;
+  ProtectControlGroups = true;
+  RestrictNamespaces = true;
+  MemoryDenyWriteExecute = true;
+  RestrictRealtime = true;
+  RestrictSUIDSGID = true;
+  RemoveIPC = true;
+  SystemCallArchitectures = "native";
+
+  CapabilityBoundingSet = [
+    "CAP_AUDIT_READ"
+    "CAP_IPC_LOCK"
+    "CAP_IPC_OWNER"
+    "CAP_KILL"
+    "CAP_NET_BIND_SERVICE"
+    "CAP_NET_BROADCAST"
+    "CAP_NET_RAW"
+    "CAP_SYS_PTRACE"
+    "CAP_SYS_RAWIO"
+    "CAP_SYSLOG"
+  ];
+
+  SystemCallFilter = [
+    "@privileged"
+    "@system-service"
+    "~@aio"
+    "~@keyring"
+    "~@memlock"
+    "~@timer"
+    "~@reboot"
+    "~@swap"
+    "~@chown"
+    "~@module"
+    "~@clock"
+  ];
+}


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

- alloy.service hardening
- Security exposure reduced to 2.8

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
  - Lenovo X1 Carbon 
- [ ] Is this a new feature
  - [x] List the test steps to verify:
  - Check if the logs are accessible on Grafana server.
     (I have tested it at my end, logs are available at Grafana Server)

- [ ] If it is an improvement how does it impact existing functionality?

