### PR TITLE
Lenovo X1 Carbon Gen 12 support

### DIFF
--- a/modules/hardware/common/devices.nix
+++ b/modules/hardware/common/devices.nix
@@ -52,7 +52,7 @@ in
         microvm.devices = mkForce (
           builtins.map (d: {
             bus = "pci";
-            inherit (d) path;
+            inherit (d) path qemu;
           }) config.ghaf.hardware.definition.gpu.pciDevices
         );
         ghaf.hardware.definition.gpu.pciDevices = config.ghaf.hardware.definition.gpu.pciDevices;

--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -98,6 +98,13 @@ let
               productId = "0052";
               description = "Lenovo X1 Integrated Camera";
             }
+            {
+              # Ignore Lenovo X1 gen 12 camera since it is attached to the business-vm
+              # Finland SKU
+              vendorId = "30c9";
+              productId = "005f";
+              description = "Lenovo X1 Integrated Camera";
+            }
           ];
         }
       ];

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -41,6 +41,13 @@ in
               PCI device name (optional)
             '';
           };
+          qemu.deviceExtraArgs = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = ''
+              Device additional arguments (optional)
+            '';
+          };
         };
       };
 
@@ -255,6 +262,7 @@ in
               path = "0000:00:02.0";
               vendorId = "8086";
               productId = "a7a1";
+              qemu.deviceExtraArgs = "x-igd-opregion=on"
             }]
           '';
         };

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
@@ -78,6 +78,7 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "7d45";
+        qemu.deviceExtraArgs = "x-igd-opregion=on";
       }
       {
         # Communication controller [0780]: Intel Corporation Device [8086:7e70] (rev 20)

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
@@ -1,0 +1,165 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{
+  # System name
+  name = "Lenovo X1 Carbon Gen 12";
+
+  # List of system SKUs covered by this configuration
+  skus = [
+    "LENOVO_MT_21KC_BU_Think_FM_ThinkPad X1 Carbon Gen 12 21KC006CMX"
+    # TODO Add more SKUs
+  ];
+
+  host = {
+    kernelConfig.kernelParams = [
+      "intel_iommu=on,sm_on"
+      "iommu=pt"
+      "module_blacklist=i915,xe,snd_pcm,mei_me" # Prevent kernel modules from being accidentally used by host
+      "acpi_backlight=vendor"
+      "acpi_osi=linux"
+    ];
+  };
+
+  input = {
+    keyboard = {
+      name = [ "AT Translated Set 2 keyboard" ];
+      evdev = [ "/dev/input/by-path/platform-i8042-serio-0-event-kbd" ];
+    };
+
+    mouse = {
+      name = [
+        [
+          "ELAN06D5:00 04F3:32B7 Mouse"
+        ]
+        "TPPS/2 Elan TrackPoint"
+      ];
+      evdev = [
+        "/dev/mouse0"
+        "/dev/mouse1"
+      ];
+    };
+
+    touchpad = {
+      name = [
+        [
+          "ELAN06D5:00 04F3:32B7 Touchpad"
+        ]
+      ];
+      evdev = [ "/dev/touchpad0" ];
+    };
+
+    misc = {
+      name = [ "ThinkPad Extra Buttons" ];
+      evdev = [ "/dev/input/by-path/platform-thinkpad_acpi-event" ];
+    };
+  };
+
+  disks = {
+    disk1.device = "/dev/nvme0n1";
+  };
+
+  network.pciDevices = [
+    {
+      # Network controller [0280]: Intel Corporation Meteor Lake PCH CNVi WiFi [8086:7e40](rev 20)
+      # iwlwifi
+      path = "0000:00:14.3";
+      vendorId = "8086";
+      productId = "7e40";
+      name = "wlp0s5f0";
+    }
+  ];
+
+  gpu = {
+    pciDevices = [
+      {
+        # VGA compatible controller [0300]: Intel Corporation Meteor Lake-P [Intel Graphics] [8086:7d45] (rev 08)
+        # i915,xe
+        path = "0000:00:02.0";
+        vendorId = "8086";
+        productId = "7d45";
+      }
+      {
+        # Communication controller [0780]: Intel Corporation Device [8086:7e70] (rev 20)
+        # mei_me (DDC/HDCP/EDID)
+        path = "0000:00:16.0";
+        vendorId = "8086";
+        productId = "7e70";
+      }
+    ];
+    kernelConfig = {
+      stage1.kernelModules = [
+        "i915"
+        "xe"
+      ];
+      kernelParams = [
+        "earlykms"
+      ];
+    };
+  };
+
+  # With the current implementation, the whole PCI IOMMU group 14:
+  #   00:1f.x in the example from Lenovo X1 Carbon
+  #   must be defined for passthrough to AudioVM
+  audio = {
+    pciDevices = [
+      {
+        # ISA bridge: Intel Corporation Device 7e03 (rev 20)
+        path = "0000:00:1f.0";
+        vendorId = "8086";
+        productId = "7e03";
+      }
+      {
+        # Audio device: Intel Corporation Meteor Lake-P HD Audio Controller (rev 20) (prog-if 80)
+        path = "0000:00:1f.3";
+        vendorId = "8086";
+        productId = "7e28";
+      }
+      {
+        # SMBus: Intel Corporation Meteor Lake-P SMBus Controller (rev 20)
+        path = "0000:00:1f.4";
+        vendorId = "8086";
+        productId = "7e22";
+      }
+      {
+        # Serial bus controller: Intel Corporation Meteor Lake-P SPI Controller (rev 20)
+        path = "0000:00:1f.5";
+        vendorId = "8086";
+        productId = "7e23";
+      }
+    ];
+    kernelConfig.kernelParams = [ "snd_intel_dspcfg.dsp_driver=0" ];
+  };
+
+  usb = {
+    internal = [
+      {
+        name = "cam0";
+        hostbus = "3";
+        hostport = "9";
+      }
+      {
+        name = "fpr0";
+        hostbus = "3";
+        hostport = "7";
+      }
+      {
+        name = "bt0";
+        hostbus = "3";
+        hostport = "10";
+      }
+    ];
+    external = [
+      {
+        name = "gps0";
+        vendorId = "067b";
+        productId = "23a3";
+      }
+      {
+        name = "yubikey";
+        vendorId = "1050";
+        productId = "0407";
+      }
+    ];
+  };
+}

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -33,6 +33,15 @@ let
         };
       }
     ])
