### PR TITLE
Enable Wayland security context protocol

### DIFF
--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -154,6 +154,13 @@ let
           '') cfg.frameColouring
         )
       }
+      ${
+        lib.concatStringsSep "\n" (
+          map (rule: ''
+            <windowRule sandboxAppId="${rule.identifier}" borderColor="${rule.color}" serverDecoration="yes" skipTaskbar="no"  />
+          '') cfg.securityContext
+        )
+      }
     </windowRules>
     <libinput>
       <device category="touchpad"><naturalScroll>yes</naturalScroll></device>

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -59,35 +59,27 @@ in
           identifier = "foot";
           colour = "#006305";
         }
-        # TODO these should reference the VM and not the application that is
-        # relayed through waypipe. Ideally this would match using metadata
-        # through Wayland security context.
-        {
-          identifier = "dev.scpp.saca.gala";
-          colour = "#027d7b";
-        }
-        {
-          identifier = "chromium-browser";
-          colour = "#630505";
-        }
-        {
-          identifier = "org.pwmt.zathura";
-          colour = "#122263";
-        }
-        {
-          identifier = "pqiv";
-          colour = "#122263";
-        }
-        {
-          identifier = "Element";
-          colour = "#337aff";
-        }
-        {
-          identifier = "org.gnome.TextEditor";
-          colour = "#353535";
-        }
       ];
       description = "List of applications and their frame colours";
+    };
+    securityContext = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            identifier = lib.mkOption {
+              type = lib.types.str;
+              description = "The identifier attached to the security context";
+            };
+            color = lib.mkOption {
+              type = lib.types.str;
+              example = "#006305";
+              description = "Window frame color";
+            };
+          };
+        }
+      );
+      default = [ ];
+      description = "Wayland security context settings";
     };
     extraAutostart = lib.mkOption {
       type = lib.types.str;

--- a/modules/microvm/virtualization/microvm/common/waypipe.nix
+++ b/modules/microvm/virtualization/microvm/common/waypipe.nix
@@ -1,0 +1,88 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  vmIndex,
+  vm,
+  configHost,
+  cid,
+}:
+{
+  config,
+  lib,
+  pkgs,
+
+  ...
+}:
+let
+  cfg = config.ghaf.waypipe;
+  waypipePort = configHost.ghaf.virtualization.microvm.appvm.waypipeBasePort + vmIndex;
+  waypipeBorder = lib.optionalString (
+    cfg.waypipeBorder && vm.borderColor != null
+  ) "--border \"${vm.borderColor}\"";
+  runWaypipe = pkgs.writeScriptBin "run-waypipe" ''
+    #!${pkgs.runtimeShell} -e
+    ${pkgs.waypipe}/bin/waypipe --vsock -s ${toString waypipePort} server "$@"
+  '';
+  vsockproxy = pkgs.callPackage ../../../../../packages/vsockproxy { };
+  guivmCID = configHost.ghaf.virtualization.microvm.guivm.vsockCID;
+in
+{
+  options.ghaf.waypipe = with lib; {
+    enable = mkEnableOption "Waypipe support";
+
+    proxyService = lib.mkOption {
+      type = lib.types.attrs;
+      description = "vsockproxy service configuration for the AppVM";
+      readOnly = true;
+      visible = false;
+    };
+
+    waypipeService = lib.mkOption {
+      type = lib.types.attrs;
+      description = "Waypipe service configuration for the AppVM";
+      readOnly = true;
+      visible = false;
+    };
+
+    waypipeBorder = lib.mkEnableOption "Waypipe window border";
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    environment.systemPackages = [
+      pkgs.waypipe
+      runWaypipe
+    ];
+
+    ghaf.waypipe = {
+      # Waypipe service runs in the GUIVM and listens for incoming connections from AppVMs
+      waypipeService = {
+        enable = true;
+        description = "Waypipe for ${vm.name}";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "1";
+          ExecStart = "${pkgs.waypipe}/bin/waypipe --vsock --secctx \"${vm.name}\" ${waypipeBorder} -s ${toString waypipePort} client";
+        };
+        startLimitIntervalSec = 0;
+        partOf = [ "ghaf-session.target" ];
+        wantedBy = [ "ghaf-session.target" ];
+      };
+
+      # vsockproxy is used on host to forward data between AppVMs and GUIVM
+      proxyService = {
+        enable = true;
+        description = "vsockproxy for ${vm.name}";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "1";
+          ExecStart = "${vsockproxy}/bin/vsockproxy ${toString waypipePort} ${toString guivmCID} ${toString waypipePort} ${toString cid}";
+        };
+        startLimitIntervalSec = 0;
+        wantedBy = [ "multi-user.target" ];
+      };
+    };
+  };
+}

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -17,6 +17,14 @@ let
   netvmAddress = lib.head (builtins.map (x: x.ip) netvmEntry);
   adminvmEntry = builtins.filter (x: x.name == "admin-vm") config.ghaf.networking.hosts.entries;
   adminvmAddress = lib.head (builtins.map (x: x.ip) adminvmEntry);
+  # Remove rounded corners from the text editor window
+  gnomeTextEditor = pkgs.gnome-text-editor.overrideAttrs (oldAttrs: {
+    postPatch =
+      (oldAttrs.postPatch or "")
+      + ''
+        echo -e '\nwindow { border-radius: 0px; }' >> src/style.css
+      '';
+  });
 in
 {
   name = "${name}";
@@ -26,7 +34,7 @@ in
       pkgs.globalprotect-openconnect
       pkgs.losslesscut-bin
       pkgs.openconnect
-      pkgs.gnome-text-editor
+      gnomeTextEditor
       pkgs.xarchiver
     ]
     ++ lib.optionals config.ghaf.profiles.debug.enable [ pkgs.tcpdump ]

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -185,7 +185,7 @@ in
       }
     )
   ];
