### PR TITLE
Fix camera access in chrome and business vm

### DIFF
--- a/modules/common/security/apparmor/profiles/google-chrome.nix
+++ b/modules/common/security/apparmor/profiles/google-chrome.nix
@@ -105,6 +105,7 @@
               @{PROC}/sys/fs/inotify/max_user_watches                   r,
               @{PROC}/ati/major                                         r,
 
+              /dev/                                                     r,
               /dev/**                                                   rw,
               /dev/fb0                                                  rw,
               /dev/hidraw@{INTEGER}                                     rw,
@@ -180,6 +181,8 @@
               /tmp/                                                     rw,
         owner /tmp/**                                                   rwkl,
               /tmp/.X[0-9]*-lock                                        r,
+              /tmp/.X11-unix                                            r,
+              /tmp/.XIM-unix                                            r,
 
         deny /boot/EFI/systemd/**                                       r,
         deny /boot/EFI/nixos/**                                         r,
@@ -196,4 +199,5 @@
       }
     '';
   };
+
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
- Fixes camera access issue in business and chrome vm
- Appropriate access provided in Google Chrome Apparmor profile
- Fixes:
https://jira.tii.ae/browse/SSRCSP-5864

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
  - Lenovo X1
- [ ] Is this a new feature
  - [x] List the test steps to verify:
    -  Check if external camera is accessible from Google chrome (I used http:://veed.io/record)
    -  Check if internal camera is accessible from Microsoft Teams.
    -  If you want to do full installation you will have to increase VM memory to avoid OOM:
```
diff --git a/modules/disko/disko-ab-partitions.nix b/modules/disko/disko-ab-partitions.nix
index 042f220..bb0d308 100644
--- a/modules/disko/disko-ab-partitions.nix
+++ b/modules/disko/disko-ab-partitions.nix
@@ -47,7 +47,7 @@
     };
     disko = {
       # 8GB is the recommeneded minimum for ZFS, so we are using this for VMs to avoid `cp` oom errors.
-      memSize = 17384;
+      memSize = 20480;
       imageBuilder = {
         extraPostVM = lib.mkIf (config.ghaf.imageBuilder.compression == "zstd") ''
           ${pkgs.zstd}/bin/zstd --compress $out/*raw
```
- [ ] If it is an improvement how does it impact existing functionality?

