### PR TITLE
Desktop: Kill user processes on logout

### DIFF
--- a/modules/desktop/graphics/ewwbar/config/widgets/default.nix
+++ b/modules/desktop/graphics/ewwbar/config/widgets/default.nix
@@ -423,7 +423,7 @@ writeText "widgets.yuck" ''
                   :class "power-menu-button"
                   :icon "${pkgs.ghaf-artwork}/icons/logout.svg"
                   :title "Log Out"
-                  :onclick "''${EWW_CMD} close power-menu & ${pkgs.labwc}/bin/labwc --exit &")
+                  :onclick "''${EWW_CMD} close power-menu & ${ghaf-powercontrol}/bin/ghaf-powercontrol logout &")
           (widget_button
                   :class "power-menu-button"
                   :icon "${pkgs.ghaf-artwork}/icons/restart.svg"

--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -273,7 +273,7 @@ let
     reboot-command=${ghaf-powercontrol}/bin/ghaf-powercontrol reboot &
     poweroff-command=${ghaf-powercontrol}/bin/ghaf-powercontrol poweroff &
     suspend-command=${ghaf-powercontrol}/bin/ghaf-powercontrol suspend &
-    logout-command=${pkgs.labwc}/bin/labwc --exit &
+    logout-command=
     #userswitch-command=
   '';
 


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
Bugfix for #1036 

## Description of changes

1. **Kill User Processes on Logout**  
   - Added a `logout` command to `ghaf-powercontrol`.  
     - `logout` first terminates any Wayland compositor using `wayland-logout`, then kills user processes via `loginctl kill-user`.  
     - `wayland-logout` is compositor-agnostic, making `ghaf-powercontrol` compatible with any compositor.  
   - The logout button was removed from the lock screen due to slow execution when triggered from there.  
   - Logout remains available via the taskbar power menu.  

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
- [ ] Is this a new feature
  - [x] List the test steps to verify:
    - Observe the logs via **ghaf** account with the following: `journalctl -fe | grep --line-buffered --color=auto "changing state deactivating"`
      - line containing `changing state deactivating → inactive` should appear before the login screen is visible
    - Follow expected behavior and steps described in #1036
- [x] If it is an improvement how does it impact existing functionality?