### PR TITLE
EWW: Hotkey indicators and performance improvements

### DIFF
--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -14,7 +14,6 @@ let
   audio-ctrl = pkgs.callPackage ../../../packages/audio-ctrl { };
 
   launcher-icon = "${pkgs.ghaf-artwork}/icons/launcher.svg";
-  security-icon = "${pkgs.ghaf-artwork}/icons/security-green.svg";
 
   battery-0-icon = "${pkgs.ghaf-artwork}/icons/battery-0.svg";
   battery-1-icon = "${pkgs.ghaf-artwork}/icons/battery-1.svg";
@@ -49,20 +48,6 @@ let
   suspend-icon = "${pkgs.ghaf-artwork}/icons/suspend.svg";
 
   arrow-right-icon = "${pkgs.ghaf-artwork}/icons/arrow-right.svg";
-
-  # Colors
-  ## Background
-  bg-secondary = "#2B2B2B";
-  ## Text
-  text-base = "#FFFFFF";
-  text-success = "#5AC379";
-  ## Icons
-  icon-subdued = "#3D3D3D";
-  ## Stroke
-  stroke-success = "#5AC379";
-
-  # Typography
-  font-bold = "600";
 
   # Called by eww.yuck for updates and reloads
   eww = "${pkgs.eww}/bin/eww -c /etc/eww";
@@ -103,9 +88,6 @@ let
           fi
       }
 
-      if [ "$1" = "calendar" ]; then
-          ${eww} update calendar_day="$(date +%d)" calendar_month="$(date +%-m)" calendar_year="$(date +%Y)"
-      fi
       open-widget "$1" "$2"
     '';
   };
@@ -168,39 +150,59 @@ let
     ];
     bashOptions = [ ];
     text = ''
-      BATTERY_PATH="/sys/class/power_supply/BAT0"
-      ENERGY_NOW=$(cat "$BATTERY_PATH/energy_now")
-      POWER_NOW=$(cat "$BATTERY_PATH/power_now")
-      CAPACITY=$(cat "$BATTERY_PATH/capacity")
-      STATUS=$(cat "$BATTERY_PATH/status")
+      icon() {
+        if [ "$1" -lt 10 ]; then
+            echo "${battery-0-icon}"
+        elif [ "$1" -lt 30 ]; then
+            echo "${battery-1-icon}"
+        elif [ "$1" -lt 70 ]; then
+            echo "${battery-2-icon}"
+        else
+            echo "${battery-3-icon}"
+        fi
+      }
 
       get() {
-          if [ "$POWER_NOW" -eq 0 ]; then
-          echo "{
-              \"remaining\": { \"hours\": \"0\", \"minutes_total\": \"0\", \"minutes\": \"0\" },
-              \"status\": \"$STATUS\",
-              \"capacity\": \"$CAPACITY\"
-          }"
-              exit
-          fi
+        BATTERY_PATH="/sys/class/power_supply/BAT0"
+        ENERGY_NOW=$(cat "$BATTERY_PATH/energy_now")
+        POWER_NOW=$(cat "$BATTERY_PATH/power_now")
+        CAPACITY=$(cat "$BATTERY_PATH/capacity")
+        STATUS=$(cat "$BATTERY_PATH/status")
+        ICON=$(icon "$CAPACITY")
+        if [ "$STATUS" = "Charging" ]; then
+            ICON="${battery-charging-icon}"
+        fi
+        if [ "$POWER_NOW" -eq 0 ]; then
+            echo "{
+                \"hours\": \"0\",
+                \"minutes_total\": \"0\",
+                \"minutes\": \"0\",
+                \"status\": \"$STATUS\",
+                \"capacity\": \"$CAPACITY\",
+                \"icon\": \"$ICON\"
+            }"
+            exit
+        fi
 
-          TIME_REMAINING=$(echo "scale=2; $ENERGY_NOW / $POWER_NOW" | bc)
+        TIME_REMAINING=$(echo "scale=2; $ENERGY_NOW / $POWER_NOW" | bc)
+        HOURS=$(echo "$TIME_REMAINING" | awk '{print int($1)}')
+        MINUTES_TOTAL=$(echo "$HOURS * 60" | bc | awk '{printf "%d\n", $1}')
+        MINUTES_REMAINDER=$(echo "($TIME_REMAINING - $HOURS) * 60" | bc | awk '{printf "%d\n", $1}')
 
-          HOURS=$(echo "$TIME_REMAINING" | awk '{print int($1)}')
-          MINUTES_TOTAL=$(echo "$HOURS * 60" | bc | awk '{printf "%d\n", $1}')
-          MINUTES_REMAINDER=$(echo "($TIME_REMAINING - $HOURS) * 60" | bc | awk '{printf "%d\n", $1}')
+        # If both hours and minutes are 0, return 0 for both
+        if [ "$HOURS" -eq 0 ] && [ "$MINUTES" -eq 0 ]; then
+            HOURS=0
+            MINUTES=0
+        fi
 
-          # If both hours and minutes are 0, return 0 for both
-          if [ "$HOURS" -eq 0 ] && [ "$MINUTES" -eq 0 ]; then
-              HOURS=0
-              MINUTES=0
-          fi
-
-          echo "{
-              \"remaining\": { \"hours\": \"$HOURS\", \"minutes_total\": \"$MINUTES_TOTAL\", \"minutes\": \"$MINUTES_REMAINDER\" },
-              \"status\": \"$STATUS\",
-              \"capacity\": \"$CAPACITY\"
-          }"
+        echo "{
+            \"hours\": \"$HOURS\",
+            \"minutes_total\": \"$MINUTES_TOTAL\",
+            \"minutes\": \"$MINUTES_REMAINDER\",
+            \"status\": \"$STATUS\",
+            \"capacity\": \"$CAPACITY\",
+            \"icon\": \"$ICON\"
+        }"
       }
 
       [ "$1" = "get" ] && get && exit
