### PR TITLE
pre-push: fix the pre-push checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ghaf-host.qcow2
 .idea
 linux-*/
 gcroot/
+.pre-commit-config.yaml

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -42,6 +42,10 @@
               package = pkgs.reuse;
               stages = [ "pre-push" ];
             };
+            end-of-file-fixer = {
+              enable = true;
+              stages = [ "pre-push" ];
+            };
           };
         };
       };

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -32,11 +32,13 @@
                 pkgs.nixVersions.latest
                 pkgs.reuse
                 config.treefmt.build.wrapper
-                #TODO: can these be made available through pkgs?
                 self'.legacyPackages.ghaf-build-helper
               ]
+              ++ config.pre-commit.settings.enabledPackages
               ++ lib.attrValues config.treefmt.build.programs # make all the trefmt packages available
               ++ lib.optional (pkgs.hostPlatform.system != "riscv64-linux") pkgs.cachix;
+
+            startup.hook.text = config.pre-commit.installationScript;
           };
           commands = [
             {


### PR DESCRIPTION
These were somehow removed in a previous refactoring.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
  - [ ] AGX
  - [ ] NX
  - [ ] x86_64
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

