### PR TITLE
gtklock-userinfo-module: Add custom Icon path

### DIFF
--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -8,6 +8,7 @@
 }:
 let
   cfg = config.ghaf.graphics.labwc;
+  userName = config.ghaf.users.accounts.user;
 in
 {
   options.ghaf.graphics.labwc = {
@@ -26,7 +27,7 @@ in
     };
     autologinUser = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
-      default = config.ghaf.users.accounts.user;
+      default = userName;
       description = ''
         Username of the account that will be automatically logged in to the desktop.
         If unspecified, the login manager is shown as usual.
@@ -190,6 +191,11 @@ in
 
     # DBus service for accessing the list of user accounts and information attached to those accounts
     services.accounts-daemon.enable = true;
+    # We can explicitly specify the icon path, using which user can set custom image when system is locked
+    system.activationScripts.userIcon.text = ''
+      mkdir -p /var/lib/AccountsService/users
+      echo -e "[User]\nIcon=/home/${userName}/Pictures/.face\n" > /var/lib/AccountsService/users/${userName}
+    '';
 
     ghaf.graphics.launchers = lib.mkIf config.ghaf.profiles.debug.enable [
       {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
With this patch user can set custom image when the system is locked for identification purpose.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [x] If it is an improvement how does it impact existing functionality? 
       User Image can be set when system is locked

### Expected output when image is kept under 
```
[ghaf@gui-vm:~]$ ls /home/ghaf/Pictures/.face (any jpg file is fine, recommended to use circular image)
```

![image](https://github.com/user-attachments/assets/748ce435-3cb3-4e48-a819-1c06b12a0d84)
