### PR TITLE
disable the appflowy

### DIFF
--- a/docs/src/release_notes/ghaf-24.06.md
+++ b/docs/src/release_notes/ghaf-24.06.md
@@ -40,7 +40,6 @@ The following target hardware is supported by this release:
   * Initial implementation of [IDS VM](../architecture/adr/idsvm.md) as a defensive network mechanism.
   * Support for [Element](https://element.io/) chat application.
   * GPS location sharing through the Element application.
-  * [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy) uses the [Flutter](https://github.com/flutter) application framework.
 * NVIDIA Jetson Orin NX:
   * UARTI passthrough.
   * The Jetpack baseline software updates and fixes.

--- a/modules/common/networking/hosts.nix
+++ b/modules/common/networking/hosts.nix
@@ -77,10 +77,6 @@ let
     }
     {
       ip = 104;
-      name = "appflowy-vm";
-    }
-    {
-      ip = 105;
       name = "business-vm";
     }
   ];

--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -140,14 +140,6 @@ in
             }
 
             {
-              name = "AppFlowy";
-              description = "Productivity & Note-Taking Application";
-              vm = "AppFlowy";
-              path = "${pkgs.givc-cli}/bin/givc-cli ${cliArgs} start appflowy";
-              icon = "${pkgs.appflowy}/opt/data/flutter_assets/assets/images/flowy_logo.svg";
-            }
-
-            {
               name = "Calculator";
               description = "Solve Math Problems";
               path = "${pkgs.gnome-calculator}/bin/gnome-calculator";

--- a/modules/desktop/graphics/demo-apps.nix
+++ b/modules/desktop/graphics/demo-apps.nix
@@ -29,7 +29,6 @@ in
     gala-app = mkProgramOption "Gala App" false;
     element-desktop = mkProgramOption "Element desktop" config.ghaf.graphics.enableDemoApplications;
     zathura = mkProgramOption "zathura" config.ghaf.graphics.enableDemoApplications;
-    appflowy = mkProgramOption "Appflowy" config.ghaf.graphics.enableDemoApplications;
   };
 
   config = lib.mkIf config.ghaf.profiles.graphics.enable {
@@ -63,12 +62,6 @@ in
         description = "PDF Viewer Application";
         path = "${pkgs.zathura}/bin/zathura";
         icon = "${pkgs.icon-pack}/document-viewer.svg";
-      }
-      ++ lib.optional (cfg.appflowy && pkgs.stdenv.isx86_64) {
-        name = "AppFlowy";
-        description = "Productivity & Note-Taking Application";
-        path = "${pkgs.appflowy}/bin/appflowy";
-        icon = "${pkgs.appflowy}/opt/data/flutter_assets/assets/images/flowy_logo.svg";
       };
   };
 }

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -79,10 +79,6 @@ in
           colour = "#337aff";
         }
         {
-          identifier = "AppFlowy";
-          colour = "#4c3f7a";
-        }
-        {
           identifier = "org.gnome.TextEditor";
           colour = "#353535";
         }

--- a/modules/reference/appvms/default.nix
+++ b/modules/reference/appvms/default.nix
@@ -22,7 +22,6 @@ in
         - Element
         - Slack
     '';
-    appflowy-vm = lib.mkEnableOption "Enable the Appflowy appvm";
     business-vm = lib.mkEnableOption "Enable the Business appvm";
     enabled-app-vms = lib.mkOption {
       type = lib.types.listOf lib.types.attrs;
@@ -40,7 +39,6 @@ in
         ++ (lib.optionals cfg.gala-vm [ (import ./gala.nix { inherit pkgs lib config; }) ])
         ++ (lib.optionals cfg.zathura-vm [ (import ./zathura.nix { inherit pkgs lib config; }) ])
         ++ (lib.optionals cfg.comms-vm [ (import ./comms.nix { inherit pkgs lib config; }) ])
-        ++ (lib.optionals cfg.appflowy-vm [ (import ./appflowy.nix { inherit pkgs lib config; }) ])
         ++ (lib.optionals cfg.business-vm [ (import ./business.nix { inherit pkgs lib config; }) ]);
     };
   };

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -36,7 +36,6 @@ in
           gala-vm = true;
           zathura-vm = true;
           comms-vm = true;
-          appflowy-vm = true;
           business-vm = true;
         };
 


### PR DESCRIPTION
unused and unloved

can be used as a reference of how we currently have to enable apps and app vms.

-------

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
carbon x1 MVP 

- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

removes appflowy. it should not be enabled `microvm -l` in the host should not show it and it should be removed from the launcher.