### PR TITLE
bump: nw-packet-forwarder

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740115923,
-        "narHash": "sha256-8LUwhGmxZ5LfKeeFc0/mrJUiCAGFqR95Z28MZtJCNqY=",
+        "lastModified": 1741929668,
+        "narHash": "sha256-avFSgefzVsZw47GY4OdpyOgR2FzZNn8w2wd0UkEI/vE=",
         "owner": "tiiuae",
         "repo": "ghafpkgs",
-        "rev": "c1eb8d4cf56af9de6a0600cea26f083ff0279ff5",
+        "rev": "820f8b82690dcfbaeba33999a6658227530c4b06",
         "type": "github"
       },
       "original": {

--- a/modules/reference/services/nw-packet-forwarder/nw-packet-forwarder.nix
+++ b/modules/reference/services/nw-packet-forwarder/nw-packet-forwarder.nix
@@ -125,13 +125,13 @@ in
         # Restart the service if it fails
         Restart = "on-failure";
         # Wait 5s before restarting.
-        RestartSec = "5s";
+        RestartSec = "30s";
         AmbientCapabilities = "CAP_NET_RAW CAP_NET_ADMIN";
         CapabilityBoundingSet = "CAP_NET_RAW CAP_NET_ADMIN";
         # PrivateTmp = true;
         # PrivateDevices = true;
         ProtectHome = true;
-        # NoNewPrivileges=true;
+        NoNewPrivileges = true;
         ProtectControlGroups = true;
         ProtectSystem = "full";
       };


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
New version of network packet forwarder
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [x] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
  - [ ] AGX
  - [ ] NX
  - [x] x86_64
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [x] If it is an improvement how does it impact existing functionality?
  - Chromecast functionality should work
  - Log issue should not appear as described in SSRCSP-6211

