### PR TITLE
VPN: Add wireguard-gui service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,7 +510,8 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "systems": "systems",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix",
+        "wireguard-gui": "wireguard-gui"
       }
     },
     "rust-overlay": {
@@ -582,6 +583,26 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "wireguard-gui": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1723618204,
+        "narHash": "sha256-kjLoDCX9k7oolZhhlsAF1QJmrcWaHdU11zGLrViOF4w=",
+        "owner": "tiiuae",
+        "repo": "wireguard-gui",
+        "rev": "084522913a393a1c38ed088fa995560f35b10ac0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "repo": "wireguard-gui",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,11 @@
       };
     };
 
+    wireguard-gui = {
+      url = "github:tiiuae/wireguard-gui";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     ci-test-automation = {
       url = "github:tiiuae/ci-test-automation";
       inputs = {

--- a/modules/common/services/wireguard-gui-vm-conf.nix
+++ b/modules/common/services/wireguard-gui-vm-conf.nix
@@ -1,0 +1,117 @@
+{ vm, hostConfig }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+{
+  environment.systemPackages = [
+    pkgs.wireguard-gui-launcher
+    pkgs.polkit
+    pkgs.wireguard-tools
+  ];
+
+  security.polkit = {
+    enable = true;
+    debug = true;
+    extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        polkit.log("user " +  subject.user + " is attempting action " + action.id + " from PID " + subject.pid);
+        polkit.log("subject = " + subject);
+        polkit.log("action = " + action);
+        polkit.log("actioncmdline = " + action.lookup("command_line"));
+      });
+      polkit.addRule(function(action, subject) {
+        var expectedcmdline = "XDG_RUNTIME_DIR=/run/user/1000 " +
+                            "XDG_DATA_DIRS=" +
+                            "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:" +
+                            "${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:" +
+                            "${pkgs.gtk4}/share/gsettings-schemas/${pkgs.gtk4.name}:" +
+                            "/home/appuser/.nix-profile/share:" +
+                            "/nix/profile/share:" +
+                            "/home/appuser/.local/state/nix/profile/share:" +
+                            "/etc/profiles/per-user/appuser/share:" +
+                            "/nix/var/nix/profiles/default/share:" +
+                            "/run/current-system/sw/share " +
+                            "PATH=/run/wrappers/bin:/run/current-system/sw/bin " +
+                            "LIBGL_ALWAYS_SOFTWARE=true " +
+                            "${pkgs.wireguard-gui}/bin/.wireguard-gui-wrapped";
+        polkit.log("Expected commandline = " + expectedcmdline);
+        if (action.id == "org.freedesktop.policykit.exec" &&
+          RegExp('^/run/current-system/sw/bin/env WAYLAND_DISPLAY=wayland-([a-zA-Z0-9]){10} $').test(action.lookup("command_line").slice(0,66)) === true &&
+          action.lookup("command_line").slice(66) == expectedcmdline &&
+          subject.user == "appuser") {
+        return polkit.Result.YES;
+          }
+      });
+    '';
+  };
+
+  ghaf =
+    lib.optionalAttrs (lib.hasAttr "storagevm" config.ghaf) {
+      storagevm = {
+#        enable = true;
+#        name = vm;
+        directories = [
+          {
+            directory = "/etc/wireguard/";
+            mode = "u=rwx,g=,o=";
+          }
+        ];
+        files = [ "/etc/wireguard/wg0.conf" ];
+      };
+    }
+    // {
+      givc.appvm.applications = [
+        {
+          name = "wireguard-gui-launcher";
+          command = "${hostConfig.ghaf.givc.appPrefix}/run-waypipe ${hostConfig.ghaf.givc.appPrefix}/wireguard-gui-launcher";
+        }
+      ];
+    };
+
+  systemd.services."wireguard-template-conf" =
+    let
+      confScript = pkgs.writeShellScriptBin "wireguard-template-conf" ''
+        set -xeuo pipefail
+        wgDir="/etc/wireguard/"
+        confFile="$wgDir""wg0.conf"
+
+        if [[ -d "$wgDir" ]]; then
+        echo "$wgDir already exists."
+        else
+        mkdir -p "$wgDir"
+        fi
+        if [[ -e "$confFile" ]]; then
+        echo "$confFile already exists."
+        else
+        cat > "$confFile" <<EOF
+        [Interface]
+        Address = 10.10.10.5/24
+        ListenPort = 51820
+        PrivateKey = WIREGUARD_PRIVATE_KEY
+        [Peer]
+        # Name = Server
+        PublicKey = PEER_PUBLIC_KEY
+        AllowedIPs = 10.10.10.0
+        Endpoint = PEER_IP:PORT
+        EOF
+        fi
+        chmod 0600 "$confFile"
+      '';
+    in
+    {
+      enable = true;
+      description = "Generate template WireGuard config file";
+      path = [ confScript ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        StandardOutput = "journal";
+        StandardError = "journal";
+        ExecStart = "${confScript}/bin/wireguard-template-conf";
+      };
+    };
+}

