### PR TITLE
Options for CUDA, podman and docker updated with nvidia-container support with cdi fix for docker

### DIFF
--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -14,6 +14,7 @@
     ./users
     ./version
     ./virtualization/docker.nix
+    ./virtualization/podman.nix
     ./systemd
     ./services
     ./networking

--- a/modules/common/development/cuda.nix
+++ b/modules/common/development/cuda.nix
@@ -1,0 +1,24 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.development.cuda;
+  inherit (lib) mkEnableOption mkIf;
+in
+{
+  options.ghaf.development.cuda = {
+    enable = mkEnableOption "CUDA Support";
+  };
+
+  config = mkIf cfg.enable {
+    #Enabling CUDA on any supported system requires below settings.
+    nixpkgs.config.allowUnfree = lib.mkForce true;
+    nixpkgs.config.allowBroken = lib.mkForce false;
+    nixpkgs.config.cudaSupport = lib.mkForce true;
+
+    # Enable Opengl
+    # Opengl enable is renamed to hardware.graphics.enable
+    # This is needed for CUDA so set it if it is already not set
+    hardware.graphics.enable = lib.mkForce true;
+  };
+}

--- a/modules/common/development/default.nix
+++ b/modules/common/development/default.nix
@@ -6,5 +6,6 @@
     ./usb-serial.nix
     ./nix.nix
     ./ssh.nix
+    ./cuda.nix
   ];
 }

--- a/modules/common/virtualization/podman.nix
+++ b/modules/common/virtualization/podman.nix
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 { lib, config, ... }:
 let
