### PR TITLE
Fix the copying and pasting of images between VMs

### DIFF
--- a/overlays/custom-packages/waypipe/default.nix
+++ b/overlays/custom-packages/waypipe/default.nix
@@ -4,5 +4,8 @@
 # Waypipe with vsock and window borders
 prev.waypipe.overrideAttrs (_prevAttrs: {
   # Upstream pull request: https://gitlab.freedesktop.org/mstoeckl/waypipe/-/merge_requests/21
-  patches = [ ./waypipe-window-borders.patch ];
+  patches = [
+    ./waypipe-window-borders.patch
+    ./waypipe-fix-reading-data-from-pipes.patch
+  ];
 })

--- a/overlays/custom-packages/waypipe/waypipe-fix-reading-data-from-pipes.patch
+++ b/overlays/custom-packages/waypipe/waypipe-fix-reading-data-from-pipes.patch
@@ -1,0 +1,32 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+From 7d4ca594b310bef7c16553fa2fb20b11fc6cc411 Mon Sep 17 00:00:00 2001
+From: Yuri Nesterov <yuriy.nesterov@unikie.com>
+Date: Thu, 3 Oct 2024 23:39:14 +0300
+Subject: [PATCH] Fix reading data from pipes
+
+Currently, pipes become readable only when poll returns POLLHUP.
+This happens when the compositor sends a small amount of data and
+closes the pipe. When the data size is larger than 64 KB the pipe stays
+open and it is never read because the POLLIN event is never requested.
+This fixes the issue.
+---
+ src/shadow.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/shadow.c b/src/shadow.c
+index 9d4c080..bc6c77d 100644
+--- a/src/shadow.c
++++ b/src/shadow.c
+@@ -2270,7 +2270,7 @@ int fill_with_pipes(const struct fd_translation_map *map, struct pollfd *pfds,
+ 		if (cur->type == FDC_PIPE && cur->pipe.fd != -1) {
+ 			pfds[np].fd = cur->pipe.fd;
+ 			pfds[np].events = 0;
+-			if (check_read && cur->pipe.readable) {
++			if (check_read) {
+ 				pfds[np].events |= POLLIN;
+ 			}
+ 			if (cur->pipe.send.used > 0) {
+-- 
+2.43.0
+


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This fixes issues with copying and pasting images from the clipboard between virtual machines. It turned out to be a bug in waypipe that prevents it from synchronizing pipes with data larger than 64 KB. This seems to be one of those issues that are not easy to track but the fix is a one-liner or even a half-liner.

Fixes SSRCSP-5120.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

Copy images from Chromium to Outlook using the clipboard. The complete testing procedure is described in SSRCSP-5120.
