### PR TITLE
Fix file manager refresh issue

### DIFF
--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -11,4 +11,5 @@
   qemu_kvm = import ./qemu { inherit final prev; };
   tpm2-pkcs11 = import ./tpm2-pkcs11 { inherit prev; };
   papirus-icon-theme = import ./papirus-icon-theme { inherit prev; };
+  libfm = import ./libfm { inherit prev; };
 })

--- a/overlays/custom-packages/libfm/default.nix
+++ b/overlays/custom-packages/libfm/default.nix
@@ -1,0 +1,11 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This overlay customizes libfm - core library of PCManFM file manager
+#
+{ prev }:
+prev.libfm.overrideAttrs {
+  patches = [ ./libfm-folder-reload.patch ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+}

--- a/overlays/custom-packages/libfm/libfm-folder-reload.patch
+++ b/overlays/custom-packages/libfm/libfm-folder-reload.patch
@@ -1,0 +1,15 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+diff --git a/src/base/fm-folder.c.bak b/src/base/fm-folder.c
+index a29339f..01cec8e 100644
+--- a/src/base/fm-folder.c.bak
++++ b/src/base/fm-folder.c
+@@ -694,6 +694,8 @@ static void on_folder_changed(GFileMonitor* mon, GFile* gf, GFile* other, GFileM
+             queue_reload(folder);
+             break;
+         case G_FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED:
++            queue_reload(folder);
++            break;
+         case G_FILE_MONITOR_EVENT_CHANGED:
+             folder->pending_change_notify = TRUE;
+             G_LOCK(lists);

--- a/packages/vinotify/default.nix
+++ b/packages/vinotify/default.nix
@@ -1,0 +1,17 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  python3Packages,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "vinotify";
+  version = "0.1";
+
+  propagatedBuildInputs = [
+    python3Packages.inotify-simple
+  ];
+
+  doCheck = false;
+
+  src = ./vinotify;
+}

--- a/packages/vinotify/vinotify/requirements.txt
+++ b/packages/vinotify/vinotify/requirements.txt
@@ -1,0 +1,3 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+inotify_simple==1.3.5

--- a/packages/vinotify/vinotify/setup.py
+++ b/packages/vinotify/vinotify/setup.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+from setuptools import find_packages, setup
+
+setup(
+    name="vinotify",
+    version="1.0",
+    packages=find_packages(),
+    entry_points={
+        "console_scripts": [
+            "vinotify=vinotify.vinotify:main",
+        ],
+    },
+)

--- a/packages/vinotify/vinotify/vinotify/__init__.py
+++ b/packages/vinotify/vinotify/vinotify/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/vinotify/vinotify/vinotify/vinotify.py
+++ b/packages/vinotify/vinotify/vinotify/vinotify.py
@@ -1,0 +1,144 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+import argparse
+import logging
+import os
+import socket
+
+from inotify_simple import INotify, flags
+
+logger = logging.getLogger("vinotify")
+
+
+def send_path(path, cid, port):
+    try:
+        with socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM) as s:
+            s.connect((cid, port))
+            message = f"{path}\n"
+            s.sendall(message.encode())
+    except Exception as e:
+        logger.error(f"Failed to send message: {e}")
+
+
+def host_mode(root_dir, cid, port):
+    inotify = INotify()
+    watch_descriptors = {}
+    inotify_flags = (
+        flags.CREATE | flags.DELETE | flags.MODIFY | flags.MOVED_FROM | flags.MOVED_TO
+    )
+    wd = inotify.add_watch(root_dir, inotify_flags)
+    watch_descriptors[wd] = root_dir
+
+    for root, dirs, files in os.walk(root_dir):
+        for dirname in dirs:
+            full_path = os.path.join(root, dirname)
+            wd = inotify.add_watch(full_path, inotify_flags)
+            watch_descriptors[wd] = full_path
+            logger.info(f"Monitoring {full_path}")
+
+    while True:
+        events_to_send = set()
+        for event in inotify.read(1000, 100):
+            logger.debug(event)
+            directory = watch_descriptors.get(event.wd)
+            if directory and event.name:
+                filepath = os.path.join(directory, event.name)
+                relative_dir = os.path.relpath(directory, root_dir)
+                if event.mask & flags.CREATE:
+                    if event.mask & flags.ISDIR:
+                        logger.info(f'New directory: "{filepath}"')
+                        wd = inotify.add_watch(filepath, inotify_flags)
+                        watch_descriptors[wd] = filepath
+                    else:
+                        logger.info(f'New file: "{filepath}"')
+                        events_to_send.add(relative_dir)
+                if event.mask & flags.DELETE:
+                    if event.mask & flags.ISDIR:
+                        logger.info(f'Deleted directory: "{filepath}"')
+                        for wd, dir_path in list(watch_descriptors.items()):
+                            if dir_path.startswith(filepath):
+                                logger.info(
+                                    f'Removing "{dir_path}" from the monitoring list'
+                                )
+                                del watch_descriptors[wd]
+                                break
+                    else:
+                        logger.info(f'Delete: "{filepath}"')
+                        events_to_send.add(relative_dir)
+                if event.mask & flags.MOVED_TO:
+                    logger.info(f'Moved to: "{filepath}"')
+                    events_to_send.add(relative_dir)
+
+        # Send all events to the guest
+        for path in events_to_send:
+            logger.info(f'Sending "{path}"')
+            send_path(path, cid, port)
+        events_to_send.clear()
+
+
+def guest_mode(path, port):
+    with socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM) as server:
+        server.bind((socket.VMADDR_CID_ANY, port))
+        server.listen()
+        logger.info(f"Listening for events on port {port}")
+
+        while True:
+            conn, _ = server.accept()
+            with conn:
+                message = conn.recv(4097).decode().strip()
+                if message:
+                    filepath = os.path.join(path, message)
+                    logger.info(f'Received "{message}", full path "{filepath}"')
+                    try:
+                        stat_info = os.stat(filepath)
+                        os.utime(filepath, (stat_info.st_atime, stat_info.st_mtime))
+                    except Exception as e:
+                        logger.error(f"Error: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Monitor host directory and forward inotify events to guest over vsock"
+    )
+    parser.add_argument("--cid", type=int, required=False, help="The CID of guest VM")
+    parser.add_argument("--port", type=int, required=True, help="VSOCK port")
+    parser.add_argument("--path", type=str, required=True, help="Path to monitor")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["guest", "host"],
+        required=True,
+        help="Run mode: guest or host",
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="Enable debug messages",
+    )
+    args = parser.parse_args()
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    logger.addHandler(handler)
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    logger.info(f"Running vinotify on {args.path}")
+
+    try:
+        if args.mode == "host":
+            if not args.cid:
+                logger.error("--cid is required in host mode")
+                return
+            else:
+                host_mode(args.path, args.cid, args.port)
+        elif args.mode == "guest":
+            guest_mode(args.path, args.port)
+    except KeyboardInterrupt:
+        logger.info("Ctrl+C")
+
+    logger.info("Exiting")


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

