### PR TITLE
Desktop: Fix volume popup appearing without volume change

### DIFF
--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -298,8 +298,8 @@ let
             get "$current_brightness" &
             if [[ "$current_brightness" != "$prev_brightness" ]]; then
                 show_popup > /dev/null 2>&1
-                prev_brightness="$current_brightness"
             fi
+            prev_brightness="$current_brightness"
         done
       }
 
@@ -369,17 +369,26 @@ let
       }
 
       get() {
-          volume=$(pamixer --get-volume | awk '{print $1 + 0.0}')
+          if [ -z "$1" ]; then
+              volume=$(pamixer --get-volume)
+          else
+              volume="$1"
+          fi
           muted=$(pamixer --get-mute)
           icon=$(icon "$volume" "$muted")
           echo "{ \"level\": \"$volume\", \"muted\": \"$muted\", \"icon\": \"$icon\" }"
       }
 
       listen() {
+        prev_volume=""
         pactl subscribe | while read -r event; do
             if [[ "$event" == *"change"* ]]; then
-                get &
-                show_popup > /dev/null 2>&1
+                volume=$(pamixer --get-volume)
+                get "$volume" &
+                if [[ "$volume" != "$prev_volume" ]]; then
+                    show_popup > /dev/null 2>&1
+                fi
+                prev_volume="$volume"
             fi
         done
       }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

1. **Fixed Volume Popup Appearing Without Volume Change:**
    - Volume popup should now appear only after these conditions are met: a pulseaudio change event occurred AND volume level has changed.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- Observe volume popup behavior in the following scenarios separately in no particular order:
  - Open chromium or other browser and start audio playback
  - Open MS Teams and join a call
  - Adjust volume with the function keys (F1, F2)
- Volume popup should appear only when adjustments are made with the function keys

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