@@ -212,6 +214,7 @@ let
     runtimeInputs = [
       pkgs.wlr-randr
       pkgs.jq
+      pkgs.bash
     ];
     bashOptions = [ ];
     text = ''
@@ -225,6 +228,8 @@ let
           echo Starting ewwbar for display $screen
           ${eww} open --no-daemonize --screen "$screen" bar --id bar:$screen --arg screen="$screen"
       done
+      ${eww} open hotkey-indicator
+      ${eww} update volume="$(${eww-volume}/bin/eww-volume get)" brightness="$(${eww-brightness}/bin/eww-brightness get)"
     '';
   };
 
@@ -233,9 +238,23 @@ let
     runtimeInputs = [
       pkgs.gawk
       pkgs.brightnessctl
+      pkgs.inotify-tools
     ];
     bashOptions = [ ];
     text = ''
+      timer_pid=0
+
+        handle_hotkey_indicator() {
+            if [ "$timer_pid" -ne 0 ]; then
+                kill "$timer_pid" 2>/dev/null
+            fi
+            if ! ${eww} active-windows | grep -q "quick-settings"; then
+                ${eww} update hotkey-source="brightness" hotkey-brightness-visible="true"
+            fi
+            ( sleep 2; ${eww} update hotkey-brightness-visible="false") &
+            timer_pid=$!
+        }
+
       screen_level() {
           brightnessctl info | grep -oP '(?<=\().+?(?=%)' | awk '{print $1 + 0.0}'
       }