--- a/modules/common/services/wireguard-gui.nix
+++ b/modules/common/services/wireguard-gui.nix
@@ -1,0 +1,55 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.services.wireguard-gui;
+  options = {
+    ghaf.services.wireguard-gui = {
+      enable = lib.mkEnableOption "WireGuard VPN configuration tool for app-vms";
+      vms = lib.mkOption {
+        type = with lib.types; listOf str;
+        description = "List of app-vms names as in microvm configuration.";
+        default = [ ];
+      };
+    };
+  };
+in
+{
+  inherit options;
+  config =
+    lib.mkIf
+      (
+        cfg.enable
+        && lib.attrsets.hasAttrByPath [
+          "microvm"
+          "vms"
+        ] config
+      )
+      {
+        ghaf = {
+          virtualization.microvm = {
+            appvm.vms =
+              let
+                vmConfigs = map (vm: {
+                  ${vm}.extraModules = [
+                    (import ./wireguard-gui-vm-conf.nix {
+                      inherit vm;
+                      hostConfig = config;
+                    })
+                  ];
+                }) cfg.vms;
+              in
+              lib.foldr lib.recursiveUpdate { } vmConfigs;
+            guivm.extraModules = [
+              {
+                inherit options;
+                config = {
+                  ghaf.services.wireguard-gui.enable = cfg.enable;
+                  ghaf.services.wireguard-gui.vms = cfg.vms;
+                };
+              }
+            ];
+          };
+        };
+      };
+}

--- a/modules/desktop/graphics/demo-apps.nix
+++ b/modules/desktop/graphics/demo-apps.nix
@@ -70,6 +70,14 @@ in
         description = "PDF Viewer Application";
         path = "${pkgs.zathura}/bin/zathura";
         icon = "document-viewer";
-      };
+      }
+      ++ (lib.optionals (config.ghaf.services.wireguard-gui.enable or false) (
+            map (vm: {
+              name = "Wireguard for ${vm}";
+              inherit vm;
+              path = "${pkgs.givc-cli}/bin/givc-cli ${config.ghaf.givc.cliArgs} start app --vm ${vm}-vm wireguard-gui-launcher";
+              icon = "preferences-system-network";
+            }) (config.ghaf.services.wireguard-gui.vms or [ ])
+          ));
   };
 }

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -11,8 +11,18 @@
   # pkgs that already has overlays in place. Otherwise the overlay will be
   # applied twice.
   nixpkgs.overlays = [ (import ../../overlays/custom-packages) ];
+
+  ghaf.services.wireguard-gui = {
+    enable = true;
+    vms = [
+      "chrome"
+      "business"
+    ];
+  };
+
   imports = [
     # To push logs to central location
+    ../common/services/wireguard-gui.nix
     ../common/logging/client.nix
   ];
 }

--- a/modules/microvm/virtualization/microvm/guivm.nix
+++ b/modules/microvm/virtualization/microvm/guivm.nix
@@ -33,7 +33,7 @@ let
           # A list of applications from all AppVMs
           virtualApps = lib.lists.concatMap (
             vm: map (app: app // { vmName = "${vm.name}-vm"; }) vm.applications
-          ) config.ghaf.virtualization.microvm.appvm.vms;
+          ) (builtins.attrValues config.ghaf.virtualization.microvm.appvm.vms);
 
           # Launchers for all virtualized applications that run in AppVMs
           virtualLaunchers = map (app: rec {
@@ -107,7 +107,7 @@ let
                 securityContext = map (vm: {
                   identifier = vm.name;
                   color = vm.borderColor;
-                }) config.ghaf.virtualization.microvm.appvm.vms;
+                }) (builtins.attrValues config.ghaf.virtualization.microvm.appvm.vms);
               };
             };
 
@@ -196,6 +196,16 @@ let
                 };
               };
           };