-  borderColor = "#00FF00";
+  borderColor = "#218838";
   ghafAudio.enable = true;
   vtpm.enable = true;
 }

--- a/modules/reference/appvms/chromium.nix
+++ b/modules/reference/appvms/chromium.nix
@@ -50,7 +50,7 @@ in
       ghaf.services.xdghandlers.enable = true;
     }
   ];
-  borderColor = "#630505";
+  borderColor = "#B83232";
   ghafAudio.enable = true;
   vtpm.enable = true;
 }

--- a/overlays/custom-packages/waypipe/default.nix
+++ b/overlays/custom-packages/waypipe/default.nix
@@ -5,7 +5,10 @@
 prev.waypipe.overrideAttrs (_prevAttrs: {
   # Upstream pull request: https://gitlab.freedesktop.org/mstoeckl/waypipe/-/merge_requests/21
   patches = [
-    ./waypipe-window-borders.patch
     ./waypipe-fix-reading-data-from-pipes.patch
+    ./waypipe-window-borders.patch
+    ./waypipe-security-context.patch
   ];
+  nativeBuildInputs = _prevAttrs.nativeBuildInputs ++ [ prev.pkgs.wayland-scanner ];
+  buildInputs = _prevAttrs.buildInputs ++ [ prev.pkgs.wayland ];
 })

