### PR TITLE
Fix1 for pulseaudio selecting default integrated audio profile

### DIFF
--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -118,6 +118,8 @@ let
               extraArgs = [
                 "-device"
                 "qemu-xhci"
+                "-acpitable"
+                "file=/sys/firmware/acpi/tables/NHLT"
               ];
             };
           };

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -60,6 +60,13 @@ in
         lib.optionalAttrs config.ghaf.virtualization.microvm.audiovm.enable
           {
             # The + here is a systemd feature to make the script run as root.
+            ExecStartPre = [
+              "+${pkgs.writeShellScript "ACPI-table-permission" ''
+                # The script gives permissionf sot a microvm user
+                # to read ACPI tables of soundcaed mic array.
+                ${pkgs.coreutils}/bin/chmod 444 /sys/firmware/acpi/tables/NHLT
+              ''}"
+            ];
             ExecStopPost = [
               "+${pkgs.writeShellScript "reload-audio" ''
                 # The script makes audio device internal state to reset

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -115,10 +115,7 @@
         productId = "51a4";
       }
     ];
-    kernelConfig.kernelParams = [
-      "snd_intel_dspcfg.dsp_driver=3"
-      "snd_sof_intel_hda_common.dmic_num=4"
-    ];
+    kernelConfig.kernelParams = [ "snd_intel_dspcfg.dsp_driver=0" ];
   };
 
   usb = {

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -122,10 +122,7 @@
         productId = "51a4";
       }
     ];
-    kernelConfig.kernelParams = [
-      "snd_intel_dspcfg.dsp_driver=3"
-      "snd_sof_intel_hda_common.dmic_num=4"
-    ];
+    kernelConfig.kernelParams = [ "snd_intel_dspcfg.dsp_driver=0" ];
   };
 
   usb = {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Fix audiovm pulseaudio initial microphone profile

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status
- [X] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing
Integrated speakers & mic should work after boot
May work with rebuild-switch but definitely requires a full reboot

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