+
+          environment.etc."ctrl-panel/wireguard-gui-vms.txt" =
+            let
+               vmstxt = lib.concatStringsSep "\n" config.ghaf.services.wireguard-gui.vms;
+            in
+            {
+              text =  ''
+                ${vmstxt}
+              '';
+            };
 
           environment = {
             systemPackages =

--- a/modules/reference/desktop/applications.nix
+++ b/modules/reference/desktop/applications.nix
@@ -72,5 +72,13 @@ in
           }
         ]
       );
+      # ++ (lib.optionals (config.ghaf.services.wireguard-gui.enable or false) (
+      #       map (vm: {
+      #         name = "Wireguard for ${vm}";
+      #         inherit vm;
+      #         path = "${pkgs.givc-cli}/bin/givc-cli ${config.ghaf.givc.cliArgs} start --vm ${vm}-vm wireguard-gui-launcher";
+      #         icon = "preferences-system-network";
+      #       }) (config.ghaf.services.wireguard-gui.vms or [ ])
+      #     ));
   };
 }

--- a/modules/reference/profiles/laptop-x86.nix
+++ b/modules/reference/profiles/laptop-x86.nix
@@ -104,7 +104,7 @@ in
 
           appvm = {
             enable = true;
-            vms = cfg.enabled-app-vms;
+            vms = lib.foldl lib.recursiveUpdate {} (lib.imap0 (vmIndex: vm: { ${vm.name} = vm // {inherit vmIndex;}; }) cfg.enabled-app-vms);
           };
         };
       };

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -20,4 +20,6 @@
     final.libsForQt5.callPackage ../../packages/globalprotect-openconnect
       { };
   gtklock = import ./gtklock { inherit prev; };
+  wireguard-gui = final.callPackage ../../packages/wireguard-gui {};
+  wireguard-gui-launcher = final.callPackage ../../packages/wireguard-gui-launcher {};
 })

--- a/packages/wireguard-gui-launcher/default.nix
+++ b/packages/wireguard-gui-launcher/default.nix
@@ -1,0 +1,14 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  writeShellScriptBin,
+  polkit,
+  wireguard-gui,
+  lib,
+  ...
+}:
+writeShellScriptBin "wireguard-gui-launcher"
+  ''
+    PATH=/run/wrappers/bin:/run/current-system/sw/bin
+    ${wireguard-gui}/bin/wireguard-gui
+  ''

--- a/packages/wireguard-gui/default.nix
+++ b/packages/wireguard-gui/default.nix
@@ -1,0 +1,35 @@
+{ wrapGAppsHook, fetchFromGitHub, lib, rustPlatform, pkg-config, wireguard-tools, glib, gtk4, polkit }:
+rustPlatform.buildRustPackage rec {
+  pname = "wireguard-gui";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "tiiuae";
+    repo = pname;
+    rev = "3f4133ef1f92300db7c5e4a8720af2ab2e80584e";
+    sha256 = "sha256-LEOP2wKovsj8NZ7UVX86f+hwmVRYay+rRjOinDKQcD0=";
+    # sha256 = lib.fakeSha256;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    wireguard-tools
+    glib.dev
+    gtk4.dev
+    polkit
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/${pname} \
+       --set LIBGL_ALWAYS_SOFTWARE true \
+       --set G_MESSAGES_DEBUG all
+  '';
+
+  # cargoHash = "sha256-XO/saJfdiawN8CF6oF5HqrvLBllNueFUiE+7A7XWC5M=";
+  cargoHash = "sha256-4s3Wjbzo8XbYOu1MiOBZ30VxrbwO7gQEv01OQO63SDs=";
+  # cargoHash = "";
+}


### PR DESCRIPTION
Wireguard-gui is a user friendly WireGuard VPN configuration tool. The user can create WireGuard VPN interfaces and turn them up/down. The business-vm and the chrome-vm are used as an example usecase environments.

Normally setting WireGuard requires sudo rights from user. In this case we add polkit rule to allow wireguard-gui execution without sudo and user authentication.

WireGuard VPN configurations are stored to /etc/wireguard/ directory and the storage-vm is utilized to make that directory persistent.

Usage of listOf instead of attrsOf doesn't allows us to modify application virtual machines configuration externally, which may be crucial for certain use cases like wireguard-gui nixos module where we want to be able to inject wireguard-gui application to a certain list of appvms. Transformation from list to attrs and back to list doesn't preserve order. So we add list element index in the attribute value to preserve it. It is a dirty hack that could remain until better implementation of virtual machines module as well as hosts module is introduced.

List of wireguard-gui enabled VMs is written to a text file.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

