### PR TITLE
Desktop: Automatic scaling on HiDPI displays

### DIFF
--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -108,10 +108,6 @@ in
       mode = "0644";
     };
 
-    services.udev.extraRules = ''
-      ACTION=="change", SUBSYSTEM=="drm", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}+="eww-display-trigger.service"
-    '';
-
     systemd.user.services = {
       ewwbar = {
         enable = true;

--- a/modules/desktop/graphics/ewwbar/config/widgets/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/widgets/default.nix
@@ -207,7 +207,7 @@ writeText "widgets.yuck" ''
               :space-evenly false
               (slider_with_children
                       :class "qs-slider"
-                      :header-left {audio_output.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in Speaker" :
+                      :header-left {audio_output.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in ''${audio_output.device_type}" :
                                     audio_output.friendly_name}
                       :header-onclick "''${EWW_CMD} update audio_output_selector_visible=''${!audio_output_selector_visible} &"
                       :child_0_visible audio_output_selector_visible
@@ -227,12 +227,13 @@ writeText "widgets.yuck" ''
               (slider_with_children
                       :visible { audio_input.state == "RUNNING" }
                       :class "qs-slider"
-                      :header-left {audio_input.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in Microphone" :
+                      :header-left {audio_input.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in ''${audio_input.device_type}" :
                                     audio_input.friendly_name }
                       :header-onclick "''${EWW_CMD} update audio_input_selector_visible=''${!audio_input_selector_visible} &"
                       :child_0_visible audio_input_selector_visible
-                      :icon { audio_input.is_muted == "true" || audio_input.volume_percentage == 0 ? "microphone-sensitivity-muted" : 
-                              "microphone-sensitivity-high" }
+                      :icon { audio_input.is_muted == "true" || audio_input.volume_percentage == 0 ? "microphone-sensitivity-muted" :
+                              audio_input.volume_percentage <= 25 ? "microphone-sensitivity-low" :
+                              audio_input.volume_percentage <= 75 ? "microphone-sensitivity-medium" : "microphone-sensitivity-high" }
                       :icon-onclick "${ewwScripts.eww-audio}/bin/eww-audio mute_source ''${audio_input.device_index} &"
                       :level { audio_input.is_muted == "true" ? "0" : audio_input.volume_percentage }
                       :onchange "${ewwScripts.eww-audio}/bin/eww-audio set_source_volume ''${audio_input.device_index} {} &"
@@ -268,8 +269,10 @@ writeText "widgets.yuck" ''
                 :class "default_button"
                 :onclick "${ewwScripts.eww-audio}/bin/eww-audio set_default_sink ''${device.id} && ''${EWW_CMD} update audio_output_selector_visible=false &"
                 (box :orientation "h" :spacing 10 :space-evenly "false"
-                  (image :halign "start" :icon {device.device_type})
-                  (label :halign "start" :limit-width 30 :text { device.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in Speaker" : device.friendly_name })
+                  (image :halign "start" :path {  device.is_muted == "true" || device.volume_percentage == 0 ? "${pkgs.ghaf-artwork}/icons/volume-0.svg" :
+                                                  device.volume_percentage <= 25 ? "${pkgs.ghaf-artwork}/icons/volume-1.svg" :
+                                                  device.volume_percentage <= 75 ? "${pkgs.ghaf-artwork}/icons/volume-2.svg" : "${pkgs.ghaf-artwork}/icons/volume-3.svg" })
+                  (label :halign "start" :limit-width 30 :text { device.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in ''${device.device_type}" : device.friendly_name })
                   (image :halign "start" :icon "emblem-ok" :style "opacity: ''${device.is_default ? "1" : "0"}")
                 )
               )
@@ -289,8 +292,10 @@ writeText "widgets.yuck" ''
                 :class "default_button"
                 :onclick "${ewwScripts.eww-audio}/bin/eww-audio set_default_source ''${device.id} && ''${EWW_CMD} update audio_input_selector_visible=false &"
                 (box :orientation "h" :spacing 10 :space-evenly "false"
-                  (image :halign "start" :icon {device.device_type == "mic" ? "microphone" : device.device_type})
-                  (label :halign "start" :limit-width 30 :text { device.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in Microphone" : device.friendly_name })
+                  (image :halign "start" :icon { device.is_muted == "true" || device.volume_percentage == 0 ? "microphone-sensitivity-muted" :
+                                                 device.volume_percentage <= 25 ? "microphone-sensitivity-low" :
+                                                 device.volume_percentage <= 75 ? "microphone-sensitivity-medium" : "microphone-sensitivity-high" })
+                  (label :halign "start" :limit-width 30 :text { device.friendly_name =~ '.*sof-hda-dsp.*' ? "Built-in ''${device.device_type}" : device.friendly_name })
                   (image :halign "start" :icon "emblem-ok" :style "opacity: ''${device.is_default ? "1" : "0"}")
                 )
               )
@@ -480,9 +485,9 @@ writeText "widgets.yuck" ''
                   (slider
                       :valign "center"
                       :image { audio_output.is_muted == "true" || audio_output.volume_percentage == 0 ? "${pkgs.ghaf-artwork}/icons/volume-0.svg" :
-                              audio_output.volume_percentage <= 25 ? "${pkgs.ghaf-artwork}/icons/volume-1.svg" :
-                              audio_output.volume_percentage <= 75 ? "${pkgs.ghaf-artwork}/icons/volume-2.svg" : "${pkgs.ghaf-artwork}/icons/volume-3.svg" }
-                      :level {audio_output.volume_percentage}))))
+                               audio_output.volume_percentage <= 25 ? "${pkgs.ghaf-artwork}/icons/volume-1.svg" :
+                               audio_output.volume_percentage <= 75 ? "${pkgs.ghaf-artwork}/icons/volume-2.svg" : "${pkgs.ghaf-artwork}/icons/volume-3.svg" }
+                      :level { audio_output.is_muted == "true" ? "0" : audio_output.volume_percentage }))))
 
       ;; Workspace Popup Widget ;;
       (defwidget workspace-popup []

--- a/modules/desktop/graphics/ewwbar/config/windows/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/windows/default.nix
@@ -9,12 +9,12 @@
 }:
 writeText "windows.yuck" ''
   ;; Bar Window ;;
-      (defwindow bar [screen]
+      (defwindow bar [screen ?width]
           :geometry (geometry  
                       :x "0px" 
                       :y "0px" 
                       :height "28px"
-                      :width "100%" 
+                      :width {width ?: "100%"} 
                       :anchor "top center")
           :focusable "false"
           :hexpand "false"
@@ -53,7 +53,7 @@ writeText "windows.yuck" ''
         ;; Volume Popup Window ;;
         (defwindow volume-popup
             :monitor 0
-            :geometry (geometry :y "150px"
+            :geometry (geometry :y "10%"
                                 :x "0px"
                                 :anchor "bottom center")
             :stacking "overlay"
@@ -62,7 +62,7 @@ writeText "windows.yuck" ''
         ;; Brightness Popup Window ;;
         (defwindow brightness-popup
             :monitor 0
-            :geometry (geometry :y "150px"
+            :geometry (geometry :y "10%"
                                 :x "0px"
                                 :anchor "bottom center")
             :stacking "overlay"
@@ -71,7 +71,7 @@ writeText "windows.yuck" ''
         ;; Workspace Popup Window ;;
         (defwindow workspace-popup
             :monitor 0
-            :geometry (geometry :y "150px"
+            :geometry (geometry :y "10%"
                                 :x "0px"
                                 :anchor "bottom center")
             :stacking "overlay"

--- a/modules/desktop/graphics/styles/ewwbar-style.nix
+++ b/modules/desktop/graphics/styles/ewwbar-style.nix
@@ -116,12 +116,12 @@
       }
 
       slider {
+          border: 0 solid transparent;
+          border-radius: 50%;
+          background-image: none;
+          box-shadow: none;
           @if $thumb {
-              box-shadow: none;
               background-color: #D3D3D3;
-              background-image: none;
-              border: 0 solid transparent;
-              border-radius: 50%;
               min-height: $thumb-width;
               min-width: $thumb-width;
               margin: -($thumb-width / 2) 0;
@@ -130,7 +130,6 @@
               min-width: 0;
               min-height: 0;
               background-color: transparent;
-              background-image: none;
           }
       }
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

1. **Automatic scaling for HiDPI displays:**  
   - Automatic scaling is now performed during system boot and on display-related events
   - Manual scaling settings are not supported.
   - See the scaling table below for more details:
   
### Automatic Scaling Table

| Condition                  | Scaling Factor | Description                                      |
|----------------------------|----------------|--------------------------------------------------|
| TV size <= 65 inches        | 1.50           | 150% scaling for TVs up to 65 inches             |
| TV size > 65 inches         | 1.75           | 175% scaling for TVs larger than 65 inches       |
| PPI < 170                   | 1              | No scaling for low PPI displays                 |
| 170 <= PPI < 200            | 1.25           | 125% scaling for medium PPI displays            |
| 200 <= PPI < 300            | 1.50           | 150% scaling for higher PPI displays            |
| PPI >= 300                  | 2              | 200% scaling for very high PPI displays         |
- With these settings the older X1 models will have no scaling applied, while newer ones (gen 11) will have a default scaling of 150%).
- 28.1 - Increased TV scaling by 0.25 based on user feedback.

3. **Added wdisplays display configurator:**  
   - Can be opened via the XF86_Display function key (F7 on X1).
   - Can be used to adjust the scaling, resolution, refresh rate, display positioning at runtime.
   Applying new settings will cause the taskbar to be reloaded.
   - Known issue: wdisplays may close unexpectedly if a display is added or removed while it's open.
   - Should close #868 

4. **Made minor adjustments to taskbar Quick Settings widget:**  
   - Updated naming conventions for built-in devices.
   - Added dynamic icons in the input/ouptut device selection lists.
   
5. **Adjusted ewwbar service to be reloaded more consistently:**
   - The taskbar can now be reloaded quickly with `systemctl --user reload ewwbar`.
   - Taskbar is now reloaded on any display event (new display, removed display, display configuration change etc.).
   
6. **(Automated tests) added "hidpi-auto-scaling-reset" service:**
   - This service should be started after logging in to reset any scaling performed at boot:
     `systemctl --user start hidpi-auto-scaling-reset`
   - Make sure to start the service only _after_ the taskbar has already appeared
   
## Future improvements/considerations

1. **Enable/disable automatic scaling as a nix config option in labwc.nix**
2. **(Optional) Adjustable scaling factors based on PPI as a nix config option in labwc.nix**
3. Persist display configuration per user session (consider using [way-displays](https://github.com/alex-courtis/way-displays) or save a snapshot output of wlr-randr to reapply settings on login).
   - Using way-displays is not possible due to conflicts with **wdisplays** - way-displays will always override any changes done by wdisplays.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [x] Is this a new feature
  - [x] List the test steps to verify:
    - Verify scaling is performed on HiDPI displays as described in the table above during:
      - Boot
      - Runtime (adding, removing displays)
    - Verify scaling does not negatively affect usability
    - Verify Audio Input/Output device selection in the Quick Settings widget properly displays:
      - Dynamic icons for all devices
      - Built-in device names based on used port
    - Verify **wdisplays** can be opened as described, functionality testing coverage can be decided by the tester
- [x] If it is an improvement how does it impact existing functionality?

