### PR TITLE
Desktop: Fix desktop services not starting after wlr-randr v0.5.0

### DIFF
--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -115,11 +115,13 @@ in
         description = "ewwbar";
         serviceConfig = {
           Type = "forking";
-          ExecCondition = "${pkgs.wlr-randr}/bin/wlr-randr > /dev/null 2>&1";
+          ExecCondition = ''
+            ${pkgs.bash}/bin/bash -c "${pkgs.wlr-randr}/bin/wlr-randr > /dev/null 2>&1"
+          '';
           ExecStart = "${ewwScripts.ewwbar-ctrl}/bin/ewwbar-ctrl start";
           ExecReload = "${ewwScripts.ewwbar-ctrl}/bin/ewwbar-ctrl reload";
           ExecStopPost = ''
-            bash -c "dbus-send --session --dest=org.ghaf.Audio --type=method_call --print-reply /org/ghaf/Audio org.ghaf.Audio.UnsubscribeFromDeviceUpdatedSignal"
+            ${pkgs.bash}/bin/bash -c "${pkgs.dbus}/bin/dbus-send --session --dest=org.ghaf.Audio --type=method_call --print-reply /org/ghaf/Audio org.ghaf.Audio.UnsubscribeFromDeviceUpdatedSignal"
           '';
           Restart = "always";
           RestartSec = "100ms";

--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -501,7 +501,9 @@ in
         serviceConfig = {
           Type = "simple";
           EnvironmentFile = "-/etc/locale.conf";
-          ExecCondition = "${pkgs.wlr-randr}/bin/wlr-randr > /dev/null 2>&1";
+          ExecCondition = ''
+            ${pkgs.bash}/bin/bash -c "${pkgs.wlr-randr}/bin/wlr-randr > /dev/null 2>&1"
+          '';
           ExecStart = "${pkgs.nwg-drawer}/bin/nwg-drawer -r -nofs -nocats -s ${drawerStyle}";
           Restart = "always";
           RestartSec = "1";


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

1. **Fixed Launcher and Taskbar Services Not Starting After `wlr-randr` v0.5.0:**  
   - `wlr-randr` v0.5.0 rejects standalone CLI arguments, preventing ghaf-launcher and ewwbar services from starting. 
   - Forced taskbar and launcher services to use Bash as an interpreter in `Exec` commands to ensure proper execution when redirecting output.
   - General note for devs: Systemd units **do not** use shell as an interpreter for `Exec` commands.
     It's therefore recommended to always call a script with no arguments nor options, or use `bash -c` (as shown in this PR) to interpret commands properly.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [x] List the test steps to verify:
    - Verify fix works as expected, taskbar and ghaf launcher work at boot.
    - Verify previously introduced fix for log flooding in headless mode still works and is effective.
- [ ] If it is an improvement how does it impact existing functionality?

