### PR TITLE
More strict configs for dnsmasq service

### DIFF
--- a/modules/common/systemd/hardened-configs/common/dbus.nix
+++ b/modules/common/systemd/hardened-configs/common/dbus.nix
@@ -2,97 +2,37 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 {
-  ##############
-  # Networking #
-  ##############
-
-  # PrivateNetwork=true;
   IPAccounting = true;
   IPAddressDeny = "any";
   RestrictAddressFamilies = [
-    #"~AF_PACKET"
-    #"~AF_NETLINK"
     "AF_UNIX"
-    #"~AF_INET"
-    #"~AF_INET6"
   ];
-
-  ###############
-  # File system #
-  ###############
 
   ProtectHome = true;
   ProtectSystem = "full";
-  # ProtectProc="noaccess";
-  # ReadWritePaths=[ "/etc"];
   ReadOnlyPaths = [ "/" ];
   PrivateTmp = true;
-
-  # Not applicable for the service runs as root
-  # PrivateMounts=true;
-  # ProcSubset="all";
-
-  ###################
-  # User separation #
-  ###################
-
-  # Not applicable for the service runs as root
-  # PrivateUsers=true;
-  # DynamicUser=true;
-
-  ###########
-  # Devices #
-  ###########
-
   PrivateDevices = true;
   DeviceAllow = [
     "/dev/null rw"
     "/dev/urandom r"
   ];
 
-  ##########
-  # Kernel #
-  ##########
-
   ProtectKernelTunables = true;
   ProtectKernelModules = true;
   ProtectKernelLogs = true;
-
-  ########
-  # Misc #
-  ########
-
-  # Delegate=false;
-  # KeyringMode="private";
   NoNewPrivileges = true;
   UMask = 77;
   ProtectHostname = true;
   ProtectClock = true;
   ProtectControlGroups = true;
   RestrictNamespaces = true;
-  /*
-      RestrictNamespaces=[
-     #"~user"
-     #"~pid"
-     #"~net"
-     #"~uts"
-     #"~mnt"
-     #"~cgroup"
-     #"~ipc"
-    ];
-  */
   LockPersonality = true;
   MemoryDenyWriteExecute = true;
   RestrictRealtime = true;
   RestrictSUIDSGID = true;
-  # RemoveIPC=true
   SystemCallArchitectures = "native";
-  # NotifyAccess=false;
   LimitMEMLOCK = 0;
-
-  ################
-  # Capabilities #
-  ################
 
   AmbientCapabilities = [
     "CAP_BPF"
@@ -104,49 +44,7 @@
     "CAP_SETPCAP"
     "CAP_SYS_RESOURCE"
     "CAP_AUDIT_WRITE"
-    # "~CAP_SYS_PACCT"
-    # "~CAP_KILL"
-    # "~CAP_WAKE_ALARM"
-    # "~CAP_DAC_*
-    # "~CAP_FOWNER"
-    # "~CAP_IPC_OWNER"
-    # "~CAP_BPF"
-    # "~CAP_LINUX_IMMUTABLE"
-    # "~CAP_IPC_LOCK"
-    # "~CAP_SYS_MODULE"
-    # "~CAP_SYS_TTY_CONFIG"
-    # "~CAP_SYS_BOOT"
-    # "~CAP_SYS_CHROOT"
-    # "~CAP_BLOCK_SUSPEND"
-    # "~CAP_LEASE"
-    # "~CAP_MKNOD"
-    # "~CAP_CHOWN"
-    # "~CAP_FSETID"
-    # "~CAP_SETFCAP"
-    # "~CAP_SETUID"
-    # "~CAP_SETGID"
-    # "~CAP_SETPCAP"
-    # "~CAP_MAC_ADMIN"
-    # "~CAP_MAC_OVERRIDE"
-    # "~CAP_SYS_RAWIO"
-    # "~CAP_SYS_PTRACE"
-    # "~CAP_SYS_NICE"
-    # "~CAP_SYS_RESOURCE"
-    # "~CAP_NET_ADMIN"
-    # "~CAP_NET_BIND_SERVICE"
-    # "~CAP_NET_BROADCAST"
-    # "~CAP_NET_RAW"
-    # "~CAP_AUDIT_CONTROL"
-    # "~CAP_AUDIT_READ"
-    # "~CAP_AUDIT_WRITE"
-    # "~CAP_SYS_ADMIN"
-    # "~CAP_SYSLOG"
-    # "~CAP_SYS_TIME
   ];
-
-  ################
-  # System calls #
-  ################
 
   SystemCallFilter = [
     "@system-service"
@@ -166,16 +64,5 @@
     "mlock"
     "mlockall"
     "personality"
-    # "~@clock"
-    # "~@cpu-emulation"
-    # "~@debug"
-    # "~@module"
-    # "~@mount"
-    # "~@obsolete"
-    # "~@privileged"
-    # "~@raw-io"
-    # "~@reboot"
-    # "~@resources"
-    # "~@swap"
   ];
 }

