### PR TITLE
Add ballooning monitor for VMs

### DIFF
--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -170,8 +170,8 @@ let
 
               microvm = {
                 optimize.enable = false;
-                mem = vm.ramMb / 2;
-                balloonMem = vm.ramMb * 2;
+                mem = vm.ramMb;
+                balloonMem = builtins.ceil (vm.ramMb * vm.balloonRatio);
                 deflateOnOOM = false;
                 vcpu = vm.cores;
                 hypervisor = "qemu";
@@ -322,9 +322,16 @@ in
             };
             ramMb = mkOption {
               description = ''
-                Amount of RAM for this AppVM
+                Minimum amount of RAM for this AppVM
               '';
               type = types.int;
+            };
+            balloonRatio = mkOption {
+              description = ''
+                Amount of dynamic RAM for this AppVM as a multiple of ramMb
+              '';
+              type = types.number;
+              default = 2;
             };
             cores = mkOption {
               description = ''

--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -170,7 +170,9 @@ let
 
               microvm = {
                 optimize.enable = false;
-                mem = vm.ramMb;
+                mem = vm.ramMb / 2;
+                balloonMem = vm.ramMb / 2;
+                deflateOnOOM = false;
                 vcpu = vm.cores;
                 hypervisor = "qemu";
                 shares = [

--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -171,7 +171,7 @@ let
               microvm = {
                 optimize.enable = false;
                 mem = vm.ramMb / 2;
-                balloonMem = vm.ramMb / 2;
+                balloonMem = vm.ramMb * 2;
                 deflateOnOOM = false;
                 vcpu = vm.cores;
                 hypervisor = "qemu";

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -18,5 +18,17 @@
       ./power-control.nix
       ../hardware/common/shared-mem.nix
     ];
+
+    mem-manager.imports = [
+      {
+        nixpkgs.overlays = [
+          inputs.ghafpkgs.overlays.default
+          (_final: prev: {
+            mem-manager = inputs.ghafpkgs.packages.${prev.stdenv.hostPlatform.system}.ghaf-mem-manager;
+          })
+        ];
+      }
+      ./mem-manager.nix
+    ];
   };
 }

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -20,14 +20,6 @@
     ];
 
     mem-manager.imports = [
-      {
-        nixpkgs.overlays = [
-          inputs.ghafpkgs.overlays.default
-          (_final: prev: {
-            mem-manager = inputs.ghafpkgs.packages.${prev.stdenv.hostPlatform.system}.ghaf-mem-manager;
-          })
-        ];
-      }
       ./mem-manager.nix
     ];
   };

--- a/modules/microvm/mem-manager.nix
+++ b/modules/microvm/mem-manager.nix
@@ -1,0 +1,56 @@
+# Copyright 2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# VM memory usage manager on host
+#
+{
+  pkgs,
+  config,
+  ...
+}:
+let
+  balloonvms = builtins.filter (
+    name: (config.microvm.vms.${name}.config.config.microvm.balloonMem or 0) >= 0
+  ) (builtins.attrNames (config.microvm.vms or { }));
+in
+{
+  systemd.services =
+    builtins.foldl'
+      (
+        result: name:
+        result
+        // (
+          let
+            microvmConfig = config.microvm.vms.${name}.config.config.microvm;
+          in
+          {
+            "ghaf-mem-manager-${name}" = {
+              description = "Manage MicroVM '${name}' memory levels";
+              after = [ "microvm@${name}.service" ];
+              requires = [ "microvm@${name}.service" ];
+              serviceConfig = {
+                Type = "simple";
+                WorkingDirectory = "${config.microvm.stateDir}/${name}";
+                ExecStart = "${pkgs.mem-manager}/bin/ghaf-mem-manager -s ${name}.sock -m ${
+                  builtins.toString (microvmConfig.mem * 1024 * 1024)
+                } -M ${builtins.toString ((microvmConfig.mem + microvmConfig.balloonMem) * 1024 * 1024)}";
+              };
+            };
+          }
+        )
+      )
+      {
+        balloon-manager =
+          let
+            balloonvmnames = builtins.map (name: "ghaf-mem-manager-" + name + ".service") balloonvms;
+          in
+          {
+            description = "Manage MicroVM balloons";
+            after = balloonvmnames;
+            requires = balloonvmnames;
+            wantedBy = [ "microvms.target" ];
+            script = ":";
+          };
+      }
+      balloonvms;
+}

--- a/modules/microvm/mem-manager.nix
+++ b/modules/microvm/mem-manager.nix
@@ -31,7 +31,7 @@ in
               serviceConfig = {
                 Type = "simple";
                 WorkingDirectory = "${config.microvm.stateDir}/${name}";
-                ExecStart = "${pkgs.mem-manager}/bin/ghaf-mem-manager -s ${name}.sock -m ${
+                ExecStart = "${pkgs.ghaf-mem-manager}/bin/ghaf-mem-manager -s ${name}.sock -m ${
                   builtins.toString (microvmConfig.mem * 1024 * 1024)
                 } -M ${builtins.toString ((microvmConfig.mem + microvmConfig.balloonMem) * 1024 * 1024)}";
               };

--- a/modules/microvm/mem-manager.nix
+++ b/modules/microvm/mem-manager.nix
@@ -10,7 +10,7 @@
 }:
 let
   balloonvms = builtins.filter (
-    name: (config.microvm.vms.${name}.config.config.microvm.balloonMem or 0) >= 0
+    name: (config.microvm.vms.${name}.config.config.microvm.balloonMem or 0) > 0
   ) (builtins.attrNames (config.microvm.vms or { }));
 in
 {

--- a/targets/laptop/laptop-configuration-builder.nix
+++ b/targets/laptop/laptop-configuration-builder.nix
@@ -21,7 +21,6 @@ let
           self.nixosModules.profiles
           self.nixosModules.profiles-laptop
           self.nixosModules.laptop
-
           self.nixosModules.microvm
           self.nixosModules.mem-manager
 

--- a/targets/laptop/laptop-configuration-builder.nix
+++ b/targets/laptop/laptop-configuration-builder.nix
@@ -21,7 +21,9 @@ let
           self.nixosModules.profiles
           self.nixosModules.profiles-laptop
           self.nixosModules.laptop
+
           self.nixosModules.microvm
+          self.nixosModules.mem-manager
 
           {
             ghaf = {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Add ballooning monitor and monitor all microvms that have a balloon size defined.
Enable balloon for app VMs, with half of their memory made dynamic.

microvm.nix PR: https://github.com/astro/microvm.nix/pull/324
ghaf-mem-manager PR: https://github.com/tiiuae/ghafpkgs/pull/19

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

Use device normally, preferably with high memory load.

- [x] List all targets that this applies to: Lenovo X1
- [x] Is this a new feature
  - [x] List the test steps to verify: as of now, there is no easy way to verify; one option is to see the journal on host and observe ghaf-mem-manager adjusting the VM sizes.
- [ ] If it is an improvement how does it impact existing functionality?

