### PR TITLE
Improved autolock functionality, relocated styles

### DIFF
--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -12,7 +12,6 @@ let
 
   cfg = config.ghaf.graphics.labwc;
   audio-ctrl = pkgs.callPackage ../../../packages/audio-ctrl { };
-  gtklockStyle = pkgs.callPackage ./styles/gtk-lock.nix { };
 
   launcher-icon = "${pkgs.ghaf-artwork}/icons/launcher.svg";
 
@@ -593,7 +592,7 @@ in
                     :class "power-menu-button"
                     :icon "${lock-icon}"
                     :title "Lock"
-                    :onclick "${eww-popup}/bin/eww-popup power-menu & ${pkgs.gtklock}/bin/gtklock -s ${gtklockStyle} &")))
+                    :onclick "${eww-popup}/bin/eww-popup power-menu & loginctl lock-session &")))
 
         ;; Quick Settings Buttons ;;
         (defwidget settings_buttons []

--- a/modules/desktop/graphics/ghaf-launcher.nix
+++ b/modules/desktop/graphics/ghaf-launcher.nix
@@ -2,49 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 { pkgs, ... }:
 let
-  drawerCSS = pkgs.writeTextDir "nwg-drawer/drawer.css" ''
-    /* Example configuration from: https://github.com/nwg-piotr/nwg-drawer/blob/main/drawer.css */
-    window {
-        background-color: #121212;
-        color: #fff;
-    }
-
-    /* search entry */
-    entry {
-        background-color: rgba (43, 43, 43, 1);
-        border: 1px solid rgba(46, 46, 46, 1);
-    }
-    entry:focus {
-        box-shadow: none;
-        border: 1px solid rgba(223, 92, 55, 1);
-    }
-
-    button, image {
-        background: none;
-        border: none;
-        box-shadow: none;
-    }
-
-    button:hover {
-        background-color: rgba (255, 255, 255, 0.06);
-    }
-
-    /* in case you wanted to give category buttons a different look */
-    #category-button {
-        margin: 0 10px 0 10px;
-    }
-
-    #pinned-box {
-        padding-bottom: 5px;
-        border-bottom: 1px dotted gray;
-    }
-
-    #files-box {
-        padding: 5px;
-        border: 1px dotted gray;
-        border-radius: 15px;
-    }
-  '';
+  drawerCSS = pkgs.callPackage ./styles/launcher-style.nix { };
 in
 pkgs.writeShellApplication {
   name = "ghaf-launcher";
@@ -63,6 +21,6 @@ pkgs.writeShellApplication {
     rm -rf "$HOME/.config/nwg-drawer"
     #ln -s "${drawerCSS}/nwg-drawer" "$HOME/.config/"
 
-    nwg-drawer -r -nofs -nocats -s ${drawerCSS}/nwg-drawer/drawer.css
+    nwg-drawer -r -nofs -nocats -s ${drawerCSS}
   '';
 }

--- a/modules/desktop/graphics/login-manager.nix
+++ b/modules/desktop/graphics/login-manager.nix
@@ -8,27 +8,8 @@
 }:
 let
   cfg = config.ghaf.graphics.login-manager;
