### PR TITLE
Added shared memory multi-server feature

### DIFF
--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -116,8 +116,9 @@ let
                     enable = true;
                     inherit vm;
                   }
-                  // optionalAttrs configHost.ghaf.shm.enable {
-                    inherit (configHost.ghaf.shm) serverSocketPath;
+                  // optionalAttrs configHost.ghaf.shm.gui {
+                    inherit (configHost.ghaf.shm.service.gui) clientSocketPath;
+                    inherit (configHost.ghaf.shm.service.gui) serverSocketPath;
                   };
 
                 ghaf-audio = {
@@ -353,7 +354,20 @@ in
       );
       default = { };
     };
-
+    shm-audio-enabled-vms = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        List of appvms that use shared memory to handle audio data
+      '';
+    };
+    shm-gui-enabled-vms = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        List of appvms that use shared memory to handle GUI data
+      '';
+    };
     extraModules = mkOption {
       description = ''
         List of additional modules to be imported and evaluated as part of

--- a/modules/microvm/host/shared-mem.nix
+++ b/modules/microvm/host/shared-mem.nix
@@ -13,12 +13,86 @@ let
   cfg = config.ghaf.shm;
   inherit (lib)
     foldl'
-    lists
     mkMerge
     mkIf
     mkOption
     types
     ;
+  # Get the list of enabled only services
+  enabledServices = lib.filterAttrs (_name: serverAttrs: serverAttrs.enabled) cfg.service;
+
+  # Get the list of enabled services that run on VMs (i.e. excluding host services)
+  enabledVmServices =
+    isVM:
+    lib.filterAttrs (_name: serverAttrs: serverAttrs.serverConfig.runsOnVm == isVM) enabledServices;
+
+  # Get the list of clients for a given service
+  # Sample output: (clientsPerService "gui-vm") -> ["chrome-vm" "business-vm" "comms-vm"]
+  clientsPerService =
+    service:
+    lib.flatten (
+      lib.mapAttrsToList (
+        name: value: if (name == service || service == "all") then value.clients else [ ]
+      ) enabledServices
+    );
+
+  # Get the list of all VMs (clients and servers)
+  # Sample output: ["chrome-vm" "business-vm" "comms-vm"]
+  allVMs = lib.unique (
+    lib.concatLists (
+      map (s: (lib.filter (client: client != "host") s.clients) ++ [ s.server ]) (
+        builtins.attrValues enabledServices
+      )
+    )
+  );
+
+  # Get the list of client-service pairs
+  # Sample output:
+  # [ {client = "chrome-vm"; service = "audio";} {client = "business-vm"; service = "audio";} ]
+  clientServicePairs = lib.unique (
+    lib.concatLists (
+      map (
+        s:
+        map (c: {
+          service = s.name;
+          client = c;
+        }) s.clients
+      ) (lib.mapAttrsToList (name: attrs: attrs // { inherit name; }) enabledServices)
+    )
+  );
+
+  # Get the list of client-service pairs with their assigned IDs
+  # Sample output:
+  # [ {client = "chrome-vm";   id = 0; service = "audio";}
+  #   {client = "business-vm"; id = 1; service = "audio";}]
+  clientServiceWithID = lib.foldl' (
+    acc: pair: acc ++ [ (pair // { id = builtins.length acc; }) ]
+  ) [ ] clientServicePairs;
+
+  # Get the client slot ID (integer) for a given client and service
+  clientID =
+    client: service:
+    let
+      filtered = builtins.filter (x: x.client == client && x.service == service) clientServiceWithID;
+    in
+    if filtered != [ ] then (builtins.toString (builtins.head filtered).id) else null;
+
+  # Generate a string of comma-separated client IDs for a given service, to be used in command line
+  # arguments for the memsocket server
+  # Sample output:  { audio = "0,1,2"; gui = "3,4,5,6,7"; }
+  clientsArg = lib.foldl' (
+    acc: pair:
+    (
+      acc
+      // {
+        "${pair.service}" =
+          if (builtins.hasAttr "${pair.service}" acc) then
+            acc.${pair.service} + "," + (builtins.toString pair.id)
+          else
+            (builtins.toString pair.id);
+      }
+    )
+  ) { } clientServiceWithID;
 in
 {
   options.ghaf.shm = {
@@ -26,30 +100,90 @@ in
       type = types.bool;
       default = false;
       description = ''
-        Enables shared memory communication between virtual machines (VMs)
+        Enables shared memory communication between virtual machines (VMs) and the host
       '';
+    };
+    gui = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables shared memory for transferring GUI data between virtual machines
+      '';
+    };
+    audio = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Enables shared memory for transferring audio data between virtual machines
+      '';
+      apply = value: if value then cfg.enable else false;
     };
     memSize = mkOption {
       type = types.int;
-      default = 16;
+      default = 32;
       description = ''
         Specifies the size of the shared memory region, measured in
         megabytes (MB)
       '';
     };
-    hugePageSz = mkOption {
-      type = types.str;
-      default = "2M";
+
+    service = mkOption {
+      type = types.attrsOf types.anything;
+      default =
+        let
+          stdConfig = service: {
+            server = "${service}-vm";
+            clientSocketPath = "/run/memsocket/${service}-client.sock";
+            serverSocketPath = service: suffix: "/run/memsocket/${service}${suffix}.sock";
+            userService = false;
+            serverConfig = {
+              runsOnVm = true;
+            };
+          };
+        in
+        {
+          gui =
+            let
+              enabled = cfg.enable && cfg.gui;
+            in
+            mkIf cfg.enable (
+              lib.attrsets.recursiveUpdate (stdConfig "gui") {
+                inherit enabled;
+                serverSocketPath = service: suffix: "/tmp/${service}${suffix}.sock";
+                serverConfig = {
+                  userService = true;
+                  systemdParams = service: suffix: {
+                    wantedBy = [ "ghaf-session.target" ];
+                    after = [ "waypipe${suffix}.service" ];
+                    partOf = [ "waypipe${suffix}.service" ];
+                    bindsTo = [ "waypipe${suffix}.service" ];
+                    serviceConfig = {
+                      KillSignal = "SIGTERM";
+                      ExecStop = "${pkgs.coreutils}/bin/rm -f ${cfg.service.gui.serverSocketPath service suffix}";
+                    };
+                  };
+                  multiProcess = true;
+                };
+                clients = config.ghaf.virtualization.microvm.appvm.shm-gui-enabled-vms;
+                clientConfig = {
+                  userService = false;
+                  systemdParams = {
+                    wantedBy = [ "default.target" ];
+                    serviceConfig = {
+                      KillSignal = "SIGTERM";
+                      User = "appuser";
+                      Group = "users";
+                    };
+                  };
+                };
+              }
+            );
+        };
       description = ''
-        Specifies the size of the large memory page area. Supported kernel
-        values are 2 MB and 1 GB
+        Specifies the configuration of shared memory services:
+        server and client VMs. The server VMs are named after the 
+        service name.
       '';
-      apply =
-        value:
-        if value != "2M" && value != "1G" then
-          builtins.throw "Invalid huge memory area page size"
-        else
-          value;
     };
     hostSocketPath = mkOption {
       type = types.path;
@@ -68,53 +202,11 @@ in
         conflicts with other memory areas, such as PCI regions.
       '';
     };
-    vms_enabled = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      description = ''
-        List of vms having access to shared memory
-      '';
-    };
-    enable_host = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Enables the memsocket functionality on the host system
-      '';
-    };
-    instancesCount = mkOption {
+    shmSlots = mkOption {
       type = types.int;
-      default =
-        if cfg.enable_host then (builtins.length cfg.vms_enabled) + 1 else builtins.length cfg.vms_enabled;
+      default = builtins.length clientServiceWithID;
       description = ''
         Number of memory slots allocated in the shared memory region
-      '';
-    };
-    serverSocketPath = mkOption {
-      type = types.path;
-      default = "/run/user/${builtins.toString config.ghaf.users.loginUser.uid}/memsocket-server.sock";
-      description = ''
-        Specifies the path of the listening socket, which is used by Waypipe
-        or other server applications as the output socket in server mode for
-        data transmission
-      '';
-    };
-    clientSocketPath = mkOption {
-      type = types.path;
-      default = "/run/user/${builtins.toString config.ghaf.users.loginUser.uid}/memsocket-client.sock";
-      description = ''
-        Specifies the location of the output socket, which will connected to
-        in order to receive data from AppVMs. This socket must be created by
-        another application, such as Waypipe, when operating in client mode
-      '';
-    };
-    display = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Enables the use of shared memory with Waypipe for Wayland-enabled
-        applications running on virtual machines (VMs), facilitating
-        efficient inter-VM communication
       '';
     };
   };
