### PR TITLE
bump: jetpack-nixos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -349,11 +349,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739108177,
-        "narHash": "sha256-GHDxCCo7Lvu4AIKSyfg79y7Pnk80ZQ4GGhjVCm43ktc=",
+        "lastModified": 1739899878,
+        "narHash": "sha256-Bf4hHPmNiz2gagoQU5UFKX7ESi8xIpeMsfvk7BCz6fk=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "0f1f2fb8912eda723b87d6664404a0cf2f1df8c7",
+        "rev": "7861702dd1d32d63c23cbe6c154bacdce35259f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Jetpack-nixos repository contain a fix for AGX USB from USB.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to: Orin AGX and NX
- [ ] Is this a new feature
  - [x] List the test steps to verify:

1. Compile and flash AGX and NX QSPI
  (1.5. AGX only: Verify AGX boots from EMMC)
 2. Compile rootfs image and flash it to USB drive
 3. Ghaf shoulf boot
- [ ] If it is an improvement how does it impact existing functionality?

