### PR TITLE
zfs: Enable LUKS encryption on data and swap partitions for mvp extras

### DIFF
--- a/modules/disko/disk-encryption.nix
+++ b/modules/disko/disk-encryption.nix
@@ -1,0 +1,14 @@
+# Copyright 2024-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkEnableOption;
+in
+{
+  options.ghaf.disk.encryption = {
+    enable = mkEnableOption "Ghaf disk encryption configuration";
+  };
+}

--- a/modules/disko/disko-zfs-postboot.nix
+++ b/modules/disko/disko-zfs-postboot.nix
@@ -1,41 +1,127 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ pkgs, ... }:
+{
+  config,
+  pkgs,
+  ...
+}:
 let
-  postBootCmds = ''
-    set -xeuo pipefail
-
-    # Check which physical disk is used by ZFS
-    ZFS_POOLNAME=$(${pkgs.zfs}/bin/zpool list | ${pkgs.gnugrep}/bin/grep -v NAME |  ${pkgs.gawk}/bin/awk '{print $1}')
-    ZFS_LOCATION=$(${pkgs.zfs}/bin/zpool status -P | ${pkgs.gnugrep}/bin/grep dev | ${pkgs.gawk}/bin/awk '{print $1}')
-
-    # Get the actual device path
-    P_DEVPATH=$(readlink -f "$ZFS_LOCATION")
-
-    # Extract the partition number using regex
-    if [[ "$P_DEVPATH" =~ [0-9]+$ ]]; then
-      PARTNUM=$(echo "$P_DEVPATH" | ${pkgs.gnugrep}/bin/grep -o '[0-9]*$')
-      PARENT_DISK=/dev/$(${pkgs.util-linux}/bin/lsblk -no pkname "$P_DEVPATH")
-    else
-      echo "No partition number found in device path: $P_DEVPATH"
-    fi
-
-    # Fix GPT first
-    ${pkgs.gptfdisk}/bin/sgdisk "$PARENT_DISK" -e
-
-    # Call partprobe to update kernel's partitions
-    ${pkgs.parted}/bin/partprobe
-
-    # Extend the partition to use unallocated space
-    ${pkgs.parted}/bin/parted -s -a opt "$PARENT_DISK" "resizepart $PARTNUM 100%"
-
-    # Extend ZFS pool to use newly allocated space
-    ${pkgs.zfs}/bin/zpool online -e "$ZFS_POOLNAME" "$ZFS_LOCATION"
-  '';
+  diskEncryption = config.ghaf.disk.encryption.enable;
 in
 {
-  # To debug postBootCommands, one may run
-  # journalctl -u initrd-nixos-activation.service
+  boot.initrd.systemd.extraBin = {
+    grep = "${pkgs.gnugrep}/bin/grep";
+    lsblk = "${pkgs.util-linux}/bin/lsblk";
+    sgdisk = "${pkgs.gptfdisk}/bin/sgdisk";
+    partprobe = "${pkgs.parted}/bin/partprobe";
+    parted = "${pkgs.parted}/bin/parted";
+    cryptsetup = "${pkgs.cryptsetup}/bin/cryptsetup";
+  };
+
+  # To debug luksEncryption, one may run
+  # journalctl -u luksEncryption.service
   # inside the running Ghaf host.
-  boot.postBootCommands = postBootCmds;
+  boot.initrd.systemd.services.luksEncryption = {
+    description = "Disk encryption service";
+    wantedBy = [ "basic.target" ];
+    before = [ "sysroot.mount" ];
+    after = [ "local-fs.target" ];
+
+    unitConfig.DefaultDependencies = false;
+    serviceConfig.Type = "oneshot";
+    script = ''
+      set -xeuo pipefail
+      DISK_PSWD="" TPM2_PIN=""
+
+      disk_resize() {
+        # Fix GPT first
+        sgdisk "$1" -e
+
+        # Call partprobe to update kernel's partitions
+        partprobe
+
+        # Extend the partition to use unallocated space
+        parted -s -a opt "$1" "resizepart $2 100%"
+
+        # Extend ZFS pool to use newly allocated space
+        zpool online -e "$3" "$4"
+      }
+
+      device_encryption() {
+        # Request the password from the user, only if not entered previously
+        if [[ -z "$DISK_PSWD" ]]; then
+          DISK_PSWD=$(systemd-ask-password --keyname=diskPswd --accept-cached -n "Please enter password you want to keep for disk encryption:")
+        fi
+
+        # Format with LUKS and open the device
+        echo -n "$DISK_PSWD" | cryptsetup luksFormat --type luks2 -q "$1"
+        echo -n "$DISK_PSWD" | cryptsetup luksOpen "$1" "$2" --persistent
+
+        # Request TPM2 PIN from the user, only if not entered previously
+        if [[ -z "$TPM2_PIN" ]]; then
+          TPM2_PIN=$(systemd-ask-password --keyname=diskPswd --accept-cached -n "Please enter TPM2 token PIN for disk encryption:")
+        fi
+
+        # Automatically assigns keys to a specific slot in the TPM
+        NEWPIN="$TPM2_PIN" PASSWORD="$DISK_PSWD" systemd-cryptenroll --tpm2-device auto --tpm2-with-pin=yes "$1"
+      }
+
+      IS_DISK_ENCRYPTION_ENABLED=${toString diskEncryption}
+      DATA_POOLNAME=zfs_data
+      zpool import -f "$DATA_POOLNAME"
+
+      # Check which physical disk is used by ZFS
+      ZFS_POOLNAME=$(zpool list | grep -v NAME | grep $DATA_POOLNAME | awk '{print $1}')
+      ZFS_LOCATION=$(zpool status "$ZFS_POOLNAME" -P | grep dev | awk '{print $1}')
+
+      # Get the actual device path
+      P_DEVPATH=$(readlink -f "$ZFS_LOCATION")
+
+      # Extract the partition number using regex
+      if [[ "$P_DEVPATH" =~ [0-9]+$ ]]; then
+        PARTNUM=$(echo "$P_DEVPATH" | grep -o '[0-9]*$')
+        PARENT_DISK=/dev/$(lsblk -no pkname "$P_DEVPATH")
+      else
+        echo "No partition number found in device path: $P_DEVPATH"
+      fi
+
+      # In case we are not using encryption, resize and exit
+      if ((!IS_DISK_ENCRYPTION_ENABLED)); then
+        disk_resize "$PARENT_DISK" "$PARTNUM" "$ZFS_POOLNAME" "$ZFS_LOCATION"
+        exit 0
+      fi
+
+      # Check if ZFS pool has LUKS encryption
+      set +o pipefail
+      if (cryptsetup status "$DATA_POOLNAME") | grep -q "is inactive"; then
+        disk_resize "$PARENT_DISK" "$PARTNUM" "$ZFS_POOLNAME" "$ZFS_LOCATION"
+
+        # Exporting pool to avoid device in use errors
+        zpool export "$ZFS_POOLNAME"
+
+        device_encryption "$P_DEVPATH" "$ZFS_POOLNAME"
+
+        # Create pool, datasets as luksFormat will erase pools, ZFS datasets stored on that partition
+        zpool create -o ashift=12 -O compression=lz4 -O acltype=posixacl -O xattr=sa -f "$ZFS_POOLNAME" /dev/mapper/"$ZFS_POOLNAME"
+        zfs create -o quota=30G "$ZFS_POOLNAME"/vm_storage
+        zfs create -o quota=10G -o mountpoint=none "$ZFS_POOLNAME"/recovery
+        zfs create -o quota=50G "$ZFS_POOLNAME"/gp_storage
+        zfs create "$ZFS_POOLNAME"/storagevm
+        # This will allocate 10GB of reserved memory on the pool
+        zfs set refreservation=10G "$ZFS_POOLNAME"
+      fi
+
+      SWAP_DEVICE=$(blkid -t TYPE=swap -o device)
+      # Check if swap memory has LUKS encryption
+      if ! (cryptsetup status "$SWAP_DEVICE" | grep -q "active"); then
+        device_encryption "$SWAP_DEVICE" "swap"
+
+        # Create a swap filesystem
+        mkswap /dev/mapper/swap -L swap
+      fi
+
+      # Activate swap memory
+      swapon /dev/mapper/swap
+    '';
+  };
 }