@@ -122,26 +214,136 @@ in
     let
       user = "microvm";
       group = "kvm";
+      memsocket = pkgs.memsocket-app.override {
+        inherit (cfg) shmSlots;
+        debug = false;
+      };
+      vectors = toString (2 * cfg.shmSlots);
+      defaultClientConfig =
+        data:
+        lib.attrsets.recursiveUpdate {
+          enable = true;
+          description = "memsocket";
+          serviceConfig = {
+            Type = "simple";
+            ExecStart =
+              let
+                hostOpt = if data.client == "host" then "-h ${cfg.hostSocketPath}" else "";
+              in
+              "${memsocket}/bin/memsocket ${hostOpt} -c ${
+                cfg.service.${data.service}.clientSocketPath
+              } ${builtins.toString (clientID data.client data.service)}";
+            Restart = "always";
+            RestartSec = "1";
+            RuntimeDirectory = "memsocket";
+            RuntimeDirectoryMode = "0770";
+          };
+        } cfg.service.${data.service}.clientConfig.systemdParams;
+      clientConfigTemplate =
+        data:
+        let
+          base =
+            if cfg.service.${data.service}.clientConfig.userService then
+              {
+                user.services."memsocket-${data.service}-client" = defaultClientConfig data;
+              }
+            else
+              {
+                services."memsocket-${data.service}-client" = defaultClientConfig data;
+              };
+
+        in
+        if data.client == "host" then
+          base
+        else
+          {
+            "${data.client}".config.config.systemd = base;
+          };
+
+      defaultServerConfig =
+        clientSuffix: clientId: service: runsOnVm:
+        lib.attrsets.recursiveUpdate {
+          enable = true;
+          description = "memsocket";
+          serviceConfig = {
+            Type = "simple";
+            ExecStart =
+              let
+                hostOpt = if !runsOnVm then "-h ${cfg.hostSocketPath}" else "";
+              in
+              "${memsocket}/bin/memsocket -s ${
+                cfg.service.${service}.serverSocketPath service clientSuffix
+              } ${hostOpt} -l ${clientId}";
+            Restart = "always";
+            RestartSec = "1";
+            RuntimeDirectory = "memsocket";
+            RuntimeDirectoryMode = "0750";
+          };
+        } (cfg.service.${service}.serverConfig.systemdParams service clientSuffix);
+      serverConfigTemplate =
+        clientSuffix: clientId: service:
+        let
+          base =
+            if cfg.service.${service}.serverConfig.userService then
+              {
+                user.services."memsocket-${service}${clientSuffix}-service" =
+                  defaultServerConfig clientSuffix clientId service
+                    cfg.service.${service}.serverConfig.runsOnVm;
+              }
+            else
+              {
+                services."memsocket-${service}${clientSuffix}-service" =
+                  defaultServerConfig clientSuffix clientId service
+                    cfg.service.${service}.serverConfig.runsOnVm;
+              };
+        in
+        if cfg.service.${service}.serverConfig.runsOnVm then
+          {
+            "${cfg.service.${service}.server}".config.config.systemd = base;
+          }
+        else
+          base;
+      serverConfig =
+        service:
+        let
+          multiProcess =
+            if lib.attrsets.hasAttr "multiProcess" cfg.service.${service}.serverConfig then
+              cfg.service.${service}.serverConfig.multiProcess
+            else
+              false;
+        in
+        if multiProcess then
+          (lib.foldl' lib.attrsets.recursiveUpdate { } (
+            map (client: serverConfigTemplate "-${client}" (clientID client service) service) (
+              clientsPerService service
+            )
+          ))
+        else
+          (serverConfigTemplate "" # clientSuffix
+            clientsArg.${service}
+            service
+          );
+
     in
     mkIf cfg.enable (mkMerge [
       {
-        boot.kernelParams =
-          let
-            hugepages = if cfg.hugePageSz == "2M" then cfg.memSize / 2 else cfg.memSize / 1024;
-          in
-          [
-            "hugepagesz=${cfg.hugePageSz}"
-            "hugepages=${toString hugepages}"
-          ];
+        systemd.services.setShmOwnership = {
+          description = "Set ownership for /dev/ivshmem";
+          wantedBy = [ "sysinit.target" ];
+          before = [ "ivshmemsrv.service" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = [
+              "/run/current-system/sw/bin/chown ${user}:${group} /dev/ivshmem"
+              "/run/current-system/sw/bin/chmod 0660 /dev/ivshmem"
+            ];
+            RemainAfterExit = true;
+          };
+        };
       }
-      {
-        systemd.tmpfiles.rules = [
-          "d /dev/hugepages 0755 ${user} ${group} - -"
-        ];
-      }
-      (mkIf cfg.enable_host {
+      (mkIf cfg.enable {
         environment.systemPackages = [
-          (pkgs.memsocket.override { vms = cfg.instancesCount; })
+          memsocket
         ];
       })
       {
@@ -150,23 +352,24 @@ in
             pidFilePath = "/tmp/ivshmem-server.pid";
             ivShMemSrv =
               let
-                vectors = toString (2 * cfg.instancesCount);
+                vectors = toString (2 * cfg.shmSlots);
               in
               pkgs.writeShellScriptBin "ivshmemsrv" ''
                 if [ -S ${cfg.hostSocketPath} ]; then
                   echo Erasing ${cfg.hostSocketPath} ${pidFilePath}
                   rm -f ${cfg.hostSocketPath}
                 fi
-                ${pkgs.qemu_kvm}/bin/ivshmem-server -p ${pidFilePath} -n ${vectors} -m /dev/hugepages/ -l ${(toString cfg.memSize) + "M"}
+                ${pkgs.qemu_kvm}/bin/ivshmem-server -p ${pidFilePath} -n ${vectors} -m /dev -l ${(toString cfg.memSize) + "M"}
               '';
           in
           {
             enable = true;
-            description = "Start qemu ivshmem memory server";
+            description = "qemu ivshmem memory server";
             path = [ ivShMemSrv ];
-            wantedBy = [ "multi-user.target" ];
+            wantedBy = [ "sysinit.target" ];
+            requires = [ "setShmOwnership.service" ];
             serviceConfig = {
-              Type = "oneshot";
+              Type = "simple";
               RemainAfterExit = true;
               StandardOutput = "journal";
               StandardError = "journal";
@@ -177,11 +380,35 @@ in
           };
       }
       {
+        boot.extraModulePackages = [
+          (pkgs.memsocket-secmem.override {
+            inherit (config.boot.kernelPackages) kernel;
+            inherit (cfg) shmSlots;
+            memSize = cfg.memSize * 1024 * 1024;
+            inherit clientServiceWithID;
+          })
+        ];
+      }
+      # shared memory driver for the host with slots control
+      {
+        boot.kernelModules = [ "secshm" ];
+      }
+      # add host systemd client services
+      {
+        systemd = foldl' lib.attrsets.recursiveUpdate { } (
+          map clientConfigTemplate (lib.filter (data: data.client == "host") clientServicePairs)
+        );
+      }
+      # add host systemd server services
+      {
+        systemd = lib.foldl' lib.attrsets.recursiveUpdate { } (
+          map serverConfig (builtins.attrNames (enabledVmServices false))
+        );
+      }
+      {
         microvm.vms =
           let
-            memsocket = pkgs.memsocket.override { vms = cfg.instancesCount; };
-            vectors = toString (2 * cfg.instancesCount);
-            makeAssignment = vmName: {
+            configCommon = vmName: {
               ${vmName} = {
                 config = {
                   config = {
@@ -197,10 +424,9 @@ in
                       kernelParams = [ "kvm_ivshmem.flataddr=${cfg.flataddr}" ];
                     };
                     boot.extraModulePackages = [
-                      # TODO: fix this to not call back to packages dir
-                      (pkgs.linuxPackages.callPackage ../../../packages/pkgs-by-name/memsocket/module.nix {
+                      (pkgs.memsocket-module.override {
                         inherit (config.microvm.vms.${vmName}.config.config.boot.kernelPackages) kernel;
-                        vmCount = cfg.instancesCount;
+                        inherit (cfg) shmSlots;
                       })
                     ];
                     services = {
@@ -213,47 +439,23 @@ in
                     environment.systemPackages = [
                       memsocket
                     ];
-                    systemd.user.services.memsocket =
-                      if vmName == "gui-vm" then
-                        {
-                          enable = true;
-                          description = "memsocket";
-                          serviceConfig = {
-                            Type = "simple";
-                            ExecStart = "${memsocket}/bin/memsocket -c ${cfg.clientSocketPath}";
-                            Restart = "always";
-                            RestartSec = "1";
-                          };
-                          after = [ "ghaf-session.target" ];
-                          wantedBy = [ "ghaf-session.target" ];
-                        }
-                      else
-                        # machines connecting to gui-vm
-                        let
-                          vmIndex = lists.findFirstIndex (vm: vm == vmName) null cfg.vms_enabled;
-                        in
-                        {
-                          enable = true;
-                          description = "memsocket";
-                          serviceConfig = {
-                            Type = "simple";
-                            ExecStart = "${memsocket}/bin/memsocket -s ${cfg.serverSocketPath} ${builtins.toString vmIndex}";
-                            Restart = "always";
-                            RestartSec = "1";
-                          };
-                          wantedBy = [ "default.target" ];
-                        };
                   };
                 };
               };
             };
+            # generate config for memsocket services  running in client mode on VMs
+            clientsConfig = foldl' lib.attrsets.recursiveUpdate { } (
+              map clientConfigTemplate (lib.filter (data: data.client != "host") clientServicePairs)
+            );
+            # generate config for memsocket services running in server mode on VMs
+            clientsAndServers = lib.foldl' lib.attrsets.recursiveUpdate clientsConfig (
+              map serverConfig (builtins.attrNames (enabledVmServices true))
+            );
+            finalMicroVmsConfig = foldl' lib.attrsets.recursiveUpdate clientsAndServers (
+              map configCommon allVMs
+            );
           in
-          foldl' lib.attrsets.recursiveUpdate { } (map makeAssignment cfg.vms_enabled);
-      }
-      {
-        microvm.vms.gui-vm.config.config.boot.kernelParams = [
-          "kvm_ivshmem.flataddr=${cfg.flataddr}"
-        ];
+          finalMicroVmsConfig;
       }
     ]);
 }

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -82,6 +82,10 @@ in
       host = {
         networking.enable = true;
       };
