### PR TITLE
fix the direnv and checkers

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
+      - "docs/**"
 jobs:
   deploy:
     name: build doc and deploy to gh pages

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,7 +15,7 @@ on:
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     # weekly on Sundays
-    - cron: '0 8 * * 0'
+    - cron: "0 8 * * 0"
   push:
     branches: ["main"]
 # Declare default permissions as read only.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version = 1
-
 SPDX-PackageName = "ghaf"
 SPDX-PackageSupplier = "Technology Innovation Institute <https://tii.ae>"
 SPDX-PackageDownloadLocation = "https://github.com/tiiuae/ghaf"
@@ -12,13 +11,15 @@ SPDX-License-Identifier = "Apache-2.0"
 SPDX-FileCopyrightText = "2022-2024 TII (SSRC) and the Ghaf contributors"
 precedence = "closest"
 path = [
-	"flake.lock", ".version",
-	"assets/**/*.png", "assets/**/*.svg",
-	"modules/common/development/audio_test/test_file1.mp3",
-	"modules/hardware/x86_64-generic/kernel/configs/ghaf_host_hardened_baseline-x86",
-	"modules/reference/hardware/jetpack/ghaf_host_hardened_baseline-jetson-orin",
-	"modules/lanzaboote/demo-secure-boot-keys/**/*",
-	"modules/microvm/virtualization/microvm/idsvm/mitmproxy/mitmproxy-ca/*",
+  "flake.lock",
+  ".version",
+  "assets/**/*.png",
+  "assets/**/*.svg",
+  "modules/common/development/audio_test/test_file1.mp3",
+  "modules/hardware/x86_64-generic/kernel/configs/ghaf_host_hardened_baseline-x86",
+  "modules/reference/hardware/jetpack/ghaf_host_hardened_baseline-jetson-orin",
+  "modules/lanzaboote/demo-secure-boot-keys/**/*",
+  "modules/microvm/virtualization/microvm/idsvm/mitmproxy/mitmproxy-ca/*"
 ]
 
 [[annotations]]
@@ -26,27 +27,26 @@ SPDX-License-Identifier = "CC-BY-SA-4.0"
 SPDX-FileCopyrightText = "2022-2024 TII (SSRC) and the Ghaf contributors"
 precedence = "closest"
 path = [
-	"docs/**/*.svg", "docs/**/*.png",
+  "docs/**/*.svg",
+  "docs/**/*.png"
 ]
-
-# External code
 
 [[annotations]]
 # See https://github.com/qemu/qemu/blob/master/LICENSE
 # Our changes affects the GPL-2.0+ parts only.
 SPDX-License-Identifier = "GPL-2.0-or-later"
 SPDX-FileCopyrightText = [
-	"Fabrice Bellard and the QEMU team",
-	"Copyright (c) 2021-2022 Canokeys.org <contact@canokeys.org>",
-	"Written by Hongren (Zenithal) Zheng <i@zenithal.me>",
-	"Copyright (c) 2019 Janus Technologies, Inc. (http://janustech.com)",
-	"Copyright (C) 2008-2010  Kevin O'Connor <kevin@koconnor.net>",
-	"Copyright (C) 2006 Fabrice Bellard",
-	"Copyright (C) 2013 Red Hat Inc",
+  "Fabrice Bellard and the QEMU team",
+  "Copyright (c) 2021-2022 Canokeys.org <contact@canokeys.org>",
+  "Written by Hongren (Zenithal) Zheng <i@zenithal.me>",
+  "Copyright (c) 2019 Janus Technologies, Inc. (http://janustech.com)",
+  "Copyright (C) 2008-2010  Kevin O'Connor <kevin@koconnor.net>",
+  "Copyright (C) 2006 Fabrice Bellard",
+  "Copyright (C) 2013 Red Hat Inc"
 ]
 path = [
-	"overlays/custom-packages/qemu/*.patch",
-	"modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/host/bpmp-virt-host/overlays/qemu/patches/0001-qemu-v8.1.3_bpmp-virt.patch"
+  "overlays/custom-packages/qemu/*.patch",
+  "modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/host/bpmp-virt-host/overlays/qemu/patches/0001-qemu-v8.1.3_bpmp-virt.patch"
 ]
 
 [[annotations]]
@@ -58,8 +58,8 @@ path = "overlays/custom-packages/labwc/*.patch"
 # gtklock doesn't specify if later versions is allowed
 SPDX-License-Identifier = "GPL-3.0-only"
 SPDX-FileCopyrightText = [
-	"Copyright (c) 2022 Kenny Levinsen, Jovan Lanik, Erik Reider, Melih Darcan, Bhaskar Khoraja",
-	"Copyright (c) 2022 Zephyr Lykos"
+  "Copyright (c) 2022 Kenny Levinsen, Jovan Lanik, Erik Reider, Melih Darcan, Bhaskar Khoraja",
+  "Copyright (c) 2022 Zephyr Lykos"
 ]
 path = "overlays/custom-packages/gtklock/*.patch"
 
@@ -81,30 +81,30 @@ path = "packages/element-web/*.patch"
 [[annotations]]
 SPDX-License-Identifier = "Apache-2.0"
 SPDX-FileCopyrightText = [
-	"Copyright 2016 Aviral Dasgupta",
-	"Copyright 2016 OpenMarket Ltd",
-	"Copyright 2017, 2019 Michael Telatynski <7t3chguy@gmail.com>",
-	"Copyright 2018 - 2021 New Vector Ltd",
+  "Copyright 2016 Aviral Dasgupta",
+  "Copyright 2016 OpenMarket Ltd",
+  "Copyright 2017, 2019 Michael Telatynski <7t3chguy@gmail.com>",
+  "Copyright 2018 - 2021 New Vector Ltd"
 ]
 path = "overlays/custom-packages/element-desktop/element-main.patch"
 
 [[annotations]]
 SPDX-License-Identifier = "GPL-2.0-only"
 SPDX-FileCopyrightText = [
-	"Copyright (C) 2013 - Virtual Open Systems",
-	"Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.",
-	"Copyright (c) 2018, NVIDIA CORPORATION.",
-	"Copyright (C) 2006 Qumranet, Inc.",
-	"Copyright 2010 Red Hat, Inc. and/or its affiliates.",
-	"2022-2024 TII (SSRC) and the Ghaf contributors",
+  "Copyright (C) 2013 - Virtual Open Systems",
+  "Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.",
+  "Copyright (c) 2018, NVIDIA CORPORATION.",
+  "Copyright (C) 2006 Qumranet, Inc.",
+  "Copyright 2010 Red Hat, Inc. and/or its affiliates.",
+  "2022-2024 TII (SSRC) and the Ghaf contributors"
 ]
 path = [
-	"modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/bpmp-virt-common/patches/*.patch",
-	"modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/host/bpmp-virt-host/patches/*.patch",
-	"modules/reference/hardware/jetpack-microvm/*.patch",
-	"modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/patches/net_vm_dtb_with_uarti.patch",
-	"modules/common/virtualization/pkvm/0001-pkvm-enable-pkvm-on-intel-x86-6.1-lts.patch",
-	"modules/microvm/virtualization/microvm/0001-x86-gpu-Don-t-reserve-stolen-memory-for-GPU-passthro.patch",
+  "modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/bpmp-virt-common/patches/*.patch",
+  "modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/host/bpmp-virt-host/patches/*.patch",
+  "modules/reference/hardware/jetpack-microvm/*.patch",
+  "modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/uarti-net-vm/patches/net_vm_dtb_with_uarti.patch",
+  "modules/common/virtualization/pkvm/0001-pkvm-enable-pkvm-on-intel-x86-6.1-lts.patch",
+  "modules/microvm/virtualization/microvm/0001-x86-gpu-Don-t-reserve-stolen-memory-for-GPU-passthro.patch"
 ]
 
 [[annotations]]
@@ -116,20 +116,19 @@ path = "modules/reference/hardware/jetpack/nvidia-jetson-orin/edk2-nvidia-always
 SPDX-License-Identifier = "LicenseRef-NvidiaProprietary"
 SPDX-FileCopyrightText = "Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved."
 path = [
-	"modules/reference/hardware/jetpack/nvidia-jetson-orin/tegra2-mb2-bct-scr.patch",
+  "modules/reference/hardware/jetpack/nvidia-jetson-orin/tegra2-mb2-bct-scr.patch"
 ]