--- a/modules/disko/flake-module.nix
+++ b/modules/disko/flake-module.nix
@@ -13,6 +13,7 @@
       inputs.disko.nixosModules.disko
       ./disko-ab-partitions.nix
       ./disko-zfs-postboot.nix
+      ./disk-encryption.nix
     ];
   };
 }

--- a/modules/reference/profiles/mvp-user-trial-extras.nix
+++ b/modules/reference/profiles/mvp-user-trial-extras.nix
@@ -48,6 +48,9 @@ in
           autologinUser = lib.mkForce null;
         };
       };
+
+      # Disk encryption
+      disk.encryption.enable = true;
     };
   };
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
This patch create separate zfs data pool and swap partitions with LUKS encryption. The password and TPM PIN for LUKS encrypted partitions are provided by user which will be later stored on TPM security chip and will be decrypted automatically on the subsequent system boots with need of user to enter TPM2 token PIN on every boot.


### Comparison  

| Branch | ZFS and disk details |
| ----------- | ----------- |
| **main**| ![image](https://github.com/user-attachments/assets/64c94765-e864-4298-9727-1a95bfd4fb56) |
| **This PR**| ![image](https://github.com/user-attachments/assets/27cca20c-158d-450f-8c68-b91e3d7b80b6) |



<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [x] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
- [x] Is this a new feature
  - [x] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?


### Test steps
1. Now there are two ZFS pools called as `zfs_data` and `zfs_root` 

    ```
      [ghaf@ghaf-host:~]$ zpool list 
      NAME       SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
      zfs_data   396G  1.13M   396G        -         -     0%     0%  1.00x    ONLINE  -
      zfs_root  29.5G  6.80G  22.7G        -         -     0%    23%  1.00x    ONLINE  -
    ```

2. To verify `zfs_data` is luks encrypted run below command

    ```
     [ghaf@ghaf-host:~]$ sudo cryptsetup status zfs_data
      /dev/mapper/zfs_data is active and is in use.
        type:    LUKS2
        cipher:  aes-xts-plain64
        keysize: 512 bits
        key location: keyring
        device:  /dev/sda5
        sector size:  512
        offset:  32768 sectors
        size:    833105935 sectors
        mode:    read/write
    ```
3. To verify `swap` is luks encrypted run below command

    ```
    [ghaf@ghaf-host:~]$ sudo cryptsetup status swap
    /dev/mapper/swap is active and is in use.
      type:    LUKS2
      cipher:  aes-xts-plain64
      keysize: 512 bits
      key location: keyring
      device:  /dev/sda3
      sector size:  512
      offset:  32768 sectors
      size:    79659008 sectors
      mode:    read/write
    ```
4. Now we don't have dedicated ZFS dataset for reserved memory, we are using zfs property called as `refreservation`  on `zfs_data` pool itself, to verify run below command.

    ```
    [ghaf@ghaf-host:~]$ zfs get  refreservation zfs_data
    NAME      PROPERTY        VALUE      SOURCE
    zfs_data  refreservation  10G        local
    ```

5.  To check swap memory usage, as swap partition need to decrypted at boot time. Make sure it's available to the user.

    ```
    [ghaf@ghaf-host:~]$ swapon --show 
    NAME             TYPE      SIZE USED PRIO
    /dev/mapper/swap partition  38G   0B   -2
    ```
6. In case OS image is flashed on external drive and user move to newer device then boot the enter correct `passphrase` and set new `TPM2 token PIN`

### Improvements
<del> * With this PR everytime user need to enter password when system boots.  </del>
<del> * Change decryption mechanism to Yubikey/TPM.  </del>