+
+      # Shared memory configuration
+      shm.enable = true;
+      shm.gui = true;
     };
   };
 }

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -27,16 +27,25 @@ in
         "chrome-vm"
       ];
 
-      virtualization.microvm.appvm = {
-        enable = true;
-        vms = {
-          chrome.enable = true;
-          gala.enable = true;
-          zathura.enable = true;
-          comms.enable = true;
-          business.enable = true;
+      virtualization.microvm.appvm =
+        let
+          vms = {
+            chrome.enable = true;
+            gala.enable = true;
+            zathura.enable = true;
+            comms.enable = true;
+            business.enable = true;
+          };
+          vmNames = builtins.map (name: "${name}-vm") (
+            builtins.attrNames (lib.filterAttrs (_: v: v.enable or false) vms)
+          );
+        in
+        {
+          enable = true;
+          inherit vms;
+          shm-gui-enabled-vms = vmNames;
+          shm-audio-enabled-vms = vmNames;
         };
-      };
 
       reference = {
         appvms.enable = true;

--- a/overlays/custom-packages/qemu/0001-ivshmem-flat-memory-support.patch
+++ b/overlays/custom-packages/qemu/0001-ivshmem-flat-memory-support.patch
@@ -1,17 +1,17 @@
-From 13229d9e11eaf15eb6679be036364b9d0256f1c1 Mon Sep 17 00:00:00 2001
+From 06a64db114c91c9519e49bdcade20e6d83313c60 Mon Sep 17 00:00:00 2001
 From: Jaroslaw Kurowski <jaroslaw.kurowski@tii.ae>
-Date: Wed, 10 Jul 2024 15:21:07 +0400
+Date: Mon, 2 Jun 2025 16:25:07 +0400
 Subject: ivshmem flat memory support
 
 ---
- contrib/ivshmem-server/ivshmem-server.c |  6 +-
+ contrib/ivshmem-server/ivshmem-server.c |  7 +--
  hw/i386/pc_q35.c                        |  2 +
- hw/misc/ivshmem.c                       | 74 ++++++++++++++++++++++---
+ hw/misc/ivshmem.c                       | 57 ++++++++++++++++++++++++-
  include/hw/misc/ivshmem.h               |  1 +
- 4 files changed, 71 insertions(+), 12 deletions(-)
+ 4 files changed, 63 insertions(+), 4 deletions(-)
 
 diff --git a/contrib/ivshmem-server/ivshmem-server.c b/contrib/ivshmem-server/ivshmem-server.c
-index 2f3c732..906c5d0 100644
+index 2f3c732..e7c7774 100644
 --- a/contrib/ivshmem-server/ivshmem-server.c
 +++ b/contrib/ivshmem-server/ivshmem-server.c
 @@ -11,6 +11,7 @@
@@ -36,6 +36,14 @@ index 2f3c732..906c5d0 100644
          g_free(filename);
      }
  
+@@ -347,6 +347,7 @@ ivshmem_server_start(IvshmemServer *server)
+ 
+     server->sock_fd = sock_fd;
+     server->shm_fd = shm_fd;
++    server->cur_id = 1;
+ 
+     return 0;
+ 
 diff --git a/hw/i386/pc_q35.c b/hw/i386/pc_q35.c
 index c7bc8a2..d76939e 100644
 --- a/hw/i386/pc_q35.c
@@ -57,7 +65,7 @@ index c7bc8a2..d76939e 100644
                       pc_q35_compat_defaults, pc_q35_compat_defaults_len);
  }
 diff --git a/hw/misc/ivshmem.c b/hw/misc/ivshmem.c
