### PR TITLE
Custom PAM rule for desktop login

### DIFF
--- a/modules/common/users/admin.nix
+++ b/modules/common/users/admin.nix
@@ -93,10 +93,12 @@ in
           extraGroups =
             [
               "wheel"
-              "video"
             ]
             ++ cfg.extraGroups
-            ++ optionals cfg.createHome [ "desktop" ]
+            ++ optionals cfg.createHome [
+              "audio"
+              "video"
+            ]
             ++ optionals config.security.tpm2.enable [ "tss" ]
             ++ optionals config.ghaf.virtualization.docker.daemon.enable [ "docker" ];
         };

--- a/modules/common/users/desktop.nix
+++ b/modules/common/users/desktop.nix
@@ -29,7 +29,10 @@ let
       extraGroups = mkOption {
         description = "Extra groups for the login user.";
         type = types.listOf types.str;
-        default = [ ];
+        default = [
+          "audio"
+          "video"
+        ];
       };
       homeSize = mkOption {
         description = ''
@@ -137,12 +140,6 @@ in
               members = [ cfg.appUser.name ];
             };
           })
-          {
-            "desktop" = {
-              name = "desktop";
-              members = [ ];
-            };
-          }
         ];
       };
     }
@@ -177,9 +174,9 @@ in
                 echo -n "Enter your user name: "
                 read -e -r USERNAME
                 USERNAME=''${USERNAME// /_}
-                USERNAME=''${USERNAME//[^a-zA-Z0-9_]/}
+                USERNAME=''${USERNAME//[^a-zA-Z0-9_-]/}
                 USERNAME=''$(echo -n "$USERNAME" | tr '[:upper:]' '[:lower:]')
-                if grep -q -w "$USERNAME:" /etc/passwd; then
+                if grep -q "$USERNAME:" /etc/passwd; then
                   echo "User $USERNAME already exists. Please choose another user name."
                 else
                   ACCEPTABLE_USER=true

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -162,12 +162,37 @@ in
         XDG_DATA_HOME = "$HOME/.local/share";
         XDG_STATE_HOME = "$HOME/.local/state";
         XDG_CACHE_HOME = "$HOME/.cache";
+        XDG_PICTURES_DIR = "$HOME/Pictures";
+        XDG_VIDEOS_DIR = "$HOME/Videos";
         GSETTINGS_SCHEMA_DIR = "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}/glib-2.0/schemas";
       };
     };
 
-    # It will create a /etc/pam.d/ file for authentication
-    security.pam.services.gtklock = { };
+    # Create custom PAM rules
+    security.pam.services = {
+      gtklock = {
+        rules.auth = {
+          systemd_home.order = 11399; # Re-order to allow either password _or_ fingerprint
+          fprintd.args = [ "maxtries=3" ];
+        };
+      };
+      greetd = {
+        fprintAuth = false; # User needs to enter password to decrypt home
+        rules = {
+          account.group = {
+            enable = true;
+            control = "requisite";
+            modulePath = "${pkgs.linux-pam}/lib/security/pam_succeed_if.so";
+            order = 10000;
+            args = [
+              "user"
+              "ingroup"
+              "video"
+            ];
+          };
+        };
+      };
+    };
 
     # Needed for power commands
     security.polkit.enable = true;
@@ -179,7 +204,6 @@ in
         BindsTo = [ "graphical-session.target" ];
         After = [ "graphical-session-pre.target" ];
         Wants = [ "graphical-session-pre.target" ];
-        ConditionGroup = "desktop";
       };
     };
 

--- a/modules/microvm/virtualization/microvm/audiovm.nix
+++ b/modules/microvm/virtualization/microvm/audiovm.nix
@@ -44,7 +44,6 @@ let
               enable = true;
               extraGroups = [
                 "audio"
-                "video"
                 "pipewire"
               ];
             };

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -72,17 +72,7 @@ let
               applications.enable = false;
               graphics.enable = true;
             };
-            users = {
-              loginUser = {
-                enable = true;
-                extraGroups = [
-                  "audio"
-                  "video"
-                  "desktop"
-                ];
-              };
-            };
-
+            users.loginUser.enable = true;
             development = {
               ssh.daemon.enable = lib.mkDefault config.ghaf.development.ssh.daemon.enable;
               debug.tools.enable = lib.mkDefault config.ghaf.development.debug.tools.enable;
@@ -108,14 +98,6 @@ let
             storagevm = {
               enable = true;
               name = vmName;
-              directories = [
-                {
-                  directory = "/var/lib/private/ollama";
-                  user = "ollama";
-                  group = "ollama";
-                  mode = "u=rwx,g=,o=";
-                }
-              ];
             };
 
             # Services
@@ -219,10 +201,6 @@ let
                 pkgs.libva-utils
                 pkgs.glib
               ];
