### PR TITLE
dell-latitude-7330-72: Add new build targets

### DIFF
--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-72.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-72.nix
@@ -1,4 +1,4 @@
-# Copyright 2024 TII (SSRC) and the Ghaf contributors
+# Copyright 2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
   # System name
@@ -70,7 +70,7 @@
         # Network controller: Intel Corporation Wi-Fi 6E(802.11ax) AX210/AX1675* 2x2 [Typhoon Peak] (rev 1a)
         # Network controller may enumerate on different PCI bus even for same Dell model
         name = "wlp0s5f0";
-        path = "0000:71:00.0";
+        path = "0000:72:00.0";
         vendorId = "8086";
         productId = "2725";
         # Detected kernel driver: iwlwifi

--- a/modules/reference/hardware/flake-module.nix
+++ b/modules/reference/hardware/flake-module.nix
@@ -24,6 +24,13 @@
         ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7330.nix;
       }
     ];
+    # New variant as network device may enumerate on different PCI BUS on same model of Dell 7330
+    # TODO: Remove once we can have better way to detect network PCI device
+    hardware-dell-latitude-7330-72.imports = [
+      {
+        ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7330-72.nix;
+      }
+    ];
     hardware-lenovo-x1-carbon-gen10.imports = [
       {
         ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen10.nix;

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -79,6 +79,16 @@ let
         };
       }
     ]))
+    # TODO: Remove once we can have better way to detect network PCI device
+    (laptop-configuration "dell-latitude-7330-72" "debug" (withCommonModules [
+      self.nixosModules.hardware-dell-latitude-7330-72
+      {
+        ghaf = {
+          reference.profiles.mvp-user-trial.enable = true;
+          partitioning.disko.enable = true;
+        };
+      }
+    ]))
     (laptop-configuration "alienware-m18-R2" "debug" (withCommonModules [
       self.nixosModules.hardware-alienware-m18-r2
       {
@@ -139,6 +149,16 @@ let
     ]))
     (laptop-configuration "dell-latitude-7330" "release" (withCommonModules [
       self.nixosModules.hardware-dell-latitude-7330
+      {
+        ghaf = {
+          reference.profiles.mvp-user-trial.enable = true;
+          partitioning.disko.enable = true;
+        };
+      }
+    ]))
+    # TODO: Remove once we can have better way to detect network PCI device
+    (laptop-configuration "dell-latitude-7330-72" "release" (withCommonModules [
+      self.nixosModules.hardware-dell-latitude-7330-72
       {
         ghaf = {
           reference.profiles.mvp-user-trial.enable = true;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
* This is needed as net-vm will fail to start as we cannot have two same network devices which may enumerate on different PCI bus on dell latitude 7330.
* This is can be workaround for time being until we find proper way to identify on which PCI bus network controller is detected.
* So adding debug and release build variants for "dell-latitude-7330-72"

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
  - [ ] AGX
  - [ ] NX
  - [ ] x86_64
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?

