### PR TITLE
Add flash scripts as build result

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -53,5 +53,21 @@ nixpkgs.lib.extend (
         in
         lib.elem system platforms
       );
+
+    genPkgWithFlashScript =
+      pkg: system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      pkgs.linkFarm "ghaf-image" [
+        {
+          name = "image";
+          path = pkg;
+        }
+        {
+          name = "flash-script";
+          path = pkgs.callPackage ./packages/flash { };
+        }
+      ];
   }
 )

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -134,7 +134,11 @@ in
       map (t: lib.nameValuePair t.name t.hostConfiguration) targets
     );
     packages = {
-      x86_64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+      x86_64-linux = builtins.listToAttrs (
+        map (
+          t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package "x86_64-linux")
+        ) targets
+      );
     };
   };
 }

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -132,6 +132,8 @@ in
     nixosConfigurations = builtins.listToAttrs (
       map (t: lib.nameValuePair t.name t.hostConfiguration) targets
     );
-    packages.${system} = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+    packages.${system} = builtins.listToAttrs (
+      map (t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package system)) targets
+    );
   };
 }

--- a/targets/microchip-icicle-kit/flake-module.nix
+++ b/targets/microchip-icicle-kit/flake-module.nix
@@ -76,7 +76,11 @@ in
       map (t: lib.nameValuePair t.name t.hostConfiguration) targets
     );
     packages = {
-      x86_64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+      x86_64-linux = builtins.listToAttrs (
+        map (
+          t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package "x86_64-linux")
+        ) targets
+      );
     };
   };
 }

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -196,9 +196,17 @@ in
     );
 
     packages = {
-      aarch64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+      aarch64-linux = builtins.listToAttrs (
+        map (
+          t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package "aarch64-linux")
+        ) targets
+      );
       x86_64-linux =
-        builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) crossTargets)
+        builtins.listToAttrs (
+          map (
+            t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package "x86_64-linux")
+          ) crossTargets
+        )
         // builtins.listToAttrs (
           map (
             t: lib.nameValuePair "${t.name}-flash-script" (generate-flash-script t "x86_64-linux")


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Flash script is changing every now and then and each Ghaf binary images must be flashed to bootable drive with correct version of the flash.sh, so provide flash scripts alongside with images.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

1. Verify that installer still works.
2. Check that all laptop and nvidia-jetson-orin packages result directory contains image and flash script(s).
