### PR TITLE
Added FEH gtk-based light image viewer to ZaturaVM

### DIFF
--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -124,6 +124,14 @@ in
             }
 
             {
+              name = "Image Viewer";
+              description = "Isolated Image Viewer";
+              vm = "Zathura";
+              path = "${pkgs.givc-cli}/bin/givc-cli ${cliArgs} start feh";
+              icon = "${pkgs.icon-pack}/image-viewer.svg";
+            }
+
+            {
               name = "Element";
               description = "General Messaging Application";
               vm = "Comms";

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -75,6 +75,10 @@ in
           colour = "#122263";
         }
         {
+          identifier = "feh";
+          colour = "#122263";
+        }
+        {
           identifier = "Element";
           colour = "#337aff";
         }

--- a/modules/reference/appvms/zathura.nix
+++ b/modules/reference/appvms/zathura.nix
@@ -9,7 +9,10 @@
 }:
 {
   name = "zathura";
-  packages = [ pkgs.zathura ];
+  packages = [ 
+                pkgs.zathura 
+                pkgs.feh
+             ];
   macAddress = "02:00:00:03:07:01";
   ramMb = 512;
   cores = 1;
@@ -27,6 +30,10 @@
             {
               name = "zathura";
               command = "${config.ghaf.givc.appPrefix}/run-waypipe ${config.ghaf.givc.appPrefix}/zathura";
+            }
+            {
+              name = "feh";
+              command = "${config.ghaf.givc.appPrefix}/run-waypipe ${config.ghaf.givc.appPrefix}/feh";
             }
           ];
         };

--- a/packages/icon-pack/default.nix
+++ b/packages/icon-pack/default.nix
@@ -16,6 +16,7 @@ let
     "distributor-logo-android.svg"
     "distributor-logo-windows.svg"
     "document-viewer.svg"
+    "image-viewer.svg"
     "element-desktop.svg"
     "firefox.svg"
     "microsoft-365.svg"


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Added FEH gtk-based light-footprint image viewer to ZaturaVM. 
XDG handlers are coming in separate commit.


<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->


- [X ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

