### PR TITLE
Fix opening files from gui-vm

### DIFF
--- a/packages/ghaf-xdg-open/default.nix
+++ b/packages/ghaf-xdg-open/default.nix
@@ -21,24 +21,21 @@ writeShellApplication {
     read -r sourcepath
     filename=$(basename "$sourcepath")
     zathurapath="/var/tmp/$filename"
-    chromiumvmip=$(dig +short chromium-vm | head -1)
-    googlechromevmip=$(dig +short chrome-vm | head -1)
 
+    googlechromevmip=$(dig +short chrome-vm | head -1)
     businessvmip=$(dig +short business-vm | head -1)
     commsvmip=$(dig +short comms-vm | head -1)
-    guivmip=$(dig +short gui-vm | head -1)
 
 
-    if [[ "$chromiumvmip" != "$REMOTE_ADDR" && \
+    if [[ "127.0.0.1" != "$REMOTE_ADDR" && \
       "$businessvmip" != "$REMOTE_ADDR" && \
       "$googlechromevmip" != "$REMOTE_ADDR" && \
-      "$commsvmip" != "$REMOTE_ADDR" && \
-      "$guivmip" != "$REMOTE_ADDR" ]]; then
-      echo "Open PDF request received from $REMOTE_ADDR, but it is only permitted for chrome-vm,chromium-vm, business-vm, comms-vm, or gui-vm"
+      "$commsvmip" != "$REMOTE_ADDR" ]]; then
+      echo "Open PDF request received from $REMOTE_ADDR, but it is only permitted for chrome-vm, business-vm, comms-vm, or gui-vm"
       exit 0
     fi
 
-    if [[ "$guivmip" != "$REMOTE_ADDR" ]]; then
+    if [[ "127.0.0.1" != "$REMOTE_ADDR" ]]; then
       echo "Copying $sourcepath from $REMOTE_ADDR to $zathurapath in zathura-vm"
       scp -i ${sshKeyPath} -o StrictHostKeyChecking=no "$REMOTE_ADDR":"$sourcepath" zathura-vm:"$zathurapath"
     else


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

- Opening PDF files from file manager should work.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: x1 carbon only
- [ ] Is this a new feature
  - [x] List the test steps to verify:
    - Open files from each VM that supports PDF and image viewing. All combinations should work.
- [ ] If it is an improvement how does it impact existing functionality?