--- a/overlays/custom-packages/waypipe/waypipe-security-context.patch
+++ b/overlays/custom-packages/waypipe/waypipe-security-context.patch
@@ -1,0 +1,565 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+From dfc51669bfd3609023e0fc31afb2b5532c19bce4 Mon Sep 17 00:00:00 2001
+From: Yuri Nesterov <yuriy.nesterov@unikie.com>
+Date: Thu, 13 Jun 2024 14:49:31 +0300
+Subject: [PATCH] Add support for the Wayland security context protocol
+
+---
+ meson.build                       |   5 +
+ meson_options.txt                 |   1 +
+ protocols/security-context-v1.xml | 180 ++++++++++++++++++++++++++++++
+ src/main.h                        |   1 +
+ src/meson.build                   |  19 ++++
+ src/secctx.c                      | 144 ++++++++++++++++++++++++
+ src/waypipe.c                     |  54 ++++++++-
+ waypipe.scd                       |   4 +
+ 8 files changed, 402 insertions(+), 6 deletions(-)
+ create mode 100644 protocols/security-context-v1.xml
+ create mode 100644 src/secctx.c
+
+diff --git a/meson.build b/meson.build
+index 0bb57d3..e8b2e8d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -99,6 +99,11 @@ if libavcodec.found() and libavutil.found() and libswscale.found()
+ 		config_data.set('HAS_VAAPI', 1, description: 'Enable hardware video (de)compression with VAAPI')
+ 	endif
+ endif
++wayland_scanner = dependency('wayland-scanner', version: '>=1.15.0', required: get_option('with_secctx'), native: true)
++wayland_client = dependency('wayland-client', required: get_option('with_secctx'))
++if wayland_scanner.found() and wayland_client.found()
++	config_data.set('HAS_SECURITY_CONTEXT', 1, description: 'Enable security-context-v1 support')
++endif
+ 
+ waypipe_includes = [include_directories('protocols'), include_directories('src')]
+ if libdrm.found()
+diff --git a/meson_options.txt b/meson_options.txt
+index 2f47494..e40517a 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -5,6 +5,7 @@ option('with_lz4', type : 'feature', value : 'auto', description : 'Support LZ4
+ option('with_zstd', type : 'feature', value : 'auto', description : 'Support ZStandard as a compression mechanism')
+ option('with_vaapi', type : 'feature', value : 'auto', description : 'Link with libva and use VAAPI to perform hardware video output color space conversions on GPU')
+ option('with_systemtap', type: 'boolean', value: true, description: 'Enable tracing using sdt and provide static tracepoints for profiling')
++option('with_secctx', type: 'feature', value: 'auto', description: 'Enable support for the Wayland security context protocol')
+ 
+ # It is recommended to keep these on; Waypipe will automatically select the highest available instruction set at runtime
+ option('with_avx512f', type: 'boolean', value: true, description: 'Compile with support for AVX512f SIMD instructions')
+diff --git a/protocols/security-context-v1.xml b/protocols/security-context-v1.xml
+new file mode 100644
+index 0000000..0b14078
+--- /dev/null
++++ b/protocols/security-context-v1.xml
+@@ -0,0 +1,180 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<protocol name="security_context_v1">
++  <copyright>
++    Copyright © 2021 Simon Ser
++
++    Permission is hereby granted, free of charge, to any person obtaining a
++    copy of this software and associated documentation files (the "Software"),
++    to deal in the Software without restriction, including without limitation
++    the rights to use, copy, modify, merge, publish, distribute, sublicense,
++    and/or sell copies of the Software, and to permit persons to whom the
++    Software is furnished to do so, subject to the following conditions:
++
++    The above copyright notice and this permission notice (including the next
++    paragraph) shall be included in all copies or substantial portions of the
++    Software.
++
++    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++    DEALINGS IN THE SOFTWARE.
++  </copyright>
++
++  <interface name="wp_security_context_manager_v1" version="1">
++    <description summary="client security context manager">
++      This interface allows a client to register a new Wayland connection to
++      the compositor and attach a security context to it.
++
++      This is intended to be used by sandboxes. Sandbox engines attach a
++      security context to all connections coming from inside the sandbox. The
++      compositor can then restrict the features that the sandboxed connections
++      can use.
++
++      Compositors should forbid nesting multiple security contexts by not
++      exposing wp_security_context_manager_v1 global to clients with a security
++      context attached, or by sending the nested protocol error. Nested
++      security contexts are dangerous because they can potentially allow
++      privilege escalation of a sandboxed client.
++
++      Warning! The protocol described in this file is currently in the testing
++      phase. Backward compatible changes may be added together with the
++      corresponding interface version bump. Backward incompatible changes can
++      only be done by creating a new major version of the extension.
++    </description>
++
++    <enum name="error">
++      <entry name="invalid_listen_fd" value="1"
++        summary="listening socket FD is invalid"/>
++      <entry name="nested" value="2"
++        summary="nested security contexts are forbidden"/>
++    </enum>
++
++    <request name="destroy" type="destructor">
++      <description summary="destroy the manager object">
++        Destroy the manager. This doesn't destroy objects created with the
++        manager.
++      </description>
++    </request>
++
++    <request name="create_listener">
++      <description summary="create a new security context">
++        Creates a new security context with a socket listening FD.
++
++        The compositor will accept new client connections on listen_fd.
++        listen_fd must be ready to accept new connections when this request is
++        sent by the client. In other words, the client must call bind(2) and
++        listen(2) before sending the FD.
++
++        close_fd is a FD closed by the client when the compositor should stop
++        accepting new connections on listen_fd.
++
++        The compositor must continue to accept connections on listen_fd when
++        the Wayland client which created the security context disconnects.
++
++        After sending this request, closing listen_fd and close_fd remains the
++        only valid operation on them.
++      </description>
++      <arg name="id" type="new_id" interface="wp_security_context_v1"/>
++      <arg name="listen_fd" type="fd" summary="listening socket FD"/>
++      <arg name="close_fd" type="fd" summary="FD closed when done"/>
++    </request>
++  </interface>
++
++  <interface name="wp_security_context_v1" version="1">
++    <description summary="client security context">
++      The security context allows a client to register a new client and attach
++      security context metadata to the connections.
++
++      When both are set, the combination of the application ID and the sandbox
++      engine must uniquely identify an application. The same application ID
++      will be used across instances (e.g. if the application is restarted, or
++      if the application is started multiple times).
++
++      When both are set, the combination of the instance ID and the sandbox
++      engine must uniquely identify a running instance of an application.
++    </description>
++
++    <enum name="error">
++      <entry name="already_used" value="1"
++        summary="security context has already been committed"/>
++      <entry name="already_set" value="2"
++        summary="metadata has already been set"/>
++      <entry name="invalid_metadata" value="3"
++        summary="metadata is invalid"/>
++    </enum>
++
++    <request name="destroy" type="destructor">
++      <description summary="destroy the security context object">
++        Destroy the security context object.
++      </description>
++    </request>
++
++    <request name="set_sandbox_engine">
++      <description summary="set the sandbox engine">
++        Attach a unique sandbox engine name to the security context. The name
++        should follow the reverse-DNS style (e.g. "org.flatpak").
++
++        A list of well-known engines is maintained at:
++        https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/security-context/engines.md
++
++        It is a protocol error to call this request twice. The already_set
++        error is sent in this case.
++      </description>
++      <arg name="name" type="string" summary="the sandbox engine name"/>
++    </request>
++
++    <request name="set_app_id">
++      <description summary="set the application ID">
++        Attach an application ID to the security context.
++
++        The application ID is an opaque, sandbox-specific identifier for an
++        application. See the well-known engines document for more details:
++        https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/security-context/engines.md
++
++        The compositor may use the application ID to group clients belonging to
++        the same security context application.
++
++        Whether this request is optional or not depends on the sandbox engine used.
++
++        It is a protocol error to call this request twice. The already_set
++        error is sent in this case.
++      </description>
++      <arg name="app_id" type="string" summary="the application ID"/>
++    </request>
++
++    <request name="set_instance_id">
++      <description summary="set the instance ID">
++        Attach an instance ID to the security context.
++
++        The instance ID is an opaque, sandbox-specific identifier for a running
++        instance of an application. See the well-known engines document for
++        more details:
++        https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/security-context/engines.md
++
++        Whether this request is optional or not depends on the sandbox engine used.
++
++        It is a protocol error to call this request twice. The already_set
++        error is sent in this case.
++      </description>
++      <arg name="instance_id" type="string" summary="the instance ID"/>
++    </request>
++
++    <request name="commit">
++      <description summary="register the security context">
++        Atomically register the new client and attach the security context
++        metadata.
++
++        If the provided metadata is inconsistent or does not match with out of
++        band metadata (see
++        https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/security-context/engines.md),
++        the invalid_metadata error may be sent eventually.
++
++        It's a protocol error to send any request other than "destroy" after
++        this request. In this case, the already_used error is sent.
++      </description>
++    </request>
++  </interface>
++</protocol>
+diff --git a/src/main.h b/src/main.h
+index 919b069..955fb93 100644
+--- a/src/main.h
++++ b/src/main.h
+@@ -49,6 +49,7 @@ struct main_config {
+ 	bool border;
+ 	struct color border_color;
+ 	uint32_t border_size;
++	const char *secctx_app_id;
+ };
+ struct globals {
+ 	const struct main_config *config;
+diff --git a/src/meson.build b/src/meson.build
+index a738737..2b91219 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -52,6 +52,25 @@ if ( host_machine.cpu_family() == 'aarch64' or cc.has_argument('-mfpu=neon') ) a
+ 	kernel_libs += static_library('kernel_neon', 'kernel_neon.c', c_args:neon_args)
+ 	config_data.set('HAVE_NEON', 1, description: 'Compiler supports NEON')
+ endif
++if config_data.has('HAS_SECURITY_CONTEXT')
++	wayland_scanner_prog = find_program(wayland_scanner.get_variable(pkgconfig: 'wayland_scanner'))
++	wl_security_context_xml = '../protocols/security-context-v1.xml'
++	protocols_src += custom_target(
++		'security-context-v1-protocol.c',
++		input: wl_security_context_xml,
++		output: 'security-context-v1-protocol.c',
++		command: [wayland_scanner_prog, 'private-code', '@INPUT@', '@OUTPUT@'],
++	)
++	protocols_src += custom_target(
++		'security-context-v1-protocol.h',
++		input: wl_security_context_xml,
++		output: 'security-context-v1-protocol.h',
++		command: [wayland_scanner_prog, 'client-header', '@INPUT@', '@OUTPUT@'],
++	)
++
++    waypipe_deps += [wayland_client]
++    waypipe_source_files += ['secctx.c']
++endif
+ 
+ configure_file(
+ 	output: 'config-waypipe.h',
+diff --git a/src/secctx.c b/src/secctx.c
+new file mode 100644
+index 0000000..7533f58
+--- /dev/null
++++ b/src/secctx.c
+@@ -0,0 +1,144 @@
++#include "security-context-v1-protocol.h"
++#include "util.h"
++#include <sys/socket.h>
++#include <sys/un.h>
++#include <unistd.h>
++#include <wayland-client.h>
++
++static struct wp_security_context_manager_v1 *security_context_manager = NULL;
++static struct wp_security_context_v1 *security_context = NULL;
++static int listen_fd = -1;
++static int close_fd[2] = {-1, -1};
++
++static void registry_handle_global(void *data, struct wl_registry *registry,
++		uint32_t name, const char *interface, uint32_t version)
++{
++	(void)data;
++	(void)version;
++
++	if (strcmp(interface, "wp_security_context_manager_v1") == 0) {
++		security_context_manager = wl_registry_bind(registry, name,
++				&wp_security_context_manager_v1_interface, 1);
++	}
++}
++
++static void registry_handle_global_remove(
++		void *data, struct wl_registry *registry, uint32_t name)
++{
++	(void)data;
++	(void)registry;
++	(void)name;
++}
++
++static const struct wl_registry_listener registry_listener = {
++		.global = registry_handle_global,
++		.global_remove = registry_handle_global_remove};
++
++void close_security_context()
++{
++	if (close_fd[1] >= 0) {
++		close(close_fd[1]);
++		close_fd[1] = -1;
++	}
++	if (listen_fd >= 0) {
++		close(listen_fd);
++		listen_fd = -1;
++	}
++}
++
++int create_security_context(const char *sock_path, const char *engine,
++		const char *instance_id, const char *app_id)
++{
++	struct wl_display *display = NULL;
++	struct wl_registry *registry = NULL;
++	int res = -1;
++
++	wp_debug("Enabling wayland security context");
++	display = wl_display_connect(NULL);
++	if (display == NULL) {
++		wp_error("Failed to connect to the Wayland compositor");
++		goto cleanup;
++	}
++
++	registry = wl_display_get_registry(display);
++	if (registry == NULL) {
++		wp_error("Failed to get Wayland display registry");
++		goto cleanup;
++	}
++
++	wl_registry_add_listener(registry, &registry_listener, NULL);
++	wl_display_dispatch(display);
++
++	if (wl_display_roundtrip(display) == -1) {
++		wp_error("Failed to execute display roundtrip");
++		goto cleanup;
++	}
++
++	if (!security_context_manager) {
++		wp_error("Security context is not supported by the Wayland compositor");
++		goto cleanup;
++	}
++
++	listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
++	if (listen_fd < 0) {
++		wp_error("Failed to create a Unix socket for security context");
++		goto cleanup;
++	}
++
++	struct sockaddr_un sockaddr = {0};
++	sockaddr.sun_family = AF_UNIX;
++	strncpy(sockaddr.sun_path, sock_path, sizeof(sockaddr.sun_path) - 1);
++	if (bind(listen_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) !=
++			0) {
++		wp_error("Failed to bind the Unix socket for the security context");
++		goto cleanup;
++	}
++
++	if (listen(listen_fd, 0) != 0) {
++		wp_error("Failed to listen on the Unix socket for the security context");
++		goto cleanup;
++	}
++
++	if (pipe(close_fd)) {
++		wp_error("Failed to create a pipe for the security context");
++		goto cleanup;
++	}
++
++	security_context = wp_security_context_manager_v1_create_listener(
++			security_context_manager, listen_fd, close_fd[0]);
++	if (security_context == NULL) {
++		wp_error("Failed to create a security context listener");
++		goto cleanup;
++	}
++
++	wp_security_context_v1_set_sandbox_engine(security_context, engine);
++	wp_security_context_v1_set_instance_id(security_context, instance_id);
++	wp_security_context_v1_set_app_id(security_context, app_id);
++	wp_security_context_v1_commit(security_context);
++	wp_security_context_v1_destroy(security_context);
++
++	if (wl_display_roundtrip(display) < 0) {
++		wp_error("Failed to execute display roundtrip");
++		goto cleanup;
++	}
++
++	wp_debug("Successfully enabled Wayland security context");
++	res = 0;
++
++cleanup:
++
++	if (res) {
++		close_security_context();
++	}
++	if (security_context_manager) {
++		wp_security_context_manager_v1_destroy(
++				security_context_manager);
++	}
++	if (registry) {
++		wl_registry_destroy(registry);
++	}
++	if (display) {
++		wl_display_disconnect(display);
++	}
++	return res;
++}
+diff --git a/src/waypipe.c b/src/waypipe.c
+index 9908677..f303464 100644
+--- a/src/waypipe.c
++++ b/src/waypipe.c
+@@ -99,6 +99,8 @@ static const char usage_string[] =
+ 		"                         V is list of options: sw,hw,bpf=1.2e5,h264,vp9,av1\n"
+ 		"      --vsock          use vsock instead of unix socket\n"
+ 		"      --border C,S     add a border with hex color C and border size S in hex around the window\n"
++		"      --secctx S       client,ssh: enable Wayland security context protocol\n"
++		"                         S is an app id to be attached to the security context\n"
+ 		"\n";
+ 
+ static int usage(int retcode)
+@@ -501,6 +503,7 @@ static const bool feature_flags[] = {
+ #define ARG_VSOCK 1013
+ #define ARG_TITLE_PREFIX 1014
+ #define ARG_BORDER 1015
++#define ARG_SECCTX 1016
+ 
+ static const struct option options[] = {
+ 		{"compress", required_argument, NULL, 'c'},
+@@ -525,9 +528,9 @@ static const struct option options[] = {
+ 		{"vsock", no_argument, NULL, ARG_VSOCK},
+ 		{"title-prefix", required_argument, NULL, ARG_TITLE_PREFIX},
+ 		{"border", required_argument, NULL, ARG_BORDER},
++		{"secctx", required_argument, NULL, ARG_SECCTX},
+ 		{0, 0, NULL, 0}
+ };
+-
+ struct arg_permissions {
+ 	int val;
+ 	uint32_t mode_mask;
+@@ -553,12 +556,19 @@ static const struct arg_permissions arg_permissions[] = {
+ 		{ARG_BENCH_TEST_SIZE, MODE_BENCH},
+ 		{ARG_VSOCK, MODE_SSH | MODE_CLIENT | MODE_SERVER},
+ 		{ARG_TITLE_PREFIX, MODE_SSH | MODE_CLIENT | MODE_SERVER},
+-		{ARG_BORDER, MODE_CLIENT | MODE_SERVER | MODE_SSH}
++		{ARG_BORDER, MODE_CLIENT | MODE_SERVER | MODE_SSH},
++		{ARG_SECCTX, MODE_SSH | MODE_CLIENT}
+ };
+ 
+ /* envp is nonstandard, so use environ */
+ extern char **environ;
+ 
++#ifdef HAS_SECURITY_CONTEXT
++int create_security_context(const char *sock_path, const char *engine,
++		const char *instance_id, const char *app_id);
++void close_security_context();
++#endif
++
+ int main(int argc, char **argv)
+ {
+ 	bool help = false;
+@@ -601,7 +611,8 @@ int main(int argc, char **argv)
+ 			.border_color = {
+ 				.a = 255, .r = 0, .g = 0, .b = 0
+ 			},
+-			.border_size = 3
++			.border_size = 3,
++			.secctx_app_id = NULL
+ 	};
+ 
+ 	/* We do not parse any getopt arguments happening after the mode choice
+@@ -792,6 +803,14 @@ int main(int argc, char **argv)
+ 				return EXIT_FAILURE;
+ 			}
+ 			break;
++		case ARG_SECCTX:
++#ifdef HAS_SECURITY_CONTEXT
++			config.secctx_app_id = optarg;
++			break;
++#else
++			fprintf(stderr, "Option --secctx not allowed: this copy of Waypipe was not built with support for the Wayland security context protocol.\n");
++			return EXIT_FAILURE;
++#endif
+ 		default:
+ 			fail = true;
+ 			break;
+@@ -900,9 +919,29 @@ int main(int argc, char **argv)
+ 		return EXIT_FAILURE;
+ 	}
+ 
+-	const char *wayland_socket = getenv("WAYLAND_SOCKET");
+-	if (wayland_socket != NULL) {
+-		oneshot = true;
++	const char *wayland_socket = NULL;
++	if (!config.secctx_app_id) {
++		wayland_socket = getenv("WAYLAND_SOCKET");
++		if (wayland_socket != NULL) {
++			oneshot = true;
++		}
++	} else {
++#ifdef HAS_SECURITY_CONTEXT
++		/* Create a new socket, send it to the compositor to attach
++		 * a security context and write it to WAYLAND_DISPLAY */
++		char secctx_sock_path[108];
++		sprintf(secctx_sock_path, "/tmp/waypipe%d", getpid());
++		unlink(secctx_sock_path);
++		char instance_id[21];
++		sprintf(instance_id, "%d", getpid());
++		if (create_security_context(secctx_sock_path, "waypipe",
++				    instance_id, config.secctx_app_id) == 0) {
++			unsetenv("WAYLAND_SOCKET");
++			setenv("WAYLAND_DISPLAY", secctx_sock_path, 1);
++		} else {
++			return EXIT_FAILURE;
++		}
++#endif
+ 	}
+ 
+ 	int ret;
+@@ -1243,6 +1282,9 @@ int main(int argc, char **argv)
+ 			checked_close(channel_folder_fd);
+ 		}
+ 	}
++#ifdef HAS_SECURITY_CONTEXT
++	close_security_context();
++#endif
+ 	checked_close(cwd_fd);
+ 	check_unclosed_fds();
+ 	return ret;
+diff --git a/waypipe.scd b/waypipe.scd
+index c86518f..17afcfb 100644
+--- a/waypipe.scd
++++ b/waypipe.scd
+@@ -181,6 +181,10 @@ compressible as images containing pictures.
+ 	The hex color should be in the format #RRGGBB or #RRGGBBAA and the border size is
+ 	in pixels.
+ 
++*--secctx S*
++	Enable the Wayland security context protocol (client or ssh modes). Specify
++	an application ID *S* that will be attached to the security context.
++
+ # EXAMPLE 
+ 
+ The following *waypipe ssh* subcommand will attempt to run *weston-flower* on
+-- 
+2.43.0
+

--- a/overlays/custom-packages/waypipe/waypipe-window-borders.patch
+++ b/overlays/custom-packages/waypipe/waypipe-window-borders.patch
@@ -1,6 +1,8 @@
-From b993dca0e0919cf16c207026605f0fe5a61f479f Mon Sep 17 00:00:00 2001
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+From 0046d82edbaddf3436f62118ee4579f47f81aa4e Mon Sep 17 00:00:00 2001
 From: Yuri Nesterov <yuriy.nesterov@unikie.com>
-Date: Fri, 24 May 2024 11:15:41 +0200
+Date: Tue, 15 Oct 2024 17:49:40 +0300
 Subject: [PATCH] Add support for coloured window borders
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -10,43 +12,32 @@ This is usefor to visually distinguish between different windows when
 using waypipe. The border is drawn around the window and can be
 configured with a hex color and a border size in pixels.
 
-Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+Co-authored-by: Jörg Thalheim <joerg@thalheim.io>
 ---
  protocols/function_list.txt |   4 ++
- src/handlers.c              | 121 ++++++++++++++++++++++++++++++++++++
+ src/handlers.c              | 123 ++++++++++++++++++++++++++++++++++++
  src/main.h                  |   3 +
  src/parsing.h               |   4 ++
  src/util.c                  |  12 ++++
  src/util.h                  |   6 ++
- src/waypipe.c               |  70 ++++++++++++++++++++-
+ src/waypipe.c               |  72 ++++++++++++++++++++-
  waypipe.scd                 |   5 ++
- 8 files changed, 223 insertions(+), 2 deletions(-)
+ 8 files changed, 227 insertions(+), 2 deletions(-)
 
 diff --git a/protocols/function_list.txt b/protocols/function_list.txt
-index 4acaec5..4750263 100644
+index 4acaec5..8912a93 100644
 --- a/protocols/function_list.txt
 +++ b/protocols/function_list.txt
-@@ -16,6 +16,7 @@ wl_registry_req_bind
- wl_shm_req_create_pool
- wl_shm_pool_req_create_buffer
- wl_shm_pool_req_resize
-+wl_surface_evt_preferred_buffer_scale
- wl_surface_req_attach
- wl_surface_req_commit
- wl_surface_req_damage
-@@ -25,7 +26,10 @@ wl_surface_req_set_buffer_scale
- wp_presentation_evt_clock_id
- wp_presentation_feedback_evt_presented
- wp_presentation_req_feedback
-+xdg_surface_req_get_toplevel
-+xdg_surface_req_set_window_geometry
- xdg_toplevel_req_set_title
+@@ -50,3 +50,7 @@ zwp_linux_dmabuf_v1_req_get_default_feedback
+ zwp_linux_dmabuf_v1_req_get_surface_feedback
+ zwp_primary_selection_offer_v1_req_receive
+ zwp_primary_selection_source_v1_evt_send
 +xdg_wm_base_req_get_xdg_surface
- zwlr_data_control_offer_v1_req_receive
- zwlr_data_control_source_v1_evt_send
- zwlr_export_dmabuf_frame_v1_evt_frame
++xdg_surface_req_set_window_geometry
++xdg_surface_req_get_toplevel
++wl_surface_evt_preferred_buffer_scale
 diff --git a/src/handlers.c b/src/handlers.c
-index c82f4e0..50ff7a3 100644
+index c82f4e0..b0bb30d 100644
 --- a/src/handlers.c
 +++ b/src/handlers.c
 @@ -98,6 +98,7 @@ struct obj_wl_surface {
@@ -71,7 +62,7 @@ index c82f4e0..50ff7a3 100644
  	return new_obj;
  }
  
-@@ -743,6 +751,88 @@ static void rotate_damage_lists(struct obj_wl_surface *surface)
+@@ -743,6 +751,87 @@ static void rotate_damage_lists(struct obj_wl_surface *surface)
  			(SURFACE_DAMAGE_BACKLOG - 1) * sizeof(uint64_t));
  	surface->attached_buffer_uids[0] = 0;
  }
@@ -112,8 +103,7 @@ index c82f4e0..50ff7a3 100644
 +		for (int32_t y = y1; y < y2; y++) {
 +			if (c->a == 255) {
 +				set_pixel(buf, x, y, c);
-+			}
-+			else {
++			} else {
 +				struct color c1;
 +				get_pixel(buf, x, y, &c1);
 +				alpha_blend(&c1, c);
@@ -123,7 +113,7 @@ index c82f4e0..50ff7a3 100644
 +	}
 +}
 +
-+void draw_border(struct context *ctx)
++void draw_border(struct context *ctx, const struct color *border_color, uint32_t border_size)
 +{
 +	struct obj_wl_surface *surface = (struct obj_wl_surface *)ctx->obj;
 +	if (!surface)
@@ -141,17 +131,17 @@ index c82f4e0..50ff7a3 100644
 +		if (ctx->obj->xdg_surface_id) {
 +			struct wp_object *xdg_surface = tracker_get(ctx->tracker, ctx->obj->xdg_surface_id);
 +			if (xdg_surface && xdg_surface->is_window) {
-+			  int32_t scale = surface->preferred_buffer_scale > 0 ? surface->preferred_buffer_scale : 1;
++				int32_t scale = surface->preferred_buffer_scale > 0 ? surface->preferred_buffer_scale : 1;
 +				int32_t x1 = xdg_surface->window_x * scale;
 +				int32_t y1 = xdg_surface->window_y * scale;
 +				int32_t x2 = min(buf->shm_width, (xdg_surface->window_x + xdg_surface->window_width) * scale);
 +				int32_t y2 = min(buf->shm_height, (xdg_surface->window_y + xdg_surface->window_height) * scale);
-+				int32_t border_size = min(min(ctx->g->config->border_size, x2 - x1), y2 - y1);
++				border_size = min(min(border_size, x2 - x1), y2 - y1);
 +
-+				draw_rect(buf, x1, y1, x2, y1 + border_size, &ctx->g->config->border_color); // top
-+				draw_rect(buf, x1, y1 + border_size, x1 + border_size, y2, &ctx->g->config->border_color); // left
-+				draw_rect(buf, x1 + border_size, y2 - border_size, x2, y2, &ctx->g->config->border_color); // bottom
-+				draw_rect(buf, x2 - border_size, y1 + border_size, x2, y2 - border_size, &ctx->g->config->border_color); // right
++				draw_rect(buf, x1, y1, x2, y1 + border_size, border_color); // top
++				draw_rect(buf, x1, y1 + border_size, x1 + border_size, y2, border_color); // left
++				draw_rect(buf, x1 + border_size, y2 - border_size, x2, y2, border_color); // bottom
++				draw_rect(buf, x2 - border_size, y1 + border_size, x2, y2 - border_size, border_color); // right
 +			}
 +		}
 +	}
@@ -160,32 +150,37 @@ index c82f4e0..50ff7a3 100644
  void do_wl_surface_req_commit(struct context *ctx)
  {
  	struct obj_wl_surface *surface = (struct obj_wl_surface *)ctx->obj;
-@@ -760,6 +850,10 @@ void do_wl_surface_req_commit(struct context *ctx)
+@@ -758,8 +847,17 @@ void do_wl_surface_req_commit(struct context *ctx)
+ 	}
+ 	if (ctx->on_display_side) {
  		/* commit signifies a client-side update only */
++
++		/* Global border for all windows - client mode */
++		if (ctx->g->config->border)
++			draw_border(ctx, &ctx->g->config->border_color, ctx->g->config->border_size);
  		return;
  	}
 +
++	/* Global border for all windows - server mode */
 +	if (ctx->g->config->border)
-+		draw_border(ctx);
++		draw_border(ctx, &ctx->g->config->border_color, ctx->g->config->border_size);
 +
  	struct wp_object *obj =
  			tracker_get(ctx->tracker, surface->attached_buffer_id);
  	if (!obj) {
-@@ -921,6 +1015,13 @@ static void append_damage_record(struct obj_wl_surface *surface, int32_t x,
+@@ -921,6 +1019,11 @@ static void append_damage_record(struct obj_wl_surface *surface, int32_t x,
  	damage->width = width;
  	damage->height = height;
  }
-+
 +void do_wl_surface_evt_preferred_buffer_scale(struct context *ctx, int32_t scale)
 +{
 +	struct obj_wl_surface *surface = (struct obj_wl_surface *)ctx->obj;
 +	surface->preferred_buffer_scale = scale;
 +}
-+
  void do_wl_surface_req_damage(struct context *ctx, int32_t x, int32_t y,
  		int32_t width, int32_t height)
  {
-@@ -2021,3 +2122,23 @@ void do_xdg_toplevel_req_set_title(struct context *ctx, const char *str)
+@@ -2021,3 +2124,23 @@ void do_xdg_toplevel_req_set_title(struct context *ctx, const char *str)
  }
  
  const struct wp_interface *the_display_interface = &intf_wl_display;
@@ -274,18 +269,18 @@ index 9970840..8e5cec1 100644
 +
  #endif // WAYPIPE_UTIL_H
 diff --git a/src/waypipe.c b/src/waypipe.c
-index c66a971..0dbec96 100644
+index c66a971..9908677 100644
 --- a/src/waypipe.c
 +++ b/src/waypipe.c
-@@ -86,6 +86,7 @@ static const char usage_string[] =
- 		"                         vsock: [[s]CID:]port\n"
- 		"      --version        print waypipe version and exit\n"
- 		"      --allow-tiled    allow gpu buffers (DMABUFs) with format modifiers\n"
-+		"      --border C,S     server: add a border with hex color C and border size S in hex around the window\n"
- 		"      --control C      server,ssh: set control pipe to reconnect server\n"
- 		"      --display D      server,ssh: the Wayland display name or path\n"
- 		"      --drm-node R     set the local render node. default: /dev/dri/renderD128\n"
-@@ -400,6 +401,53 @@ static int parse_vsock_addr(const char *str, struct main_config *config)
+@@ -98,6 +98,7 @@ static const char usage_string[] =
+ 		"      --video[=V]      compress certain linear dmabufs only with a video codec\n"
+ 		"                         V is list of options: sw,hw,bpf=1.2e5,h264,vp9,av1\n"
+ 		"      --vsock          use vsock instead of unix socket\n"
++		"      --border C,S     add a border with hex color C and border size S in hex around the window\n"
+ 		"\n";
+ 
+ static int usage(int retcode)
+@@ -400,6 +401,55 @@ static int parse_vsock_addr(const char *str, struct main_config *config)
  }
  #endif
  
@@ -303,11 +298,13 @@ index c66a971..0dbec96 100644
 +	c->b = (hex_char_to_int(str[5]) << 4) + hex_char_to_int(str[6]);
 +	if (l == 9)
 +		c->a = (hex_char_to_int(str[7]) << 4) + hex_char_to_int(str[8]);
++	else
++		c->a = 255;
 +
 +	return 0;
 +}
 +
-+static int parse_border(const char *str, struct main_config *config)
++static int parse_border(const char *str, struct color *color, uint32_t *size)
 +{
 +	if (str == NULL)
 +		return -1;
@@ -319,16 +316,16 @@ index c66a971..0dbec96 100644
 +	}
 +	memcpy(tmp, str, l + 1);
 +
-+	char *color = strtok(tmp, ",");
-+	if (color) {
-+		if (parse_color(color, &config->border_color) == -1) {
++	char *c = strtok(tmp, ",");
++	if (c) {
++		if (parse_color(c, color) == -1) {
 +			return -1;
 +		}
 +	}
 +
 +	char *border_size = strtok(NULL, ",");
 +	if (border_size) {
-+		if (parse_uint32(border_size, &config->border_size) == -1) {
++		if (parse_uint32(border_size, size) == -1) {
 +			return -1;
 +		}
 +	}
@@ -339,7 +336,7 @@ index c66a971..0dbec96 100644
  static const char *feature_names[] = {
  		"lz4",
  		"zstd",
-@@ -450,6 +498,7 @@ static const bool feature_flags[] = {
+@@ -450,6 +500,7 @@ static const bool feature_flags[] = {
  #define ARG_BENCH_TEST_SIZE 1012
  #define ARG_VSOCK 1013
  #define ARG_TITLE_PREFIX 1014
@@ -347,7 +344,7 @@ index c66a971..0dbec96 100644
  
  static const struct option options[] = {
  		{"compress", required_argument, NULL, 'c'},
-@@ -473,7 +522,10 @@ static const struct option options[] = {
+@@ -473,7 +524,10 @@ static const struct option options[] = {
  		{"test-size", required_argument, NULL, ARG_BENCH_TEST_SIZE},
  		{"vsock", no_argument, NULL, ARG_VSOCK},
  		{"title-prefix", required_argument, NULL, ARG_TITLE_PREFIX},
@@ -359,18 +356,18 @@ index c66a971..0dbec96 100644
  struct arg_permissions {
  	int val;
  	uint32_t mode_mask;
-@@ -498,7 +550,9 @@ static const struct arg_permissions arg_permissions[] = {
+@@ -498,7 +552,9 @@ static const struct arg_permissions arg_permissions[] = {
  		{ARG_CONTROL, MODE_SSH | MODE_SERVER},
  		{ARG_BENCH_TEST_SIZE, MODE_BENCH},
  		{ARG_VSOCK, MODE_SSH | MODE_CLIENT | MODE_SERVER},
 -		{ARG_TITLE_PREFIX, MODE_SSH | MODE_CLIENT | MODE_SERVER}};
 +		{ARG_TITLE_PREFIX, MODE_SSH | MODE_CLIENT | MODE_SERVER},
-+		{ARG_BORDER, MODE_SERVER},
++		{ARG_BORDER, MODE_CLIENT | MODE_SERVER | MODE_SSH}
 +};
  
  /* envp is nonstandard, so use environ */
  extern char **environ;
-@@ -541,6 +595,11 @@ int main(int argc, char **argv)
+@@ -541,6 +597,11 @@ int main(int argc, char **argv)
  			.vsock_to_host = false, /* VMADDR_FLAG_TO_HOST */
  			.vsock_port = 0,
  			.title_prefix = NULL,
@@ -382,13 +379,13 @@ index c66a971..0dbec96 100644
  	};
  
  	/* We do not parse any getopt arguments happening after the mode choice
-@@ -724,6 +783,13 @@ int main(int argc, char **argv)
+@@ -724,6 +785,13 @@ int main(int argc, char **argv)
  			}
  			config.title_prefix = optarg;
  			break;
 +		case ARG_BORDER:
 +			config.border = true;
-+			if (parse_border(optarg, &config) == -1) {
++			if (parse_border(optarg, &config.border_color, &config.border_size) == -1) {
 +				fprintf(stderr, "Invalid border argument: %s\n", optarg);
 +				return EXIT_FAILURE;
 +			}
@@ -397,21 +394,21 @@ index c66a971..0dbec96 100644
  			fail = true;
  			break;
 diff --git a/waypipe.scd b/waypipe.scd
-index d0b300d..f555b30 100644
+index d0b300d..c86518f 100644
 --- a/waypipe.scd
 +++ b/waypipe.scd
-@@ -111,6 +111,11 @@ compressible as images containing pictures.
- 	absolute path, the socket will be created in the folder given by the
- 	environment variable _XDG_RUNTIME_DIR_.)
+@@ -176,6 +176,11 @@ compressible as images containing pictures.
+ 	CID is only used in the server mode and can be omitted when connecting from a
+ 	guest virtual machine to host.
  
 +*--border C,S*
-+	For server: add a border with hex color C and border size S in hex around the
-+	window. The hex color should be in the format #RRGGBB or #RRGGBBAA and
-+	the border size is in pixels.
++	Add a border with hex color C and border size S in hex around the window.
++	The hex color should be in the format #RRGGBB or #RRGGBBAA and the border size is
++	in pixels.
 +
- *--drm-node R*
- 	Specify the path *R* to the drm device that this instance of waypipe should
- 	use and (in server mode) notify connecting applications about.
+ # EXAMPLE 
+ 
+ The following *waypipe ssh* subcommand will attempt to run *weston-flower* on
 -- 
-2.45.1
+2.43.0
 

--- a/packages/vsockproxy/default.nix
+++ b/packages/vsockproxy/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "tiiuae";
     repo = "vsockproxy";
-    rev = "851e995b4c24a776f78d56310010e4e29456921c";
-    sha256 = "sha256-fyawskwts4OIBshGDeh5ANeBCEm3h5AyHCyhwfxgP14=";
+    rev = "860038bd8a97f85f89dda30c703bf816a6ac7409";
+    sha256 = "sha256-U+gwIEstKiV3o69Bf+Y6a7VFlmD75pIv465z8xcWmN8=";
   };
 
   installPhase = ''


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This enables support for the Wayland security context protocol in Ghaf. I previously added support for it to Labwc and Waypipe and upstreamed those changes. The version of Labwc used in Ghaf already includes it. For Waypipe, I added a patch but it was merged upstream recently. The new version should be released close to the end of the year. After that we should be able to get rid of the Waypipe overlay.

The security context protocol allows window frame colors to be defined on a per-VM basis rather than by application identifier. All settings are defined on the compositor side and AppVMs cannot change them. The same application can now have different border colors when run from different VMs. For example, the trusted browser and the regular one now have different colors, even though they are both Chromium.

Also, enabling the Security Context seems to resolve the issue with window caption rendering reported in SSRCSP-5343.

Technical details:
- Each AppVM now gets its own instance of waypipe and vsockproxy.
- vsockproxy has been updated to prevent one VM from connecting to the port designated for another VM.
- Waypipe borders patch has been updated to draw borders on the GUIVM side. Currently, waypipe border is disabled but it might be useful in the future in case we change the compositor, as not many compositors support security contexts and custom border colors. 

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

On Lenovo X1, make sure all apps still work fine after this change and that the window borders have the correct colors. The regular Chromium and Trusted versions should now have different colors as defined in chromium.nix and business.nix.