### PR TITLE
Fix issue with (not) auto-selecting 3.5mm headphone jack

### DIFF
--- a/modules/common/services/audio.nix
+++ b/modules/common/services/audio.nix
@@ -78,6 +78,11 @@ in
         "wireplumber.settings" = {
           "bluetooth.autoswitch-to-headset-profile" = "false";
         };
+        # Enable alsa ACP auto profile for headphones
+        "monitor.alsa.properties" = {
+          "alsa.use-acp" = "true";
+          "acp.auto-profile" = "true";
+        };
       };
     };
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Fixes issue with 3,5mm headphone jack did not get automatically selected
Issue caused with Pipewire/wireplumber default configuration change

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [X] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [X] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [X] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

Boot X1 without headphones, play music, connect 3.5mm headphones, disconnect 3.5mm headphones.
Expacted mucis to continue playing from headphones and return back to internal speakers