### PR TITLE
Desktop: Taskbar per-VM volume mixer

### DIFF
--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -117,6 +117,9 @@ in
           Type = "forking";
           ExecStart = "${ewwScripts.ewwbar-ctrl}/bin/ewwbar-ctrl start";
           ExecReload = "${ewwScripts.ewwbar-ctrl}/bin/ewwbar-ctrl reload";
+          ExecStopPost = ''
+            bash -c "dbus-send --session --dest=org.ghaf.Audio --type=method_call --print-reply /org/ghaf/Audio org.ghaf.Audio.UnsubscribeFromDeviceUpdatedSignal"
+          '';
           Restart = "always";
           RestartSec = "100ms";
         };

--- a/modules/desktop/graphics/ewwbar/config/variables/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/variables/default.nix
@@ -20,7 +20,7 @@ writeText "variables.yuck" ''
   (deflisten audio_input :initial "{}" "${ewwScripts.eww-audio}/bin/eww-audio listen_input")
   (defpoll audio_outputs :interval "1s" "${ewwScripts.eww-audio}/bin/eww-audio get_outputs")
   (defpoll audio_inputs :interval "1s" "${ewwScripts.eww-audio}/bin/eww-audio get_inputs")
-  (defvar audio_streams "[]")
+  (deflisten audio_streams :initial "[]" "${ewwScripts.eww-audio}/bin/eww-audio listen_vms")
   (deflisten workspace :initial "1" "${ghaf-workspace}/bin/ghaf-workspace subscribe")
   (deflisten windows :initial "[]" "${ewwScripts.eww-windows}/bin/eww-windows listen")
 

--- a/modules/desktop/graphics/ewwbar/config/widgets/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/widgets/default.nix
@@ -24,10 +24,11 @@ writeText "widgets.yuck" ''
                   :style "background-image: url(\"${pkgs.ghaf-artwork}/icons/launcher.svg\")")))
 
       ;; Generic slider widget ;;
