### PR TITLE
Desktop: Select audio device from taskbar

### DIFF
--- a/modules/desktop/graphics/ewwbar/config/variables/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/variables/default.nix
@@ -14,11 +14,13 @@ let
 in
 writeText "variables.yuck" ''
   (defpoll keyboard_layout :interval "5s" "${setxkbmap}/bin/setxkbmap -query | ${gawk}/bin/awk '/layout/{print $2}' | tr a-z A-Z")
-  (defpoll battery  :interval "5s" :initial "{}" "${ewwScripts.eww-bat}/bin/eww-bat get")
+  (defpoll battery :interval "5s" :initial "{}" "${ewwScripts.eww-bat}/bin/eww-bat get")
   (deflisten brightness :initial "{}" "${ewwScripts.eww-brightness}/bin/eww-brightness listen")
   (deflisten audio_output :initial "{}" "${ewwScripts.eww-audio}/bin/eww-audio listen_output")
   (deflisten audio_input :initial "{}" "${ewwScripts.eww-audio}/bin/eww-audio listen_input")
-  (deflisten audio_streams :initial "[]" "echo []")
+  (defpoll audio_outputs :interval "1s" "${ewwScripts.eww-audio}/bin/eww-audio get_outputs")
+  (defpoll audio_inputs :interval "1s" "${ewwScripts.eww-audio}/bin/eww-audio get_inputs")
+  (defpoll audio_streams :interval "60s" "echo []")
   (deflisten workspace :initial "1" "${ghaf-workspace}/bin/ghaf-workspace subscribe")
 
   (defvar calendar_day "date '+%d'")
@@ -30,4 +32,6 @@ writeText "variables.yuck" ''
   (defvar workspace-popup-visible "false")
   (defvar workspaces-visible "false")
   (defvar volume-mixer-visible "false")
+  (defvar audio_output_selector_visible "false")
+  (defvar audio_input_selector_visible "false")
 ''