@@ -264,20 +283,27 @@ let
 
       set_screen() {
           brightnessctl set "$1""%" -q
-          ${eww} update brightness="$(get)"
       }
 
       get() {
           brightness=$(screen_level)
           icon=$(icon "$brightness")
-          echo "{
-              \"screen\": { \"level\": \"$brightness\" },
-              \"icon\": \"$icon\"
-          }"
+          echo "{ \"screen\": { \"level\": \"$brightness\" }, \"icon\": \"$icon\" }"
+      }
+
+      listen() {
+        inotifywait -m /sys/class/backlight/*/brightness | \
+        while read -r line; do
+            if echo "$line" | grep -q "CLOSE_WRITE"; then
+                handle_hotkey_indicator
+                get
+            fi
+        done
       }
 
       if [[ "$1" == 'get' ]]; then get; fi
       if [[ "$1" == 'set_screen' ]]; then set_screen "$2"; fi
+      if [[ "$1" == 'listen' ]]; then listen; fi
     '';
   };
 
@@ -285,16 +311,35 @@ let
     name = "eww-volume";
     runtimeInputs = [
       pkgs.gawk
+      pkgs.pulseaudio
       audio-ctrl
     ];
     bashOptions = [ ];
     text = ''
+        timer_pid=0
+
+        handle_hotkey_indicator() {
+            if [ "$timer_pid" -ne 0 ]; then
+                kill "$timer_pid" 2>/dev/null
+            fi
+
+            if ! ${eww} active-windows | grep -q "quick-settings"; then
+                ${eww} update hotkey-source="volume" hotkey-volume-visible="true"
+            fi
+            ( sleep 2; ${eww} update hotkey-volume-visible="false") &
+            timer_pid=$!
+        }
+
       volume_level() {
           audio-ctrl get | awk '{print $1 + 0.0}'
       }
 
+      is_muted() {
+          audio-ctrl get_mut
+      }
+
       icon() {
-          if [ "$1" -eq 0 ]; then
+          if [[ "$2" == "true" || "$1" -eq 0 ]]; then
               echo "${volume-0-icon}"
           elif [ "$1" -lt 25 ]; then
               echo "${volume-1-icon}"
@@ -307,20 +352,46 @@ let
 
       set_volume() {
           audio-ctrl set "$1"
-          ${eww} update volume="$(get)"
+      }
+
+      mute() {
+          audio-ctrl mut
       }
 
       get() {
           volume=$(volume_level)
-          icon=$(icon "$volume")
-          echo "{
-              \"level\": \"$volume\",
-              \"icon\": \"$icon\"
-          }"
+          muted=$(is_muted)
+          icon=$(icon "$volume" "$muted")
+          echo "{ \"level\": \"$volume\", \"muted\": \"$muted\", \"icon\": \"$icon\" }"
+      }
+
+      listen() {
+        # Initialize variables to store previous volume and mute state
+        prev_volume=""
+        prev_mute_status=""
+
+        pactl -s audio-vm:4713 subscribe | while read -r event; do
+            if echo "$event" | grep -q "sink"; then
+                current_volume=$(volume_level)
+                current_mute_status=$(is_muted)
+
+                # Check if volume or mute status changed
+                if [[ "$current_volume" != "$prev_volume" || "$current_mute_status" != "$prev_mute_status" ]]; then
+                    handle_hotkey_indicator
+                    get
+
+                    # Update previous states
+                    prev_volume="$current_volume"
+                    prev_mute_status="$current_mute_status"
+                fi
+            fi
+        done
       }
 
       if [[ "$1" == 'get' ]]; then get; fi
       if [[ "$1" == 'set_volume' ]]; then set_volume "$2"; fi
+      if [[ "$1" == 'listen' ]]; then listen; fi
+      if [[ "$1" == 'mute' ]]; then mute; fi
     '';
   };
 
@@ -329,14 +400,11 @@ let
     runtimeInputs = [ pkgs.givc-cli ];
     bashOptions = [ ];
     text = ''
-      # Check if an argument is provided
       if [ $# -ne 1 ]; then
       echo "Usage: $0 {reboot|poweroff|suspend}"
       fi
 
-      # Validate the argument
       case "$1" in (reboot|poweroff|suspend)
-          # Call the givc-cli command with the provided argument
           givc-cli ${cliArgs} "$1"
           ;;
       *)
@@ -356,19 +424,19 @@ in
         ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
         ;;							   Variables        					     ;;	
         ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-        (defpoll keyboard_layout :interval "1s" "${pkgs.xorg.setxkbmap}/bin/setxkbmap -query | ${pkgs.gawk}/bin/awk '/layout/{print $2}' | tr a-z A-Z")
-        (defpoll time :interval "1s" "date +'%H:%M'")
-        (defpoll date :interval "1m" "date +'%a %b %-d'")
-        (defpoll calendar_day :interval "10h"
-            "date '+%d'")
-        (defpoll calendar_month :interval "10h"
-            "date '+%-m'")
-        (defpoll calendar_year :interval "10h"
-            "date '+%Y'")
+        (defpoll keyboard_layout :interval "5s" "${pkgs.xorg.setxkbmap}/bin/setxkbmap -query | ${pkgs.gawk}/bin/awk '/layout/{print $2}' | tr a-z A-Z")
         (defpoll wifi  :interval "5s" :initial "{}" "${eww-wifi}/bin/eww-wifi get")
-        (defpoll battery  :interval "2s" :initial "{}" "${eww-bat}/bin/eww-bat get")
-        (defpoll brightness  :interval "1s" :initial "{}" "${eww-brightness}/bin/eww-brightness get")
-        (defpoll volume  :interval "1s" :initial "{}" "${eww-volume}/bin/eww-volume get")
+        (defpoll battery  :interval "5s" :initial "{}" "${eww-bat}/bin/eww-bat get")
+        (deflisten brightness "${eww-brightness}/bin/eww-brightness listen")
+        (deflisten volume "${eww-volume}/bin/eww-volume listen")
+
+        (defvar calendar_day "date '+%d'")
+        (defvar calendar_month "date '+%-m'")
+        (defvar calendar_year "date '+%Y'")
+
+        (defvar hotkey-brightness-visible "false")
+        (defvar hotkey-volume-visible "false")
+        (defvar hotkey-source "volume")
         ;; (defpoll bluetooth  :interval "3s" :initial "{}" "${pkgs.bt-launcher}/bin/bt-launcher status")
 
         ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -381,112 +449,123 @@ in
                 (image :path "${launcher-icon}")))
 
         ;; Generic slider widget ;;
-        (defwidget sys_slider [?header icon ?settings-icon level onchange ?onclick ?class ?font-icon ?min] 
-        (box :orientation "v"
-            :class "qs-slider"
-            :spacing 10
-            :space-evenly false
-            (label :class "header" 
-                :visible { header != "" && header != "null" ? "true" : "false" } 
-                :text header
-                :hexpand true
-                :halign "start")
-            (box :orientation "h"
-                :space-evenly false
-                (box :class "icon"
-                    :visible {font-icon == "" ? "true" : "false"}
-                    :hexpand false
-                    :style "background-image: url(\"''${icon}\")")
-                (label :class "icon" :visible {font-icon != "" ? "true" : "false"} :text font-icon)
-                (eventbox
-                    :valign "CENTER"
-                    :class "slider"
-                    :hexpand true
-                    (scale
-                        :hexpand true
-                        :orientation "h"
-                        :halign "fill"
-                        :value level
-                        :onchange onchange
-                        :max 101 
-                        :min { min ?: 0 }))
-                (eventbox 
-                    :visible { onclick != "" && onclick != "null" ? "true" : "false" }
-                    :onclick onclick
-                    :class "settings"
-                    (box :class "icon"
-                        :hexpand false
-                        :style "background-image: url(\"''${settings-icon}\")")))
-        ))
-        (defwidget sys_sliders []
-        (box
-            :orientation "v"
-            :spacing 10
-            :hexpand false
-            (sys_slider
-                    :header "Volume"
-                    :icon {volume.icon}
-                    :settings-icon "${arrow-right-icon}"
-                    :level {volume.level}
-                    :onchange "${eww-volume}/bin/eww-volume set_volume {} &")
-            (sys_slider
-                    :header "Display"
-                    :level {brightness.screen.level}
-                    :icon {brightness.icon}
-                    :min "5"
-                    :onchange "${eww-brightness}/bin/eww-brightness set_screen {} &")
-        ))
-        (defwidget widget_button [icon ?title header ?subtitle ?onclick ?font-icon] 
-        (eventbox :class "qs-info-button" :onclick onclick
-        (box :orientation "v"
-            :class "qs-info-button-padding"
-            :spacing 10
-            :space-evenly false
-            (label :class "title" 
-                :visible { title != "" && title != "null" ? "true" : "false" } 
-                :text title
-                :hexpand true
-                :vexpand false
-                :halign "start")
-            (box :orientation "h"
+        (defwidget sys_slider [?header icon ?settings-icon level ?onchange ?settings-onclick ?icon-onclick ?class ?font-icon ?min] 
+            (box :orientation "v"
+                :class "qs-slider"
                 :spacing 10
-                :valign "center"
-                :vexpand "false"
                 :space-evenly false
-                (box :class "icon"
-                    :visible {font-icon == "" ? "true" : "false"}
-                    :valign "center"
+                (label :class "header" 
+                    :visible { header != "" && header != "null" ? "true" : "false" } 
+                    :text header
                     :halign "start"
-                    :hexpand false
-                    :style "background-image: url(\"''${icon}\")")
-                (label :class "icon" :visible {font-icon != "" ? "true" : "false"} :text font-icon)
-                (box :class "text"
+                    :hexpand true)
+                (box :orientation "h" 
+                    :valign "end"
+                    :space-evenly false
+                    (eventbox 
+                        :active { icon-onclick != "" && icon-onclick != "null" ? "true" : "false" }
+                        :visible {font-icon == "" ? "true" : "false"}
+                        :onclick icon-onclick
+                        :hexpand false
+                        :class "icon_settings"
+                        (box :class "icon"
+                            :hexpand false
+                            :style "background-image: url(\"''${icon}\")"))
+                    (label :class "icon" :visible {font-icon != "" ? "true" : "false"} :text font-icon)
+                    (eventbox
+                        :valign "CENTER"
+                        :class "slider"
+                        :hexpand true
+                        (scale
+                            :hexpand true
+                            :orientation "h"
+                            :halign "fill"
+                            :value level
+                            :onchange onchange
+                            :max 101 
+                            :min { min ?: 0 }))
+                    (eventbox 
+                        :visible { settings-onclick != "" && settings-onclick != "null" ? "true" : "false" }
+                        :onclick settings-onclick
+                        :class "settings"
+                        (box :class "icon"
+                            :hexpand false
+                            :style "background-image: url(\"''${settings-icon}\")")))))
+
+        (defwidget sys_sliders []
+            (box
+                :orientation "v"
+                :spacing 10
+                :hexpand false
+                :space-evenly false
+                (sys_slider
+                        :header "Volume"
+                        :icon {volume.icon}
+                        :icon-onclick "${eww-volume}/bin/eww-volume mute &"
+                        :settings-icon "${arrow-right-icon}"
+                        :level { volume.muted == "true" ? "0" : volume.level }
+                        :onchange "${eww-volume}/bin/eww-volume set_volume {} &")
+                (sys_slider
+                        :header "Display"
+                        :level {brightness.screen.level}
+                        :icon {brightness.icon}
+                        :min "5"
+                        :onchange "${eww-brightness}/bin/eww-brightness set_screen {} &")))
+
+        ;; Generic Widget Buttons For Quick Settings ;;
+        (defwidget widget_button [icon ?title header ?subtitle ?onclick ?font-icon] 
+            (eventbox :class "qs-info-button" :onclick onclick
+                (box :orientation "v"
+                    :class "qs-info-button-padding"
+                    :spacing 10
                     :valign "center"
-                    :orientation "v" 
-                    :spacing 3
-                    :halign "start"
-                    :hexpand true
-                    (label :halign "start" :class "header" :text header)
-                    (label :visible {subtitle != "" ? "true" : "false"} :halign "start" :class "subtitle" :text subtitle :limit-width 13))
-        ))))
+                    :space-evenly false
+                    (label :class "title" 
+                        :visible { title != "" && title != "null" ? "true" : "false" } 
+                        :text title
+                        :hexpand true
+                        :vexpand false
+                        :halign "start")
+                    (box :orientation "h"
+                        :spacing 10
+                        :valign "center"
+                        :vexpand "false"
+                        :space-evenly false
+                        (box :class "icon"
+                            :visible {font-icon == "" ? "true" : "false"}
+                            :valign "center"
+                            :halign "start"
+                            :hexpand false
+                            :style "background-image: url(\"''${icon}\")")
+                        (label :class "icon" :visible {font-icon != "" ? "true" : "false"} :text font-icon)
+                        (box :class "text"
+                            :valign "center"
+                            :orientation "v" 
+                            :spacing 3
+                            :halign "start"
+                            :hexpand true
+                            (label :halign "start" :class "header" :text header)
+                            (label :visible {subtitle != "" ? "true" : "false"} :halign "start" :class "subtitle" :text subtitle :limit-width 13))))))
+
         (defwidget widget_button_small [icon ?onclick ?header] 
-        (eventbox :class "qs-info-button-small"
-            :onclick onclick
-            (box :orientation "h"
-                :space-evenly false
-                (box :class "icon"
-                    :valign "center"
-                    :halign "start"
-                    :hexpand false
-                    :style "background-image: url(\"''${icon}\")")
-                (box :class "text"
-                    :valign "center"
-                    :orientation "v" 
-                    :spacing 3
-                    :halign "start"
-                    :hexpand true
-                    (label :halign "start" :class "header" :text header :visible {header != "" ? "true" : "false"}))
-        )))
+            (eventbox :class "qs-info-button-small"
+                :onclick onclick
+                (box :orientation "h"
+                    :space-evenly false
+                    (box :class "icon"
+                        :valign "center"
+                        :halign "start"
+                        :hexpand false
+                        :style "background-image: url(\"''${icon}\")")
+                    (box :class "text"
+                        :valign "center"
+                        :orientation "v" 
+                        :spacing 3
+                        :halign "start"
+                        :hexpand true
+                        (label :halign "start" :class "header" :text header :visible {header != "" ? "true" : "false"})))))
+
+        ;; Power Menu Buttons ;;
         (defwidget power_menu []
         (box
             :orientation "v"
@@ -506,142 +585,100 @@ in
             (widget_button
                     :icon "${restart-icon}"
                     :header "Reboot"
-                    :onclick "${eww-popup}/bin/eww-popup power-menu & ${eww-power}/bin/eww-power reboot &")
-        ))
+                    :onclick "${eww-popup}/bin/eww-popup power-menu & ${eww-power}/bin/eww-power reboot &")))
+
+        ;; Quick Settings Buttons ;;
         (defwidget settings_buttons []
-        (box
-            :orientation "v"
-            :spacing 10
             (box
-                :orientation "h"
+                :orientation "v"
+                :spacing 10
+                (box
+                    :orientation "h"
+                    :space-evenly true
+                    :spacing 10
+                    (widget_button
+                        :icon {wifi.icon}
+                        :header "WiFi"
+                        :subtitle {wifi.ssid ?: "Not connected"}
+                        :onclick "${eww-popup}/bin/eww-popup quick-settings; ${pkgs.nm-launcher}/bin/nm-launcher &")
+                    (widget_button
+                        :icon "${bluetooth-1-icon}"
+                        :header "Bluetooth"
+                        :onclick "${eww-popup}/bin/eww-popup quick-settings; ${pkgs.bt-launcher}/bin/bt-launcher &"))))
+
+        ;; Battery Widget In Quick Settings ;;
+        (defwidget etc []
+            (box :orientation "h"
                 :space-evenly true
                 :spacing 10
                 (widget_button
-                    :icon {wifi.icon}
-                    :header "WiFi"
-                    :subtitle {wifi.ssid ?: "Not connected"}
-                    :onclick "${eww-popup}/bin/eww-popup quick-settings; ${pkgs.nm-launcher}/bin/nm-launcher &")
-                (widget_button
-                    :icon "${bluetooth-1-icon}"
-                    :header "Bluetooth"
-                    :onclick "${eww-popup}/bin/eww-popup quick-settings; ${pkgs.bt-launcher}/bin/bt-launcher &"))
-        ))
-        (defwidget etc []
-        (box :orientation "h"
-            :space-evenly true
-            :spacing 10
-            (widget_button
-                :visible { EWW_BATTERY != "" ? "true" : "false" }
-                :hexpand true
-                :vexpand true
-                :subtitle { battery.status == 'Charging' ? "Charging" : 
-                            battery.remaining.hours != "0" && battery.remaining.minutes != "0" ? "''${battery.remaining.hours}h ''${battery.remaining.minutes}m" : 
-                            battery.remaining.hours == "0" && battery.remaining.minutes != "0" ? "''${battery.remaining.minutes}m" :
-                            battery.remaining.hours != "0" && battery.remaining.minutes == "0" ? "''${battery.remaining.hours}h" : 
-                            "" }
-                :header {EWW_BATTERY != "" ? "''${EWW_BATTERY.BAT0.capacity}%" : "100%"}
-                :icon {EWW_BATTERY.BAT0.status == 'Charging' ? "${battery-charging-icon}" :
-                        EWW_BATTERY.BAT0.capacity < 10 ? "${battery-0-icon}" :
-                            EWW_BATTERY.BAT0.capacity <= 30 ? "${battery-1-icon}" :
-                                EWW_BATTERY.BAT0.capacity <= 70 ? "${battery-2-icon}" : "${battery-3-icon}"})
-            (box
-                :hexpand true
-                :vexpand true
-                :class "spacer"
-            )
-        ))
-        (defwidget quick-settings-widget []
-        (box :class "quick-settings"  
-            :orientation "v"
-            :space-evenly false
-            (box 
-                :class "wrapper_widget"
-                :space-evenly false
-                :spacing 10
-                :orientation "v"
-                (etc)
-                (sys_sliders)
-                (settings_buttons))))
-
-        (defwidget power-menu-widget []
-        (box :class "quick-settings"  
-            :orientation "v"
-            :space-evenly false
-            (box 
-                :class "wrapper_widget"
-                :space-evenly false
-                :orientation "v"
-                (power_menu))))
-
-        (defwidget hotkey_indicator [icon level] 
-        (box :class "widget"
-            :orientation "h"
-            (box :class "icon"
-                :style "background-image: url(\"''${icon}\")")
-            (box
-                :space-evenly false
-                :class "percent"
-                (label
-                    :visible { level != "" && level != "null" ? "true" : "false" }
+                    :visible { EWW_BATTERY != "" ? "true" : "false" }
                     :hexpand true
-                    :halign "END"
-                    :text "''${level}%"))))
+                    :vexpand true
+                    :subtitle { battery.status == 'Charging' ? "Charging" : 
+                                battery.hours != "0" && battery.minutes != "0" ? "''${battery.hours}h ''${battery.minutes}m" : 
+                                battery.hours == "0" && battery.minutes != "0" ? "''${battery.minutes}m" :
+                                battery.hours != "0" && battery.minutes == "0" ? "''${battery.hours}h" : 
+                                "" }
+                    :header {EWW_BATTERY != "" ? "''${battery.capacity}%" : "100%"}
+                    :icon {battery.icon})
+                (box
+                    :hexpand true
+                    :vexpand true
+                    :class "spacer"
+                )))
 
-        (defwidget brightness_hotkey_indicator []
-        (box :class "hotkey-indicator"
-            (hotkey_indicator
-                :icon "${security-icon}"
-                :level {brightness.screen.level})))
-        (defwidget volume_hotkey_indicator []
-        (box :class "hotkey-indicator"
-            (hotkey_indicator
-                :icon "${bluetooth-1-icon}"
-                :level {volume?.level})))
+        ;; Quick Settings Widget ;;
+        (defwidget quick-settings-widget []
+            (box :class "quick-settings"  
+                :orientation "v"
+                :space-evenly false
+                (box 
+                    :class "wrapper_widget"
+                    :space-evenly false
+                    :spacing 10
+                    :orientation "v"
+                    (etc)
+                    (sys_sliders)
+                    (settings_buttons))))
 
-        ;; Battery ;;
-        (defwidget bat [?capacity ?status ?remaining]
-            (tooltip
-                (label  :class "tooltip"
-                        :text { status == 'Charging' ? "''${status} ''${capacity}%" :
-                                status == 'N/A' ? "Battery N/A" :
-                                remaining != "" ? "Battery ''${capacity}% (''${remaining})" : "Battery ''${capacity}%" })
-                (button :class "icon_button"
-                    (image :path { status == 'Charging' ? "${battery-charging-icon}" : status == 'N/A' ? "${battery-charging-icon}" :
-                                    capacity < 10 ? "${battery-0-icon}" :
-                                        capacity <= 30 ? "${battery-1-icon}" :
-                                            capacity <= 70 ? "${battery-2-icon}" : "${battery-3-icon}" }))))
-        (defwidget bat-icon-widget [?capacity ?status]
-            (image :path { status == 'Charging' ? "${battery-charging-icon}" : status == 'N/A' ? "${battery-charging-icon}" :
-                    capacity < 10 ? "${battery-0-icon}" :
-                        capacity <= 30 ? "${battery-1-icon}" :
-                            capacity <= 70 ? "${battery-2-icon}" : "${battery-3-icon}" }))
+        ;; Power Menu Widget ;;
+        (defwidget power-menu-widget []
+            (box :class "quick-settings"  
+                :orientation "v"
+                :space-evenly false
+                (box 
+                    :class "wrapper_widget"
+                    :space-evenly false
+                    :orientation "v"
+                    (power_menu))))
 
-        ;; Wifi ;;
-        (defwidget wifi []
-            (tooltip
-            (label  :class "tooltip"
-                    :text {wifi.connected != 'false' ? "''${wifi.connected}: ''${wifi.ssid}" : "No connection"})
-            (button :class "icon_button"
-                    :onclick "${pkgs.nm-launcher}/bin/nm-launcher &"
-                    (image :path {wifi.connected == "false" ? "${wifi-0-icon}":
-                            "''${wifi.signal ?: -1}" < 0 ? "${wifi-0-icon}" :
-                                "''${wifi.signal ?: -1}" < 30 ? "${wifi-1-icon}" :
-                                    "''${wifi.signal ?: -1}" < 60 ? "${wifi-2-icon}" :
-                                        "''${wifi.signal ?: -1}" < 80 ? "${wifi-3-icon}" : "${wifi-4-icon}"}))))
+        ;; Generic Hotkey Indicator Widget ;;
+        (defwidget hotkey_indicator [icon level] 
+            (box :class "hotkey" 
+                :active false
+                (sys_slider
+                    :valign "center"
+                    :icon icon
+                    :level level)))
 
-        ;; Bluetooth ;;
-        (defwidget bluetooth []
-            (button :class "icon_button"
-                (image 
-                :path "${bluetooth-1-icon}")))
+        ;; Hotkeys Widget ;;
+        (defwidget hotkeys []
+            (revealer :transition "crossfade" :duration "200ms" :reveal { hotkey-brightness-visible || hotkey-volume-visible }
+                (box :vexpand false
+                    :hexpand false
+                    :orientation "v"
+                    :class "wrapper_widget"
+                    (stack :transition "none"
+                        :selected { hotkey-source == "brightness" ? "0" : "1" }
+                        (hotkey_indicator
+                            :icon {brightness.icon}
+                            :level {brightness.screen.level})
+                        (hotkey_indicator
+                            :icon {volume.icon}
+                            :level { volume.muted == "true" ? "0" : volume.level })))))
 
-        ;; Security ;;
-        (defwidget security []
-            (button :class "icon_button"
-                (image 
-                :path "${security-icon}")))
-
-        ;; Quick settings button ;;
+        ;; Quick Settings Button ;;
         (defwidget quick-settings-button [screen wifi-icon bat-icon vol-icon bright-icon]
             (button :class "icon_button" :onclick "${eww-popup}/bin/eww-popup quick-settings ''${screen} &"
                 (box :orientation "h"
@@ -661,7 +698,7 @@ in
                         :hexpand false
                         :style "background-image: url(\"''${wifi-icon}\")"))))
 
-        ;; Power menu launcher ;;
+        ;; Power Menu Launcher ;;
         (defwidget power-menu-launcher [screen]
             (button :class "icon_button icon" 
                 :halign "center" 
@@ -671,7 +708,7 @@ in
                     :hexpand false
                     :style "background-image: url(\"${power-icon}\")")))
 
-        ;; Control Panel Widgets ;;	
+        ;; Quick Settings Launcher ;;	
         (defwidget control [screen]
             (box :orientation "h" 
                 :space-evenly "false" 
@@ -682,13 +719,7 @@ in
                     :bright-icon {brightness.icon}
                     :vol-icon {volume.icon}
                     :wifi-icon {wifi.icon}
-                    :bat-icon { EWW_BATTERY.BAT0.status == "Charging" ? "${battery-charging-icon}" : 
-                                EWW_BATTERY.BAT0.status == "" ?         "${battery-charging-icon}" :
-                                EWW_BATTERY.BAT0.capacity < 10 ?        "${battery-0-icon}" :
-                                EWW_BATTERY.BAT0.capacity <= 30 ?       "${battery-1-icon}" :
-                                EWW_BATTERY.BAT0.capacity <= 70 ?       "${battery-2-icon}" : 
-                                                                        "${battery-3-icon}" }
-                    )))
+                    :bat-icon {battery.icon})))
 
         ;; Divider ;;
         (defwidget divider []
@@ -708,26 +739,24 @@ in
         ;; Clock ;;
         (defwidget time []
             (label 
-                :text time
+                :text "''${formattime(EWW_TIME, "%H:%M")}"
                 :class "time"))
 
         ;; Date ;;
         (defwidget date [screen]
             (button 
-                :onclick "${eww-popup}/bin/eww-popup calendar ''${screen} &"
-                :class "icon_button date" date))
+                :onclick "''${EWW_CMD} update calendar_day=\"$(date +%d)\" calendar_month=\"$(date +%-m)\" calendar_year=\"$(date +%Y)\"; ${eww-popup}/bin/eww-popup calendar ''${screen} &"
+                :class "icon_button date" "''${formattime(EWW_TIME, "%a %b %-d")}"))
 
         ;; Calendar ;;
         (defwidget cal []
-        (eventbox
-            :onhoverlost "${eww-popup}/bin/eww-popup calendar &"
             (box :class "cal-box" 
-            (box :class "cal-inner-box"
-                (calendar :class "cal" 
-                    :show-week-numbers false
-                    :day calendar_day 
-                    :month calendar_month 
-                    :year calendar_year)))))
+                (box :class "cal-inner-box"
+                    (calendar :class "cal" 
+                        :show-week-numbers false
+                        :day calendar_day
+                        :month calendar_month
+                        :year calendar_year))))
 
         ;; Left Widgets ;;
         (defwidget left []
@@ -742,7 +771,7 @@ in
         (defwidget datetime-locale [screen]
             (box	
                 :orientation "h"
-                :space-evenly "false" 
+                :space-evenly "false"
                 :spacing 14
                 (language)
                 (box
@@ -820,20 +849,13 @@ in
             (power-menu-widget))
 
         ;; Hotkey indicator window ;;
-        (defwindow volume-hotkey-indicator
+        (defwindow hotkey-indicator
             :monitor 0
-            :geometry (geometry :y "-200px" 
+            :geometry (geometry :y "150px" 
                                 :x "0px"
-                                :anchor "center")
+                                :anchor "bottom center")
             :stacking "overlay"
-            (volume_hotkey_indicator))
-        (defwindow brightness-hotkey-indicator
-            :monitor 0
-            :geometry (geometry :y "-200px" 
-                                :x "0px"
-                                :anchor "center")
-            :stacking "overlay"
-            (brightness_hotkey_indicator))
+            (hotkeys))
       '';
 
       # The UNIX file mode bits
@@ -847,6 +869,12 @@ in
         $bg-primary: #121212;
         $widget-bg: #1A1A1A;
         $widget-hover: #282828;
+        $bg-secondary: #2B2B2B;
+        $text-base: #FFFFFF;
+        $text-success: #5AC379;
+        $icon-subdued: #3D3D3D;
+        $stroke-success: #5AC379;
+        $font-bold: 600;
 
         @mixin unset($rec: false) {
             all: unset;
@@ -864,16 +892,16 @@ in
             padding: $padding;
         }
 
-        @mixin wrapper_widget(){
+        @mixin wrapper_widget($padding: 14px, $radius: 6px){
             @include widget($padding: 14px, $radius: 6px, $bg: $bg-primary);
         }
 
-        @mixin floating_widget($margin: 0.3em 0.3em 0em 0em){
+        @mixin floating_widget($margin: 0.3em 0.3em 0em 0em, $padding: 14px, $radius: 6px){
             @include unset($rec: true);
-            border-radius: 6px;
+            border-radius: $radius;
             margin: $margin;
 
-            .wrapper_widget { @include wrapper_widget; }
+            .wrapper_widget { @include wrapper_widget($padding: $padding, $radius: $radius); }
             box-shadow: 0px 32px 64px 0px rgba(0, 0, 0, 0.24);
         }
 
@@ -881,6 +909,7 @@ in
             background-color: transparent;
             background-repeat: no-repeat;
             background-position: center;
+            background-size: contain;
             min-height: 24px;
             min-width: 24px;
             font-family: Fira Code;
@@ -911,30 +940,37 @@ in
             }
         }
 
-        @mixin slider($slider-width: 225px, $slider-height: 2px, $thumb: true, $thumb-width: 1em, $focusable: true, $radius: 7px, $shadows: true, $trough-bg: #282828) {
+        @mixin slider($slider-width: 225px, $slider-height: 2px, $thumb: true, $thumb-width: 1em, $focusable: true, $radius: 7px, $shadows: true, $trough-bg: $widget-hover) {
             trough {
                 border-radius: $radius;
                 border: 0;
                 background-color: $trough-bg;
                 min-height: $slider-height;
                 min-width: $slider-width;
-                margin: $thumb-width;
+                margin: $thumb-width / 2;
 
                 highlight,
                 progress {
-                    background-color: ${stroke-success};
+                    background-color: $stroke-success;
                     border-radius: $radius;
                 }
             }
 
             slider {
-                box-shadow: none;
-                background-color: #D3D3D3;
-                border: 0 solid transparent;
-                border-radius: 50%;
-                min-height: $thumb-width;
-                min-width: $thumb-width;
-                margin: -($thumb-width / 2) 0;
+                @if $thumb {
+                    box-shadow: none;
+                    background-color: #D3D3D3;
+                    border: 0 solid transparent;
+                    border-radius: 50%;
+                    min-height: $thumb-width;
+                    min-width: $thumb-width;
+                    margin: -($thumb-width / 2) 0;
+                } @else {
+                    margin: 0;
+                    min-width: 0;
+                    min-height: 0;
+                    background-color: transparent;
+                }
             }
 
             &:hover {
@@ -950,10 +986,8 @@ in
             }
 
             &:disabled {
-
                 highlight,
                 progress {
-                    background-color: transparentize(#D3D3D3, 0.4);
                     background-image: none;
                 }
             }
@@ -985,18 +1019,10 @@ in
             .settings{
                 @include icon-button;
                 margin-left: 0.15em;
-
-                .icon{
-                    @include icon;
-                }
             }
 
-            .icon{
-                background-color: transparent;
-                background-repeat: no-repeat;
-                background-position: center;
-                min-height: 24px;
-                min-width: 24px;
+            .icon_settings{
+                @include icon-button;
                 margin-right: 0.15em;
             }
         }
@@ -1064,7 +1090,7 @@ in
             }
 
             .text {
-                color: ${text-base};
+                color: $text-base;
                 font-family: "Inter";
                 
                 .header {
@@ -1080,43 +1106,24 @@ in
             }
         }
 
-        .qs-widget{ @include qs-widget; }
+        .qs-widget { @include qs-widget; }
 
         .wrapper_widget { @include wrapper_widget; }
 
         .icon { @include icon; }
 
-        .quick-settings{
-            @include floating_widget;
-        }
+        .quick-settings { @include floating_widget; }
 
-        .qs-slider{ 
+        .qs-slider { 
             @include sys-sliders;
-            @include qs-widget;
-            padding: 0.625em;
+            @include qs-widget($min-height: 0px);
+            padding: 0.8em;
         }
 
-        .hotkey-indicator{
-            @include floating_widget($margin: 0);
-
-            .widget{
-                @include widget;
-            }
-
-            .percent{
-                margin-left: 1em;
-                min-width: 2.6em;
-            }
-            
-            .icon{
-                background-color: $bg-primary;
-                background-repeat: no-repeat;
-                background-position: center;
-                min-height: 24px;
-                min-width: 24px;
-                margin-right: 1em;
-
-            }
+        .hotkey {
+            @include floating_widget($margin: 0, $padding: 10px 12px);
+            @include icon;
+            .slider{ @include slider($slider-width: 150px, $thumb: false, $slider-height: 5px); }
         }
 
         .widget-button { @include widget-button; }
@@ -1136,18 +1143,8 @@ in
             @include icon-button;
         }
 
-        .tooltip {
-            background-color: $bg-primary;
-            color: ${text-base};
-            font-family: "Inter";
-            font-size: 1em;
-            font-weight: ${font-bold};
-            padding: 0.25em 0.5em;
-            border-radius: 4px;
-        }
-
         .divider {
-            background-color: ${icon-subdued};
+            background-color: $icon-subdued;
             padding-left: 1px;
             padding-right: 1px;
             border-radius: 10px;
@@ -1158,18 +1155,18 @@ in
             border-radius: 0.25em;
             background-color: $bg-primary;
             font-family: "Inter";
-            font-weight: ${font-bold};
+            font-weight: $font-bold;
             font-size: 1em;
-            color: ${text-base};
+            color: $text-base;
         }
 
         .date {
             padding: 0.4em 0.25em;
             border-radius: 0.25em;
             font-family: "Inter";
-            font-weight: ${font-bold};
+            font-weight: $font-bold;
             font-size: 1em;
-            color: ${text-base};
+            color: $text-base;
         }
 
         .keyboard-layout {
@@ -1177,9 +1174,9 @@ in
             border-radius: 4px;
             background-color: $bg-primary;
             font-family: "Inter";
-            font-weight: ${font-bold};
+            font-weight: $font-bold;
             font-size: 1em;
-            color: ${text-base};
+            color: $text-base;
         }
 
         .spacer {
@@ -1189,40 +1186,42 @@ in
         .cal-box {
             @include floating_widget;
             background-color: $bg-primary;
-        }
 
-        .cal {
-            font-family: "Inter";
-            font-size: 1.2em;
-            padding: 0.2em 0.2em;
-        }
+            .cal {
+                font-family: "Inter";
+                font-size: 1.2em;
+                padding: 0.2em 0.2em;
+            }
 
-        .cal-box .cal-inner-box {
-            @include wrapper_widget;
-        }
+            .cal-inner-box {
+                @include wrapper_widget;
+            }
 
-        calendar.header {
-            color: ${text-base};
-            font-weight: ${font-bold};
-        }
+            calendar {
+                &.header {
+                    color: $text-base;
+                    font-weight: $font-bold;
+                }
 
-        calendar:selected {
-            color: ${text-success};
-        }
+                &:selected {
+                    color: $text-success;
+                }
 
-        calendar.button {
-            color: ${stroke-success};
-            padding: 0.3;
-            border-radius: 4px;
-            border: none;
-        }
+                &.button {
+                    color: $stroke-success;
+                    padding: 0.3;
+                    border-radius: 4px;
+                    border: none;
 
-        calendar.button:hover {
-            background-color: ${bg-secondary};
-        }
+                    &:hover {
+                        background-color: $bg-secondary;
+                    }
+                }
 
-        calendar:indeterminate {
-            color: $bg-primary;
+                &:indeterminate {
+                    color: $bg-primary;
+                }
+            }
         }
 
       '';

--- a/packages/audio-ctrl/default.nix
+++ b/packages/audio-ctrl/default.nix
@@ -10,22 +10,31 @@ writeShellApplication {
   text = ''
     export PULSE_SERVER=audio-vm:4713
 
+    unmute() {
+      if [[ "$(pamixer --get-mute)" == "true" ]]; then
+          pamixer -t
+      fi
+    }
+
     case "$1" in
       inc)
+        # Unmute if muted
+        unmute
         # Increase volume by 5%
         pamixer -i 5
         ;;
       dec)
+        # Unmute if muted
+        unmute
         # Decrease volume by 5%
         pamixer -d 5
         ;;
       mut)
         # Toggle mute
-        if [ "$(pamixer --get-mute)" = "false" ]; then
-          pamixer -m
-        else
-          pamixer -u
-        fi
+        pamixer -t
+        ;;
+      get_mut)
+        pamixer --get-mute
         ;;
       get)
         # Get current volume level
@@ -34,6 +43,10 @@ writeShellApplication {
       set)
         # Set volume to a specific level
         if [ -n "$2" ]; then
+          # Unmute if muted
+          if [[ "$(pamixer --get-mute)" == "true" ]]; then
+              pamixer -t
+          fi
           pamixer --set-volume "$2"
         fi
         ;;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

1. **Added Hotkey Indicators:**
   - Hotkey indicators are simple, non-interactive widgets designed to display changes in volume and brightness.
   - The indicators appear only on the built-in display (display:0) when volume or brightness events are detected.
   - Note that the hotkey indicators will not appear when the Quick Settings widget is open. This is by design.

2. **Volume Mute Button In Quick Settings:**
   - Volume can now be muted by clicking the speaker icon in the Quick Settings widget.

3. **Volume Icon Now Accurately Displays Muted State**

4. **Changed From Polling To Event Listeners:**
   - Replaced some polling variables with event listeners to enhance efficiency.
   - Added the `get_mut` option in audio-ctrl script to retrieve the current mute status.
   - Adjusted audio-ctrl script to automatically unmute audio if a volume level change is detected.
   This change affects Ghaf as a whole, due to most (if not all) audio control being done through audio-ctrl.

5. **UI & Formatting Clean-up:**
   - Cleaned up `.yuck` and `.scss` formatting for better readability and maintainability.
   - Removed unused widgets and styles.
   - Moved color definitions to `.scss` for easier theming and maintenance.

### Known Issues/Limitations:

1. **Bluetooth Status Not Currently Fetched**
   - More investigation needed to find a good way of listening for bluetooth events and updating status.

2. **Hotkey Indicator May Become Slow To Respond**
   - Hotkey indicator may slow down and appear to "lag" when multiple brightness and volume events are triggered at the same time.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
Lenovo X1
- [x] Is this a new feature
  - [x] List the test steps to verify:
  Can be tested on Lenovo X1 following usual installation or `nixos-rebuild ... switch`
- [x] If it is an improvement how does it impact existing functionality?
Listed in the description above.

