### PR TITLE
build.yml: Use nix-fast-build to build on remote

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,30 +100,6 @@ jobs:
       group: ${{ github.workflow }}.${{ github.event.pull_request.number || github.ref }}.${{ matrix.arch }}.${{ matrix.target }}
       cancel-in-progress: true
     steps:
-      - name: Maximize space available on rootfs
-        # Why not use https://github.com/easimon/maximize-build-space directly?
-        # The reason is: we want to maximize the space on rootfs, since that's
-        # where the nix store (`/nix/store`) is located. Github action
-        # https://github.com/easimon/maximize-build-space maximizes
-        # the builder space on ${GITHUB_WORKSPACE}, which is not what we need.
-        # Alternatively, we could move the nix store to ${GITHUB_WORKSPACE}
-        # and use https://github.com/easimon/maximize-build-space as such, but
-        # we suspect other tooling (e.g. cachix) would not work well with such
-        # configuration.
-        run: |
-          echo "Available storage before cleanup:"
-          df -h
-          echo
-          echo "Removing unwanted software... "
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          echo "... done"
-          echo
-          echo "Available storage after cleanup:"
-          df -h
       - name: Apt install
         run: sudo apt-get update; sudo apt-get install -y inxi git
       - name: Print runner system info
@@ -147,36 +123,24 @@ jobs:
           git log --oneline -n$(( COMMITS + CONTEXT ))
       - name: Install nix
         uses: cachix/install-nix-action@v30
-        with:
-          extra_nix_config: |
-            connect-timeout = 5
-            system-features = nixos-test benchmark big-parallel kvm
-            builders-use-substitutes = true
-            builders = @/etc/nix/machines
-            log-lines = 100
-            # do not build anything locally, delegate all builds to remote builders:
-            max-jobs = 0
-            # allow nix build to use the binary cache(s) configured in ghaf flake:
-            trusted-users = runner
-            accept-flake-config = true
-      - name: Configure remote builder
+      - name: Prepare build
         run: |
-          sudo sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >/etc/nix/id_builder_key"
+          sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >builder_key"
           sudo sh -c "echo '${{ vars.BUILDER_SSH_KNOWN_HOST }}' >>/etc/ssh/ssh_known_hosts"
-          sudo sh -c "echo '${{ vars.BUILDER_MACHINE_CONFIG }}' >/etc/nix/machines"
-      - name: Install cachix
-        run: |
-          nix-env -iA cachix -f https://cachix.org/api/v1/install
-          echo "Using cachix version:"
-          cachix --version
       - name: Build ${{ matrix.arch }}.${{ matrix.target }}
         run: |
-          if [ "${{ secrets.CACHIX_AUTH_TOKEN }}" == "" ]; then
-            echo "::error::Missing CACHIX_AUTH_TOKEN, will not build"
-            exit 1
+          if [ "${{ matrix.arch }}" == "x86_64-linux" ]; then
+            BUILDER='${{ vars.BUILDER_X86 }}'
+          elif [ "${{ matrix.arch }}" == "aarch64-linux" ]; then
+            BUILDER='${{ vars.BUILDER_AARCH }}'
           else
-            echo "Running nix build, with cachix watch-exec"
-            cachix authtoken ${{ secrets.CACHIX_AUTH_TOKEN }}
-            cachix watch-exec -v ghaf-dev -- \
-              nix build .#packages.${{ matrix.arch }}.${{ matrix.target }}
+            echo "::error::Unknown architecture: '${{ matrix.arch }}'"
+            exit 1
           fi
+          NIX_FAST_BUILD_GITREF="1775c732"
+          nix run github:Mic92/nix-fast-build/"$NIX_FAST_BUILD_GITREF"#nix-fast-build -- \
+            --flake .#packages.${{ matrix.arch }}.${{ matrix.target }} \
+            --remote "$BUILDER" \
+            --remote-ssh-option IdentityFile builder_key \
+            --option accept-flake-config true \
+            --no-download --skip-cached --no-nom


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Start using [nix-fast-build](https://github.com/Mic92/nix-fast-build) in the build.yml workflow to execute all build operations completely on the remote end.

Removes the step 'Maximize space available on rootfs' since with `nix-fast-build`, we no longer download the full build closure on the github-hosted runner. Furthermore, with the `--no-download` option, we also skip the download of the final build result (ghaf image), so we no longer need to free up the storage on the github runner.

This change also removes the upload to https://ghaf-dev.cachix.org from the build workflow: it is no longer needed, since builds are already cached on the remote builders' local nix store. Jenkins builds will take care of uploading the build binaries to a separate nix binary cache, maintained with [ghaf-infra](https://github.com/tiiuae/ghaf-infra).

With the above summarized changes, build times on the build.yml workflow will significantly reduce. It should also completely remove the [hash mismatch issues](https://github.com/tiiuae/ghaf/issues/444) on the build workflow as builds and also evaluation operations are executed on the remote.

This change was tested on a fork, as an example, see: https://github.com/henrirosten/ghaf/actions/runs/11587433044. 

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

