### PR TITLE
Disable nix tooling

### DIFF
--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -73,6 +73,7 @@ in
         withHardenedConfigs = true;
       };
       ghaf.givc.host.enable = true;
+      ghaf.development.nix-setup.automatic-gc.enable = config.ghaf.development.nix-setup.enable;
       services.logind.lidSwitch = "ignore";
 
       # TODO: remove hardcoded paths


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->
- Disables nix tooling if development setup is not enabled
         - Indirectly disables nix tooling in release build
- Enables automatic garbaze collection in ghaf-host and disable everywhere else.
- Fixes:
    https://jira.tii.ae/browse/SSRCSP-3457

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
     - Lenovo X1
     - Jetson Orin NX and AGX 
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
      - In release build, no nix commands should be available, nix daemon should not be running.
            - As Terminal is not available in release flavor, disable nix-setup in `./modules/common/profiles/debug.nix` (to imitate release)
               ```
               nix-setup.enable = false;
               ```
           - Build debug image and run. No nix commands should be available, nix daemon should not be running. 
                
      - In debug build nix daemon should be running in all VMs and automatic garbage collection should be available only in host.
      - If automatic garbaze collection is enabled 'systemctl list-timers' should list 'nix-gc' also
- [ ] If it is an improvement how does it impact existing functionality?

