### PR TITLE
Add generic script for smoke tests in dev shell

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -68,12 +68,101 @@
           };
 
           commands = [
-            # TODO: Add smoke test commands
-            # something like this
             {
-              help = "Run smoke tests";
-              name = "smoke-test-agx";
-              command = "ci-test-automation smoke-test-agx";
+              help = "
+                Usage: robot-test -i [ip] -d [device] -p [password]
+                                  -t [tag] -c [commit] -n [threads] -f [configpath] -o [outputdir]
+
+                Runs automated tests (only pre-merge tests by default) on the defined target.
+
+                Required arguments:
+                -i  --ip          IP address of the target device
+                                  (if running locally from ghaf-host of the target device use
+                                  127.0.0.1 for orin-agx
+                                  192.168.100.1 for lenovo-x1 and orin-nx)
+                -d  --device      Device name of the target. Use exactly one of these options:
+                                    Lenovo-X1
+                                    Orin-AGX
+                                    Orin-NX
+                                    NUC
+                -p  --password    Password for the ghaf user
+
+                Optional arguments:
+                -t  --tag         Test tag which defines which test cases will be run.
+                                  Defaults to 'pre-merge'.
+                -c  --commit      This can be commit hash or any identifier.
+                                  Relevant only if running performance tests.
+                                  It will be used in presenting preformance test results in plots.
+                                  Defaults to 'smoke'.
+                -n  --threads     How many threads the device has.
+                                  This parameter is relevant only for performance tests.
+                                  Defaults to
+                                    20 with -d Lenovo-X1
+                                    12 with -d Orin-AGX
+                                    8 with other devices
+                -f  --configpath  Path to config directory.
+                                  Defaults to 'None'.
+                -o  --outputdir   Path to directory where all helper files and result files are saved.
+                                  Defaults to '/tmp/test_results'
+              ";
+              name = "robot-test";
+              command = ''
+                tag="pre-merge"
+                commit="smoke"
+                configpath="None"
+                outputdir="/tmp/test_results"
+                threads=8
+                threads_manual_set=false
+
+                while [ ''$# -gt 0 ]; do
+                  if [[ ''$1 == "-i" || ''$1 == "--ip" ]]; then
+                    ip="''$2"
+                    shift
+                  elif [[ ''$1 == "-d" || ''$1 == "--device" ]]; then
+                    device="''$2"
+                    shift
+                  elif [[ ''$1 == "-p" || ''$1 == "--password" ]]; then
+                    pw="''$2"
+                    shift
+                  elif [[ ''$1 == "-t" || ''$1 == "--tag" ]]; then
+                    tag="''$2"
+                    shift
+                  elif [[ ''$1 == "-c" || ''$1 == "--commit" ]]; then
+                    commit="''$2"
+                    shift
+                  elif [[ ''$1 == "-n" || ''$1 == "--threads" ]]; then
+                    threads="''$2"
+                    threads_manual_set=true
+                    shift
+                  elif [[ ''$1 == "-f" || ''$1 == "--config" ]]; then
+                    configpath="''$2"
+                    shift
+                  elif [[ ''$1 == "-o" || ''$1 == "--outputdir" ]]; then
+                    outputdir="''$2"
+                    shift
+                  else
+                    echo "Unknown option: ''$1"
+                    exit 1
+                  fi
+                  shift
+                done
+
+                if [[ ''${threads_manual_set} == false ]]; then
+                  grep -q "X1" <<< "''$device" && threads=20
+                  grep -q "AGX" <<< "''$device" && threads=12
+                fi
+
+                cd ${inputs.ci-test-automation.outPath}/Robot-Framework/test-suites
+                ${
+                  inputs.ci-test-automation.packages.${system}.ghaf-robot
+                }/bin/ghaf-robot -v CONFIG_PATH:''${configpath} -v DEVICE_IP_ADDRESS:''${ip} -v THREADS_NUMBER:''${threads} -v COMMIT_HASH:''${commit} -v DEVICE:''${device} -v PASSWORD:''${pw} -i ''${device,,}AND''${tag} --outputdir ''${outputdir} .
+              '';
+              category = "test";
+            }
+            {
+              help = "Show path to ci-test-automation repo in nix store";
+              name = "robot-path";
+              command = "echo ${inputs.ci-test-automation.outPath}";
               category = "test";
             }
           ];


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

This PR introduces low threshold access to automated (smoke) testing via ghaf dev shell script which 
- cd to Robot-Framework/test-suites in nix store
- launches the test run and passes the given arguments to Robot Framework

Prerequisites: https://github.com/tiiuae/ci-test-automation/pull/237 (merged) 

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to: All
- [ ] Is this a new feature
  - [x] List the test steps to verify:

1. git clone https://github.com/tiiuae/ghaf.git
2. cd ghaf
3. nix develop .#smoke-tests
4. Read the instructions of the smoke-test command shown in terminal
5. Ensure target device is running and it has IP address
6. Start the smoke test, e.g.
```
robot-test -i ip_address -d Lenovo-X1 -p password
robot-test -i ip_address -d Orin-AGX -p password
robot-test -i ip_address -d Orin-NX -p password
```

It's also possible pass more arguments and run other than smoke-tests e.g.
`robot-test --ip ip_address --device Lenovo-X1 --password password --tag test/suite-tag --commit commit --threads 16 --outputdir /home/test_results`
 
- [ ] If it is an improvement how does it impact existing functionality?

