### PR TITLE
Restrict service 'kmod-static-nodes'

### DIFF
--- a/modules/common/systemd/hardened-configs/common/kmod-static-nodes.nix
+++ b/modules/common/systemd/hardened-configs/common/kmod-static-nodes.nix
@@ -2,133 +2,36 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 {
-  ##############
-  # Networking #
-  ##############
-
   PrivateNetwork = true;
-  # IPAccounting=yes
   IPAddressDeny = "any";
-  RestrictAddressFamilies = [
-    #"~AF_PACKET"
-    #"~AF_NETLINK"
-    #"~AF_UNIX"
-    #"~AF_INET"
-    #"~AF_INET6"
-  ];
-
-  ###############
-  # File system #
-  ###############
-
-  # ProtectHome=true;
-  ProtectSystem = "full";
+  RestrictAddressFamilies = "none";
+  RestrictNamespaces = true;
   ProtectProc = "noaccess";
-  # ReadWritePaths=[ "/etc"];
-  # PrivateTmp=true;
-
-  # Not applicable for the service runs as root
-  # PrivateMounts=true;
-  # ProcSubset="all";
-
-  ###################
-  # User separation #
-  ###################
-
-  # Not applicable for the service runs as root
+  PrivateMounts = true; # ##
   PrivateUsers = true;
-  # DynamicUser=true;
-
-  ###########
-  # Devices #
-  ###########
-
-  # PrivateDevices=false;
-  # DeviceAllow=/dev/null
-
-  ##########
-  # Kernel #
-  ##########
-
+  DynamicUser = false;
+  PrivateDevices = false;
   ProtectKernelTunables = true;
   ProtectKernelModules = true;
   ProtectKernelLogs = true;
-
-  ########
-  # Misc #
-  ########
-
   Delegate = false;
-  # KeyringMode="private";
+  KeyringMode = "private";
   NoNewPrivileges = true;
   UMask = 77;
   ProtectHostname = true;
   ProtectClock = true;
   ProtectControlGroups = true;
-  RestrictNamespaces = true;
-  /*
-      RestrictNamespaces=[
-     #"~user"
-     #"~pid"
-     #"~net"
-     #"~uts"
-     #"~mnt"
-     #"~cgroup"
-     #"~ipc"
-    ];
-  */
   LockPersonality = true;
   MemoryDenyWriteExecute = true;
   RestrictRealtime = true;
   RestrictSUIDSGID = true;
-  # RemoveIPC=true
   SystemCallArchitectures = "native";
-  # NotifyAccess=false;
+  NotifyAccess = "main";
 
-  ################
-  # Capabilities #
-  ################
-
-  #AmbientCapabilities=
   CapabilityBoundingSet = [
-    "~CAP_SYS_PACCT"
-    "~CAP_KILL"
-    # "~CAP_WAKE_ALARM"
-    # "~CAP_DAC_*
-    "~CAP_FOWNER"
-    # "~CAP_IPC_OWNER"
-    # "~CAP_BPF"
-    "~CAP_LINUX_IMMUTABLE"
-    # "~CAP_IPC_LOCK"
-    "~CAP_SYS_MODULE"
-    "~CAP_SYS_TTY_CONFIG"
-    "~CAP_SYS_BOOT"
-    "~CAP_SYS_CHROOT"
-    # "~CAP_BLOCK_SUSPEND"
-    "~CAP_LEASE"
-    "~CAP_MKNOD"
-    # "~CAP_CHOWN"
-    # "~CAP_FSETID"
-    # "~CAP_SETFCAP"
-    # "~CAP_SETUID"
-    # "~CAP_SETGID"
-    # "~CAP_SETPCAP"
-    # "~CAP_MAC_ADMIN"
-    # "~CAP_MAC_OVERRIDE"
-    "~CAP_SYS_RAWIO"
-    "~CAP_SYS_PTRACE"
-    # "~CAP_SYS_NICE"
-    # "~CAP_SYS_RESOURCE"
-    "~CAP_NET_ADMIN"
-    "~CAP_NET_BIND_SERVICE"
-    "~CAP_NET_BROADCAST"
-    "~CAP_NET_RAW"
-    # "~CAP_AUDIT_CONTROL"
-    # "~CAP_AUDIT_READ"
-    # "~CAP_AUDIT_WRITE"
-    "~CAP_SYS_ADMIN"
-    # "~CAP_SYSLOG"
-    # "~CAP_SYS_TIME
+    "CAP_SYS_MODULE"
+    "CAP_MKNOD"
+    "CAP_SYS_ADMIN"
   ];
 
   ################
@@ -137,13 +40,11 @@
 
   SystemCallFilter = [
     "~@clock"
-    # "~@cpu-emulation"
+    "~@cpu-emulation"
     "~@debug"
     "~@module"
     "~@mount"
     "~@obsolete"
-    # "~@privileged"
-    # "~@raw-io"
     "~@reboot"
     "~@resources"
     "~@swap"


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Restrict service 'kmod-static-nodes'

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [x] List the test steps to verify:
    - Check if  kmod-static-nodes service executed successfully in VMs
    - Test general system functionality
- [ ] If it is an improvement how does it impact existing functionality?