-index de49d1b..b1761b3 100644
+index de49d1b..8b96b75 100644
 --- a/hw/misc/ivshmem.c
 +++ b/hw/misc/ivshmem.c
 @@ -36,6 +36,7 @@
@@ -102,7 +110,7 @@ index de49d1b..b1761b3 100644
  };
  
  /* registers for the Inter-VM shared memory device */
-@@ -476,8 +490,11 @@ static void setup_interrupt(IVShmemState *s, int vector, Error **errp)
+@@ -476,8 +490,12 @@ static void setup_interrupt(IVShmemState *s, int vector, Error **errp)
  
  static void process_msg_shmem(IVShmemState *s, int fd, Error **errp)
  {
@@ -111,16 +119,19 @@ index de49d1b..b1761b3 100644
      size_t size;
 +    void *ptr;
 +    SysBusDevice *sbd;
++    extern const char *qemu_name;
  
      if (s->ivshmem_bar2) {
          error_setg(errp, "server sent unexpected shared memory message");
-@@ -494,13 +511,26 @@ static void process_msg_shmem(IVShmemState *s, int fd, Error **errp)
+@@ -494,13 +512,27 @@ static void process_msg_shmem(IVShmemState *s, int fd, Error **errp)
  
      size = buf.st_size;
  
 +    if (s->flataddr) {
 +
-+        ptr = mmap(0, size, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_HUGETLB|MAP_LOCKED,
++        /* Let the memory driver know my VM name */
++        write(fd, qemu_name, strlen(qemu_name)+1);
++        ptr = mmap(0, size, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_LOCKED,
 +                fd, 0);
 +        s->flat_dev = sysbus_create_simple(TYPE_IVSHMEM_FLAT, -1, 0);
 +
@@ -132,68 +143,16 @@ index de49d1b..b1761b3 100644
 +    }
 +
      /* mmap the region and map into the BAR2 */
--    if (!memory_region_init_ram_from_fd(&s->server_bar2, OBJECT(s),
--                                        "ivshmem.bar2", size, RAM_SHARED,
--                                        fd, 0, errp)) {
-+    memory_region_init_ram_from_fd(&s->server_bar2, OBJECT(s), "ivshmem.bar2",
-+                                   size, RAM_SHARED, fd, 0, &local_err);
-+    if (local_err) {
-+        error_propagate(errp, local_err);
+     if (!memory_region_init_ram_from_fd(&s->server_bar2, OBJECT(s),
+                                         "ivshmem.bar2", size, RAM_SHARED,
+                                         fd, 0, errp)) {
          return;
      }
 -
      s->ivshmem_bar2 = &s->server_bar2;
  }
  
-@@ -832,7 +862,6 @@ static void ivshmem_write_config(PCIDevice *pdev, uint32_t address,
- 
- static void ivshmem_common_realize(PCIDevice *dev, Error **errp)
- {
--    ERRP_GUARD();
-     IVShmemState *s = IVSHMEM_COMMON(dev);
-     Error *err = NULL;
-     uint8_t *pci_conf;
-@@ -902,7 +931,8 @@ static void ivshmem_common_realize(PCIDevice *dev, Error **errp)
-     if (!ivshmem_is_master(s)) {
-         error_setg(&s->migration_blocker,
-                    "Migration is disabled when using feature 'peer mode' in device 'ivshmem'");
--        if (migrate_add_blocker(&s->migration_blocker, errp) < 0) {
-+        if (migrate_add_blocker(&s->migration_blocker, errp) < 0) {
-+            error_free(s->migration_blocker);
-             return;
-         }
-     }
-@@ -920,7 +950,10 @@ static void ivshmem_exit(PCIDevice *dev)
-     IVShmemState *s = IVSHMEM_COMMON(dev);
-     int i;
- 
--    migrate_del_blocker(&s->migration_blocker);
-+    if (s->migration_blocker) {
-+        migrate_del_blocker(&s->migration_blocker);
-+        error_free(s->migration_blocker);
-+    }
- 
-     if (memory_region_is_mapped(s->ivshmem_bar2)) {
-         if (!s->hostmem) {
-@@ -1014,7 +1047,7 @@ static const VMStateDescription ivshmem_plain_vmsd = {
-     .minimum_version_id = 0,
-     .pre_load = ivshmem_pre_load,
-     .post_load = ivshmem_post_load,
--    .fields = (const VMStateField[]) {
-+    .fields = (VMStateField[]) {
-         VMSTATE_PCI_DEVICE(parent_obj, IVShmemState),
-         VMSTATE_UINT32(intrstatus, IVShmemState),
-         VMSTATE_UINT32(intrmask, IVShmemState),
-@@ -1068,7 +1101,7 @@ static const VMStateDescription ivshmem_doorbell_vmsd = {
-     .minimum_version_id = 0,
-     .pre_load = ivshmem_pre_load,
-     .post_load = ivshmem_post_load,
--    .fields = (const VMStateField[]) {
-+    .fields = (VMStateField[]) {
-         VMSTATE_PCI_DEVICE(parent_obj, IVShmemState),
-         VMSTATE_MSIX(parent_obj, IVShmemState),
-         VMSTATE_UINT32(intrstatus, IVShmemState),
-@@ -1083,6 +1116,7 @@ static Property ivshmem_doorbell_properties[] = {
+@@ -1083,6 +1115,7 @@ static Property ivshmem_doorbell_properties[] = {
      DEFINE_PROP_BIT("ioeventfd", IVShmemState, features, IVSHMEM_IOEVENTFD,
                      true),
      DEFINE_PROP_ON_OFF_AUTO("master", IVShmemState, master, ON_OFF_AUTO_OFF),
@@ -201,7 +160,7 @@ index de49d1b..b1761b3 100644
      DEFINE_PROP_END_OF_LIST(),
  };
  
-@@ -1115,6 +1149,20 @@ static void ivshmem_doorbell_class_init(ObjectClass *klass, void *data)
+@@ -1115,6 +1148,20 @@ static void ivshmem_doorbell_class_init(ObjectClass *klass, void *data)
      dc->vmsd = &ivshmem_doorbell_vmsd;
  }
  
@@ -222,7 +181,7 @@ index de49d1b..b1761b3 100644
  static const TypeInfo ivshmem_doorbell_info = {
      .name          = TYPE_IVSHMEM_DOORBELL,
      .parent        = TYPE_IVSHMEM_COMMON,
-@@ -1123,11 +1171,19 @@ static const TypeInfo ivshmem_doorbell_info = {
+@@ -1123,11 +1170,19 @@ static const TypeInfo ivshmem_doorbell_info = {
      .class_init    = ivshmem_doorbell_class_init,
  };
  
@@ -254,5 +213,5 @@ index 433ef53..43aeab7 100644
  
  #endif /* IVSHMEM_H */
 -- 
-2.45.2
+2.49.0
 

--- a/packages/ghaf-powercontrol/package.nix
+++ b/packages/ghaf-powercontrol/package.nix
@@ -116,7 +116,11 @@ writeShellApplication {
       ;;
       logout)
         wayland-logout
-        loginctl kill-user "$USER" -s SIGTERM # Allow services to clean up
+        loginctl terminate-user "$USER"
+        sleep 2
+        loginctl kill-user "$USER" -s SIGTERM
+        sleep 2
+        loginctl kill-user "$USER" -s SIGKILL
         ;;
       help|--help)
           help_msg

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -24,7 +24,9 @@
       final.python3Packages.callPackage ./python-packages/kernel-hardening-checker/package.nix
         { };
     make-checks = final.callPackage ./pkgs-by-name/make-checks/package.nix { };
-    memsocket = final.callPackage ./pkgs-by-name/memsocket/package.nix { };
+    memsocket-app = final.callPackage ./pkgs-by-name/memsocket/package.nix { };
+    memsocket-module = final.callPackage ./pkgs-by-name/memsocket/module.nix { };
+    memsocket-secmem = final.callPackage ./pkgs-by-name/memsocket/secmem.nix { };
     open-normal-extension = final.callPackage ./pkgs-by-name/open-normal-extension/package.nix { };
     qemuqmp = final.python3Packages.callPackage ./python-packages/qemuqmp/package.nix { };
     rtl8126 = final.callPackage ./pkgs-by-name/rtl8126/package.nix { };

--- a/packages/pkgs-by-name/memsocket/module.nix
+++ b/packages/pkgs-by-name/memsocket/module.nix
@@ -3,20 +3,20 @@
 {
   stdenv,
   lib,
-  kernel,
+  kernel ? null,
   fetchFromGitHub,
-  vmCount,
+  shmSlots ? null,
   ...
 }:
 stdenv.mkDerivation {
-  inherit vmCount;
+  inherit shmSlots;
   name = "ivshmem-driver-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "tiiuae";
     repo = "shmsockproxy";
-    rev = "2357926b94ed12c050fdbfbfc0f248393a4c9ea1";
-    sha256 = "sha256-9KlHuVbe5qvjRUXj7oyJ1X7CLvqj7/OoVGDWRqpIY2s=";
+    rev = "2c0a4bad482ec2e076aee9a1ce550b3d9891f05e";
+    sha256 = "sha256-4cXNdG1k45/mF+yqBsfvfYkRK6N9kgsGeeqGB6mRSj4=";
   };
 
   sourceRoot = "source/module";
@@ -26,11 +26,21 @@ stdenv.mkDerivation {
   ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    "MODULEDIR=$(out)/lib/modules/${kernel.modDirVersion}/kernel/drivers/char"
-    "CFLAGS_kvm_ivshmem.o=\"-DCONFIG_KVM_IVSHMEM_VM_COUNT=${builtins.toString vmCount}\""
-  ];
+  makeFlags =
+    [
+      "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      "MODULEDIR=$(out)/lib/modules/${kernel.modDirVersion}/kernel/drivers/char"
+      "CFLAGS_kvm_ivshmem.o=\"-DCONFIG_KVM_IVSHMEM_SHM_SLOTS=${builtins.toString shmSlots}\""
+      "ARCH=${stdenv.hostPlatform.linuxArch}"
+      "INSTALL_MOD_PATH=${placeholder "out"}"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "CROSS_COMPILE=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}"
+    ];
+
+  CROSS_COMPILE = lib.optionalString (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}";
 
   meta = with lib; {
     description = "Shared memory Linux kernel module";

--- a/packages/pkgs-by-name/memsocket/package.nix
+++ b/packages/pkgs-by-name/memsocket/package.nix
@@ -3,7 +3,7 @@
 {
   stdenv,
   debug ? false,
-  vms ? 0,
+  shmSlots ? null,
   fetchFromGitHub,
   ...
 }:
@@ -13,11 +13,11 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "tiiuae";
     repo = "shmsockproxy";
-    rev = "2357926b94ed12c050fdbfbfc0f248393a4c9ea1";
-    sha256 = "sha256-9KlHuVbe5qvjRUXj7oyJ1X7CLvqj7/OoVGDWRqpIY2s=";
+    rev = "2c0a4bad482ec2e076aee9a1ce550b3d9891f05e";
+    sha256 = "sha256-4cXNdG1k45/mF+yqBsfvfYkRK6N9kgsGeeqGB6mRSj4=";
   };
 
-  CFLAGS = "-O2 -DVM_COUNT=" + (toString vms) + (if debug then " -DDEBUG_ON" else "");
+  CFLAGS = "-O2 -DSHM_SLOTS=" + (toString shmSlots) + (if debug then " -DDEBUG_ON" else "");
   sourceRoot = "source/app";
 
   installPhase = ''

--- a/packages/pkgs-by-name/memsocket/secmem.nix
+++ b/packages/pkgs-by-name/memsocket/secmem.nix
@@ -1,0 +1,120 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenv,
+  lib,
+  kernel ? null,
+  shmSlots ? null,
+  memSize ? null,
+  fetchFromGitHub,
+  debug ? false,
+  clientServiceWithID ? null,
+  ...
+}:
+stdenv.mkDerivation {
+  name = "sec_shm-driver-${kernel.version}";
+
+  src = fetchFromGitHub {
+    owner = "tiiuae";
+    repo = "shmsockproxy";
+    rev = "2c0a4bad482ec2e076aee9a1ce550b3d9891f05e";
+    sha256 = "sha256-4cXNdG1k45/mF+yqBsfvfYkRK6N9kgsGeeqGB6mRSj4=";
+  };
+  /*
+    Convert clientServiceWithID into C structure to be
+    included into on-host driver's source code.
+    The structure is put into the secshm_config.h and
+    is used to generate the client table and service table
+    for the driver.
+  */
+  patchPhase =
+    let
+      pow = base: exp: if exp == 0 then 1 else base * (pow base (exp - 1));
+
+      clientNames = lib.unique (map (x: x.client) clientServiceWithID);
+      serviceNames = lib.unique (map (x: x.service) clientServiceWithID);
+
+      clientTable = builtins.concatStringsSep ",\n  " (
+        map (
+          client:
+          let
+            mask = builtins.foldl' (
+              acc: x: if x.client == client then acc + (pow 2 x.id) else acc
+            ) 0 clientServiceWithID;
+          in
+          "  { .name = \"${client}\", .bitmask = 0x${lib.toHexString mask}, .pid = 0 }"
+        ) clientNames
+      );
+
+      serviceTable = builtins.concatStringsSep ",\n  " (
+        map (
+          service:
+          let
+            mask = builtins.foldl' (
+              acc: x: if x.service == service then acc + (pow 2 x.id) else acc
+            ) 0 clientServiceWithID;
+          in
+          "  { .name = \"${service}-vm\", .bitmask = 0x${lib.toHexString mask}, .pid = 0 }"
+        ) serviceNames
+      );
+    in
+    ''
+        cat > secshm_config.h <<EOF
+        #ifndef SECSHM_CONFIG_H
+        #define SECSHM_CONFIG_H
+
+        #define SHM_SLOTS ${builtins.toString shmSlots}
+        #define SHM_SIZE ${builtins.toString memSize}
+
+        struct client_entry {
+          const char* name;
+          const long long int bitmask;
+          pid_t pid;
+        };
+
+        static struct client_entry client_table[] = {
+          ${clientTable},
+          ${serviceTable}
+        };
+
+        #define CLIENT_TABLE_SIZE ${
+          builtins.toString (builtins.length clientNames + builtins.length serviceNames)
+        }
+
+        #endif // SECSHM_CONFIG_H
+      EOF
+    '';
+
+  sourceRoot = "source/secure_shmem";
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags =
+    [
+      "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      "MODULEDIR=$(out)/lib/modules/${kernel.modDirVersion}/kernel/drivers/char"
+      "ARCH=${stdenv.hostPlatform.linuxArch}"
+      "INSTALL_MOD_PATH=${placeholder "out"}"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "CROSS_COMPILE=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}"
+    ]
+    ++ lib.optionals debug [
+      "EXTRA_CFLAGS=-DDEBUG_ON"
+    ];
+
+  CROSS_COMPILE = lib.optionalString (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}";
+
+  meta = with lib; {
+    description = "Secured shared memory on host Linux kernel module";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Description of changes

The memsocket application has been enhanced with the following new features and updates:

    Shared memory protection:
        Shared memory is allocated by a custom driver on the host. At runtime, the driver verifies 
        the requesting VM's identity and maps only the memory regions it is authorized to access.
        Memory access permissions are automatically generated by Nix scripts.

    Host Support:
        The application can now run on the host in addition to virtual machines (VMs).

    Multi-Server Capability:
        Multiple memsocket instances operating in server mode are now supported.
        Each server instance is configured with a list of specific client IDs it serves.
        Multiple servers can run simultaneously on a single VM or the host.

    Client ID Exclusivity:
        Each client ID must be managed by only one server across the entire system.

    Configuration Updates:
        Renamed some Nix configuration options for clarity.

    Option Changes:
        Added long option aliases: --server (-s), --listen (-l), --client (-c), --host (-h), --force (-f)
        The -c and -s options have been swapped:
            -c: Now used for running in server mode.
            -s: Now used for running in client mode.
        A new -l option has been introduced for server mode to specify the list of client IDs to be serviced.   
        A new -h option has been introduced for indicating run on the host

Introduced a Nix framework for the automatic generation of configurations for servers (currently supporting audio and video) and their clients.
Enabled the transfer of gui data via shared memory from application VMs to designated gui-vm server.

### Type of Change
- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has run `make-checks` and it passes
- [ X All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [X] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [X] Other: requires rebooting after updating with `nixos-rebuild ... switch`

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Run gui enabled applications, e.g.: chrome, outlook, slack, zathura, teams, etc. Check if they are displaying properly.
2. Repeat in a loop: close and start the above applications. Check if they are running and displaying properly.