-  gtkgreetStyle = pkgs.writeText "gtkgreet.css" ''
-    window {
-      background: rgba(18, 18, 18, 1);
-      color: #fff;
-    }
-    button {
-      box-shadow: none;
-      border-radius: 5px;
-      border: 1px solid rgba(255, 255, 255, 0.09);
-      background: rgba(255, 255, 255, 0.06);
-    }
-    entry {
-      background-color: rgba (43, 43, 43, 1);
-      border: 1px solid rgba(46, 46, 46, 1);
-      color: #eee;
-    }
-    entry:focus {
-      box-shadow: none;
-      border: 1px solid rgba(223, 92, 55, 1);
-    }
-  '';
+
+  gtkgreetStyle = pkgs.callPackage ./styles/login-style.nix { };
 in
 {
   options.ghaf.graphics.login-manager = {

--- a/modules/desktop/graphics/styles/launcher-style.nix
+++ b/modules/desktop/graphics/styles/launcher-style.nix
@@ -1,0 +1,51 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Ghaf app launcher style
+{
+  pkgs,
+  ...
+}:
+pkgs.writeText "ghaf-launcher.css" ''
+  /* Example configuration from: https://github.com/nwg-piotr/nwg-drawer/blob/main/drawer.css */
+  window {
+      background-color: #121212;
+      color: #fff;
+  }
+
+  /* search entry */
+  entry {
+      background-color: rgba (43, 43, 43, 1);
+      border: 1px solid rgba(46, 46, 46, 1);
+  }
+  entry:focus {
+      box-shadow: none;
+      border: 1px solid rgba(223, 92, 55, 1);
+  }
+
+  button, image {
+      background: none;
+      border: none;
+      box-shadow: none;
+  }
+
+  button:hover {
+      background-color: rgba (255, 255, 255, 0.06);
+  }
+
+  /* in case you wanted to give category buttons a different look */
+  #category-button {
+      margin: 0 10px 0 10px;
+  }
+
+  #pinned-box {
+      padding-bottom: 5px;
+      border-bottom: 1px dotted gray;
+  }
+
+  #files-box {
+      padding: 5px;
+      border: 1px dotted gray;
+      border-radius: 15px;
+  }
+''

--- a/modules/desktop/graphics/styles/lock-style.nix
+++ b/modules/desktop/graphics/styles/lock-style.nix
@@ -1,0 +1,29 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Ghaf lock screen style
+{
+  pkgs,
+  ...
+}:
+pkgs.writeText "ghaf-lock.css" ''
+  window {
+      background: rgba(18, 18, 18, 1);
+      color: #fff;
+  }
+  button {
+      box-shadow: none;
+      border-radius: 5px;
+      border: none;
+      background: #171717;
+  }
+  entry {
+      background-color: #232323;
+      border: 1px solid rgba(46, 46, 46, 1);
+      color: #fff;
+  }
+  entry:focus {
+      box-shadow: none;
+      border: 1px solid rgba(223, 92, 55, 1);
+  }
+''

--- a/modules/desktop/graphics/styles/login-style.nix
+++ b/modules/desktop/graphics/styles/login-style.nix
@@ -1,10 +1,12 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+
+# Ghaf login screen style
 {
   pkgs,
   ...
 }:
-pkgs.writeText "gtklock.css" ''
+pkgs.writeText "ghaf-login.css" ''
   window {
       background: rgba(18, 18, 18, 1);
       color: #fff;
@@ -12,13 +14,13 @@ pkgs.writeText "gtklock.css" ''
   button {
       box-shadow: none;
       border-radius: 5px;
-      border: none;
-      background: #171717;
+      border: 1px solid rgba(255, 255, 255, 0.09);
+      background: rgba(255, 255, 255, 0.06);
   }
   entry {
-      background-color: #232323;
+      background-color: rgba (43, 43, 43, 1);
       border: 1px solid rgba(46, 46, 46, 1);
-      color: #fff;
+      color: #eee;
   }
   entry:focus {
       box-shadow: none;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

1. **Improved Autolock Functionality**:
   - Previously, when inactive for 5 minutes, the screen would dim to low brightness and return to 100% brightness for a moment before locking.
   This behavior should be fixed now - the transition from dimming to the lock screen should now be smooth.
   - Can be tested by letting system idle for 5 minutes or replacing `${builtins.toString cfg.autolock.duration}` with desired time in seconds in `/modules/desktop/graphics/labwc.config.nix:267`.

2. **Relocated Styles**:
   - Moved the definitions for the lock screen, login screen, and app launcher styles into the dedicated styles directory.

3. **Updated Default Lock Behavior**:
   - Changed the default lock behavior to use `loginctl`. Loginctl `lock-session` behavior is defined in labwc.config `lock-event` service.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
Lenovo X1
- [ ] Is this a new feature
  - [x] List the test steps to verify:
  Can be tested on Lenovo X1 following usual installation or `nixos-rebuild ... switch`
  To test functionality, check the following:
  - Session locks automatically after screen dims
  - Session lock can be interrupted by user input while screen is dimming
  - Screen dims and transitions to lock screen smoothly without flashing back to full brightness in-between

- [x] If it is an improvement how does it impact existing functionality?
Listed in the description above.