--- a/modules/common/systemd/hardened-configs/common/dnsmasq.nix
+++ b/modules/common/systemd/hardened-configs/common/dnsmasq.nix
@@ -2,150 +2,60 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 {
-  ##############
-  # Networking #
-  ##############
-
-  # PrivateNetwork=true;
-  # IPAccounting=yes
-  # IPAddressDeny="any";
-  RestrictAddressFamilies = [
-    "AF_PACKET"
-    "AF_NETLINK"
-    "AF_UNIX"
-    "AF_INET"
-    "AF_INET6"
-  ];
-
-  ###############
-  # File system #
-  ###############
-
+  PrivateNetwork = false;
+  IPAccounting = true;
+  IPAddressDeny = "any";
   ProtectHome = true;
   ProtectSystem = true;
-  ProtectProc = "invisible";
-  # ReadWritePaths=[ "/etc"];
+  ProtectProc = "noaccess";
   PrivateTmp = true;
-
-  # Not applicable for the service runs as root
-  # PrivateMounts=true;
-  # ProcSubset="all";
-
-  ###################
-  # User separation #
-  ###################
-
-  # Not applicable for the service runs as root
-  # PrivateUsers=true;
-  # DynamicUser=true;
-
-  ###########
-  # Devices #
-  ###########
-
+  PrivateMounts = true;
+  ProcSubset = "pid";
+  PrivateUsers = false;
+  DynamicUser = false;
   PrivateDevices = true;
-  # DeviceAllow=/dev/null
-
-  ##########
-  # Kernel #
-  ##########
-
   ProtectKernelTunables = true;
   ProtectKernelModules = true;
   ProtectKernelLogs = true;
-
-  ########
-  # Misc #
-  ########
-
-  # Delegate=false;
-  # KeyringMode="private";
+  Delegate = false;
+  KeyringMode = "private";
   NoNewPrivileges = true;
-  # UMask=077;
+  UMask = 65;
   ProtectHostname = true;
   ProtectClock = true;
-  # ProtectControlGroups=true;
-  # RestrictNamespaces=true;
-  /*
-      RestrictNamespaces=[
-     #"~user"
-     #"~pid"
-     #"~net"
-     #"~uts"
-     #"~mnt"
-     #"~cgroup"
-     #"~ipc"
-    ];
-  */
+  ProtectControlGroups = true;
+  RestrictNamespaces = true;
   LockPersonality = true;
   MemoryDenyWriteExecute = true;
   RestrictRealtime = true;
   RestrictSUIDSGID = true;
-  # RemoveIPC=true
+  RemoveIPC = true;
   SystemCallArchitectures = "native";
-  # NotifyAccess=false;
+  NotifyAccess = "main";
 
-  ################
-  # Capabilities #
-  ################
-
-  #AmbientCapabilities=
-  CapabilityBoundingSet = [
-    "~CAP_SYS_PACCT"
-    "~CAP_KILL"
-    # "~CAP_WAKE_ALARM"
-    # "~CAP_DAC_*
-    "~CAP_FOWNER"
-    # "~CAP_IPC_OWNER"
-    # "~CAP_BPF"
-    "~CAP_LINUX_IMMUTABLE"
-    # "~CAP_IPC_LOCK"
-    "~CAP_SYS_MODULE"
-    "~CAP_SYS_TTY_CONFIG"
-    "~CAP_SYS_BOOT"
-    "~CAP_SYS_CHROOT"
-    # "~CAP_BLOCK_SUSPEND"
-    "~CAP_LEASE"
-    "~CAP_MKNOD"
-    # "~CAP_CHOWN"
-    # "~CAP_FSETID"
-    # "~CAP_SETFCAP"
-    # "~CAP_SETUID"
-    # "~CAP_SETGID"
-    # "~CAP_SETPCAP"
-    # "~CAP_MAC_ADMIN"
-    # "~CAP_MAC_OVERRIDE"
-    "~CAP_SYS_RAWIO"
-    "~CAP_SYS_PTRACE"
-    # "~CAP_SYS_NICE"
-    # "~CAP_SYS_RESOURCE"
-    # "~CAP_NET_ADMIN"
-    # "~CAP_NET_BIND_SERVICE"
-    # "~CAP_NET_BROADCAST"
-    # "~CAP_NET_RAW"
-    # "~CAP_AUDIT_CONTROL"
-    # "~CAP_AUDIT_READ"
-    # "~CAP_AUDIT_WRITE"
-    # "~CAP_SYS_ADMIN"
-    # "~CAP_SYSLOG"
-    # "~CAP_SYS_TIME
+  RestrictAddressFamilies = [
+    "~AF_PACKET"
   ];
 
-  ################
-  # System calls #
-  ################
+  CapabilityBoundingSet = [
+    "CAP_NET_BIND_SERVICE"
+    "CAP_NET_RAW"
+    "CAP_SYS_RESOURCE"
+    "CAP_SETGID"
+    "CAP_SETUID"
+    "CAP_CHOWN"
+    "CAP_DAC_OVERRIDE"
+  ];
 
   SystemCallFilter = [
     "~@clock"
-    # "~@cpu-emulation"
     "~@debug"
     "~@module"
     "~@mount"
     "~@obsolete"
-    # "~@privileged"
-    # "~@raw-io"
     "~@reboot"
     "~@resources"
     "~@swap"
   ];
+
 }


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
- Cleanup dbus dervice
- Strict configs for dnsmasq service
- Service is not enabled by default in Ghaf
- Tested in net-vm by enabling DNS.


<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [x] List the test steps to verify:
    - Enable DNS in net-vm (Optional)
        - Allow port 1053 in firewall. 
        - Config to enable DNS.
        ```
        services.dnsmasq = {
           enable = true;
           settings = {
              bogus-priv = true;
              domain-needed = true;
              interface = "wlp0s5f0";
              listen-address = [ "0.0.0.0" ];
              port = 1053;
           };
        };
        ```
    - Test general functionality:

- [ ] If it is an improvement how does it impact existing functionality?

