### PR TITLE
ewwbar: initialize eww-bat script variables

### DIFF
--- a/modules/desktop/graphics/ewwbar/config/scripts/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/scripts/default.nix
@@ -24,11 +24,11 @@ let
     text = ''
       get() {
         BATTERY_PATH="/sys/class/power_supply/BAT0"
-        ENERGY_NOW=$(cat "$BATTERY_PATH/energy_now")
-        POWER_NOW=$(cat "$BATTERY_PATH/power_now")
-        CAPACITY=$(cat "$BATTERY_PATH/capacity")
-        STATUS=$(cat "$BATTERY_PATH/status")
-        if [ "$POWER_NOW" -eq 0 ]; then
+        ENERGY_NOW=$([ -d "$BATTERY_PATH" ] && cat "$BATTERY_PATH/energy_now" || echo 0)
+        POWER_NOW=$([ -d "$BATTERY_PATH" ] && cat "$BATTERY_PATH/power_now" || echo 0)
+        CAPACITY=$([ -d "$BATTERY_PATH" ] && cat "$BATTERY_PATH/capacity" || echo 0)
+        STATUS=$([ -d "$BATTERY_PATH" ] && cat "$BATTERY_PATH/status" || echo 0)
+        if (( POWER_NOW == 0 )); then
             echo "{
                 \"hours\": \"0\",
                 \"minutes_total\": \"0\",
@@ -45,7 +45,7 @@ let
         MINUTES_REMAINDER=$(echo "($TIME_REMAINING - $HOURS) * 60" | bc | awk '{printf "%d\n", $1}')
 
         # If both hours and minutes are 0, return 0 for both
-        if [ "$HOURS" -eq 0 ] && [ "$MINUTES" -eq 0 ]; then
+        if (( HOURS == 0  &&  MINUTES == 0 )); then
             HOURS=0
             MINUTES=0
         fi


### PR DESCRIPTION
_eww-bat_-script generates * unnecessary * log prints on NVIDIA Jetson Orin NX / AGX platfroms:

```
ghaf-host ewwbar-ctrl[xx]: cat: /sys/class/power_supply/BAT0/energy_now: No such file or directory
ghaf-host ewwbar-ctrl[xx]: cat: /sys/class/power_supply/BAT0/power_now: No such file or directory
ghaf-host ewwbar-ctrl[xx]: cat: /sys/class/power_supply/BAT0/capacity: No such file or directory
ghaf-host ewwbar-ctrl[xx]: cat: /sys/class/power_supply/BAT0/status: No such file or directory
ghaf-host ewwbar-ctrl[xx]: /nix/store/hash-eww-bat/bin/eww-bat: line 12: [: : integer expression expected
ghaf-host ewwbar-ctrl[xx]: (standard_in) 1: syntax error
ghaf-host ewwbar-ctrl[xx]: /nix/store/hash-eww-bat/bin/eww-bat: line 29: [: : integer expression expected
```
It seems like _eww-bat_-script prints correct output ("time-json") in this specific scenario, but it also clutter logs with prints above. Assuming BAT0 traslates to BATTERY0 and NVIDIA orin NX/AGX does not have battery.

### Changes
* Initilaize variables with zeros, because bc-tool does not like empty/null variables
* if arithmetic expansion, because comparing integers. 

### Functionality changes
_From_
```
{
            "hours": "0",
            "minutes_total": "0",
            "minutes": "0",
            "status": "",
            "capacity": ""
        }
```
_To_
```
{
            "hours": "0",
            "minutes_total": "0",
            "minutes": "0",
            "status": "0",
            "capacity": "0"
        }
```
NOTE: "status" and  "capacity"


<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

