### PR TITLE
Enable USB controller for AppVMs

### DIFF
--- a/modules/microvm/virtualization/microvm/appvm.nix
+++ b/modules/microvm/virtualization/microvm/appvm.nix
@@ -161,6 +161,8 @@ let
                       "accel=kvm:tcg,mem-merge=on,sata=off"
                       "-device"
                       "vhost-vsock-pci,guest-cid=${toString cid}"
+                      "-device"
+                      "qemu-xhci"
                     ]
                     ++ lib.optionals vm.vtpm.enable [
                       "-chardev"


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

QEMU VMs require a USB controller for hotplugging to work. MicroVM.nix automatically enables the USB controller when any static USB devices are added or when graphics.enable is set to true, but this is not the case for all AppVMs. For example, after the internal USB camera passthrough to ChromiumVM was commented out, there is no USB controller present and USB camera hotplugging no longer works. This fix addresses that issue.

Fixes SSRCSP-5500.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

Connect a USB camera to Lenovo X1 and make sure it's available in Chromium.