-
 
 [[annotations]]
 SPDX-License-Identifier = "MIT"
 SPDX-FileCopyrightText = "Copyright 2019-2021 Microchip Corporation."
 path = [
-	"packages/hart-software-services/0001-Workaround-for-a-compilation-issue.patch",
+  "packages/hart-software-services/0001-Workaround-for-a-compilation-issue.patch"
 ]
 
 [[annotations]]
 SPDX-License-Identifier = "BSD-2-Clause"
 SPDX-FileCopyrightText = "Copyright (c) 2017-2020, Linaro Limited"
 path = [
-	"targets/nvidia-jetson-orin/0001-ta-pkcs11-Build-time-option-for-controlling-pin-lock.patch",
+  "targets/nvidia-jetson-orin/0001-ta-pkcs11-Build-time-option-for-controlling-pin-lock.patch"
 ]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -17,5 +17,6 @@ git-repository-icon = "fa-github"
 additional-css = ["theme/pagetoc.css"]
 additional-js = ["theme/pagetoc.js"]
 
-[preprocessor.footnote]
 [preprocessor.alerts]
+
+[preprocessor.footnote]

--- a/docs/theme/pagetoc.css
+++ b/docs/theme/pagetoc.css
@@ -5,103 +5,103 @@ SPDX-License-Identifier: WTFPL
 */
 
 :root {
-    --toc-width: 270px;
-    --center-content-toc-shift: calc(-1 * var(--toc-width) / 2);
+  --toc-width: 270px;
+  --center-content-toc-shift: calc(-1 * var(--toc-width) / 2);
 }
 
 .nav-chapters {
-    /* adjust width of buttons that bring to the previous or the next page */
-    min-width: 50px;
+  /* adjust width of buttons that bring to the previous or the next page */
+  min-width: 50px;
 }
 
 .previous {
-    /*
+  /*
     adjust the space between the left sidebar or the left side of the screen 
     and the button that leads to the previous page
     */
-    margin-left: var(--page-padding);
+  margin-left: var(--page-padding);
 }
 
 @media only screen {
-    main {
-        display: flex;
-    }
+  main {
+    display: flex;
+  }
 
-    @media (max-width: 1179px) {
-        .sidebar-hidden .sidetoc {
-            display: none;
-        }
+  @media (max-width: 1179px) {
+    .sidebar-hidden .sidetoc {
+      display: none;
     }
+  }
 
-    @media (max-width: 1439px) {
-        .sidebar-visible .sidetoc {
-            display: none;
-        }
+  @media (max-width: 1439px) {
+    .sidebar-visible .sidetoc {
+      display: none;
     }
+  }
 
-    @media (1180px <= width <= 1439px) {
-        .sidebar-hidden main {
-            position: relative;
-            left: var(--center-content-toc-shift);
-        }
+  @media (1180px <= width <= 1439px) {
+    .sidebar-hidden main {
+      position: relative;
+      left: var(--center-content-toc-shift);
     }
+  }
 
-    @media (1440px <= width <= 1700px) {
-        .sidebar-visible main {
-            position: relative;
-            left: var(--center-content-toc-shift);
-        }
+  @media (1440px <= width <= 1700px) {
+    .sidebar-visible main {
+      position: relative;
+      left: var(--center-content-toc-shift);
     }
+  }
 
-    .content-wrap {
-        overflow-y: auto;
-        width: 100%;
-    }
+  .content-wrap {
+    overflow-y: auto;
+    width: 100%;
+  }
 
-    .sidetoc {
-        margin-top: 20px;
-        margin-left: 10px;
-        margin-right: auto;
-    }
-    .pagetoc {
-        position: fixed;
-        /* adjust TOC width */
-        width: var(--toc-width);
-        height: calc(100vh - var(--menu-bar-height) - 0.67em * 4);
-        overflow: auto;
-    }
-    .pagetoc a {
-        border-left: 1px solid var(--sidebar-bg);
-        color: var(--fg) !important;
-        display: block;
-        padding-bottom: 5px;
-        padding-top: 5px;
-        padding-left: 10px;
-        text-align: left;
-        text-decoration: none;
-    }
-    .pagetoc a:hover,
-    .pagetoc a.active {
-        background: var(--sidebar-bg);
-        color: var(--sidebar-fg) !important;
-    }
-    .pagetoc .active {
-        background: var(--sidebar-bg);
-        color: var(--sidebar-fg);
-    }
-    .pagetoc .pagetoc-H2 {
-        padding-left: 20px;
-    }
-    .pagetoc .pagetoc-H3 {
-        padding-left: 40px;
-    }
-    .pagetoc .pagetoc-H4 {
-        padding-left: 60px;
-    }
+  .sidetoc {
+    margin-top: 20px;
+    margin-left: 10px;
+    margin-right: auto;
+  }
+  .pagetoc {
+    position: fixed;
+    /* adjust TOC width */
+    width: var(--toc-width);
+    height: calc(100vh - var(--menu-bar-height) - 0.67em * 4);
+    overflow: auto;
+  }
+  .pagetoc a {
+    border-left: 1px solid var(--sidebar-bg);
+    color: var(--fg) !important;
+    display: block;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    padding-left: 10px;
+    text-align: left;
+    text-decoration: none;
+  }
+  .pagetoc a:hover,
+  .pagetoc a.active {
+    background: var(--sidebar-bg);
+    color: var(--sidebar-fg) !important;
+  }
+  .pagetoc .active {
+    background: var(--sidebar-bg);
+    color: var(--sidebar-fg);
+  }
+  .pagetoc .pagetoc-H2 {
+    padding-left: 20px;
+  }
+  .pagetoc .pagetoc-H3 {
+    padding-left: 40px;
+  }
+  .pagetoc .pagetoc-H4 {
+    padding-left: 60px;
+  }
 }
 
 @media print {
-    .sidetoc {
-        display: none;
-    }
+  .sidetoc {
+    display: none;
+  }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -181,7 +181,7 @@
           "nixpkgs"
         ],
         "pre-commit-hooks-nix": [
-          "pre-commit-hooks-nix"
+          "git-hooks-nix"
         ],
         "treefmt-nix": [
           "treefmt-nix"
@@ -201,10 +201,37 @@
         "type": "github"
       }
     },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1728092656,
+        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks-nix",
+          "git-hooks-nix",
           "nixpkgs"
         ]
       },
@@ -238,7 +265,7 @@
           "nixpkgs"
         ],
         "pre-commit-hooks-nix": [
-          "pre-commit-hooks-nix"
+          "git-hooks-nix"
         ],
         "treefmt-nix": [
           "treefmt-nix"
@@ -309,7 +336,7 @@
           "nixpkgs"
         ],
         "pre-commit-hooks-nix": [
-          "pre-commit-hooks-nix"
+          "git-hooks-nix"
         ],
         "rust-overlay": "rust-overlay"
       },
@@ -461,33 +488,6 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks-nix": {
-      "inputs": {
-        "flake-compat": [
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1727514110,
-        "narHash": "sha256-0YRcOxJG12VGDFH8iS8pJ0aYQQUAgo/r3ZAL+cSh9nk=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devshell": "devshell",
@@ -497,6 +497,7 @@
         "flake-root": "flake-root",
         "flake-utils": "flake-utils",
         "ghafpkgs": "ghafpkgs",
+        "git-hooks-nix": "git-hooks-nix",
         "givc": "givc",
         "impermanence": "impermanence",
         "jetpack-nixos": "jetpack-nixos",
@@ -506,7 +507,6 @@
         "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
-        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";
         treefmt-nix.follows = "treefmt-nix";
-        pre-commit-hooks-nix.follows = "pre-commit-hooks-nix";
+        pre-commit-hooks-nix.follows = "git-hooks-nix";
         flake-compat.follows = "flake-compat";
       };
     };
@@ -61,8 +61,8 @@
     };
 
     # To ensure that checks are run locally to enforce cleanliness
-    pre-commit-hooks-nix = {
-      url = "github:cachix/pre-commit-hooks.nix";
+    git-hooks-nix = {
+      url = "github:cachix/git-hooks.nix";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         nixpkgs-stable.follows = "nixpkgs";
@@ -136,7 +136,7 @@
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";
         flake-parts.follows = "flake-parts";
-        pre-commit-hooks-nix.follows = "pre-commit-hooks-nix";
+        pre-commit-hooks-nix.follows = "git-hooks-nix";
         flake-compat.follows = "flake-compat";
       };
     };
@@ -153,7 +153,7 @@
         flake-root.follows = "flake-root";
         treefmt-nix.follows = "treefmt-nix";
         devshell.follows = "devshell";
-        pre-commit-hooks-nix.follows = "pre-commit-hooks-nix";
+        pre-commit-hooks-nix.follows = "git-hooks-nix";
       };
     };
   };

--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -225,64 +225,66 @@ in
       };
     };
 
