### PR TITLE
Implement autoreconnect for hotplugged devices on VM restarts

### DIFF
--- a/packages/vhotplug/default.nix
+++ b/packages/vhotplug/default.nix
@@ -15,6 +15,7 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = [
     python3Packages.pyudev
     python3Packages.psutil
+    python3Packages.inotify-simple
     qemuqmp
   ];
 
@@ -23,7 +24,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "tiiuae";
     repo = "vhotplug";
-    rev = "fd05361ed893d06cdb5ac4a538c171e4a86b6f5a";
-    hash = "sha256-6fl5xeSpcIIBKn3dZUAEHiNRRpn9LbYC4Imap5KBH2M=";
+    rev = "dc91f43d90da24782bd32cfc5a79afc9fe74d9e6";
+    hash = "sha256-qyLEUNoXHzj5BjUV0i7YjWA9U206J/BGwgvLkni0kIs=";
   };
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This updates the hotplugging service to detect VM restarts and automatically reconnect devices. Currently, users need to manually reconnect USB devices like keyboards and mice after a gui-vm restart, which happens quite often after nixos-rebuild switch. This fix makes all hotplugged devices persist through VM restarts.

Fixes SSRCSP-5141.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

On Lenovo X1, connect USB input devices, restart gui-vm and make sure they still work.
A more detailed testing procedure is described in SSRCSP-5141.

Note: A reboot or hotplugging service restart is required if the system is updated using nixos-rebuild.

