### PR TITLE
Options for CUDA, podman and docker updated with nvidia-container support

### DIFF
--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -14,6 +14,7 @@
     ./users/accounts.nix
     ./version
     ./virtualization/docker.nix
+    ./virtualization/podman.nix
     ./systemd
     ./services
     ./networking

--- a/modules/common/development/cuda.nix
+++ b/modules/common/development/cuda.nix
@@ -1,0 +1,24 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ lib, config, ... }:
+let
+  cfg = config.ghaf.development.cuda;
+  inherit (lib) mkEnableOption mkIf;
+in
+{
+  options.ghaf.development.cuda = {
+    enable = mkEnableOption "CUDA Support";
+  };
+
+  config = mkIf cfg.enable {
+    #Enabling CUDA on any supported system requires below settings. 
+    nixpkgs.config.allowUnfree = lib.mkForce true;
+    nixpkgs.config.allowBroken = lib.mkForce false;
+    nixpkgs.config.cudaSupport = lib.mkForce true;
+    
+    # Enable Opengl
+    # Opengl enable is renamed to hardware.graphics.enable
+    # This is needed for CUDA so set it if it is already not set
+    hardware.graphics.enable = lib.mkForce true;
+  };
+}

--- a/modules/common/development/default.nix
+++ b/modules/common/development/default.nix
@@ -6,5 +6,6 @@
     ./usb-serial.nix
     ./nix.nix
     ./ssh.nix
+    ./cuda.nix
   ];
 }

--- a/modules/common/virtualization/podman.nix
+++ b/modules/common/virtualization/podman.nix
@@ -6,28 +6,26 @@ let
   inherit (lib) mkEnableOption mkIf;
 in
 {
-  options.ghaf.virtualization.docker.daemon = {
-    enable = mkEnableOption "Docker Daemon";
+  options.ghaf.virtualization.podman.daemon = {
+    enable = mkEnableOption "Podman Daemon";
   };
-
   config = mkIf cfg.enable {
     # Just ensure containers are enabled by boot.
     boot.enableContainers = lib.mkForce true;
 
-    # For CUDA support unfree libraries and CudaSupport should be set
+    # For CUDA support: Enable if not already enabled.
     ghaf.development.cuda.enable = lib.mkForce true;
 
-    # Docker Daemon Settings
-    virtualisation.docker = {
-      # To force Docker package version settings
-      #package = pkgs.docker_26;
-
+    virtualisation.podman = {
       enable = true;
-      rootless = {
-        enable = true;
-        setSocketVariable = true;
-      };
-
+      # The enableNvidia option is still used in jetpack-nixos while it is obsolete in nixpkgs
+      # but it is still only option for nvidia-orin devices.
+      enableNvidia = (config.nixpkgs.localSystem.isAarch64 == true) && (config.hardware.nvidia-jetpack.enable == true);
+      # Create a `docker` alias for podman, to use it as a drop-in replacement
+      dockerCompat = (config.virtualisation.docker.enable == false);
+      dockerSocket.enable = (config.virtualisation.docker.enable == false);
+      # Required for containers under podman-compose to be able to talk to each other.
+      defaultNetwork.settings.dns_enabled = true;
       # Container file and processor limits 
       # daemon.settings = {
       #   default-ulimits = {
@@ -44,7 +42,7 @@ in
       #     };
       #   };
     };
-
+      
     # Enabling CDI NVIDIA devices in podman or docker (nvidia docker container)
     # For Orin devices this setting does not work as jetpack-nixos still does not support them.
     # jetpack-nixos uses enableNvidia = true; even though it is deprecated
@@ -52,17 +50,14 @@ in
     # virtualisation.containers.cdi.dynamic.nvidia.enable = true;
     # but deprecated and changed to hardware.nvidia-container-toolkit.enable
     # We enable below setting if architecture ix x86_64 and if the video driver is nvidia set it true
-    hardware.nvidia-container-toolkit.enable =
-      config.nixpkgs.localSystem.isx86_64
-      && (builtins.elem "nvidia" config.services.xserver.videoDrivers);
+    hardware.nvidia-container-toolkit.enable = (config.nixpkgs.localSystem.isx86_64 == true) &&
+       (builtins.elem "nvidia" config.services.xserver.videoDrivers) ;
 
     # Enable Opengl renamed to hardware.graphics.enable
     hardware.graphics.enable = lib.mkForce true;
 
-    # Add user to docker group and dialout group for access to serial ports
-    users.users."ghaf".extraGroups = [
-      "docker"
-      "dialout"
-    ];
+    # Add user to podman and docker group (due to compatibility mode) 
+    # and dialout group for access to serial ports
+    users.users."ghaf".extraGroups = ["docker" "dialout" "podman"];
   };
 }

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -31,7 +31,7 @@ let
           # For WLAN firmwares
           hardware = {
             enableRedistributableFirmware = som == "agx";
-            wirelessRegulatoryDatabase = true;
+            wirelessRegulatoryDatabase = som == "agx";
           };
 
           services.dnsmasq.settings.dhcp-option = [


### PR DESCRIPTION
A ghaf option for CUDA added to enable on supporting platforms. Options for podman and docker are also updated to support nvidia containers (on supporting platforms) and allow both coexist together. 