-    systemd.user.services.ghaf-launcher = {
-      enable = true;
-      description = "Ghaf launcher daemon";
-      serviceConfig = {
-        Type = "simple";
-        ExecStart = "${ghaf-launcher}/bin/ghaf-launcher";
-        Restart = "always";
-        RestartSec = "1";
+    systemd.user.services = {
+      ghaf-launcher = {
+        enable = true;
+        description = "Ghaf launcher daemon";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${ghaf-launcher}/bin/ghaf-launcher";
+          Restart = "always";
+          RestartSec = "1";
+        };
+        partOf = [ "ghaf-session.target" ];
+        wantedBy = [ "ghaf-session.target" ];
       };
-      partOf = [ "ghaf-session.target" ];
-      wantedBy = [ "ghaf-session.target" ];
-    };
 
-    systemd.user.services.swaybg = {
-      enable = true;
-      description = "Wallpaper daemon";
-      serviceConfig = {
-        Type = "simple";
-        ExecStart = "${pkgs.swaybg}/bin/swaybg -m fill -i ${cfg.wallpaper}";
+      swaybg = {
+        enable = true;
+        description = "Wallpaper daemon";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkgs.swaybg}/bin/swaybg -m fill -i ${cfg.wallpaper}";
+        };
+        partOf = [ "ghaf-session.target" ];
+        wantedBy = [ "ghaf-session.target" ];
       };
-      partOf = [ "ghaf-session.target" ];
-      wantedBy = [ "ghaf-session.target" ];
-    };
 
-    systemd.user.services.mako = {
-      enable = true;
-      description = "Notification daemon";
-      serviceConfig = {
-        Type = "simple";
-        ExecStart = "${pkgs.mako}/bin/mako -c /etc/mako/config";
+      mako = {
+        enable = true;
+        description = "Notification daemon";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkgs.mako}/bin/mako -c /etc/mako/config";
+        };
+        partOf = [ "ghaf-session.target" ];
+        wantedBy = [ "ghaf-session.target" ];
       };
-      partOf = [ "ghaf-session.target" ];
-      wantedBy = [ "ghaf-session.target" ];
-    };
 
-    systemd.user.services.lock-event = {
-      enable = true;
-      description = "Lock Event Handler";
-      serviceConfig = {
-        Type = "simple";
-        ExecStart = "${pkgs.swayidle}/bin/swayidle lock \"${lockCmd}\"";
+      lock-event = {
+        enable = true;
+        description = "Lock Event Handler";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkgs.swayidle}/bin/swayidle lock \"${lockCmd}\"";
+        };
+        partOf = [ "ghaf-session.target" ];
+        wantedBy = [ "ghaf-session.target" ];
       };
-      partOf = [ "ghaf-session.target" ];
-      wantedBy = [ "ghaf-session.target" ];
-    };
 
-    systemd.user.services.autolock = lib.mkIf cfg.autolock.enable {
-      enable = true;
-      description = "System autolock";
-      serviceConfig = {
-        Type = "simple";
-        ExecStart = ''
-          ${pkgs.swayidle}/bin/swayidle -w timeout ${builtins.toString cfg.autolock.duration} \
-          '${pkgs.chayang}/bin/chayang && ${lockCmd}'
-        '';
+      autolock = lib.mkIf cfg.autolock.enable {
+        enable = true;
+        description = "System autolock";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = ''
+            ${pkgs.swayidle}/bin/swayidle -w timeout ${builtins.toString cfg.autolock.duration} \
+            '${pkgs.chayang}/bin/chayang && ${lockCmd}'
+          '';
+        };
+        partOf = [ "ghaf-session.target" ];
+        wantedBy = [ "ghaf-session.target" ];
       };
-      partOf = [ "ghaf-session.target" ];
-      wantedBy = [ "ghaf-session.target" ];
     };
 
     ghaf.graphics.launchers = [

--- a/modules/desktop/graphics/login-manager.nix
+++ b/modules/desktop/graphics/login-manager.nix
@@ -36,39 +36,41 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    services.greetd = {
-      enable = true;
-      settings = {
-        default_session =
-          let
-            greeter-autostart = pkgs.writeShellApplication {
-              name = "greeter-autostart";
-              runtimeInputs = [
-                pkgs.greetd.gtkgreet
-                pkgs.wayland-logout
-              ];
-              text = ''
-                gtkgreet -l -s ${gtkgreetStyle}
-                wayland-logout
-              '';
+    services = {
+      greetd = {
+        enable = true;
+        settings = {
+          default_session =
+            let
+              greeter-autostart = pkgs.writeShellApplication {
+                name = "greeter-autostart";
+                runtimeInputs = [
+                  pkgs.greetd.gtkgreet
+                  pkgs.wayland-logout
+                ];
+                text = ''
+                  gtkgreet -l -s ${gtkgreetStyle}
+                  wayland-logout
+                '';
+              };
+            in
+            {
+              command = "${pkgs.labwc}/bin/labwc -C /etc/labwc -s ${greeter-autostart}/bin/greeter-autostart";
             };
-          in
-          {
-            command = "${pkgs.labwc}/bin/labwc -C /etc/labwc -s ${greeter-autostart}/bin/greeter-autostart";
-          };
+        };
       };
-    };
 
-    services.seatd = {
-      enable = true;
-      group = "video";
+      seatd = {
+        enable = true;
+        group = "video";
+      };
+
+      #Allow video group to change brightness
+      udev.extraRules = ''
+        ACTION=="add", SUBSYSTEM=="backlight", RUN+="${pkgs.coreutils}/bin/chgrp video $sys$devpath/brightness", RUN+="${pkgs.coreutils}/bin/chmod a+w $sys$devpath/brightness"
+      '';
     };
 
     users.users.greeter.extraGroups = [ "video" ];
-
-    #Allow video group to change brightness
-    services.udev.extraRules = ''
-      ACTION=="add", SUBSYSTEM=="backlight", RUN+="${pkgs.coreutils}/bin/chgrp video $sys$devpath/brightness", RUN+="${pkgs.coreutils}/bin/chmod a+w $sys$devpath/brightness"
-    '';
   };
 }

--- a/modules/reference/profiles/laptop-x86.nix
+++ b/modules/reference/profiles/laptop-x86.nix
@@ -53,9 +53,11 @@ in
       hardware = {
         x86_64.common.enable = true;
         tpm2.enable = true;
-        usb.internal.enable = true;
-        usb.external.enable = true;
-        usb.vhotplug.enable = true;
+        usb = {
+          internal.enable = true;
+          external.enable = true;
+          vhotplug.enable = true;
+        };
       };
 
       # Virtualization options
@@ -121,11 +123,16 @@ in
       };
 
       # Logging configuration
-      logging.client.enable = true;
-      logging.client.endpoint = "http://${listenerAddress}:${listenerPort}/loki/api/v1/push";
-      logging.listener.address =
-        "admin-vm" + lib.optionalString config.ghaf.profiles.debug.enable "-debug";
-      logging.listener.port = 9999;
+      logging = {
+        client = {
+          enable = true;
+          endpoint = "http://${listenerAddress}:${listenerPort}/loki/api/v1/push";
+        };
+        listener = {
+          address = "admin-vm" + lib.optionalString config.ghaf.profiles.debug.enable "-debug";
+          port = 9999;
+        };
+      };
     };
   };
 }