This is a workaround for SSRCSP-5894. The problem occurs when the “Unsafe chrome-vm share” is open in the file manager and the user downloads a file in Chrome and saves it there. In this case the file manager does not display the downloaded file. It is very confusing since it looks as if the file has not been downloaded or has been saved to the wrong location.

The reason for this behavior is that the file manager on Linux uses the inotify API to watch for file changes. However, it turns out that virtiofs doesn’t propagate inotify events to the guest. There was an [attempt](https://lore.kernel.org/all/CAOQ4uxieK3KpY7pf0YTKcrNHW7rnTATTDZdK9L4Mqy32cDwV8w@mail.gmail.com/T/) to add support for this but as far as I understand it has not been merged into the mainline.

As a workaround, this PR adds a small script that monitors inotify events for the shared folder on the host and sends them to the guivm over vsock. In the guivm, when the script receives a notification from the host it rewrites the modification time of the directory to the same value triggering an inotify event which causes the file manager to refresh the folder contents.

As an alternative implementation we could try using polling in the guivm instead of passing inotify events from the host. Many file managers seem to use the GFileMonitor class from glib which relies on inotify on Linux but it can be updated to use polling for virtiofs folders as it already has something similar for NFS. However, polling has its drawbacks and modifying glib or implementing a plugin for it might be quite complex.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
  Lenovo X1
- [x] Is this a new feature
  - [x] List the test steps to verify:
    - Open "Unsafe chrome-vm share" folder in the file manager
    - Download a file from Chrome to that directory
    - Make sure the list of files refreshes automatically and the new file is in the list
- [x] If it is an improvement how does it impact existing functionality?
  Fixes SSRCSP-5894