--- a/modules/desktop/graphics/ewwbar/config/widgets/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/widgets/default.nix
@@ -17,13 +17,13 @@ in
 writeText "widgets.yuck" ''
   ;; Launcher ;;
       (defwidget launcher []
-          (button :class "icon_button"
+          (button :class "default_button"
               :onclick "${pkgs.nwg-drawer}/bin/nwg-drawer &"
               (box :class "icon"
                   :style "background-image: url(\"${pkgs.ghaf-artwork}/icons/launcher.svg\")")))
 
       ;; Generic slider widget ;;
-      (defwidget sys_slider [?visible ?header-left ?header-right ?icon ?image ?app_icon ?settings_icon level ?onchange ?settings-onclick ?icon-onclick ?class ?min]
+      (defwidget slider [?visible ?header-left ?header-onclick ?header-right ?icon ?image ?app_icon ?settings_icon level ?onchange ?settings-onclick ?icon-onclick ?class ?min]
           (box :orientation "v"
               :visible { visible ?: "true"}
               :class "''${class}"
@@ -33,19 +33,32 @@ writeText "widgets.yuck" ''
                 :hexpand true
                 :visible { header-left != "" ? "true" : "false" }
                 :orientation "h"
-                :spacing 20
+                :spacing 5
                 :halign "fill"
                 :space-evenly false
                 (label :class "header"
                   :visible { header-left != "" && header-left != "null" ? "true" : "false" }
                   :text header-left
                   :halign "start")
+                (eventbox
+                  :halign "start"
+                  :visible { header-onclick != "" && header-onclick != "null" }
+                  :onclick header-onclick
+                  :height 24
+                  :width 24
+                  :class "default_button"
+                  (image 
+                    :class "icon"
+                    :icon "arrow-down"
+                  )
+                )
                 (label :class "header"
                   :visible { header-right != "" && header-right != "null" ? "true" : "false" }
                   :text header-right
                   :hexpand "true"
                   :limit-width 35
-                  :halign "end"))
+                  :halign "end")
+              )
               (box :orientation "h"
                   :valign "end"
                   :spacing 5
@@ -56,7 +69,98 @@ writeText "widgets.yuck" ''
                       :onclick icon-onclick
                       :height 24
                       :width 24
-                      :class "icon_settings"
+                      :class "default_button"
+                      (box
+                        (image :class "icon" :visible { image != "" } :path image :image-height 24 :image-width 24)
+                        (image 
+                          :class "icon"
+                          :visible { image == "" }
+                          :path {image ?: ""}
+                          :icon {icon != "" ? icon : app_icon != "" ? app_icon : "" } 
+                          :image-height 24
+                          :image-width 24
+                          :style {app_icon != "" ? "opacity: ''${level == 0 || level == min ? "0.5" : "1"}" : ""} 
+                        )
+                      )
+                  )
+                  (eventbox
+                      :class "slider"
+                      :hexpand true
+                      (scale
+                          :orientation "h"
+                          :value level
+                          :round-digits 0
+                          :onchange onchange
+                          :max 100 
+                          :min { min ?: 0 }))
+                  (eventbox
+                      :visible { settings-onclick != "" && settings-onclick != "null" ? "true" : "false" }
+                      :onclick settings-onclick
+                      :height 24
+                      :width 24
+                      :class "default_button"
+                      (image :class "icon" :icon settings_icon)))))
+
+      (defwidget slider_with_children [?visible ?child_0_visible ?child_1_visible ?header-left ?header-onclick ?header-right ?icon ?image ?app_icon ?settings_icon level ?onchange ?settings-onclick ?icon-onclick ?class ?min]
+          (box :orientation "v"
+              :visible { visible ?: "true"}
+              :class "''${class}"
+              :spacing 10
+              :space-evenly false
+              (box :orientation "v" :space-evenly "false" :spacing 0
+              (box
+                :hexpand true
+                :visible { header-left != "" ? "true" : "false" }
+                :orientation "h"
+                :spacing 5
+                :halign "fill"
+                :space-evenly false
+                (eventbox
+                  :halign "start"
+                  :hexpand true
+                  :active { header-onclick != "" && header-onclick != "null" }
+                  :visible { header-left != "" ? "true" : "false" }
+                  :onclick header-onclick
+                  :height 24
+                  :width 24
+                  :class "default_button"
+                  (box :orientation "h" :space-evenly "false" :spacing 5 :halign "fill"
+                    (label :class "header"
+                      :visible { header-left != "" && header-left != "null" ? "true" : "false" }
+                      :text header-left
+                      :halign "start")
+                    (image 
+                      :class "icon"
+                      :icon "arrow-down")
+                  )
+                )
+
+                (label :class "header"
+                  :visible { header-right != "" && header-right != "null" ? "true" : "false" }
+                  :text header-right
+                  :hexpand "true"
+                  :limit-width 35
+                  :halign "end")
+              )
+              (revealer
+                :transition "slidedown"
+                :duration "250ms" 
+                :reveal {child_0_visible ?: "false"}
+                (children :nth 0)
+              )
+              )
+              (box :orientation "v" :space-evenly "false" :spacing 0
+              (box :orientation "h"
+                  :valign "end"
+                  :spacing 5
+                  :space-evenly false
+                  (eventbox
+                      :active { icon-onclick != "" && icon-onclick != "null" ? "true" : "false" }
+                      :visible {image != "" || icon != "" || app_icon != ""}
+                      :onclick icon-onclick
+                      :height 24
+                      :width 24
+                      :class "default_button"
                       (box
                         (image :class "icon" :visible { image != "" } :path image :image-height 24 :image-width 24)
                         (image 
@@ -85,20 +189,29 @@ writeText "widgets.yuck" ''
                       :onclick settings-onclick
                       :height 24
                       :width 24
-                      :class "settings"
+                      :class "default_button"
                       (image :class "icon" :icon settings_icon)))
-          (children)))
-
+              (revealer
+                :transition "slidedown"
+                :duration "250ms" 
+                :reveal {child_1_visible ?: "false"}
+                (children :nth 1)
+              )
+              )))
+      
       (defwidget sys_sliders []
           (box
               :orientation "v"
               :spacing 10
               :hexpand false
               :space-evenly false
-              (sys_slider
+              (slider_with_children
                       :class "qs-slider"
                       :header-left {audio_output.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in Speaker" :
                                     audio_output.friendly_name}
+                      :header-onclick "''${EWW_CMD} update audio_output_selector_visible=''${!audio_output_selector_visible} &"
+                      :child_0_visible audio_output_selector_visible
+                      :child_1_visible volume-mixer-visible
                       :image { audio_output.is_muted == "true" || audio_output.volume_percentage == 0 ? "${pkgs.ghaf-artwork}/icons/volume-0.svg" :
                               audio_output.volume_percentage <= 25 ? "${pkgs.ghaf-artwork}/icons/volume-1.svg" :
                               audio_output.volume_percentage <= 75 ? "${pkgs.ghaf-artwork}/icons/volume-2.svg" : "${pkgs.ghaf-artwork}/icons/volume-3.svg" }
@@ -106,27 +219,27 @@ writeText "widgets.yuck" ''
                       :settings_icon "adjustlevels"
                       :level { audio_output.is_muted == "true" ? "0" : audio_output.volume_percentage }
                       :onchange "${ewwScripts.eww-audio}/bin/eww-audio set_volume {} &"
-                      (revealer
-                        :visible "false"
-                        :transition "slidedown"
-                        :duration "250ms"
-                        :reveal volume-mixer-visible
-                        (box :orientation "v"
-                          (label :text "No audio streams" :visible {arraylength(audio_streams) == 0} :halign "center" :valign "center")
-                          (volume_mixer :visible {arraylength(audio_streams) > 0})
-                        )))
-              (sys_slider
+                      (audio_output_selector)
+                      (box :orientation "v"
+                        (label :text "No audio streams" :visible {arraylength(audio_streams) == 0} :halign "center" :valign "center")
+                        (volume_mixer :visible {arraylength(audio_streams) > 0})
+                      ))
+              (slider_with_children
                       :visible { audio_input.state == "RUNNING" }
                       :class "qs-slider"
                       :header-left {audio_input.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in Microphone" :
                                     audio_input.friendly_name }
+                      :header-onclick "''${EWW_CMD} update audio_input_selector_visible=''${!audio_input_selector_visible} &"
+                      :child_0_visible audio_input_selector_visible
                       :icon { audio_input.is_muted == "true" || audio_input.volume_percentage == 0 ? "microphone-sensitivity-muted" : 
                               "microphone-sensitivity-high" }
                       :icon-onclick "${ewwScripts.eww-audio}/bin/eww-audio mute_source ''${audio_input.device_index} &"
                       :level { audio_input.is_muted == "true" ? "0" : audio_input.volume_percentage }
-                      :onchange "${ewwScripts.eww-audio}/bin/eww-audio set_source_volume ''${audio_input.device_index} {} &")
+                      :onchange "${ewwScripts.eww-audio}/bin/eww-audio set_source_volume ''${audio_input.device_index} {} &"
+                      (audio_input_selector)
+                      )
               
-              (sys_slider
+              (slider
                       :class "qs-slider"
                       :header-left "Brightness"
                       :level {brightness.screen.level}
@@ -144,6 +257,48 @@ writeText "widgets.yuck" ''
           )
       )
 
+      (defwidget audio_output_selector []
+        (scroll
+          :hscroll "false"
+          :vscroll "true"
+          :height { 30 * min(4,arraylength(audio_outputs)) }
+          (box :orientation "v" :space-evenly false :spacing 5
+            (for device in {audio_outputs}
+              (button
+                :class "default_button"
+                :onclick "${ewwScripts.eww-audio}/bin/eww-audio set_default_sink ''${device.id} && ''${EWW_CMD} update audio_output_selector_visible=false &"
+                (box :orientation "h" :spacing 10 :space-evenly "false"
+                  (image :halign "start" :icon {device.device_type})
+                  (label :halign "start" :limit-width 30 :text { device.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in Speaker" : device.friendly_name })
+                  (image :halign "start" :icon "emblem-ok" :style "opacity: ''${device.is_default ? "1" : "0"}")
+                )
+              )
+            )
+          )
+        )
+      )
+
+      (defwidget audio_input_selector []
+        (scroll
+          :hscroll "false"
+          :vscroll "true"
+          :height { 30 * min(4,arraylength(audio_inputs)) }
+          (box :orientation "v" :space-evenly false :spacing 5
+            (for device in {audio_inputs}
+              (button
+                :class "default_button"
+                :onclick "${ewwScripts.eww-audio}/bin/eww-audio set_default_source ''${device.id} && ''${EWW_CMD} update audio_input_selector_visible=false &"
+                (box :orientation "h" :spacing 10 :space-evenly "false"
+                  (image :halign "start" :icon {device.device_type == "mic" ? "microphone" : device.device_type})
+                  (label :halign "start" :limit-width 30 :text { device.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in Microphone" : device.friendly_name })
+                  (image :halign "start" :icon "emblem-ok" :style "opacity: ''${device.is_default ? "1" : "0"}")
+                )
+              )
+            )
+          )
+        )
+      )
+
       (defwidget volume_mixer [?visible]
           (scroll
               :hscroll "false"
@@ -152,7 +307,7 @@ writeText "widgets.yuck" ''
               :height { 30 * min(4,arraylength(audio_streams)) }
               (box :orientation "v" :space-evenly false :spacing 10
                 (for entry in {audio_streams}
-                  (sys_slider 
+                  (slider 
                       :class "qs-slider"
                       :header-left {entry.name}
                       :level {entry.muted == "true" ? "0" : entry.level} 
@@ -305,7 +460,7 @@ writeText "widgets.yuck" ''
       (defwidget brightness-popup []
           (revealer :transition "crossfade" :duration "200ms" :reveal brightness-popup-visible :active false
               (desktop-widget :class "popup"
-                  (sys_slider
+                  (slider
                       :valign "center"
                       :image { brightness.screen.level == 0 ? "${pkgs.ghaf-artwork}/icons/brightness-0.svg" :
                               brightness.screen.level < 12 ? "${pkgs.ghaf-artwork}/icons/brightness-1.svg" :
@@ -322,7 +477,7 @@ writeText "widgets.yuck" ''
       (defwidget volume-popup []
           (revealer :transition "crossfade" :duration "200ms" :reveal volume-popup-visible :active false
               (desktop-widget :class "popup"
-                  (sys_slider
+                  (slider
                       :valign "center"
                       :image { audio_output.is_muted == "true" || audio_output.volume_percentage == 0 ? "${pkgs.ghaf-artwork}/icons/volume-0.svg" :
                               audio_output.volume_percentage <= 25 ? "${pkgs.ghaf-artwork}/icons/volume-1.svg" :
@@ -337,8 +492,8 @@ writeText "widgets.yuck" ''
 
       ;; Quick Settings Button ;;
       (defwidget quick-settings-button [screen bat-icon vol-icon bright-icon]
-          (button :class "icon_button"
-              :onclick "${ewwScripts.eww-open-widget}/bin/eww-open-widget quick-settings \"''${screen}\" &"
+          (button :class "default_button"
+              :onclick "''${EWW_CMD} update audio_output_selector_visible=false audio_input_selector_visible=false & ${ewwScripts.eww-open-widget}/bin/eww-open-widget quick-settings \"''${screen}\" &"
               (box :orientation "h"
                   :space-evenly "false"
                   :spacing 14
@@ -360,7 +515,7 @@ writeText "widgets.yuck" ''
 
       ;; Power Menu Launcher ;;
       (defwidget power-menu-launcher [screen]
-          (button :class "icon_button icon" 
+          (button :class "default_button icon" 
               :halign "center" 
               :valign "center" 
               :onclick "${ewwScripts.eww-open-widget}/bin/eww-open-widget power-menu \"''${screen}\" &"
@@ -421,7 +576,7 @@ writeText "widgets.yuck" ''
       (defwidget datetime [screen]
           (button 
               :onclick "${ewwScripts.eww-open-widget}/bin/eww-open-widget calendar \"''${screen}\" &"
-              :class "icon_button date" "''${formattime(EWW_TIME, "%H:%M  %a %b %-d")}"))
+              :class "default_button date" "''${formattime(EWW_TIME, "%H:%M  %a %b %-d")}"))
 
       ;; Calendar ;;
       (defwidget cal []
@@ -437,7 +592,7 @@ writeText "widgets.yuck" ''
           (box :class "workspace"
               :orientation "h"
               :space-evenly "false"
-              (button :class "icon_button"
+              (button :class "default_button"
                       :tooltip "Current desktop"
                       :onclick {workspaces-visible == "false" ? "''${EWW_CMD} update workspaces-visible=true" : "''${EWW_CMD} update workspaces-visible=false"}
                       workspace)
@@ -451,7 +606,7 @@ writeText "widgets.yuck" ''
                           ${
                             lib.concatStringsSep "\n" (
                               builtins.map (index: ''
-                                (button :class "icon_button"
+                                (button :class "default_button"
                                     :onclick "${ghaf-workspace}/bin/ghaf-workspace switch ${toString index}; ''${EWW_CMD} update workspaces-visible=false"
                                     "${toString index}")
                               '') (lib.lists.range 1 cfg.maxDesktops)

--- a/modules/desktop/graphics/styles/ewwbar-style.nix
+++ b/modules/desktop/graphics/styles/ewwbar-style.nix
@@ -53,7 +53,7 @@
 
   @mixin floating_widget($bg: $bg-primary, $margin: 0.3em 0.3em 0em 0em, $padding: 14px, $radius: 12px, $unset: true) {
       @if $unset {
-        @include unset($rec: true);
+        @include unset;
       }
       background-color: $bg;
       border-radius: $radius;
@@ -68,18 +68,16 @@
       background-size: contain;
       min-height: 24px;
       min-width: 24px;
-      font-family: ${fontName};
-      font-size: 1.5em;
       color: #FFFFFF;
       -gtk-icon-effect: none;
   }
 
-  @mixin icon-button($bg: transparent, $hover-bg: $widget-hover) {
+  @mixin button($bg: transparent, $hover-bg: $widget-hover) {
       @include unset;
       @include icon;
 
       border-radius: 0.25em;
-      padding: 0.3em;
+      padding: 0.4em;
       background-color: $bg;
 
       .icon{
@@ -98,6 +96,10 @@
   }
 
   @mixin slider($slider-width: 225px, $slider-height: 2px, $thumb: true, $thumb-width: 1em, $focusable: true, $radius: 7px, $shadows: true, $trough-bg: $widget-hover, $trough-fg: $stroke-success) {
+      scale {
+          padding: 0px;
+      }
+      
       trough {
           border-radius: $radius;
           border: 0;
@@ -117,6 +119,7 @@
           @if $thumb {
               box-shadow: none;
               background-color: #D3D3D3;
+              background-image: none;
               border: 0 solid transparent;
               border-radius: 50%;
               min-height: $thumb-width;
@@ -127,6 +130,7 @@
               min-width: 0;
               min-height: 0;
               background-color: transparent;
+              background-image: none;
           }
       }
 
@@ -172,14 +176,6 @@
           font-weight: $font-bold;
           font-family: ${fontName};
       }
-
-      .settings{
-          @include icon-button;
-      }
-
-      .icon_settings{
-          @include icon-button;
-      }
   }
 
   @mixin qs-widget($min-height: 70px, $min-width: 150px, $radius: 0.75em, $bg: $widget-bg) {
@@ -189,7 +185,7 @@
       background-color: $bg;
   }
 
-  @mixin widget-button($min-width: 133px, $min-height: 58px, $radius: 0.75em, $bg: $widget-bg, $padding: 0.8em, $icon-padding: 0) {
+  @mixin widget-button($min-width: 133px, $min-height: 58px, $radius: 0.75em, $bg: $widget-bg, $padding: 0.8em) {
       @include qs-widget($min-width: $min-width, $min-height: $min-height);
 
       .inner-box {
@@ -218,7 +214,6 @@
           background-position: center;
           min-height: 24px;
           min-width: 24px;
-          padding: $icon-padding;
       }
 
       .text {
@@ -237,7 +232,7 @@
   }
 
   .qs-widget {
-      @include unset($rec: true);
+      @include unset;
       @include qs-widget;
   }
 
@@ -246,7 +241,7 @@
   .floating-widget { @include floating_widget; }
 
   .qs-slider {
-      @include unset($rec: true);
+      @include unset;
       @include sys-sliders;
       @include qs-widget($min-height: 0px);
       padding: 0.8em;
@@ -254,9 +249,6 @@
 
   .popup {
       .slider{ @include slider($slider-width: 150px, $thumb: false, $slider-height: 5px); }
-      .icon_settings{
-          @include icon-button;
-      }
       font-size: 1.3em;
       :disabled {
           color: $text-base;
@@ -272,8 +264,16 @@
       padding: 0.2em 0.5em 0.2em 0.5em;
   }
 
-  .icon_button {
-      @include icon-button;
+  .default_button {
+      @include button;
+      label {
+        font-size: 0.9em;
+      }
+      .header {
+        font-size: 0.9em;
+        font-weight: $font-bold;
+        font-family: ${fontName};
+      }
   }
 
   .divider {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

1. **Added active audio device selection in the Quick Settings widget**
   - Can be opened by clicking the device name above the audio volume slider.
   - Output and Input devices can be selected independently.
   - The currently active device can be identified by the checkmark next to its' name.
   - Designs are not final.
2. **Adjusted the fetching of audio data to improve performance**


## Known Issues:
1. **Non-critical error messages can be observed in Eww logs when opening Quick Settings widget**

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [x] Is this a new feature
  - [x] List the test steps to verify:
    - For both Output and Input devices:
      - Verify device selection opens and closes as expected
      - Verify device can be selected and becomes active immediately
      - Verify new devices are added to the list when connected
      - Verify devices are removed from the list when disconnected
      - Verify selected device name is the same in both the device selection list and in the header above the slider.
- [ ] If it is an improvement how does it impact existing functionality?

