### PR TITLE
Move all workflow builds to remote builders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
           echo -e "\n[+] Git log after rebase (with $CONTEXT commits context):"
           git log --oneline -n$(( COMMITS + CONTEXT ))
       - name: Install nix
-        uses: cachix/install-nix-action@v24
+        uses: cachix/install-nix-action@v30
         with:
           extra_nix_config: |
             connect-timeout = 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,13 +147,16 @@ jobs:
         uses: cachix/install-nix-action@v24
         with:
           extra_nix_config: |
-            trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://ghaf-dev.cachix.org?priority=20 https://cache.nixos.org
             connect-timeout = 5
             system-features = nixos-test benchmark big-parallel kvm
             builders-use-substitutes = true
             builders = @/etc/nix/machines
             log-lines = 100
+            # do not build anything locally, delegate all builds to remote builders:
+            max-jobs = 0
+            # allow nix build to use the binary cache(s) configured in ghaf flake:
+            trusted-users = runner
+            accept-flake-config = true
       - name: Configure remote builder
         run: |
           sudo sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >/etc/nix/id_builder_key"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install nix
-        uses: cachix/install-nix-action@v24
+        uses: cachix/install-nix-action@v30
       - name: Check .nix formatting
         run: nix fmt -- --fail-on-change
       - name: Check reuse lint

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v24
+      - uses: cachix/install-nix-action@v30
       - name: build
         run: nix build .#doc
       - name: deploy


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

- Stop building any ghaf targets directly on github-hosted runners in the `build.yml` workflow. Instead, delegate all builds to remote builders as configured in github action variable `BUILDER_MACHINE_CONFIG`. Currently, all builds will be delegated to `hetzarm.vedenemo.dev` (aarch64) and `build4.vedenemo.dev` (x86_64). We hope this change also makes it possible to start building ghaf's biggest targets (`package-lenovo-x1-carbon-gen11-debug` and `package-generic-x86_64-debug`) in the `build.yml` github action. Adding those targets to the `build.yml` will be done later in a follow-up PR.
- Make builds in `build.yml` start using binary caches as configured in the [ghaf flake](https://github.com/tiiuae/ghaf/blob/285596115982fd3eb53ebd358b1dbcc3c5128414/flake.nix#L6-L24) by setting the `accept-flake-config = true` and by making the github action user '`runner`' a nix trusted user on the github hosted runner. This way, we don't have to change the `build.yml` every time we change the binary cache config in ghaf flake, but the github action builds will automatically follow the ghaf flake configuration.
- Update `cachix/install-nix-action` on all workflows to its current latest version.

This change was tested in a fork at: https://github.com/henrirosten/ghaf.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