-  cfg = config.ghaf.virtualization.docker.daemon;
+  cfg = config.ghaf.virtualization.podman.daemon;
   inherit (lib) mkEnableOption mkIf;
 in
 {
-  options.ghaf.virtualization.docker.daemon = {
-    enable = mkEnableOption "Docker Daemon";
+  options.ghaf.virtualization.podman.daemon = {
+    enable = mkEnableOption "Podman Daemon";
   };
-
   config = mkIf cfg.enable {
     # Just ensure containers are enabled by boot.
     boot.enableContainers = lib.mkForce true;
@@ -17,7 +16,7 @@ in
     # Enable Opengl renamed to hardware.graphics.enable
     hardware.graphics.enable = lib.mkForce true;
 
-    # For CUDA support unfree libraries and CudaSupport should be set
+    # For CUDA support: Enable if not already enabled.
     ghaf.development.cuda.enable = lib.mkForce true;
 
     # Enabling CDI NVIDIA devices in podman or docker (nvidia docker container)
@@ -31,32 +30,16 @@ in
       config.nixpkgs.localSystem.isx86_64 && (builtins.elem "nvidia" config.services.xserver.videoDrivers)
     ) true;
 
-    # Temporary fix for nvidia service restart remove with new nixpkgs reference.
-    # systemd.services.nvidia-container-toolkit-cdi-generator.WantedBy = [ "multi-user.target" ];
-    systemd.services.nvidia-cdi-generate.after = [
-      "multi-user.target"
-      "greetd.service"
-      "avahi-daemon.service"
-    ];
-
-    # Docker Daemon Settings
-    virtualisation.docker = {
-      # To force Docker package version settings need to import pkgs first
-      # package = pkgs.docker_26;
-
+    virtualisation.podman = {
       enable = true;
       # The enableNvidia option is still used in jetpack-nixos while it is obsolete in nixpkgs
-      # but it is still only option for nvidia-orin devices. Added extra fix for CDI to
-      # make it run with docker.
+      # but it is still only option for nvidia-orin devices.
       enableNvidia = config.nixpkgs.localSystem.isAarch64 && config.hardware.nvidia-jetpack.enable;
-      daemon.settings.features.cdi = true;
-      rootless = {
-        enable = true;
-        setSocketVariable = true;
-        daemon.settings.features.cdi = true;
-        daemon.settings.cdi-spec-dirs = [ "/var/run/cdi/" ];
-      };
-
+      # Create a `docker` alias for podman, to use it as a drop-in replacement
+      dockerCompat = !config.virtualisation.docker.enable;
+      dockerSocket.enable = !config.virtualisation.docker.enable;
+      # Required for containers under podman-compose to be able to talk to each other.
+      defaultNetwork.settings.dns_enabled = true;
       # Container file and processor limits
       # daemon.settings = {
       #   default-ulimits = {
@@ -74,10 +57,12 @@ in
       #   };
     };
 
-    # Add user to docker group and dialout group for access to serial ports
+    # Add user to podman and docker group (due to compatibility mode)
+    # and dialout group for access to serial ports
     users.users."ghaf".extraGroups = [
       "docker"
       "dialout"
+      "podman"
     ];
   };
 }

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -31,7 +31,7 @@ let
           # For WLAN firmwares
           hardware = {
             enableRedistributableFirmware = som == "agx";
-            wirelessRegulatoryDatabase = true;
+            wirelessRegulatoryDatabase = som == "agx";
           };
 
           services.dnsmasq.settings.dhcp-option = [
@@ -58,6 +58,9 @@ let
 
           {
             ghaf = {
+              #virtualization.podman.daemon.enable = true;
+              virtualization.docker.daemon.enable = true;
+
               hardware.nvidia.orin = {
                 enable = true;
                 somType = som;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
This PR is for CUDA 12.x supported nvidia containers.
Configuration options below:
- ghaf.development.cuda option is introduced for supported platforms. 
- ghaf.virtualization.podman.daemon is added for podman support with nvidia containers and docker compatibility options.
- ghaf.virtualization.docker.daemon is updated for docker support with nvidia containers 

Both docker and podman can coexist together as an option.
Planned to be removed or moved to work inside vm's later but this option is required for nvidia containers and ML software.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [X] Test procedure described (or includes tests). Select one or more:
  - [X] Tested on Lenovo X1 `x86_64`
  - [X] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [x] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [X] List all targets that this applies to:
- [X] Is this a new feature
  - [X] List the test steps to verify:
    - **For Docker:**
    - In your ghaf configuration (targets/nvidia-jetson-orin/flake-module.nix of your target platform) add `ghaf.virtualization.docker.daemon.enable=true;`
    - rebuild your config
    - For x86_64 platforms:
      - Run `sudo docker run --rm --device=nvidia.com/gpu=all ubuntu nvidia-smi ` and the top part of your output will be like 
`+-----------------------------------------------------------------------------+`
`| NVIDIA-SMI 535.86.10    Driver Version: 535.86.10    CUDA Version: 12.2     |`
`|-------------------------------+----------------------+----------------------+`
`| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |`
where second line shows CUDA version.
    - For nvidia jetson platforms we don't have nvidia-smi so we use python torch:
      - Run `sudo docker run -it --rm --device=nvidia.com/gpu=all --network host nvcr.io/nvidia/pytorch:24.09-py3-igpu`
 and from the docker shell you run: `python3 -c 'import torch; print(torch.cuda.is_available())'` and expecting output `True`
      
      Note:  It was `sudo docker run -it --rm --device=nvidia.com/gpu=all --network host nvcr.io/nvidia/l4t-pytorch:r35.2.1-pth2.0-py3 ` for CUDA 11.x where the Jetpack versions were 5.x but the old CUDA in containers fail to detect CUDA 12.x on the host so we started using the latest common pytorch image for both x86_64 and aarch64 with CUDA 12.x libraries.
      
    - **For Podman:**
    - In your ghaf configuration (preferably your flake-module.nix of your target platform) add `ghaf.virtualization.podman.daemon.enable=true;`
    - rebuild your config
    - For x86_64 platforms:
      - Run `sudo podman run --rm --device=nvidia.com/gpu=all ubuntu nvidia-smi ` and the top part of your output will be like 
`+-----------------------------------------------------------------------------+`
`| NVIDIA-SMI 535.86.10    Driver Version: 535.86.10    CUDA Version: 12.2     |`
`|-------------------------------+----------------------+----------------------+`
`| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |`
where second line shows CUDA version.
    - For nvidia jetson platforms we don't have nvidia-smi so we use python torch:
      - Run `sudo podman run -it --rm --device=nvidia.com/gpu=all nvcr.io/nvidia/pytorch:24.09-py3-igpu /bin/bash` and from the docker shell you run: `python3 -c 'import torch; print(torch.cuda.is_available())'` and expecting output `True` 

      Note:  It was `sudo podman run -it --rm --device=nvidia.com/gpu=all --network host nvcr.io/nvidia/l4t-pytorch:r35.2.1-pth2.0-py3 /bin/bash` for CUDA 11.x where the Jetpack versions were 5.x but the old CUDA in containers fail to detect CUDA 12.x on the host so we started using the latest common pytorch image for both x86_64 and aarch64 with CUDA 12.x libraries

**Note: You can test podman with docker commands as podman has docker compatibility option (will not work in case of having both docker and podman daemons together.**
- [X] If it is an improvement how does it impact existing functionality?
Docker daemon was already in ghaf but nvidia containers and cuda support is also added to docker daemon. Podman is a new feature.