+    (laptop-configuration "lenovo-x1-carbon-gen12" "debug" [
+      self.nixosModules.disko-ab-partitions-v1
+      {
+        ghaf = {
+          hardware.definition = import ../../modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix;
+          reference.profiles.mvp-user-trial.enable = true;
+        };
+      }
+    ])
     (laptop-configuration "lenovo-x1-extras" "debug" [
       self.nixosModules.disko-ab-partitions-v1
       {
@@ -76,6 +85,15 @@ let
       {
         ghaf = {
           hardware.definition = import ../../modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix;
+          reference.profiles.mvp-user-trial.enable = true;
+        };
+      }
+    ])
+    (laptop-configuration "lenovo-x1-carbon-gen12" "release" [
+      self.nixosModules.disko-ab-partitions-v1
+      {
+        ghaf = {
+          hardware.definition = import ../../modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix;
           reference.profiles.mvp-user-trial.enable = true;
         };
       }

--- a/targets/lenovo-x1-installer/flake-module.nix
+++ b/targets/lenovo-x1-installer/flake-module.nix
@@ -69,8 +69,10 @@ let
   targets = [
     (installer "gen10" "debug")
     (installer "gen11" "debug")
+    (installer "gen12" "debug")
     (installer "gen10" "release")
     (installer "gen11" "release")
+    (installer "gen12" "release")
   ];
 in
 {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Added new target for gen12.
Added pass-through for gen12 devices.
Enable access to video bios table (VBT) to gui-vm.
Requires update to microvm side to enable passing of extra arguments: [https://github.com/astro/microvm.nix/pull/325](https://github.com/astro/microvm.nix/pull/325)

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [N/A] Tested on Jetson Orin NX or AGX `aarch64`
  - [N/A] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [x] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
  * lenovo-x1-carbon-gen12-debug
  * lenovo-x1-carbon-gen12-release
- [x] Is this a new feature
  - [x] List the test steps to verify:
  * Build a Ghaf gen12 target
  * Test that Ghaf works on a Lenovo X1 Carbon Gen 12 laptop
- [ ] If it is an improvement how does it impact existing functionality?
