### PR TITLE
Fix the camera pass through to the business-vm

### DIFF
--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -78,8 +78,23 @@ let
           ignore = [
             {
               # Ignore Lenovo X1 camera since it is attached to the business-vm
+              # Finland SKU
               vendorId = "04f2";
               productId = "b751";
+              description = "Lenovo X1 Integrated Camera";
+            }
+            {
+              # Ignore Lenovo X1 camera since it is attached to the business-vm
+              # Uae 1st SKU
+              vendorId = "5986";
+              productId = "2145";
+              description = "Lenovo X1 Integrated Camera";
+            }
+            {
+              # Ignore Lenovo X1 camera since it is attached to the business-vm
+              # UAE #2 SKU
+              vendorId = "30c9";
+              productId = "0052";
               description = "Lenovo X1 Integrated Camera";
             }
           ];


### PR DESCRIPTION
Using the vendor:product ID for the UAE SKU

-------

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
MVP X1 carbon
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [x] If it is an improvement how does it impact existing functionality?
Enables internal camera in the business-vm for the UAE laptops running on X1