### PR TITLE
Display management in gui vm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -299,17 +299,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1728498882,
-        "narHash": "sha256-S5NEtxfgC3pbglhKxHCymqhId689DzMUU2v2LUobYeA=",
+        "lastModified": 1731077327,
+        "narHash": "sha256-YOPfvknMR9xWrL3YeytprRA26n8v8unaP8djFSQpbZA=",
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "be24afa09e310546ea84832994e59efb0272c303",
+        "rev": "f48fa34f2c6e52b8ccfcdecb3a71d1858130a242",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "be24afa09e310546ea84832994e59efb0272c303",
+        "rev": "f48fa34f2c6e52b8ccfcdecb3a71d1858130a242",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,7 @@
     };
 
     givc = {
-      url = "github:tiiuae/ghaf-givc/be24afa09e310546ea84832994e59efb0272c303";
+      url = "github:tiiuae/ghaf-givc/f48fa34f2c6e52b8ccfcdecb3a71d1858130a242";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/modules/givc/flake-module.nix
+++ b/modules/givc/flake-module.nix
@@ -12,6 +12,10 @@
       inputs.givc.nixosModules.host
       ./common.nix
       ./host.nix
+      {
+        # Include givc overlay to import app
+        nixpkgs.overlays = [ inputs.givc.overlays.default ];
+      }
     ];
     givc-guivm.imports = [
       inputs.givc.nixosModules.sysvm

--- a/modules/givc/host.nix
+++ b/modules/givc/host.nix
@@ -33,6 +33,7 @@ in
         services = [
           "reboot.target"
           "poweroff.target"
+          "suspend.target"
         ] ++ map (vmName: "microvm@${vmName}.service") (attrNames config.microvm.vms);
         tls.enable = config.ghaf.givc.enableTls;
         admin = config.ghaf.givc.adminConfig;

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -31,6 +31,18 @@ let
       ../../../common/logging/client.nix
       (
         { lib, pkgs, ... }:
+        let
+          inherit (builtins) replaceStrings;
+          cliArgs = replaceStrings [ "\n" ] [ " " ] ''
+            --name ${config.ghaf.givc.adminConfig.name}
+            --addr ${config.ghaf.givc.adminConfig.addr}
+            --port ${config.ghaf.givc.adminConfig.port}
+            ${lib.optionalString config.ghaf.givc.enableTls "--cacert /run/givc/ca-cert.pem"}
+            ${lib.optionalString config.ghaf.givc.enableTls "--cert /run/givc/ghaf-host-cert.pem"}
+            ${lib.optionalString config.ghaf.givc.enableTls "--key /run/givc/ghaf-host-key.pem"}
+            ${lib.optionalString (!config.ghaf.givc.enableTls) "--notls"}
+          '';
+        in
         {
           ghaf = {
             users.accounts.enable = lib.mkDefault config.ghaf.users.accounts.enable;
@@ -92,6 +104,37 @@ let
             services.disks.enable = true;
             services.disks.fileManager = "${pkgs.pcmanfm}/bin/pcmanfm";
             services.xdghandlers.enable = true;
+          };
+
+          services.acpid = lib.mkIf config.ghaf.givc.enable {
+            enable = true;
+            lidEventCommands = ''
+              case "$1" in
+                "button/lid LID close")
+                  # Lock sessions
+                  ${pkgs.systemd}/bin/loginctl lock-sessions
+
+                  # Switch off display, if wayland is running
+                  if ${pkgs.procps}/bin/pgrep -fl "wayland" > /dev/null; then
+                    wl_running=1
+                    WAYLAND_DISPLAY=/run/user/1000/wayland-0 ${pkgs.wlopm}/bin/wlopm --off '*'
+                  else
+                    wl_running=0
+                  fi
+
+                  # Initiate Suspension
+                  ${pkgs.givc-cli}/bin/givc-cli ${cliArgs} suspend
+
+                  # Enable display
+                  if [ "$wl_running" -eq 1 ]; then
+                    WAYLAND_DISPLAY=/run/user/1000/wayland-0 ${pkgs.wlopm}/bin/wlopm --on '*'
+                  fi
+                  ;;
+                "button/lid LID open")
+                  # Command to run when the lid is opened
+                  ;;
+              esac
+            '';
           };
 
           systemd.services."waypipe-ssh-keygen" =

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -55,6 +55,7 @@ in
         withHardenedConfigs = true;
       };
       ghaf.givc.host.enable = true;
+      services.logind.lidSwitch = "ignore";
 
       # TODO: remove hardcoded paths
       systemd.services."microvm@audio-vm".serviceConfig =


### PR DESCRIPTION

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
- Turn off the display when system is suspended (Lid closed) and turn on when it resumes(Lid Open).
- Host notifies admin vm for the events and admin vm starts and stops display-resume and display suspend services based on event on gui vm.

More details are available on [Confluence](https://ssrc.atlassian.net/wiki/spaces/GA/pages/1428357127/Power+and+Display+Management+in+Laptops).

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: Lenovo X1 `x86_64`
- [x] Is this a new feature
  - [x] List the test steps to verify:
  - [x] Close laptop lid and wait for 3-4 seconds and open the lid and check if display is suspended and restored.
  - [x] Also check gui-vm and host-vm journalctl log for error. There should not be any error regarding display suspend and resume.
- [ ] If it is an improvement how does it impact existing functionality?

