### PR TITLE
Desktop: Enhance virtual desktop configuration and add desktop id popup

### DIFF
--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -449,6 +449,7 @@ in
 
         (defvar volume-popup-visible "false")
         (defvar brightness-popup-visible "false")
+        (defvar workspace-popup-visible "false")
         (defvar workspaces-visible "false")
         ;; (defpoll bluetooth  :interval "3s" :initial "{}" "${pkgs.bt-launcher}/bin/bt-launcher status")
 
@@ -681,6 +682,13 @@ in
                         :icon {volume.icon}
                         :level {volume.level})))))
 
+        ;; Workspace Popup Widget ;;
+        (defwidget workspace-popup []
+            (revealer :transition "crossfade" :duration "200ms" :reveal workspace-popup-visible :active false
+                (box :class "wrapper_widget"
+                (box :class "hotkey"
+                    (label :text "Desktop ''${workspace}")))))
+
         ;; Quick Settings Button ;;
         (defwidget quick-settings-button [screen bat-icon vol-icon bright-icon]
             (button :class "icon_button"
@@ -785,7 +793,7 @@ in
                 :orientation "h"
                 :space-evenly "false"
                 (button :class "icon_button"
-                        :tooltip "Current workspace"
+                        :tooltip "Current desktop"
                         :onclick {workspaces-visible == "false" ? "''${EWW_CMD} update workspaces-visible=true" : "''${EWW_CMD} update workspaces-visible=false"}
                         workspace)
                 (revealer 
@@ -795,12 +803,15 @@ in
                     (eventbox :onhoverlost "''${EWW_CMD} update workspaces-visible=false"
                         (box :orientation "h"
                             :space-evenly "true"
-                            (button :class "icon_button"
-                                :onclick "${ghaf-workspace}/bin/ghaf-workspace switch 1; ''${EWW_CMD} update workspaces-visible=false"
-                                "1")
-                            (button :class "icon_button"
-                                :onclick "${ghaf-workspace}/bin/ghaf-workspace switch 2; ''${EWW_CMD} update workspaces-visible=false"
-                                "2"))))))
+                            ${
+                              lib.concatStringsSep "\n" (
+                                builtins.map (index: ''
+                                  (button :class "icon_button"
+                                      :onclick "${ghaf-workspace}/bin/ghaf-workspace switch ${toString index}; ''${EWW_CMD} update workspaces-visible=false"
+                                      "${toString index}")
+                                '') (lib.lists.range 1 cfg.maxDesktops)
+                              )
+                            })))))
 
         (defwidget left []
             (box	
@@ -912,6 +923,15 @@ in
                                   :anchor "bottom center")
               :stacking "overlay"
               (brightness-popup))
+
+          ;; Workspace Popup Window ;;
+          (defwindow workspace-popup
+              :monitor 0
+              :geometry (geometry :y "150px"
+                                  :x "0px"
+                                  :anchor "bottom center")
+              :stacking "overlay"
+              (workspace-popup))
         ''}
 
         ;; Closer Window ;;
@@ -1188,6 +1208,7 @@ in
             @include floating_widget($margin: 0, $padding: 10px 12px);
             @include icon;
             .slider{ @include slider($slider-width: 150px, $thumb: false, $slider-height: 5px); }
+            font-size: 1.3em;
         }
 
         .widget-button {@include widget-button; }
@@ -1411,6 +1432,24 @@ in
             popupName = "volume-popup";
           }
         }/bin/volume-popup-handler";
+        Restart = "on-failure";
+      };
+      after = [ "ewwbar.service" ];
+      wantedBy = [ "ewwbar.service" ];
+      partOf = [ "ghaf-session.target" ];
+    };
+
+    systemd.user.services.eww-workspace-popup = {
+      enable = true;
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${
+          mkPopupHandler {
+            name = "workspace-popup-handler";
+            stateFile = "workspace";
+            popupName = "workspace-popup";
+          }
+        }/bin/workspace-popup-handler";
         Restart = "on-failure";
       };
       after = [ "ewwbar.service" ];