-            sessionVariables = {
-              XDG_PICTURES_DIR = "$HOME/Pictures";
-              XDG_VIDEOS_DIR = "$HOME/Videos";
-            };
           };
 
           time.timeZone = config.time.timeZone;

--- a/modules/microvm/virtualization/microvm/microvm-host.nix
+++ b/modules/microvm/virtualization/microvm/microvm-host.nix
@@ -134,15 +134,13 @@ in
             '';
           };
         in
-        mkIf config.ghaf.profiles.debug.enable {
+        {
           description = "Remove ghaf login users";
           enable = true;
           path = [ userRemovalScript ];
           unitConfig.ConditionPathExists = "/storagevm/gui-vm/var/lib/nixos/user.lock";
           serviceConfig = {
             Type = "oneshot";
-            StandardOutput = "journal";
-            StandardError = "journal";
             ExecStart = "${userRemovalScript}/bin/remove-users";
           };
         };

--- a/modules/reference/services/ollama/ollama.nix
+++ b/modules/reference/services/ollama/ollama.nix
@@ -8,14 +8,23 @@
 }:
 let
   cfg = config.ghaf.reference.services;
-  inherit (lib) mkIf;
+  inherit (lib) mkIf optionalAttrs;
 in
 {
   config = mkIf cfg.ollama {
     services.ollama = {
       enable = true;
       openFirewall = true;
-      host = "0.0.0.0";
+      host = "127.0.0.1";
+    };
+
+    ghaf = optionalAttrs (builtins.hasAttr "storagevm" config.ghaf) {
+      storagevm.directories = [
+        {
+          directory = "/var/lib/private/ollama";
+          mode = "u=rwx,g=,o=";
+        }
+      ];
     };
 
     environment.systemPackages = [
@@ -72,23 +81,24 @@ in
     # its own.
     system.userActivationScripts.alpaca-configure = {
       text = ''
-                source ${config.system.build.setEnvironment}
-                mkdir -p $HOME/.config/com.jeffser.Alpaca
-                cat <<EOF > $HOME/.config/com.jeffser.Alpaca/server.json
+        [[ "$UID" != ${toString config.ghaf.users.loginUser.uid} ]] && exit 0
+        source ${config.system.build.setEnvironment}
+        mkdir -p $HOME/.config/com.jeffser.Alpaca
+        cat <<EOF > $HOME/.config/com.jeffser.Alpaca/server.json
         {
-              "remote_url": "http://localhost:11434",
-              "remote_bearer_token": "",
-              "run_remote": true,
-              "local_port": 11435,
-              "run_on_background": false,
-              "powersaver_warning": true,
-              "model_tweaks": {
-                    "temperature": 0.7,
-                    "seed": 0,
-                    "keep_alive": 5
-              },
-              "ollama_overrides": {},
-              "idle_timer": 0
+          "remote_url": "http://localhost:11434",
+          "remote_bearer_token": "",
+          "run_remote": true,
+          "local_port": 11435,
+          "run_on_background": false,
+          "powersaver_warning": true,
+          "model_tweaks": {
+                "temperature": 0.7,
+                "seed": 0,
+                "keep_alive": 5
+          },
+          "ollama_overrides": {},
+          "idle_timer": 0
         }
         EOF
       '';


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This PR includes the following changes and fixes:

  - remove fingerprint authentication from `greetd` as user home needs decryption
  - re-ordering PAM modules on gtklock to unlock with either password or fingerprint, not requiring both
  - add custom rule to require users to be in group `video`, preventing
    admin login on GUI. Still works for AGX/NX with `createHome` option. 
  - remove older 'desktop' group in favor of 'video'
  - fix user creation script to disallow creating user duplicates
  - fix user creation script to allow '-' characters in name
  -  move ollama persistent directory to service, removing failing ollama
    user/group setting, adding guard for launcher
  - move XDG parameters from gui-vm to labc config
 
This should also fix [SRCSP-5891](https://jira.tii.ae/browse/SSRCSP-5891). The user is now not asked for fingerprint
during login, which won't work as the home folder must be decrypted with key derived from users password. 

Does not address multiple error messages when entering wrong password on lock-screen.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

Tested on x1 and agx. 

## Instructions for Testing

- [x] List all targets that this applies to: x1, agx, nx?
- [x] List the test steps to verify:
  - [ ] Remove existing user, reboot and try to create `ghaf` as user
  - [ ] Create user, login with wrong password, observe only 1 error message
  - [ ] Login, create fingerprint for user, and lock screen. 
    - [ ] Enter + fprint unlocks
    - [ ] wrong password + fprint unlocks
    - [ ] correct password unlocks
  - [ ] Reboot (gui-vm) and observe user is not asked for fingerprint
  - [ ] Verify ollama app works and no errors in journal anymore
  - [ ] (optional) test login/lock on agx as ghaf user
 

