### PR TITLE
Forbid changing home directory

### DIFF
--- a/modules/common/services/desktop.nix
+++ b/modules/common/services/desktop.nix
@@ -181,7 +181,7 @@ in
             {
               name = "File Manager";
               description = "Organize & Manage Files";
-              path = "${pkgs.pcmanfm}/bin/pcmanfm";
+              path = "${pkgs.pcmanfm}/bin/pcmanfm /Shares";
               icon = "system-file-manager";
             }
 

--- a/modules/common/users/desktop.nix
+++ b/modules/common/users/desktop.nix
@@ -31,6 +31,9 @@ let
         type = types.listOf types.str;
         default = [ ];
       };
+      readOnlyHome = mkEnableOption "read-only home directory" // {
+        default = true;
+      };
       homeSize = mkOption {
         description = ''
           Size of the home directory for the login user in MB (integer).
@@ -273,6 +276,7 @@ in
               --noexec=true \
               --nodev=true \
               --disk-size=${toString cfg.loginUser.homeSize}M \
+              --access-mode=${if cfg.loginUser.readOnlyHome then "500" else "700"} \
               --shell=/run/current-system/sw/bin/bash \
               --uid=${toString cfg.loginUser.uid} \
               --member-of=users${

--- a/modules/reference/desktop/applications.nix
+++ b/modules/reference/desktop/applications.nix
@@ -35,7 +35,7 @@ in
           name = "File Manager";
           description = "Organize & Manage Files";
           icon = "system-file-manager";
-          command = "${pkgs.pcmanfm}/bin/pcmanfm";
+          command = "${pkgs.pcmanfm}/bin/pcmanfm /Shares";
         }
 
         {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Forbid changing home directory to prevent users from filling RAM, since all directories except finitely many use tmpfs. Also, change file manager default directory to Shares. 

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

1. File manager must open `/home/ghaf/Shares` instead of default home directory.
2. Ensure that home directory is not writable. 