--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -48,7 +48,7 @@ let
         else
             ${ghaf-workspace}/bin/ghaf-workspace switch "$current_workspace"
         fi
-        ${ghaf-workspace}/bin/ghaf-workspace max 2
+        ${ghaf-workspace}/bin/ghaf-workspace max ${toString cfg.maxDesktops}
 
         # Write the GTK settings to the settings.ini file in the GTK config directory
         # Note:
@@ -100,22 +100,26 @@ let
       <policy>cascade</policy>
       <cascadeOffset x="40" y="30" />
     </placement>
-    <desktops number="2">
+    <desktops number="${toString cfg.maxDesktops}">
       <popupTime>0</popupTime>
     </desktops>
     <keyboard>
       <default />
-      <keybind key="W-1"><action name="GoToDesktop" to="1" />
-        <action name="Execute" command="${ghaf-workspace}/bin/ghaf-workspace update 1" />
-      </keybind>
-      <keybind key="W-2"><action name="GoToDesktop" to="2" />
-        <action name="Execute" command="${ghaf-workspace}/bin/ghaf-workspace update 2" />
-      </keybind>
+      ${
+        lib.concatStringsSep "\n" (
+          builtins.map (index: ''
+            <keybind key="W-${toString index}">
+              <action name="GoToDesktop" to="${toString index}" />
+              <action name="Execute" command="bash -c 'echo 1 > ~/.config/eww/workspace; ${ghaf-workspace}/bin/ghaf-workspace update ${toString index}'" />
+            </keybind>
+          '') (lib.lists.range 1 cfg.maxDesktops)
+        )
+      }
       <keybind key="W-A-Right">
-        <action name="Execute" command="${ghaf-workspace}/bin/ghaf-workspace next" />
+        <action name="Execute" command="bash -c 'echo 1 > ~/.config/eww/workspace; ${ghaf-workspace}/bin/ghaf-workspace next'" />
       </keybind>
       <keybind key="W-A-Left">
-        <action name="Execute" command="${ghaf-workspace}/bin/ghaf-workspace prev" />
+        <action name="Execute" command="bash -c 'echo 1 > ~/.config/eww/workspace; ${ghaf-workspace}/bin/ghaf-workspace prev'" />
       </keybind>
       <keybind key="W-l">
         <action name="Execute" command="${pkgs.systemd}/bin/loginctl lock-session" />

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -81,6 +81,11 @@ in
       default = [ ];
       description = "Wayland security context settings";
     };
+    maxDesktops = lib.mkOption {
+      type = lib.types.int;
+      default = 4;
+      description = "Max number of virtual desktops.";
+    };
     gtk = lib.mkOption {
       type = lib.types.submodule {
         options = {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

1. **Increased Default Number of Virtual Desktops to 4**

2. **Added Configurable `maxDesktops` Setting:**
   - Added a `maxDesktops` option in the `labwc` nix config (`labwc.nix`).
   - Changes to the compositor and taskbar configs are handled automatically based on the `maxDesktops` value.

3. **Desktop ID Popup on Desktop Switch:**
   - Implemented a popup window to display the current desktop when switching between virtual desktops.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [x] Is this a new feature
  - [x] List the test steps to verify:
    1. Confirm that the number of available virtual desktops has increased from 2 to 4.
    2. Verify that switching between desktops works using:
       - `Super` (Windows key) + `[number]`.
       - `Super` + `Alt` + `[left/right]` to cycle through desktops.
    3. Ensure a popup appears when switching desktops, indicating the currently active desktop.
    4. (Optional) Verify Desktop id popup window doesn't reserve space after closing - area behind the popup should be immediately clickable after popup disappears.
- [x] If it is an improvement how does it impact existing functionality?
  More virtual desktops, popup indicating which desktop is currently active.