### PR TITLE
Compress generic-x86_64 image

### DIFF
--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -49,6 +49,28 @@ let
           self.nixosModules.hw-x86_64-generic
           self.nixosModules.reference-programs
 
+          (
+            {
+              lib,
+              config,
+              pkgs,
+              modulesPath,
+              ...
+            }:
+            {
+              # https://github.com/nix-community/nixos-generators/blob/master/formats/raw-efi.nix#L24-L29
+              system.build.raw = lib.mkOverride 98 (
+                import "${toString modulesPath}/../lib/make-disk-image.nix" {
+                  inherit lib config pkgs;
+                  partitionTableType = "efi";
+                  inherit (config.virtualisation) diskSize;
+                  format = "raw";
+                  postVM = "${pkgs.zstd}/bin/zstd --compress --rm $out/nixos.img";
+                }
+              );
+            }
+          )
+
           {
             ghaf = {
               hardware.x86_64.common.enable = true;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

Binary images of all other targets are compressed already during the build phase. This makes downloads significantly faster. Compress also x86_64-linux.generic-x86_64-debug image in the build phase.

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

Check that image works as expected after manual decompression or check that flash script succeeds.

