### PR TITLE
bump: jetpack-nixos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -349,11 +349,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739899878,
-        "narHash": "sha256-Bf4hHPmNiz2gagoQU5UFKX7ESi8xIpeMsfvk7BCz6fk=",
+        "lastModified": 1740056450,
+        "narHash": "sha256-cMxgdrC/WzhBwpjHVyw3+OYOLVurvSB5eB6rOOxOy8c=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "7861702dd1d32d63c23cbe6c154bacdce35259f2",
+        "rev": "d2577fd465a4d4cd05a9d46c92ea0cbf594f1326",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bump is initialized by firewall.service fix in jetpack-nixos

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to: Nvidia Orin NX/AGX
- [ ] Is this a new feature
  - [x] List the test steps to verify:
1. Clone, compile and flash AGX and NX
2. Boot device
-> No firewall error in boot logs
-> `sudo systemctl status firewall.service` : Enabled
- [ ] If it is an improvement how does it impact existing functionality?

