### PR TITLE
NVIDIA NX/AGX: Update OP-TEE revision

### DIFF
--- a/targets/nvidia-jetson-orin/optee.nix
+++ b/targets/nvidia-jetson-orin/optee.nix
@@ -18,8 +18,11 @@ _:
     opteeSource = pkgs.applyPatches {
       src = pkgs.fetchgit {
         url = "https://nv-tegra.nvidia.com/r/tegra/optee-src/nv-optee";
-        rev = "jetson_${l4tVersion}";
-        sha256 = "sha256-jJOMig2+9FlKA9gJUCH/dva7ZtAq1typZSNGKyM7tlg=";
+        # Can't use l4tVersion version directly, because it contains an
+        # extra zero. If-else is a sanity check so the sources are
+        # in sync!
+        rev = if l4tVersion == "35.6.0" then "jetson_35.6" else throw "Mismatching OP-TEE sources";
+        sha256 = "sha256-hxgXRNtyZlfFMK8+3vVNxg2O1yrLJTFiFyjnE8Gmqqs=";
       };
       patches = [ ./0001-ta-pkcs11-Build-time-option-for-controlling-pin-lock.patch ];
     };


### PR DESCRIPTION
Jetpack-Nixos has switched Jetson BSP version from 35.2. to 35.6.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: NVIDIA NX and AGX
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

