### PR TITLE
Desktop: Persistent display config for each user session

### DIFF
--- a/modules/desktop/graphics/ewwbar.nix
+++ b/modules/desktop/graphics/ewwbar.nix
@@ -170,18 +170,6 @@ in
         wantedBy = [ "ewwbar.service" ];
       };
 
-      eww-display-handler = {
-        enable = true;
-        serviceConfig = {
-          Type = "simple";
-          ExecStart = "${ewwScripts.eww-display}/bin/eww-display";
-          Restart = "on-failure";
-        };
-        after = [ "ewwbar.service" ];
-        bindsTo = [ "ewwbar.service" ];
-        wantedBy = [ "ewwbar.service" ];
-      };
-
       eww-volume-popup = {
         enable = true;
         serviceConfig = {

--- a/modules/desktop/graphics/ewwbar/config/scripts/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/scripts/default.nix
@@ -545,38 +545,6 @@ let
     '';
   };
 
-  eww-display = pkgs.writeShellApplication {
-    name = "eww-display";
-    runtimeInputs = [
-      pkgs.wlr-randr
-      pkgs.systemd
-    ];
-    bashOptions = [ ];
-    text = ''
-      CONFIG_FILE="/tmp/display-config.txt"
-
-      # Function to check if the configuration has changed
-      check_for_changes() {
-          current_config=$(wlr-randr)
-          last_config=$(cat "$CONFIG_FILE" 2>/dev/null)
-
-          # If there's no previous configuration, write the current one and exit
-          if [ "$current_config" != "$last_config" ]; then
-              echo "$current_config" > "$CONFIG_FILE"
-              return 0  # Change detected
-          fi
-          return 1  # No change
-      }
-
-      while true; do
-          if check_for_changes; then
-              systemctl --user reload ewwbar
-          fi
-          sleep 1
-      done
-    '';
-  };
-
   eww-open-widget = pkgs.writeShellApplication {
     name = "eww-open-widget";
     bashOptions = [ ];
@@ -728,7 +696,6 @@ in
     ewwbar-ctrl
     eww-brightness
     eww-audio
-    eww-display
     eww-open-widget
     eww-windows
     eww-fullscreen-update


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

1. **Persistent display configuration per user session:**  
   - Saves a simple display configuration whenever the display setup changes.  
   - Stores enabled/disabled state, position, transform, and scale for each display.  
   - Default polling interval set to 1 minute.  
   - If a saved configuration is present, it is applied automatically on user login.

Notes:
- In rare cases, the display config may be lost on logout or when the session ends.  
  This can happen if the polling check happens within <1s time window as the session terminating.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [x] Is this a new feature
  - [x] List the test steps to verify:
  - Login and adjust the display setup, preferably with 2 or more displays connected, focusing on these settings:
    - Positioning
    - Scaling
    - Enabled/Disabled state (optional)
  - Wait at least 1min before logging out or rebooting.
  - Verify your display config is re-applied upon login.
- [ ] If it is an improvement how does it impact existing functionality?

