### PR TITLE
Enable systemd hardened configs in gui-vm

### DIFF
--- a/modules/common/systemd/hardened-configs/common/systemd-udevd.nix
+++ b/modules/common/systemd/hardened-configs/common/systemd-udevd.nix
@@ -126,7 +126,7 @@
     # "~CAP_AUDIT_CONTROL"
     # "~CAP_AUDIT_READ"
     # "~CAP_AUDIT_WRITE"
-    "~CAP_SYS_ADMIN"
+    # "~CAP_SYS_ADMIN"
     # "~CAP_SYSLOG"
     # "~CAP_SYS_TIME
   ];
@@ -137,8 +137,8 @@
 
   SystemCallFilter = [
     # "~@clock"
-    # "~@cpu-emulation"
-    # "~@debug"
+    "~@cpu-emulation"
+    "~@debug"
     # "~@module"
     # "~@mount"
     "~@obsolete"

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -90,7 +90,7 @@ let
               withResolved = true;
               withTimesyncd = true;
               withDebug = config.ghaf.profiles.debug.enable;
-              withHardenedConfigs = false;
+              withHardenedConfigs = true;
             };
             givc.guivm.enable = true;
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
- Fixed dynamic user login issue with hardened systemd configs.
- Mounting user home requires admin capability in systemd-udevd, so allowed it.


## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [x] List the test steps to verify:
    - Login to gui-vm and see if everything is working fine.  
- [ ] If it is an improvement how does it impact existing functionality?