--- a/modules/reference/services/proxy-server/ms_urls.json
+++ b/modules/reference/services/proxy-server/ms_urls.json
@@ -1,1132 +1,1015 @@
 [
-    {
-        "_comment": [
-            "Copyright 2024 TII (SSRC) and the Ghaf contributors",
-            "SPDX-License-Identifier: Apache-2.0"
-        ],
-        "id": 1,
-        "serviceArea": "Exchange",
-        "serviceAreaDisplayName": "Exchange Online",
-        "urls": [
-            "outlook.cloud.microsoft",
-            "outlook.office.com",
-            "outlook.office365.com"
-        ],
-        "ips": [
-            "13.107.6.152/31",
-            "13.107.18.10/31",
-            "13.107.128.0/22",
-            "23.103.160.0/20",
-            "40.96.0.0/13",
-            "40.104.0.0/15",
-            "52.96.0.0/14",
-            "131.253.33.215/32",
-            "132.245.0.0/16",
-            "150.171.32.0/22",
-            "204.79.197.215/32",
-            "2603:1006::/40",
-            "2603:1016::/36",
-            "2603:1026::/36",
-            "2603:1036::/36",
-            "2603:1046::/36",
-            "2603:1056::/36",
-            "2620:1ec:4::152/128",
-            "2620:1ec:4::153/128",
-            "2620:1ec:c::10/128",
-            "2620:1ec:c::11/128",
-            "2620:1ec:d::10/128",
-            "2620:1ec:d::11/128",
-            "2620:1ec:8f0::/46",
-            "2620:1ec:900::/46",
-            "2620:1ec:a92::152/128",
-            "2620:1ec:a92::153/128"
-        ],
-        "tcpPorts": "80,443",
-        "udpPorts": "443",
-        "expressRoute": true,
-        "category": "Optimize",
-        "required": true
-    },
-    {
-        "id": 2,
-        "serviceArea": "Exchange",
-        "serviceAreaDisplayName": "Exchange Online",
-        "urls": [
-            "outlook.office365.com",
-            "smtp.office365.com"
-        ],
-        "ips": [
-            "13.107.6.152/31",
-            "13.107.18.10/31",
-            "13.107.128.0/22",
-            "23.103.160.0/20",
-            "40.96.0.0/13",
-            "40.104.0.0/15",
-            "52.96.0.0/14",
-            "131.253.33.215/32",
-            "132.245.0.0/16",
-            "150.171.32.0/22",
-            "204.79.197.215/32",
-            "2603:1006::/40",
-            "2603:1016::/36",
-            "2603:1026::/36",
-            "2603:1036::/36",
-            "2603:1046::/36",
-            "2603:1056::/36",
-            "2620:1ec:4::152/128",
-            "2620:1ec:4::153/128",
-            "2620:1ec:c::10/128",
-            "2620:1ec:c::11/128",
-            "2620:1ec:d::10/128",
-            "2620:1ec:d::11/128",
-            "2620:1ec:8f0::/46",
-            "2620:1ec:900::/46",
-            "2620:1ec:a92::152/128",
-            "2620:1ec:a92::153/128"
-        ],
-        "tcpPorts": "143, 587, 993, 995",
-        "expressRoute": true,
-        "category": "Allow",
-        "required": false,
-        "notes": "POP3, IMAP4, SMTP Client traffic"
-    },
-    {
-        "id": 8,
-        "serviceArea": "Exchange",
-        "serviceAreaDisplayName": "Exchange Online",
-        "urls": [
-            "*.outlook.com",
-            "autodiscover.*.onmicrosoft.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 9,
-        "serviceArea": "Exchange",
-        "serviceAreaDisplayName": "Exchange Online",
-        "urls": [
-            "*.protection.outlook.com"
-        ],
-        "ips": [
-            "40.92.0.0/15",
-            "40.107.0.0/16",
-            "52.100.0.0/14",
-            "52.238.78.88/32",
-            "104.47.0.0/17",
-            "2a01:111:f400::/48",
-            "2a01:111:f403::/48"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": true,
-        "category": "Allow",
-        "required": true
-    },
-    {
-        "id": 10,
-        "serviceArea": "Exchange",
-        "serviceAreaDisplayName": "Exchange Online",
-        "urls": [
-            "*.mail.protection.outlook.com",
-            "*.mx.microsoft"
-        ],
-        "ips": [
-            "40.92.0.0/15",
-            "40.107.0.0/16",
-            "52.100.0.0/14",
-            "104.47.0.0/17",
-            "2a01:111:f400::/48",
-            "2a01:111:f403::/48"
-        ],
-        "tcpPorts": "25",
-        "expressRoute": true,
-        "category": "Allow",
-        "required": true
-    },
-    {
-        "id": 11,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "ips": [
-            "52.112.0.0/14",
-            "52.122.0.0/15",
-            "2603:1063::/38"
-        ],
-        "udpPorts": "3478,3479,3480,3481",
-        "expressRoute": true,
-        "category": "Optimize",
-        "required": true
-    },
-    {
-        "id": 12,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "urls": [
-            "*.lync.com",
-            "*.teams.cloud.microsoft",
-            "*.teams.microsoft.com",
-            "teams.cloud.microsoft",
-            "teams.microsoft.com"
-        ],
-        "ips": [
-            "52.112.0.0/14",
-            "52.122.0.0/15",
-            "52.238.119.141/32",
-            "52.244.160.207/32",
-            "2603:1027::/48",
-            "2603:1037::/48",
-            "2603:1047::/48",
-            "2603:1057::/48",
-            "2603:1063::/38",
-            "2620:1ec:6::/48",
-            "2620:1ec:40::/42"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": true,
-        "category": "Allow",
-        "required": true
-    },
-    {
-        "id": 16,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "urls": [
-            "*.keydelivery.mediaservices.windows.net",
-            "*.streaming.mediaservices.windows.net",
-            "mlccdn.blob.core.windows.net"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 17,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "urls": [
-            "aka.ms"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 18,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "urls": [
-            "*.users.storage.live.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Federation with Skype and public IM connectivity: Contact picture retrieval"
-    },
-    {
-        "id": 19,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "urls": [
-            "adl.windows.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Applies only to those who deploy the Conference Room Systems"
-    },
-    {
-        "id": 27,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "urls": [
-            "*.secure.skypeassets.com",
-            "mlccdnprod.azureedge.net"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 31,
-        "serviceArea": "SharePoint",
-        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
-        "urls": [
-            "*.sharepoint.com"
-        ],
-        "ips": [
-            "13.107.136.0/22",
-            "40.108.128.0/17",
-            "52.104.0.0/14",
-            "104.146.128.0/17",
-            "150.171.40.0/22",
-            "2603:1061:1300::/40",
-            "2620:1ec:8f8::/46",
-            "2620:1ec:908::/46",
-            "2a01:111:f402::/48"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": true,
-        "category": "Optimize",
-        "required": true
-    },
-    {
-        "id": 32,
-        "serviceArea": "SharePoint",
-        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
-        "urls": [
-            "ssw.live.com",
-            "storage.live.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "OneDrive for Business: supportability, telemetry, APIs, and embedded email links"
-    },
-    {
-        "id": 33,
-        "serviceArea": "SharePoint",
-        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
-        "urls": [
-            "*.search.production.apac.trafficmanager.net",
-            "*.search.production.emea.trafficmanager.net",
-            "*.search.production.us.trafficmanager.net"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "SharePoint Hybrid Search - Endpoint to SearchContentService where the hybrid crawler feeds documents"
-    },
-    {
-        "id": 35,
-        "serviceArea": "SharePoint",
-        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
-        "urls": [
-            "*.wns.windows.com",
-            "admin.onedrive.com",
-            "officeclient.microsoft.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 36,
-        "serviceArea": "SharePoint",
-        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
-        "urls": [
-            "g.live.com",
-            "oneclient.sfx.ms"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 37,
-        "serviceArea": "SharePoint",
-        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
-        "urls": [
-            "*.sharepointonline.com",
-            "spoprod-a.akamaihd.net"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 39,
-        "serviceArea": "SharePoint",
-        "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
-        "urls": [
-            "*.svc.ms"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 46,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.officeapps.live.com",
-            "*.online.office.com",
-            "office.live.com"
-        ],
-        "ips": [
-            "13.107.6.171/32",
-            "13.107.18.15/32",
-            "13.107.140.6/32",
-            "52.108.0.0/14",
-            "52.244.37.168/32",
-            "2603:1006:1400::/40",
-            "2603:1016:2400::/40",
-            "2603:1026:2400::/40",
-            "2603:1036:2400::/40",
-            "2603:1046:1400::/40",
-            "2603:1056:1400::/40",
-            "2603:1063:2000::/38",
-            "2620:1ec:c::15/128",
-            "2620:1ec:8fc::6/128",
-            "2620:1ec:a92::171/128",
-            "2a01:111:f100:2000::a83e:3019/128",
-            "2a01:111:f100:2002::8975:2d79/128",
-            "2a01:111:f100:2002::8975:2da8/128",
-            "2a01:111:f100:7000::6fdd:6cd5/128",
-            "2a01:111:f100:a004::bfeb:88cf/128"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": true,
-        "category": "Allow",
-        "required": true
-    },
-    {
-        "id": 47,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.office.net"
-        ],
-        "tcpPorts": "443,80",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 49,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.onenote.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 50,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.microsoft.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "OneNote notebooks (wildcards)"
-    },
-    {
-        "id": 51,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*cdn.onenote.net"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 53,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "ajax.aspnetcdn.com",
-            "apis.live.net",
-            "officeapps.live.com",
-            "www.onedrive.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 56,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.auth.microsoft.com",
-            "*.msftidentity.com",
-            "*.msidentity.com",
-            "account.activedirectory.windowsazure.com",
-            "accounts.accesscontrol.windows.net",
-            "adminwebservice.microsoftonline.com",
-            "api.passwordreset.microsoftonline.com",
-            "autologon.microsoftazuread-sso.com",
-            "becws.microsoftonline.com",
-            "ccs.login.microsoftonline.com",
-            "clientconfig.microsoftonline-p.net",
-            "companymanager.microsoftonline.com",
-            "device.login.microsoftonline.com",
-            "graph.microsoft.com",
-            "graph.windows.net",
-            "login.microsoft.com",
-            "login.microsoftonline.com",
-            "login.microsoftonline-p.com",
-            "login.windows.net",
-            "logincert.microsoftonline.com",
-            "loginex.microsoftonline.com",
-            "login-us.microsoftonline.com",
-            "nexus.microsoftonline-p.com",
-            "passwordreset.microsoftonline.com",
-            "provisioningapi.microsoftonline.com"
-        ],
-        "ips": [
-            "20.20.32.0/19",
-            "20.190.128.0/18",
-            "20.231.128.0/19",
-            "40.126.0.0/18",
-            "2603:1006:2000::/48",
-            "2603:1007:200::/48",
-            "2603:1016:1400::/48",
-            "2603:1017::/48",
-            "2603:1026:3000::/48",
-            "2603:1027:1::/48",
-            "2603:1036:3000::/48",
-            "2603:1037:1::/48",
-            "2603:1046:2000::/48",
-            "2603:1047:1::/48",
-            "2603:1056:2000::/48",
-            "2603:1057:2::/48"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": true,
-        "category": "Allow",
-        "required": true
-    },
-    {
-        "id": 59,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.hip.live.com",
-            "*.microsoftonline.com",
-            "*.microsoftonline-p.com",
-            "*.msauth.net",
-            "*.msauthimages.net",
-            "*.msecnd.net",
-            "*.msftauth.net",
-            "*.msftauthimages.net",
-            "*.phonefactor.net",
-            "enterpriseregistration.windows.net",
-            "policykeyservice.dc.ad.msft.net"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 64,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.protection.office.com",
-            "*.security.microsoft.com",
-            "compliance.microsoft.com",
-            "defender.microsoft.com",
-            "protection.office.com",
-            "purview.microsoft.com",
-            "security.microsoft.com"
-        ],
-        "ips": [
-            "13.107.6.192/32",
-            "13.107.9.192/32",
-            "2620:1ec:4::192/128",
-            "2620:1ec:a92::192/128"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": true,
-        "category": "Allow",
-        "required": true
-    },
-    {
-        "id": 66,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.portal.cloudappsecurity.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 68,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "firstpartyapps.oaspapps.com",
-            "prod.firstpartyapps.oaspapps.com.akadns.net",
-            "telemetryservice.firstpartyapps.oaspapps.com",
-            "wus-firstpartyapps.oaspapps.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Portal and shared: 3rd party office integration. (including CDNs)"
-    },
-    {
-        "id": 69,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.aria.microsoft.com",
-            "*.events.data.microsoft.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 70,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.o365weve.com",
-            "amp.azure.net",
-            "appsforoffice.microsoft.com",
-            "assets.onestore.ms",
-            "auth.gfx.ms",
-            "c1.microsoft.com",
-            "dgps.support.microsoft.com",
-            "docs.microsoft.com",
-            "msdn.microsoft.com",
-            "platform.linkedin.com",
-            "prod.msocdn.com",
-            "shellprod.msocdn.com",
-            "support.microsoft.com",
-            "technet.microsoft.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 71,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.office365.com"
-        ],
-        "tcpPorts": "443,80",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 73,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.aadrm.com",
-            "*.azurerms.com",
-            "*.informationprotection.azure.com",
-            "ecn.dev.virtualearth.net",
-            "informationprotection.hosting.portal.azure.net"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 75,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.sharepointonline.com",
-            "dc.services.visualstudio.com",
-            "mem.gfx.ms",
-            "staffhub.ms",
-            "staffhubweb.azureedge.net"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Graph.windows.net, Office 365 Management Pack for Operations Manager, SecureScore, Azure AD Device Registration, Forms, StaffHub, Application Insights, captcha services"
-    },
-    {
-        "id": 78,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.microsoft.com",
-            "*.msocdn.com",
-            "*.onmicrosoft.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Some Office 365 features require endpoints within these domains (including CDNs). Many specific FQDNs within these wildcards have been published recently as we work to either remove or better explain our guidance relating to these wildcards."
-    },
-    {
-        "id": 79,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "o15.officeredir.microsoft.com",
-            "officepreviewredir.microsoft.com",
-            "officeredir.microsoft.com",
-            "r.office.microsoft.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 83,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "activation.sls.microsoft.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 84,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "crl.microsoft.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 86,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "office15client.microsoft.com",
-            "officeclient.microsoft.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 89,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "go.microsoft.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 91,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "ajax.aspnetcdn.com",
-            "cdn.odc.officeapps.live.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 92,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "officecdn.microsoft.com",
-            "officecdn.microsoft.com.edgesuite.net",
-            "otelrules.azureedge.net"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 93,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.virtualearth.net",
-            "c.bing.net",
-            "ocos-office365-s2s.msedge.net",
-            "tse1.mm.bing.net",
-            "www.bing.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "ProPlus: auxiliary URLs"
-    },
-    {
-        "id": 95,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.acompli.net",
-            "*.outlookmobile.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Outlook for Android and iOS"
-    },
-    {
-        "id": 96,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "login.windows-ppe.net"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Outlook for Android and iOS: Authentication"
-    },
-    {
-        "id": 97,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "account.live.com",
-            "login.live.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Outlook for Android and iOS: Consumer Outlook.com and OneDrive integration"
-    },
-    {
-        "id": 105,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "www.acompli.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Outlook for Android and iOS: Outlook Privacy"
-    },
-    {
-        "id": 114,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.appex.bing.com",
-            "*.appex-rf.msn.com",
-            "c.bing.com",
-            "c.live.com",
-            "d.docs.live.net",
-            "docs.live.net",
-            "partnerservices.getmicrosoftkey.com",
-            "signup.live.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Office Mobile URLs"
-    },
-    {
-        "id": 116,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "account.live.com",
-            "auth.gfx.ms",
-            "login.live.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Office for iPad URLs"
-    },
-    {
-        "id": 117,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.yammer.com",
-            "*.yammerusercontent.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Yammer"
-    },
-    {
-        "id": 118,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.assets-yammer.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Yammer CDN"
-    },
-    {
-        "id": 121,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "www.outlook.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Planner: auxiliary URLs"
-    },
-    {
-        "id": 122,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "eus-www.sway-cdn.com",
-            "eus-www.sway-extensions.com",
-            "wus-www.sway-cdn.com",
-            "wus-www.sway-extensions.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Sway CDNs"
-    },
-    {
-        "id": 124,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "sway.com",
-            "www.sway.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Sway"
-    },
-    {
-        "id": 125,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.entrust.net",
-            "*.geotrust.com",
-            "*.omniroot.com",
-            "*.public-trust.com",
-            "*.symcb.com",
-            "*.symcd.com",
-            "*.verisign.com",
-            "*.verisign.net",
-            "apps.identrust.com",
-            "cacerts.digicert.com",
-            "cert.int-x3.letsencrypt.org",
-            "crl.globalsign.com",
-            "crl.globalsign.net",
-            "crl.identrust.com",
-            "crl3.digicert.com",
-            "crl4.digicert.com",
-            "isrg.trustid.ocsp.identrust.com",
-            "mscrl.microsoft.com",
-            "ocsp.digicert.com",
-            "ocsp.globalsign.com",
-            "ocsp.msocsp.com",
-            "ocsp2.globalsign.com",
-            "ocspx.digicert.com",
-            "secure.globalsign.com",
-            "www.digicert.com",
-            "www.microsoft.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 126,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "officespeech.platform.bing.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "Connection to the speech service is required for Office Dictation features. If connectivity is not allowed, Dictation will be disabled."
-    },
-    {
-        "id": 127,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "urls": [
-            "*.skype.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 147,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.office.com",
-            "www.microsoft365.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 152,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.microsoftusercontent.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": false,
-        "notes": "These endpoints enable the Office Scripts functionality in Office clients available through the Automate tab and the Python in Excel functionality available through the Formulas tab. The Office Scripts feature can also be disabled through the Office 365 Admin portal. For admin controls related to Python in Excel, see [Data security and Python in Excel](https://support.microsoft.com/office/data-security-and-python-in-excel-33cc88a4-4a87-485e-9ff9-f35958278327)."
-    },
-    {
-        "id": 153,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.azure-apim.net",
-            "*.flow.microsoft.com",
-            "*.powerapps.com",
-            "*.powerautomate.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 156,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.activity.windows.com",
-            "activity.windows.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 158,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.cortana.ai"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 159,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "admin.microsoft.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 160,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "cdn.odc.officeapps.live.com",
-            "cdn.uci.officeapps.live.com"
-        ],
-        "tcpPorts": "80,443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 180,
-        "serviceArea": "Skype",
-        "serviceAreaDisplayName": "Microsoft Teams",
-        "urls": [
-            "compass-ssl.microsoft.com"
-        ],
-        "tcpPorts": "443",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    },
-    {
-        "id": 184,
-        "serviceArea": "Common",
-        "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
-        "urls": [
-            "*.cloud.microsoft",
-            "*.static.microsoft",
-            "*.usercontent.microsoft"
-        ],
-        "tcpPorts": "443,80",
-        "expressRoute": false,
-        "category": "Default",
-        "required": true
-    }
+  {
+    "_comment": [
+      "Copyright 2024 TII (SSRC) and the Ghaf contributors",
+      "SPDX-License-Identifier: Apache-2.0"
+    ],
+    "id": 1,
+    "serviceArea": "Exchange",
+    "serviceAreaDisplayName": "Exchange Online",
+    "urls": [
+      "outlook.cloud.microsoft",
+      "outlook.office.com",
+      "outlook.office365.com"
+    ],
+    "ips": [
+      "13.107.6.152/31",
+      "13.107.18.10/31",
+      "13.107.128.0/22",
+      "23.103.160.0/20",
+      "40.96.0.0/13",
+      "40.104.0.0/15",
+      "52.96.0.0/14",
+      "131.253.33.215/32",
+      "132.245.0.0/16",
+      "150.171.32.0/22",
+      "204.79.197.215/32",
+      "2603:1006::/40",
+      "2603:1016::/36",
+      "2603:1026::/36",
+      "2603:1036::/36",
+      "2603:1046::/36",
+      "2603:1056::/36",
+      "2620:1ec:4::152/128",
+      "2620:1ec:4::153/128",
+      "2620:1ec:c::10/128",
+      "2620:1ec:c::11/128",
+      "2620:1ec:d::10/128",
+      "2620:1ec:d::11/128",
+      "2620:1ec:8f0::/46",
+      "2620:1ec:900::/46",
+      "2620:1ec:a92::152/128",
+      "2620:1ec:a92::153/128"
+    ],
+    "tcpPorts": "80,443",
+    "udpPorts": "443",
+    "expressRoute": true,
+    "category": "Optimize",
+    "required": true
+  },
+  {
+    "id": 2,
+    "serviceArea": "Exchange",
+    "serviceAreaDisplayName": "Exchange Online",
+    "urls": ["outlook.office365.com", "smtp.office365.com"],
+    "ips": [
+      "13.107.6.152/31",
+      "13.107.18.10/31",
+      "13.107.128.0/22",
+      "23.103.160.0/20",
+      "40.96.0.0/13",
+      "40.104.0.0/15",
+      "52.96.0.0/14",
+      "131.253.33.215/32",
+      "132.245.0.0/16",
+      "150.171.32.0/22",
+      "204.79.197.215/32",
+      "2603:1006::/40",
+      "2603:1016::/36",
+      "2603:1026::/36",
+      "2603:1036::/36",
+      "2603:1046::/36",
+      "2603:1056::/36",
+      "2620:1ec:4::152/128",
+      "2620:1ec:4::153/128",
+      "2620:1ec:c::10/128",
+      "2620:1ec:c::11/128",
+      "2620:1ec:d::10/128",
+      "2620:1ec:d::11/128",
+      "2620:1ec:8f0::/46",
+      "2620:1ec:900::/46",
+      "2620:1ec:a92::152/128",
+      "2620:1ec:a92::153/128"
+    ],
+    "tcpPorts": "143, 587, 993, 995",
+    "expressRoute": true,
+    "category": "Allow",
+    "required": false,
+    "notes": "POP3, IMAP4, SMTP Client traffic"
+  },
+  {
+    "id": 8,
+    "serviceArea": "Exchange",
+    "serviceAreaDisplayName": "Exchange Online",
+    "urls": ["*.outlook.com", "autodiscover.*.onmicrosoft.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 9,
+    "serviceArea": "Exchange",
+    "serviceAreaDisplayName": "Exchange Online",
+    "urls": ["*.protection.outlook.com"],
+    "ips": [
+      "40.92.0.0/15",
+      "40.107.0.0/16",
+      "52.100.0.0/14",
+      "52.238.78.88/32",
+      "104.47.0.0/17",
+      "2a01:111:f400::/48",
+      "2a01:111:f403::/48"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": true,
+    "category": "Allow",
+    "required": true
+  },
+  {
+    "id": 10,
+    "serviceArea": "Exchange",
+    "serviceAreaDisplayName": "Exchange Online",
+    "urls": ["*.mail.protection.outlook.com", "*.mx.microsoft"],
+    "ips": [
+      "40.92.0.0/15",
+      "40.107.0.0/16",
+      "52.100.0.0/14",
+      "104.47.0.0/17",
+      "2a01:111:f400::/48",
+      "2a01:111:f403::/48"
+    ],
+    "tcpPorts": "25",
+    "expressRoute": true,
+    "category": "Allow",
+    "required": true
+  },
+  {
+    "id": 11,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "ips": ["52.112.0.0/14", "52.122.0.0/15", "2603:1063::/38"],
+    "udpPorts": "3478,3479,3480,3481",
+    "expressRoute": true,
+    "category": "Optimize",
+    "required": true
+  },
+  {
+    "id": 12,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "urls": [
+      "*.lync.com",
+      "*.teams.cloud.microsoft",
+      "*.teams.microsoft.com",
+      "teams.cloud.microsoft",
+      "teams.microsoft.com"
+    ],
+    "ips": [
+      "52.112.0.0/14",
+      "52.122.0.0/15",
+      "52.238.119.141/32",
+      "52.244.160.207/32",
+      "2603:1027::/48",
+      "2603:1037::/48",
+      "2603:1047::/48",
+      "2603:1057::/48",
+      "2603:1063::/38",
+      "2620:1ec:6::/48",
+      "2620:1ec:40::/42"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": true,
+    "category": "Allow",
+    "required": true
+  },
+  {
+    "id": 16,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "urls": [
+      "*.keydelivery.mediaservices.windows.net",
+      "*.streaming.mediaservices.windows.net",
+      "mlccdn.blob.core.windows.net"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 17,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "urls": ["aka.ms"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 18,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "urls": ["*.users.storage.live.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Federation with Skype and public IM connectivity: Contact picture retrieval"
+  },
+  {
+    "id": 19,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "urls": ["adl.windows.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Applies only to those who deploy the Conference Room Systems"
+  },
+  {
+    "id": 27,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "urls": ["*.secure.skypeassets.com", "mlccdnprod.azureedge.net"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 31,
+    "serviceArea": "SharePoint",
+    "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+    "urls": ["*.sharepoint.com"],
+    "ips": [
+      "13.107.136.0/22",
+      "40.108.128.0/17",
+      "52.104.0.0/14",
+      "104.146.128.0/17",
+      "150.171.40.0/22",
+      "2603:1061:1300::/40",
+      "2620:1ec:8f8::/46",
+      "2620:1ec:908::/46",
+      "2a01:111:f402::/48"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": true,
+    "category": "Optimize",
+    "required": true
+  },
+  {
+    "id": 32,
+    "serviceArea": "SharePoint",
+    "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+    "urls": ["ssw.live.com", "storage.live.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "OneDrive for Business: supportability, telemetry, APIs, and embedded email links"
+  },
+  {
+    "id": 33,
+    "serviceArea": "SharePoint",
+    "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+    "urls": [
+      "*.search.production.apac.trafficmanager.net",
+      "*.search.production.emea.trafficmanager.net",
+      "*.search.production.us.trafficmanager.net"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "SharePoint Hybrid Search - Endpoint to SearchContentService where the hybrid crawler feeds documents"
+  },
+  {
+    "id": 35,
+    "serviceArea": "SharePoint",
+    "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+    "urls": [
+      "*.wns.windows.com",
+      "admin.onedrive.com",
+      "officeclient.microsoft.com"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 36,
+    "serviceArea": "SharePoint",
+    "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+    "urls": ["g.live.com", "oneclient.sfx.ms"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 37,
+    "serviceArea": "SharePoint",
+    "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+    "urls": ["*.sharepointonline.com", "spoprod-a.akamaihd.net"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 39,
+    "serviceArea": "SharePoint",
+    "serviceAreaDisplayName": "SharePoint Online and OneDrive for Business",
+    "urls": ["*.svc.ms"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 46,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.officeapps.live.com", "*.online.office.com", "office.live.com"],
+    "ips": [
+      "13.107.6.171/32",
+      "13.107.18.15/32",
+      "13.107.140.6/32",
+      "52.108.0.0/14",
+      "52.244.37.168/32",
+      "2603:1006:1400::/40",
+      "2603:1016:2400::/40",
+      "2603:1026:2400::/40",
+      "2603:1036:2400::/40",
+      "2603:1046:1400::/40",
+      "2603:1056:1400::/40",
+      "2603:1063:2000::/38",
+      "2620:1ec:c::15/128",
+      "2620:1ec:8fc::6/128",
+      "2620:1ec:a92::171/128",
+      "2a01:111:f100:2000::a83e:3019/128",
+      "2a01:111:f100:2002::8975:2d79/128",
+      "2a01:111:f100:2002::8975:2da8/128",
+      "2a01:111:f100:7000::6fdd:6cd5/128",
+      "2a01:111:f100:a004::bfeb:88cf/128"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": true,
+    "category": "Allow",
+    "required": true
+  },
+  {
+    "id": 47,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.office.net"],
+    "tcpPorts": "443,80",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 49,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.onenote.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 50,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.microsoft.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "OneNote notebooks (wildcards)"
+  },
+  {
+    "id": 51,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*cdn.onenote.net"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 53,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "ajax.aspnetcdn.com",
+      "apis.live.net",
+      "officeapps.live.com",
+      "www.onedrive.com"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 56,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.auth.microsoft.com",
+      "*.msftidentity.com",
+      "*.msidentity.com",
+      "account.activedirectory.windowsazure.com",
+      "accounts.accesscontrol.windows.net",
+      "adminwebservice.microsoftonline.com",
+      "api.passwordreset.microsoftonline.com",
+      "autologon.microsoftazuread-sso.com",
+      "becws.microsoftonline.com",
+      "ccs.login.microsoftonline.com",
+      "clientconfig.microsoftonline-p.net",
+      "companymanager.microsoftonline.com",
+      "device.login.microsoftonline.com",
+      "graph.microsoft.com",
+      "graph.windows.net",
+      "login.microsoft.com",
+      "login.microsoftonline.com",
+      "login.microsoftonline-p.com",
+      "login.windows.net",
+      "logincert.microsoftonline.com",
+      "loginex.microsoftonline.com",
+      "login-us.microsoftonline.com",
+      "nexus.microsoftonline-p.com",
+      "passwordreset.microsoftonline.com",
+      "provisioningapi.microsoftonline.com"
+    ],
+    "ips": [
+      "20.20.32.0/19",
+      "20.190.128.0/18",
+      "20.231.128.0/19",
+      "40.126.0.0/18",
+      "2603:1006:2000::/48",
+      "2603:1007:200::/48",
+      "2603:1016:1400::/48",
+      "2603:1017::/48",
+      "2603:1026:3000::/48",
+      "2603:1027:1::/48",
+      "2603:1036:3000::/48",
+      "2603:1037:1::/48",
+      "2603:1046:2000::/48",
+      "2603:1047:1::/48",
+      "2603:1056:2000::/48",
+      "2603:1057:2::/48"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": true,
+    "category": "Allow",
+    "required": true
+  },
+  {
+    "id": 59,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.hip.live.com",
+      "*.microsoftonline.com",
+      "*.microsoftonline-p.com",
+      "*.msauth.net",
+      "*.msauthimages.net",
+      "*.msecnd.net",
+      "*.msftauth.net",
+      "*.msftauthimages.net",
+      "*.phonefactor.net",
+      "enterpriseregistration.windows.net",
+      "policykeyservice.dc.ad.msft.net"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 64,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.protection.office.com",
+      "*.security.microsoft.com",
+      "compliance.microsoft.com",
+      "defender.microsoft.com",
+      "protection.office.com",
+      "purview.microsoft.com",
+      "security.microsoft.com"
+    ],
+    "ips": [
+      "13.107.6.192/32",
+      "13.107.9.192/32",
+      "2620:1ec:4::192/128",
+      "2620:1ec:a92::192/128"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": true,
+    "category": "Allow",
+    "required": true
+  },
+  {
+    "id": 66,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.portal.cloudappsecurity.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 68,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "firstpartyapps.oaspapps.com",
+      "prod.firstpartyapps.oaspapps.com.akadns.net",
+      "telemetryservice.firstpartyapps.oaspapps.com",
+      "wus-firstpartyapps.oaspapps.com"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Portal and shared: 3rd party office integration. (including CDNs)"
+  },
+  {
+    "id": 69,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.aria.microsoft.com", "*.events.data.microsoft.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 70,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.o365weve.com",
+      "amp.azure.net",
+      "appsforoffice.microsoft.com",
+      "assets.onestore.ms",
+      "auth.gfx.ms",
+      "c1.microsoft.com",
+      "dgps.support.microsoft.com",
+      "docs.microsoft.com",
+      "msdn.microsoft.com",
+      "platform.linkedin.com",
+      "prod.msocdn.com",
+      "shellprod.msocdn.com",
+      "support.microsoft.com",
+      "technet.microsoft.com"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 71,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.office365.com"],
+    "tcpPorts": "443,80",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 73,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.aadrm.com",
+      "*.azurerms.com",
+      "*.informationprotection.azure.com",
+      "ecn.dev.virtualearth.net",
+      "informationprotection.hosting.portal.azure.net"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 75,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.sharepointonline.com",
+      "dc.services.visualstudio.com",
+      "mem.gfx.ms",
+      "staffhub.ms",
+      "staffhubweb.azureedge.net"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Graph.windows.net, Office 365 Management Pack for Operations Manager, SecureScore, Azure AD Device Registration, Forms, StaffHub, Application Insights, captcha services"
+  },
+  {
+    "id": 78,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.microsoft.com", "*.msocdn.com", "*.onmicrosoft.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Some Office 365 features require endpoints within these domains (including CDNs). Many specific FQDNs within these wildcards have been published recently as we work to either remove or better explain our guidance relating to these wildcards."
+  },
+  {
+    "id": 79,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "o15.officeredir.microsoft.com",
+      "officepreviewredir.microsoft.com",
+      "officeredir.microsoft.com",
+      "r.office.microsoft.com"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 83,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["activation.sls.microsoft.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 84,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["crl.microsoft.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 86,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["office15client.microsoft.com", "officeclient.microsoft.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 89,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["go.microsoft.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 91,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["ajax.aspnetcdn.com", "cdn.odc.officeapps.live.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 92,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "officecdn.microsoft.com",
+      "officecdn.microsoft.com.edgesuite.net",
+      "otelrules.azureedge.net"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 93,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.virtualearth.net",
+      "c.bing.net",
+      "ocos-office365-s2s.msedge.net",
+      "tse1.mm.bing.net",
+      "www.bing.com"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "ProPlus: auxiliary URLs"
+  },
+  {
+    "id": 95,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.acompli.net", "*.outlookmobile.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Outlook for Android and iOS"
+  },
+  {
+    "id": 96,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["login.windows-ppe.net"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Outlook for Android and iOS: Authentication"
+  },
+  {
+    "id": 97,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["account.live.com", "login.live.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Outlook for Android and iOS: Consumer Outlook.com and OneDrive integration"
+  },
+  {
+    "id": 105,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["www.acompli.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Outlook for Android and iOS: Outlook Privacy"
+  },
+  {
+    "id": 114,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.appex.bing.com",
+      "*.appex-rf.msn.com",
+      "c.bing.com",
+      "c.live.com",
+      "d.docs.live.net",
+      "docs.live.net",
+      "partnerservices.getmicrosoftkey.com",
+      "signup.live.com"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Office Mobile URLs"
+  },
+  {
+    "id": 116,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["account.live.com", "auth.gfx.ms", "login.live.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Office for iPad URLs"
+  },
+  {
+    "id": 117,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.yammer.com", "*.yammerusercontent.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Yammer"
+  },
+  {
+    "id": 118,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.assets-yammer.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Yammer CDN"
+  },
+  {
+    "id": 121,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["www.outlook.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Planner: auxiliary URLs"
+  },
+  {
+    "id": 122,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "eus-www.sway-cdn.com",
+      "eus-www.sway-extensions.com",
+      "wus-www.sway-cdn.com",
+      "wus-www.sway-extensions.com"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Sway CDNs"
+  },
+  {
+    "id": 124,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["sway.com", "www.sway.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Sway"
+  },
+  {
+    "id": 125,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.entrust.net",
+      "*.geotrust.com",
+      "*.omniroot.com",
+      "*.public-trust.com",
+      "*.symcb.com",
+      "*.symcd.com",
+      "*.verisign.com",
+      "*.verisign.net",
+      "apps.identrust.com",
+      "cacerts.digicert.com",
+      "cert.int-x3.letsencrypt.org",
+      "crl.globalsign.com",
+      "crl.globalsign.net",
+      "crl.identrust.com",
+      "crl3.digicert.com",
+      "crl4.digicert.com",
+      "isrg.trustid.ocsp.identrust.com",
+      "mscrl.microsoft.com",
+      "ocsp.digicert.com",
+      "ocsp.globalsign.com",
+      "ocsp.msocsp.com",
+      "ocsp2.globalsign.com",
+      "ocspx.digicert.com",
+      "secure.globalsign.com",
+      "www.digicert.com",
+      "www.microsoft.com"
+    ],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 126,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["officespeech.platform.bing.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "Connection to the speech service is required for Office Dictation features. If connectivity is not allowed, Dictation will be disabled."
+  },
+  {
+    "id": 127,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "urls": ["*.skype.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 147,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.office.com", "www.microsoft365.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 152,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.microsoftusercontent.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": false,
+    "notes": "These endpoints enable the Office Scripts functionality in Office clients available through the Automate tab and the Python in Excel functionality available through the Formulas tab. The Office Scripts feature can also be disabled through the Office 365 Admin portal. For admin controls related to Python in Excel, see [Data security and Python in Excel](https://support.microsoft.com/office/data-security-and-python-in-excel-33cc88a4-4a87-485e-9ff9-f35958278327)."
+  },
+  {
+    "id": 153,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.azure-apim.net",
+      "*.flow.microsoft.com",
+      "*.powerapps.com",
+      "*.powerautomate.com"
+    ],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 156,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.activity.windows.com", "activity.windows.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 158,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["*.cortana.ai"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 159,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["admin.microsoft.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 160,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": ["cdn.odc.officeapps.live.com", "cdn.uci.officeapps.live.com"],
+    "tcpPorts": "80,443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 180,
+    "serviceArea": "Skype",
+    "serviceAreaDisplayName": "Microsoft Teams",
+    "urls": ["compass-ssl.microsoft.com"],
+    "tcpPorts": "443",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  },
+  {
+    "id": 184,
+    "serviceArea": "Common",
+    "serviceAreaDisplayName": "Microsoft 365 Common and Office Online",
+    "urls": [
+      "*.cloud.microsoft",
+      "*.static.microsoft",
+      "*.usercontent.microsoft"
+    ],
+    "tcpPorts": "443,80",
+    "expressRoute": false,
+    "category": "Default",
+    "required": true
+  }
 ]

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,8 +1,11 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+{ inputs, ... }:
 {
+  imports = [ inputs.git-hooks-nix.flakeModule ];
   perSystem =
     {
+      config,
       pkgs,
       self',
       lib,
@@ -25,5 +28,22 @@
         #  pkgs.callPackage ../modules/hardware/x86_64-generic/kernel/host/pkvm/test
         #    { inherit pkgs; };
       } // (lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages);
+
+      pre-commit = {
+        settings = {
+          hooks = {
+            treefmt = {
+              enable = true;
+              package = config.treefmt.build.wrapper;
+              stages = [ "pre-push" ];
+            };
+            reuse = {
+              enable = true;
+              package = pkgs.reuse;
+              stages = [ "pre-push" ];
+            };
+          };
+        };
+      };
     };
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,47 +1,69 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+{ inputs, lib, ... }:
 {
-  imports = [ ./devshell/kernel.nix ];
+  imports = [
+    inputs.devshell.flakeModule
+    ./devshell/kernel.nix
+  ];
   perSystem =
     {
       config,
       pkgs,
       inputs',
-      lib,
       ...
     }:
     {
-      devShells.default = pkgs.mkShell {
-        name = "Ghaf devshell";
-        meta.description = "Ghaf development environment";
-        #TODO look at adding Mission control etc here
-        inputsFrom = [
-          config.treefmt.build.programs # See ./treefmt.nix
-        ];
-        packages =
-          builtins.attrValues {
-            inherit (pkgs)
-              git
-              mdbook
-              nix
-              nixci
-              nixos-rebuild
-              nix-output-monitor
-              nix-tree
-              reuse
-              nix-eval-jobs
-              jq
-              ;
+      devshells.default = {
+        devshell = {
+          name = "Ghaf devshell";
+          meta.description = "Ghaf development environment";
+          packages =
+            builtins.attrValues {
+              inherit (pkgs)
+                git
+                mdbook
+                nix
+                nixci
+                nixos-rebuild
+                nix-output-monitor
+                nix-tree
+                reuse
+                nix-eval-jobs
+                jq
+                ;
+            }
+            ++ [
+              inputs'.nix-fast-build.packages.default
+              config.treefmt.build.wrapper
+            ]
+            ++ [
+              (pkgs.callPackage ../packages/flash { })
+              (pkgs.callPackage ../packages/make-checks { })
+            ]
+            ++ lib.attrValues config.treefmt.build.programs # make all the trefmt packages available
+            ++ lib.optional (pkgs.hostPlatform.system != "riscv64-linux") pkgs.cachix;
+        };
+        commands = [
+          {
+            help = "Check flake evaluation";
+            name = "check-eval";
+            command = "make-checks";
+            category = "checker";
           }
-          ++ [ inputs'.nix-fast-build.packages.default ]
-          ++ [
-            (pkgs.callPackage ../packages/flash { })
-            (pkgs.callPackage ../packages/make-checks { })
-          ]
-          ++ lib.optional (pkgs.hostPlatform.system != "riscv64-linux") pkgs.cachix;
-
-        # TODO Add pre-commit.devShell (needs to exclude RiscV)
-        # https://flake.parts/options/pre-commit-hooks-nix
+          {
+            help = "Format";
+            name = "format-repo";
+            command = "treefmt";
+            category = "checker";
+          }
+          {
+            help = "Check license";
+            name = "check-license";
+            command = "reuse lint";
+            category = "linters";
+          }
+        ];
       };
     };
 }

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -5,13 +5,11 @@
   imports = [
     inputs.flake-root.flakeModule
     inputs.treefmt-nix.flakeModule
-    inputs.pre-commit-hooks-nix.flakeModule
   ];
   perSystem =
     { config, pkgs, ... }:
     {
       treefmt.config = {
-        package = pkgs.treefmt;
         inherit (config.flake-root) projectRootFile;
 
         programs = {

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -29,43 +29,61 @@
           # Bash
           shellcheck.enable = true; # lints shell scripts https://github.com/koalaman/shellcheck
 
-          yamlfmt.enable = true; # YAML formatter
+          # TODO: treefmt claims it changes the files
+          # though the files are not in the diff
+          # and hence fail in the ci ????
+          #toml-sort.enable = true; # TOML formatter
+          prettier.enable = true; # JavaScript formatter
+
         };
 
-        settings.global.excludes = [
-          "*.key"
-          "*.lock"
-          "*.config"
-          "*.dts"
-          "*.pfx"
-          "*.p12"
-          "*.crt"
-          "*.cer"
-          "*.csr"
-          "*.der"
-          "*.jks"
-          "*.keystore"
-          "*.pem"
-          "*.pkcs12"
-          "*.pfx"
-          "*.p12"
-          "*.pem"
-          "*.pkcs7"
-          "*.p7b"
-          "*.p7c"
-          "*.p7r"
-          "*.p7m"
-          "*.p7s"
-          "*.p8"
-          "*.png"
-          "*.svg"
-          "*.license"
-          "*.db"
-          "*.mp3"
-          "*.txt"
-          #TODO: fix the MD
-          "*.md"
-        ];
+        settings = {
+          formatter = {
+            "statix-check" = {
+              command = "${pkgs.statix}/bin/statix";
+              options = [ "check" ];
+              includes = [ "." ];
+            };
+          };
+
+          global.excludes = [
+            "*.key"
+            "*.lock"
+            "*.config"
+            "*.dts"
+            "*.pfx"
+            "*.p12"
+            "*.crt"
+            "*.cer"
+            "*.csr"
+            "*.der"
+            "*.jks"
+            "*.keystore"
+            "*.pem"
+            "*.pkcs12"
+            "*.pfx"
+            "*.p12"
+            "*.pem"
+            "*.pkcs7"
+            "*.p7b"
+            "*.p7c"
+            "*.p7r"
+            "*.p7m"
+            "*.p7s"
+            "*.p8"
+            "*.png"
+            "*.svg"
+            "*.license"
+            "*.db"
+            "*.mp3"
+            "*.txt"
+            ".version"
+            ".nojekyll"
+            "*.git*"
+            "*.hbs"
+            "*.md"
+          ];
+        };
       };
 
       formatter = config.treefmt.build.wrapper;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 # Copyright 2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+
 [tool.ruff]
 line-length = 88
 target-version = "py312"
-lint.select = [ "E", "F", "I", "U", "N", "RUF", "A" ]
-lint.ignore = [ "E501", "A003"]
+lint.select = ["E", "F", "I", "U", "N", "RUF", "A"]
+lint.ignore = ["E501", "A003"]


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

just loads the applications into the devshell correctly

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

this change only targets the development shell that is seen with either `nix develop` or `direnv allow`