-      (defwidget slider [?visible ?header-left ?header-onclick ?header-right ?icon ?image ?app_icon ?settings_icon level ?onchange ?settings-onclick ?icon-onclick ?class ?min ?slider-active]
+      (defwidget slider [?visible ?header-left ?header-onclick ?header-right ?icon ?image ?app_icon ?settings_icon level ?onchange ?settings-onclick ?icon-onclick ?class ?min ?slider-active ?style]
           (box :orientation "v"
               :visible { visible ?: "true"}
               :class "''${class}"
+              :style "''${style}"
               :spacing 10
               :space-evenly false
               (box
@@ -244,11 +245,12 @@ writeText "widgets.yuck" ''
                               audio_output.volume_percentage <= 75 ? "${pkgs.ghaf-artwork}/icons/volume-2.svg" : "${pkgs.ghaf-artwork}/icons/volume-3.svg" }
                       :icon-onclick "${ewwScripts.eww-audio}/bin/eww-audio mute &"
                       :settings_icon "adjustlevels"
+                      :settings-onclick "''${EWW_CMD} update volume-mixer-visible=''${!volume-mixer-visible} &"
                       :level { audio_output.is_muted == "true" ? "0" : audio_output.volume_percentage }
                       :onchange "${ewwScripts.eww-audio}/bin/eww-audio set_volume {} &"
                       (audio_output_selector)
                       (box :orientation "v"
-                        (label :text "No audio streams" :visible {arraylength(audio_streams) == 0} :halign "center" :valign "center")
+                        (label :text "No active VM audio streams" :style "margin: 10px 0;" :visible {arraylength(audio_streams) == 0} :halign "center" :valign "center")
                         (volume_mixer :visible {arraylength(audio_streams) > 0})
                       ))
               (slider_with_children
@@ -336,20 +338,25 @@ writeText "widgets.yuck" ''
           (scroll
               :hscroll "false"
               :vscroll "true"
+              :style "margin: 20px 0;"
+              :height { arraylength(audio_streams) <= 3 ? 80 * arraylength(audio_streams) : 240 }
               :visible { visible ?: "true" }
-              :height { 50 * min(4,arraylength(audio_streams)) }
-              (box :orientation "v" :space-evenly true :spacing 10
+              (box 
+                :orientation "v" 
+                :space-evenly true 
+                :spacing 10
                 (for entry in {audio_streams}
                   (slider
                       :class "qs-slider"
+                      :style "padding: 0 15px 0 0;"
                       :header-left {entry.name}
                       :level {entry.muted == "true" ? "0" : entry.level}
                       :app_icon {entry.icon_name != "" ? entry.icon_name : "icon-missing"}
                       :image { entry.muted == "true" || entry.level == 0 ? "${pkgs.ghaf-artwork}/icons/volume-0.svg" :
                               entry.level <= 25 ? "${pkgs.ghaf-artwork}/icons/volume-1.svg" :
                               entry.level <= 75 ? "${pkgs.ghaf-artwork}/icons/volume-2.svg" : "${pkgs.ghaf-artwork}/icons/volume-3.svg" }
-                      :onchange "${ewwScripts.eww-audio}/bin/eww-audio set_sink_input_volume ''${entry.id} {} &"
-                      :icon-onclick "${ewwScripts.eww-audio}/bin/eww-audio mute_sink_input ''${entry.id} {} &")
+                      :onchange "${ewwScripts.eww-audio}/bin/eww-audio set_vm_volume ''${entry.id} {} &"
+                      :icon-onclick "${ewwScripts.eww-audio}/bin/eww-audio mute_vm ''${entry.id} ''${!entry.muted} &")
                 )
               )
           )

--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -48,6 +48,15 @@ let
             ${ghaf-workspace}/bin/ghaf-workspace switch "$current_workspace"
         fi
         ${ghaf-workspace}/bin/ghaf-workspace max ${toString cfg.maxDesktops}
+
+        # Write the GTK settings to the settings.ini file in the GTK config directory
+        # Note:
+        # - On Wayland, GTK+ is known for not picking themes from settings.ini.
+        # - We define GTK+ theme on Wayland using gsettings (e.g., `gsettings set org.gnome.desktop.interface ...`).
+        mkdir -p "$XDG_CONFIG_HOME/gtk-3.0" "$XDG_CONFIG_HOME/gtk-4.0"
+
+        echo -e "${gtk-settings}" > "$XDG_CONFIG_HOME/gtk-3.0/settings.ini"
+        echo -e "${gtk-settings}" > "$XDG_CONFIG_HOME/gtk-4.0/settings.ini"
       ''
       + cfg.extraAutostart;
   };
@@ -300,6 +309,27 @@ let
 
     text = "labwc -C /etc/labwc -s labwc-autostart >/tmp/session.labwc.log 2>&1";
   };
+
+  gtk-settings = ''
+    [Settings]
+    ${
+      if cfg.gtk.colorScheme == "prefer-dark" then
+        "gtk-application-prefer-dark-theme=1"
+      else
+        "gtk-application-prefer-dark-theme=0"
+    }
+    gtk-theme-name=${cfg.gtk.theme}
+    gtk-icon-theme-name=${cfg.gtk.iconTheme}
+    gtk-font-name=${cfg.gtk.fontName} ${cfg.gtk.fontSize}
+    gtk-button-images=1
+    gtk-menu-images=1
+    gtk-enable-event-sounds=1
+    gtk-enable-input-feedback-sounds=1
+    gtk-xft-antialias=1
+    gtk-xft-hinting=1
+    gtk-xft-hintstyle=hintslight
+    gtk-xft-rgba=rgb
+  '';
 
   auto-display-scale = pkgs.writeShellApplication {
     name = "auto-display-scale";


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

1. **Added Per-VM Volume Mixer to Quick Settings Widget:**  
   - VM volume sliders now appear beneath the system volume slider when clicking the button on its right side.  
   - Sliders for closed VMs remain visible but become non-functional. 
   - VM volume sliders affect only the respective VM and its children. 

2. **Fixed Default System Theme Not Applying Dark Mode On Fresh Installs**

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [x] Change requires full re-installation
- [x] (PARTLY) Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [x] Is this a new feature
  - [x] List the test steps to verify:
   - Verify VM volume sliders become appear as respective VMs with audio playback are opened.
   - Verify VM volume sliders affect their respective VM volume as expected.
   - Verify VM volume sliders become non-functional if the VM is closed completely and become functional again when VM is opened.
   - Verify GTK dark theme is applied correctly system-wide on a fresh install of Ghaf.
- [ ] If it is an improvement how does it impact existing functionality?

