### PR TITLE
EWW: Fix popup window not closing properly, add wlr-randr to guivm

### DIFF
--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -126,6 +126,7 @@ let
                 pkgs.bt-launcher
                 pkgs.pamixer
                 pkgs.eww
+                pkgs.wlr-randr
               ]
               ++ [ pkgs.ctrl-panel ]
               ++ (lib.optional (


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

1. **Fixed Popups Not Closing Automatically**
   - Resolved an issue where popups were reserving screen space even after "closing".
   - This applies to volume and brightness change indicators (previously referred to as hotkey indicators).

2. **Adjusted Popups to Have Their Own Windows**
   - Updated popup behavior so that each popup now opens in a separate, isolated window.
     Popups will no longer interfere with each other and simply overlap instead.

3. **Added Functionality to Close Widgets by Clicking Outside**
   - Widgets should now close automatically when clicking outside their area (e.g. on the desktop).
   - This applies to power menu, calendar and quick settings widgets.

4. **Added wlr-randr to guivm**:
   - To be used in the future by Ghaf control panel.

## Notes:

- If multiple displays are connected, volume and brightness popups show up only on the built-in display.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [x] List the test steps to verify:
    - **Please Verify All Functionality With Multiple Displays As Well**
    - Adjust system brightness or volume using hotkeys (F1-F3, F5-F6) and observe behavior of popup window:
      - The area behind the popup window should be immediately accessible (can be clicked) when popup disappears
    - Open any taskbar widget and attempt to click outside of its area - the widget should close.
    - (Optional) open a terminal and verify `wlr-randr` is a recognized command.
- [x] If it is an improvement how does it impact existing functionality?

