### PR TITLE
Add OTA update to ghaf

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741623188,
-        "narHash": "sha256-le4euR6poVubytNbDWG6/duBgZEZvEpmpPoyRVuCnZA=",
-        "owner": "tiiuae",
+        "lastModified": 1742318186,
+        "narHash": "sha256-C/hlc1Q+GE+ftdXwyQXr8lADz0aKk2fUnoVcT74BSsU=",
+        "owner": "avnik",
         "repo": "ghaf-givc",
-        "rev": "bfd9d1adffae67f2ef482199a79881a9e2a8d740",
+        "rev": "dec538844cb0b18a2cd81337ae793e3de473df75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->
Update GIVC version with experimental OTA update

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [x] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
  - [ ] AGX
  - [ ] NX
  - [x] x86_64
- [x] Is this a new feature
  - [x] On fresh installed system run on host -- `ota-update set <path-to-new-system-existing-on-server>`
          Reboot, ensure that system is <new system>
  - [x] On fresh system, on GuiVM -- run `givc-cli ...<tls options> ... <connect options> set-generation <path-to-new-system-existing-on-server>`
          Reboot, ensure that system is <new system>
- [ ] If it is an improvement how does it impact existing functionality?

