### PR TITLE
Fix integrated camera in business-vm

### DIFF
--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -75,6 +75,14 @@ let
         {
           class = 14;
           description = "Video (USB Webcams)";
+          ignore = [
+            {
+              # Ignore Lenovo X1 camera since it is attached to the business-vm
+              vendorId = "04f2";
+              productId = "b751";
+              description = "Lenovo X1 Integrated Camera";
+            }
+          ];
         }
       ];
     }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

The integrated camera is passed to the business-vm through the QEMU options but the hot-plugging service is configured to pass all USB cameras to the chromium-vm. This adds it to the ignore list so that it stays connected to the business-vm.

Fixes SSRCSP-5557.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

Test that the integrated Lenovo X1 camera works in applications launched from the business-vm.
Note: A reboot is required if the system is updated using nixos-rebuild.

