### PR TITLE
Add network manager applet

### DIFF
--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -161,13 +161,6 @@ in
             }
 
             {
-              name = "Network Settings";
-              description = "Manage Network & Wi-Fi Settings";
-              path = "${pkgs.nm-launcher}/bin/nm-launcher";
-              icon = "${pkgs.icon-pack}/preferences-system-network.svg";
-            }
-
-            {
               name = "Bluetooth Settings";
               description = "Manage Bluetooth Devices & Settings";
               path = "${pkgs.bt-launcher}/bin/bt-launcher";

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -200,18 +200,33 @@ let
           ghaf.reference.services.ollama = true;
 
           # Waypipe service runs in the GUIVM and listens for incoming connections from AppVMs
-          systemd.user.services.waypipe = {
-            enable = true;
-            description = "waypipe";
-            serviceConfig = {
-              Type = "simple";
-              ExecStart = "${pkgs.waypipe}/bin/waypipe --vsock -s ${toString cfg.waypipePort} client";
-              Restart = "always";
-              RestartSec = "1";
+          systemd.user.services = {
+            waypipe = {
+              enable = true;
+              description = "waypipe";
+              serviceConfig = {
+                Type = "simple";
+                ExecStart = "${pkgs.waypipe}/bin/waypipe --vsock -s ${toString cfg.waypipePort} client";
+                Restart = "always";
+                RestartSec = "1";
+              };
+              startLimitIntervalSec = 0;
+              partOf = [ "ghaf-session.target" ];
+              wantedBy = [ "ghaf-session.target" ];
             };
-            startLimitIntervalSec = 0;
-            partOf = [ "ghaf-session.target" ];
-            wantedBy = [ "ghaf-session.target" ];
+
+            nm-applet = {
+              enable = true;
+              description = "network manager graphical interface.";
+              serviceConfig = {
+                Type = "simple";
+                Restart = "always";
+                RestartSec = "1";
+                ExecStart = "${pkgs.nm-launcher}/bin/nm-launcher";
+              };
+              partOf = [ "ghaf-session.target" ];
+              wantedBy = [ "ghaf-session.target" ];
+            };
           };
         }
       )

--- a/packages/nm-launcher/default.nix
+++ b/packages/nm-launcher/default.nix
@@ -15,7 +15,8 @@ writeShellApplication {
   name = "nm-launcher";
 
   text = ''
-    export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
+    # Keep only system dbus so nm-applet can talk to network-manager deaemon on net-vm.
+    # export DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/ssh_session_dbus.sock
     export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/ssh_system_dbus.sock
     ${openssh}/bin/ssh -M -S /tmp/control_socket \
         -f -N -q ghaf@net-vm \
@@ -26,7 +27,7 @@ writeShellApplication {
         -o ExitOnForwardFailure=yes \
         -L /tmp/ssh_session_dbus.sock:/run/user/1000/bus \
         -L /tmp/ssh_system_dbus.sock:/run/dbus/system_bus_socket
-    ${networkmanagerapplet}/bin/nm-connection-editor
+    ${networkmanagerapplet}/bin/nm-applet --indicator
     # Use the control socket to close the ssh tunnel.
     ${openssh}/bin/ssh -q -S /tmp/control_socket -O exit ghaf@net-vm
   '';


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Replace `nm-connection-editor` with `nm-applet` for system network configuration.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- Check that application appears in tray on startup.
- Test that it is easier to connect to wifi using network manager applet in comparison with `nm-connection-editor`.

