### PR TITLE
desktop: add COSMIC Epoch DE

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,6 +33,7 @@
     - [Hardware Configuration](ref_impl/hw-config.md)
     - [Profiles Configuration](ref_impl/profiles-config.md)
     - [labwc Desktop Environment](ref_impl/labwc.md)
+    - [COSMIC Desktop Environment](ref_impl/cosmic.md)
     - [IDS VM Further Development](ref_impl/idsvm-development.md)
     - [systemd Service Hardening](ref_impl/systemd-service-config.md)
   - [Troubleshooting](troubleshooting/troubleshooting.md)

--- a/docs/src/ref_impl/cosmic.md
+++ b/docs/src/ref_impl/cosmic.md
@@ -1,0 +1,75 @@
+<!--
+    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# COSMIC Desktop Environment
+
+[COSMIC](https://github.com/pop-os/cosmic-epoch) is a modern, configurable, and lightweight Wayland desktop environment developed by System76. It is designed to be fast, efficient and user-friendly while maintaining a professional appearance.
+As of February 2025, COSMIC's latest release is Alpha 6, with a beta release planned in the coming months.
+
+## Enabling COSMIC in Ghaf
+
+While COSMIC is not the default desktop environment in Ghaf, it can be enabled manually. To enable COSMIC DE in Ghaf, modify the graphics configuration as shown below:
+
+```nix
+profiles.graphics.compositor = "cosmic";
+```
+
+This configuration sets COSMIC as the active desktop environment for Ghaf.
+
+> **Note**: Starting from April 2025, COSMIC DE is fully integrated into NixOS options, and its tools are included in `nixpkgs`. Prior to this, COSMIC had to be added to Ghaf from the external flake [nixos-cosmic](https://github.com/lilyinstarlight/nixos-cosmic).
+
+## Configuration Components
+
+COSMIC's configuration in Ghaf consists of several key components:
+
+### 1. Core COSMIC DE Configuration
+
+COSMIC handles its configuration via simple Rust Object Notation (RON) files located in the user's home directory under `.config/cosmic`. 
+
+In the Ghaf Nix configuration, however, we have introduced a conversion mechanism where the entire directory tree is represented by a single YAML file (`cosmic.config.yaml`). This YAML file acts as the system default COSMIC configuration and is applied to all fresh installations of Ghaf. 
+
+If the user makes manual changes to the configuration while using Ghaf, those changes will take precedence over the system defaults.
+
+### 2. Ghaf COSMIC Nix Configuration
+
+The `cosmic.nix` module in Ghaf customizes COSMIC to better align with the system's requirements. Below are the key modifications and adjustments made:
+
+#### Disabled COSMIC Settings pages
+- **User Management**: The `page-users` feature in COSMIC settings is disabled.
+- **Power Settings**: The `page-power` feature is removed, as power management is handled by `swayidle` and `ghaf-powercontrol`.
+- **Sound Settings**: The `page-sound` feature is disabled, with audio control managed by a custom service.
+
+#### Replacements and Overrides
+- **Icon Theme**: The default COSMIC icon theme is changed to Papirus icon theme.
+- **GTK Settings**: Some default GTK settings are applied to ensure a consistent look and feel.
+- **Session Management**: COSMIC's session management integrates with `ghaf-session.target` for better control of Ghaf services.
+- **Power Management**: `swayidle` replaces `cosmic-idle` as the default idle and power manager, including configuration for automatic suspend and brightness adjustments.
+- **Audio Control**: A custom Ghaf audio control service works alongside the COSMIC audio applet to provide Ghaf-specific audio control features.
+
+#### Additional Changes
+- **DBUS Proxy Integration**: Custom DBUS proxy sockets are added for audio, network, and Bluetooth applets.
+- **Configuration Format**: COSMIC's configuration is centralized into a single YAML file (`cosmic.config.yaml`) for easier management and deployment. This configuration is installed as an explicit package `ghaf-cosmic-config`, the derivation of which can be found in `cosmic.nix`.
+- **Disabled Services**: Several default services, such as `geoclue2`, `pipewire`, and `gnome-keyring`, are explicitly disabled.
+
+These changes ensure that COSMIC in Ghaf is tailored to the system's specific needs.
+
+## Configuration Files
+The main configuration files are located in the `modules/desktop/graphics/` directory:
+
+```
+modules/desktop/graphics/
+├── cosmic-config/
+│   ├── cosmic-config-to-yaml.sh    # Helper script to convert `.config/cosmic` to a YAML config
+│   └── cosmic.config.yaml          # Main COSMIC desktop configuration which expands into `.config/cosmic`
+└── cosmic.nix                      # Main COSMIC Nix configuration
+```
+
+## Known Limitations
+
+- COSMIC does not allow forcing Server-Side Decorations for apps running under COSMIC
+- COSMIC does not yet support all common Wayland protocols (e.g. zwlr_virtual_pointer_manager_v1, etc.)
+- COSMIC is still in relatively early development, with a Beta release planned some time in 2025
+
+For more detailed information about COSMIC's architecture and features, visit the [COSMIC Epoch repository](https://github.com/pop-os/cosmic-epoch) and the [System76 COSMIC Epoch homepage](https://system76.com/cosmic/).

--- a/docs/src/ref_impl/reference_implementations.md
+++ b/docs/src/ref_impl/reference_implementations.md
@@ -47,6 +47,7 @@ The same goes with the architectural variants as headless devices or end-user de
    - [Hardware Configuration](ref_impl/hw-config.md)
    - [Profiles Configuration](ref_impl/profiles-config.md)
    - [labwc Desktop Environment](./labwc.md)
+   - [COSMIC Desktop Environment](./cosmic.md)
    - [IDS VM Further Development](./idsvm-development.md)
    - [systemd Service Hardening](./systemd-service-config.md)
 - [Troubleshooting](../troubleshooting/troubleshooting.md)

--- a/modules/common/services/disks.nix
+++ b/modules/common/services/disks.nix
@@ -48,6 +48,12 @@ in
         # Command to be executed on any device event
         # event_hook = "";
       };
+      device_config = [
+        {
+          device_file = "/dev/loop*";
+          ignore = true;
+        }
+      ];
       quickmenu_actions = [
         "browse"
         "mount"
@@ -72,9 +78,12 @@ in
         RestartSec = "1";
         ExecStart = "${pkgs.udiskie}/bin/udiskie -c /etc/udiskie.yml";
       };
-      wantedBy = [ "ewwbar.service" ];
-      after = [ "ewwbar.service" ];
-      partOf = [ "ewwbar.service" ];
+      wantedBy = [ "ghaf-session.target" ];
+      after = [
+        "ghaf-session.target"
+        "ewwbar.service"
+      ];
+      partOf = [ "ghaf-session.target" ];
     };
   };
 }

--- a/modules/desktop/graphics/cosmic/config/cosmic-config-to-yaml.sh
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config-to-yaml.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# This script generates a YAML file from the Cosmic config file tree in the specified directory
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <source_directory>"
+    exit 1
+fi
+
+OUTPUT_FILE="cosmic.config.yaml"
+BASE_DIR="$1"
+
+echo "" > "$OUTPUT_FILE"
+
+# Iterate over top-level directories
+for dir in "$BASE_DIR"/*/; do
+    # Get the top-level directory name
+    dir_name=$(basename "$dir")
+    echo "$dir_name:" >> "$OUTPUT_FILE"
+    
+    # Iterate over files in the v1 subdirectory
+    for file in "$dir"v1/*; do
+        if [[ -f "$file" ]]; then
+            key=$(basename "$file")
+            value=$(cat "$file")
+            
+            # Format the value correctly
+            if [[ "$value" == *$'\n'* ]]; then
+                echo "  $key: |" >> "$OUTPUT_FILE"
+                while IFS= read -r line; do
+                    echo "    $line" >> "$OUTPUT_FILE"
+                done <<< "$value"
+            else
+                echo "  $key: $value" >> "$OUTPUT_FILE"
+            fi
+        fi
+    done
+    echo "" >> "$OUTPUT_FILE"
+done
+
+echo "Cosmic config YAML generated at $OUTPUT_FILE"

--- a/modules/desktop/graphics/cosmic/config/cosmic-config.nix
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.nix
@@ -1,0 +1,58 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "ghaf-cosmic-config";
+  version = "0.1";
+
+  phases = [
+    "unpackPhase"
+    "installPhase"
+    "postInstall"
+  ];
+
+  src = ./.;
+
+  nativeBuildInputs = [ pkgs.yq-go ];
+
+  unpackPhase = ''
+    mkdir -p cosmic-unpacked
+
+    # Process the YAML configuration
+    for entry in $(yq e 'keys | .[]' $src/cosmic-config.yaml); do
+      mkdir -p "cosmic-unpacked/$entry/v1"
+
+      for subentry in $(yq e ".\"$entry\" | keys | .[]" "$src/cosmic-config.yaml"); do
+        content=$(yq e --unwrapScalar=false ".\"$entry\".\"$subentry\"" $src/cosmic-config.yaml | grep -vE '^\s*\|')
+        echo -ne "$content" > "cosmic-unpacked/$entry/v1/$subentry"
+      done
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/cosmic
+    cp -rf cosmic-unpacked/* $out/share/cosmic/
+    rm -rf cosmic-unpacked
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/share/cosmic/com.system76.CosmicBackground/v1/all \
+    --replace-fail "None" "Path(\"${pkgs.ghaf-artwork}/ghaf-desert-sunset.jpg\")"
+    substituteInPlace $out/share/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions \
+    --replace-fail 'VolumeLower: ""' 'VolumeLower: "pamixer --unmute --decrease 5 && ${pkgs.pulseaudio}/bin/paplay ${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo/audio-volume-change.oga"' \
+    --replace-fail 'VolumeRaise: ""' 'VolumeRaise: "pamixer --unmute --increase 5 && ${pkgs.pulseaudio}/bin/paplay ${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo/audio-volume-change.oga"'
+  '';
+
+  meta = with lib; {
+    description = "Installs default Ghaf COSMIC configuration";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
@@ -1,0 +1,3341 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+com.system76.CosmicAppletTime:
+  first_day_of_week: 0
+
+com.system76.CosmicAppList:
+  favorites: |
+    [
+      "com.system76.CosmicFiles",
+      "com.system76.CosmicTerm",
+      "com.system76.CosmicSettings",
+    ]
+  filter_top_levels: None
+
+com.system76.CosmicFiles:
+  favorites: |
+    [
+      Home,
+      Path("/Shares"),
+    ]
+
+com.system76.CosmicBackground:
+  all: |
+    (
+        output: "all",
+        source: None,
+        filter_by_theme: true,
+        rotation_frequency: 3600,
+        filter_method: Lanczos,
+        scaling_mode: Zoom,
+        sampling_method: Alphanumeric,
+    )
+  backgrounds: [All]
+  same-on-all: true
+
+com.system76.CosmicComp:
+  autotile_behavior: PerWorkspace
+  input_default: |
+    (
+        state: Enabled,
+        scroll_config: Some((
+            method: None,
+            natural_scroll: Some(false),
+            scroll_button: None,
+            scroll_factor: None,
+        )),
+    )
+  input_touchpad: |
+    (
+        state: Enabled,
+        click_method: Some(Clickfinger),
+        scroll_config: Some((
+            method: Some(TwoFinger),
+            natural_scroll: Some(true),
+            scroll_button: None,
+            scroll_factor: None,
+        )),
+        tap_config: Some((
+            enabled: true,
+            button_map: Some(LeftRightMiddle),
+            drag: true,
+            drag_lock: false,
+        )),
+    )
+  workspaces: |
+    (
+        workspace_mode: OutputBound,
+        workspace_layout: Horizontal,
+    )
+  xkb_config: |
+    (
+        rules: "",
+        model: "pc104",
+        layout: "us,ara,fi",
+        variant: ",,",
+        options: Some("terminate:ctrl_alt_bksp"),
+        repeat_delay: 600,
+        repeat_rate: 25,
+    )
+
+com.system76.CosmicIdle:
+  screen_off_time: None
+  suspend_on_ac_time: None
+  suspend_on_battery_time: None
+
+com.system76.CosmicPanel:
+  entries: |
+    [
+        "Panel",
+        "Dock",
+    ]
+
+com.system76.CosmicPanel.Dock:
+  anchor: Bottom
+  anchor_gap: true
+  autohide: |
+    Some((
+        wait_time: 1000,
+        transition_time: 200,
+        handle_size: 4,
+    ))
+  autohover_delay_ms: Some(500)
+  background: ThemeDefault
+  border_radius: 8
+  exclusive_zone: false
+  expand_to_edges: false
+  keyboard_interactivity: OnDemand
+  layer: Overlay
+  margin: 4
+  name: "Dock"
+  opacity: 1.0
+  output: All
+  padding: 0
+  plugins_center: |
+    Some([
+        "com.system76.CosmicAppList",
+    ])
+  plugins_wings: |
+    Some(([
+        "com.system76.CosmicPanelAppButton",
+    ], [
+        "com.system76.CosmicAppletMinimize",
+    ]))
+  size: L
+  size_center: None
+  size_wings: None
+  spacing: 4
+
+com.system76.CosmicPanel.Panel:
+  anchor: Top
+  anchor_gap: false
+  autohide: None
+  autohover_delay_ms: Some(500)
+  background: ThemeDefault
+  border_radius: 0
+  exclusive_zone: true
+  expand_to_edges: true
+  keyboard_interactivity: OnDemand
+  layer: Top
+  margin: 0
+  name: "Panel"
+  opacity: 1.0
+  output: All
+  padding: 0
+  plugins_center: |
+    Some([
+        "com.system76.CosmicAppletTime",
+    ])
+  plugins_wings: |
+    Some(([
+        "com.system76.CosmicAppletWorkspaces",
+    ], [
+        "com.system76.CosmicAppletInputSources",
+        "com.system76.CosmicAppletStatusArea",
+        "com.system76.CosmicAppletTiling",
+        "com.system76.CosmicAppletAudio",
+        "com.system76.CosmicAppletBattery",
+        "com.system76.CosmicAppletNotifications",
+        "com.system76.CosmicAppletPower",
+    ]))
+  size: XS
+  spacing: 2
+
+com.system76.CosmicSettings.Shortcuts:
+  defaults: |
+    {
+        (modifiers: [Super, Alt], key: "Escape"): Terminate,
+        (modifiers: [Super, Shift], key: "Escape"): System(LogOut),
+        (modifiers: [Super, Ctrl], key: "Escape"): Debug,
+        (modifiers: [Super], key: "l"): System(LockScreen),
+        (modifiers: [Alt], key: "F4"): Close,
+
+        (modifiers: [Super, Alt], key: "1"): Workspace(1),
+        (modifiers: [Super, Alt], key: "2"): Workspace(2),
+        (modifiers: [Super, Alt], key: "3"): Workspace(3),
+        (modifiers: [Super, Alt], key: "4"): Workspace(4),
+        (modifiers: [Super, Alt], key: "5"): Workspace(5),
+        (modifiers: [Super, Alt], key: "6"): Workspace(6),
+        (modifiers: [Super, Alt], key: "7"): Workspace(7),
+        (modifiers: [Super, Alt], key: "8"): Workspace(8),
+        (modifiers: [Super, Alt], key: "9"): Workspace(9),
+        (modifiers: [Super, Alt], key: "0"): LastWorkspace,
+        (modifiers: [Super, Shift], key: "1"): MoveToWorkspace(1),
+        (modifiers: [Super, Shift], key: "2"): MoveToWorkspace(2),
+        (modifiers: [Super, Shift], key: "3"): MoveToWorkspace(3),
+        (modifiers: [Super, Shift], key: "4"): MoveToWorkspace(4),
+        (modifiers: [Super, Shift], key: "5"): MoveToWorkspace(5),
+        (modifiers: [Super, Shift], key: "6"): MoveToWorkspace(6),
+        (modifiers: [Super, Shift], key: "7"): MoveToWorkspace(7),
+        (modifiers: [Super, Shift], key: "8"): MoveToWorkspace(8),
+        (modifiers: [Super, Shift], key: "9"): MoveToWorkspace(9),
+        (modifiers: [Super, Shift], key: "0"): MoveToLastWorkspace,
+        (modifiers: [Super, Shift], key: "Right"): MoveToNextWorkspace,
+        (modifiers: [Super, Shift], key: "Left"): MoveToPreviousWorkspace,
+
+        (modifiers: [Super, Ctrl, Alt], key: "Left"): MoveToOutput(Left),
+        (modifiers: [Super, Ctrl, Alt], key: "Down"): MoveToOutput(Down),
+        (modifiers: [Super, Ctrl, Alt], key: "Up"): MoveToOutput(Up),
+        (modifiers: [Super, Ctrl, Alt], key: "Right"): MoveToOutput(Right),
+        (modifiers: [Super, Ctrl, Alt], key: "h"): MoveToOutput(Left),
+        (modifiers: [Super, Ctrl, Alt], key: "k"): MoveToOutput(Down),
+        (modifiers: [Super, Ctrl, Alt], key: "j"): MoveToOutput(Up),
+        (modifiers: [Super, Ctrl, Alt], key: "l"): MoveToOutput(Right),
+
+        (modifiers: [Super], key: "Period"): NextOutput,
+        (modifiers: [Super], key: "Comma"): PreviousOutput,
+        (modifiers: [Super, Shift], key: "Period"): MoveToNextOutput,
+        (modifiers: [Super, Shift], key: "Comma"): MoveToPreviousOutput,
+
+        (modifiers: [Super], key: "Left"): Move(Left),
+        (modifiers: [Super], key: "Right"): Move(Right),
+        (modifiers: [Super], key: "Up"): Move(Up),
+        (modifiers: [Super], key: "Down"): Move(Down),
+
+        (modifiers: [Super], key: "o"): ToggleOrientation,
+        (modifiers: [Super], key: "s"): ToggleStacking,
+        (modifiers: [Super], key: "y"): ToggleTiling,
+        (modifiers: [Super], key: "g"): ToggleWindowFloating,
+        (modifiers: [Super], key: "x"): SwapWindow,
+
+        (modifiers: [Super], key: "m"): Maximize,
+        (modifiers: [Super], key: "r"): Resizing(Outwards),
+        (modifiers: [Super, Shift], key: "r"): Resizing(Inwards),
+
+        (modifiers: [Super], key: "equal"): ZoomIn,
+        (modifiers: [Super], key: "minus"): ZoomOut,
+
+        (modifiers: [Super], key: "b"): System(WebBrowser),
+        (modifiers: [Super], key: "f"): System(HomeFolder),
+        (modifiers: [Alt, Shift]): System(InputSourceSwitch),
+        (modifiers: [Ctrl, Alt], key: "t"): System(Terminal),
+
+        (modifiers: [Super], key: "w"): System(WorkspaceOverview),
+        (modifiers: [Super], key: "slash"): System(Launcher),
+        (modifiers: [Super]): System(AppLibrary),
+        (modifiers: [Alt], key: "Tab"): System(WindowSwitcher),
+        (modifiers: [Alt, Shift], key: "Tab"): System(WindowSwitcherPrevious),
+        (modifiers: [Super, Shift], key: "Tab"): System(WindowSwitcherPrevious),
+
+        (modifiers: [], key: "Print"): System(Screenshot),
+        (modifiers: [], key: "XF86AudioRaiseVolume"): System(VolumeRaise),
+        (modifiers: [], key: "XF86AudioLowerVolume"): System(VolumeLower),
+        (modifiers: [], key: "XF86AudioMute"): System(Mute),
+        (modifiers: [], key: "XF86AudioMicMute"): System(MuteMic),
+        (modifiers: [], key: "XF86MonBrightnessUp"): System(BrightnessUp),
+        (modifiers: [], key: "XF86MonBrightnessDown"): System(BrightnessDown),
+        (modifiers: [], key: "XF86AudioPlay"): System(PlayPause),
+        (modifiers: [], key: "XF86AudioPrev"): System(PlayPrev),
+        (modifiers: [], key: "XF86AudioNext"): System(PlayNext),
+    }
+  system_actions: |
+    {
+        /// Opens the application library
+        AppLibrary: "cosmic-app-library",
+        /// Decreases screen brightness
+        BrightnessDown: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness",
+        /// Increases screen brightness
+        BrightnessUp: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness",
+        /// Switch between input sources
+        InputSourceSwitch: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon InputSourceSwitch",
+        /// Opens the home folder in a system default file browser
+        HomeFolder: "xdg-open ~",
+        /// Logs out
+        LogOut: "cosmic-osd log-out",
+        /// Decreases keyboard brightness
+        // KeyboardBrightnessDown,
+        /// Increases keyboard brightness
+        // KeyboardBrightnessUp,
+        /// Opens the launcher
+        Launcher: "cosmic-launcher",
+        /// Locks the screen
+        LockScreen: "loginctl lock-session",
+        /// Mutes the active output device
+        Mute: "pamixer --toggle-mute",
+        /// Mutes the active microphone
+        MuteMic: "pamixer --default-source --toggle-mute",
+        /// Plays and Pauses audio
+        PlayPause: "playerctl play-pause",
+        /// Goes to the next track
+        PlayNext: "playerctl next",
+        /// Goes to the previous track
+        PlayPrev: "playerctl previous",
+        /// Takes a screenshot
+        Screenshot: "cosmic-screenshot",
+        /// Opens the system default terminal
+        Terminal: "cosmic-term",
+        /// Lowers the volume of the active output device
+        VolumeLower: "",
+        /// Raises the volume of the active output device
+        VolumeRaise: "",
+        /// Opens the system default web browser
+        WebBrowser: "xdg-open http://",
+        /// Opens the (alt+tab) window switcher
+        WindowSwitcher: "cosmic-launcher alt-tab",
+        /// Opens the (alt+shift+tab) window switcher
+        WindowSwitcherPrevious: "cosmic-launcher shift-alt-tab",
+        /// Opens the workspace overview
+        WorkspaceOverview: "cosmic-workspaces",
+    }
+
+com.system76.CosmicSettings.WindowRules:
+  tiling_exception_defaults: |
+    [
+    	// Any appid title only matching
+    	(
+    		appid: ".*", 
+    		titles: [
+    			"Discord Updater",
+    		]
+    	),
+    	// Empty appid title only matches
+    	(
+    		appid: "", 
+    		titles: [
+    			"Steam",
+    			"wl-clipboard",
+    		]
+    	),
+
+
+    	// Appid matches
+    	(appid: "Authy Desktop", titles: [".*"]),
+    	(appid: "Com.github.amezin.ddterm", titles: [".*"]),
+    	(appid: "Com.github.donadigo.eddy", titles: [".*"]),
+    	(appid: "com.system76.CosmicFilesDialog", titles: [".*"]),
+    	(appid: "Enpass", titles: ["Enpass Assistant"]),
+    	(appid: "Gjs", titles: ["Settings"]),
+    	(appid: "Gnome-initial-setup", titles: [".*"]),
+    	(appid: "Gnome-terminal", titles: ["Preferences - General"]),
+    	(appid: "Guake", titles: [".*"]),
+    	(appid: "Io.elementary.sideload", titles: [".*"]),
+    	(appid: "KotatogramDesktop", titles: ["Media viewer"]),
+    	(appid: "Mozilla VPN", titles: [".*"]),
+    	(appid: "update-manager", titles: ["Software Updater"]),
+    	(appid: "Solaar", titles: [".*"]),
+    	(appid: "Steam", titles: ["^.*?(Guard|Login).*"]),
+    	(appid: "TelegramDesktop", titles: ["Media viewer"]),
+    	(appid: "Zotero", titles: ["Quick Format Citation"]),
+    	(appid: "gjs", titles: [".*"]),
+    	(appid: "gnome-screenshot", titles: [".*"]),
+    	(appid: "ibus-.*", titles: [".*"]),
+    	(appid: "jetbrains-toolbox", titles: [".*"]),
+    	(appid: "jetbrains-webstorm", titles: ["Customize WebStorm", "License Activation", "Welcome to WebStorm"]),
+    	(appid: "krunner", titles: [".*"]),
+    	(appid: "pritunl", titles: [".*"]),
+    	(appid: "re.sonny.Junction", titles: [".*"]),
+    	(appid: "system76-driver", titles: [".*"]),
+    	(appid: "tilda", titles: [".*"]),
+    	(appid: "zoom", titles: [".*"]),
+    	(appid: "^.*?action=join.*$", titles: [".*"]),
+
+    ]
+
+com.system76.CosmicTerm:
+  font_name: "Noto Sans Mono"
+
+com.system76.CosmicTheme.Dark:
+  accent: |
+    (
+        base: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.37568632,
+            green: 0.70509803,
+            blue: 0.4729412,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.27058825,
+            green: 0.4764706,
+            blue: 0.33137256,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.37568632,
+            green: 0.70509803,
+            blue: 0.4729412,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.17647061,
+            green: 0.38235295,
+            blue: 0.2372549,
+            alpha: 1.0,
+        ),
+        border: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 0.5,
+        ),
+    )
+  accent_button: |
+    (
+        base: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.37568632,
+            green: 0.70509803,
+            blue: 0.4729412,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.27058825,
+            green: 0.4764706,
+            blue: 0.33137256,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.37568632,
+            green: 0.70509803,
+            blue: 0.4729412,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.105882354,
+            green: 0.105882354,
+            blue: 0.105882354,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 0.5,
+        ),
+    )
+  accent_text: None
+  active_hint: 1
+  background: |
+    (
+        base: (
+            red: 0.105882354,
+            green: 0.105882354,
+            blue: 0.105882354,
+            alpha: 1.0,
+        ),
+        component: (
+            base: (
+                red: 0.18219745,
+                green: 0.18219745,
+                blue: 0.18219745,
+                alpha: 1.0,
+            ),
+            hover: (
+                red: 0.2639777,
+                green: 0.2639777,
+                blue: 0.2639777,
+                alpha: 1.0,
+            ),
+            pressed: (
+                red: 0.34575796,
+                green: 0.34575796,
+                blue: 0.34575796,
+                alpha: 1.0,
+            ),
+            selected: (
+                red: 0.2639777,
+                green: 0.2639777,
+                blue: 0.2639777,
+                alpha: 1.0,
+            ),
+            selected_text: (
+                red: 0.35294122,
+                green: 0.7647059,
+                blue: 0.4745098,
+                alpha: 1.0,
+            ),
+            focus: (
+                red: 0.35294122,
+                green: 0.7647059,
+                blue: 0.4745098,
+                alpha: 1.0,
+            ),
+            divider: (
+                red: 0.7532969,
+                green: 0.7532969,
+                blue: 0.75329685,
+                alpha: 0.2,
+            ),
+            on: (
+                red: 0.7532969,
+                green: 0.7532969,
+                blue: 0.75329685,
+                alpha: 1.0,
+            ),
+            disabled: (
+                red: 0.18219745,
+                green: 0.18219745,
+                blue: 0.18219745,
+                alpha: 1.0,
+            ),
+            on_disabled: (
+                red: 0.46774718,
+                green: 0.46774718,
+                blue: 0.46774715,
+                alpha: 1.0,
+            ),
+            border: (
+                red: 0.7764706,
+                green: 0.7764706,
+                blue: 0.7764706,
+                alpha: 1.0,
+            ),
+            disabled_border: (
+                red: 0.7764706,
+                green: 0.7764706,
+                blue: 0.7764706,
+                alpha: 0.5,
+            ),
+        ),
+        divider: (
+            red: 0.2662247,
+            green: 0.2662247,
+            blue: 0.2662247,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.90759414,
+            green: 0.9075942,
+            blue: 0.90759414,
+            alpha: 1.0,
+        ),
+        small_widget: (
+            red: 0.15292811,
+            green: 0.15292811,
+            blue: 0.15292808,
+            alpha: 0.25,
+        ),
+    )
+  button: |
+    (
+        base: (
+            red: 0.67058825,
+            green: 0.67058825,
+            blue: 0.67058825,
+            alpha: 0.25,
+        ),
+        hover: (
+            red: 0.42862746,
+            green: 0.42862746,
+            blue: 0.42862746,
+            alpha: 0.4,
+        ),
+        pressed: (
+            red: 0.2282353,
+            green: 0.2282353,
+            blue: 0.2282353,
+            alpha: 0.625,
+        ),
+        selected: (
+            red: 0.42862746,
+            green: 0.42862746,
+            blue: 0.42862746,
+            alpha: 0.4,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.7532969,
+            green: 0.7532969,
+            blue: 0.75329685,
+            alpha: 0.2,
+        ),
+        on: (
+            red: 0.7532969,
+            green: 0.7532969,
+            blue: 0.75329685,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.51056147,
+            green: 0.51056147,
+            blue: 0.51056147,
+            alpha: 0.34375,
+        ),
+        on_disabled: (
+            red: 0.5107661,
+            green: 0.5107661,
+            blue: 0.5107661,
+            alpha: 0.625,
+        ),
+        border: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 0.5,
+        ),
+    )
+  corner_radii: |
+    (
+        radius_0: (0.0, 0.0, 0.0, 0.0),
+        radius_xs: (2.0, 2.0, 2.0, 2.0),
+        radius_s: (8.0, 8.0, 8.0, 8.0),
+        radius_m: (8.0, 8.0, 8.0, 8.0),
+        radius_l: (8.0, 8.0, 8.0, 8.0),
+        radius_xl: (8.0, 8.0, 8.0, 8.0),
+    )
+  destructive: |
+    (
+        base: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.88705885,
+            green: 0.59843135,
+            blue: 0.5952941,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.5901961,
+            green: 0.40980393,
+            blue: 0.40784314,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.88705885,
+            green: 0.59843135,
+            blue: 0.5952941,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.49607843,
+            green: 0.3156863,
+            blue: 0.3137255,
+            alpha: 1.0,
+        ),
+        border: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 0.5,
+        ),
+    )
+  destructive_button: |
+    (
+        base: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.88705885,
+            green: 0.59843135,
+            blue: 0.5952941,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.5901961,
+            green: 0.40980393,
+            blue: 0.40784314,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.88705885,
+            green: 0.59843135,
+            blue: 0.5952941,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.105882354,
+            green: 0.105882354,
+            blue: 0.105882354,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 0.5,
+        ),
+    )
+  gaps: (0, 8)
+  icon_button: |
+    (
+        base: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        hover: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 0.2,
+        ),
+        pressed: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 0.5,
+        ),
+        selected: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 0.2,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 0.2,
+        ),
+        on: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        on_disabled: (
+            red: 0.3882353,
+            green: 0.3882353,
+            blue: 0.3882353,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 0.5,
+        ),
+    )
+  is_dark: true
+  is_frosted: false
+  is_high_contrast: false
+  link_button: |
+    (
+        base: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        hover: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        pressed: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        selected: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 0.2,
+        ),
+        on: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        on_disabled: (
+            red: 0.17647061,
+            green: 0.38235295,
+            blue: 0.2372549,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 0.5,
+        ),
+    )
+  name: "cosmic-dark"
+  palette: |
+    (
+        name: "cosmic-dark",
+        bright_red: (
+            red: 1.0,
+            green: 0.627451,
+            blue: 0.5647059,
+            alpha: 1.0,
+        ),
+        bright_green: (
+            red: 0.36862746,
+            green: 0.85882354,
+            blue: 0.54901963,
+            alpha: 1.0,
+        ),
+        bright_orange: (
+            red: 1.0,
+            green: 0.6392157,
+            blue: 0.49019608,
+            alpha: 1.0,
+        ),
+        gray_1: (
+            red: 0.105882354,
+            green: 0.105882354,
+            blue: 0.105882354,
+            alpha: 1.0,
+        ),
+        gray_2: (
+            red: 0.14901961,
+            green: 0.14901961,
+            blue: 0.14901961,
+            alpha: 1.0,
+        ),
+        neutral_0: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        neutral_1: (
+            red: 0.105882354,
+            green: 0.105882354,
+            blue: 0.105882354,
+            alpha: 1.0,
+        ),
+        neutral_2: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 1.0,
+        ),
+        neutral_3: (
+            red: 0.2784314,
+            green: 0.2784314,
+            blue: 0.2784314,
+            alpha: 1.0,
+        ),
+        neutral_4: (
+            red: 0.36862746,
+            green: 0.36862746,
+            blue: 0.36862746,
+            alpha: 1.0,
+        ),
+        neutral_5: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 1.0,
+        ),
+        neutral_6: (
+            red: 0.5686275,
+            green: 0.5686275,
+            blue: 0.5686275,
+            alpha: 1.0,
+        ),
+        neutral_7: (
+            red: 0.67058825,
+            green: 0.67058825,
+            blue: 0.67058825,
+            alpha: 1.0,
+        ),
+        neutral_8: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 1.0,
+        ),
+        neutral_9: (
+            red: 0.8862745,
+            green: 0.8862745,
+            blue: 0.8862745,
+            alpha: 1.0,
+        ),
+        neutral_10: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        accent_blue: (
+            red: 0.3882353,
+            green: 0.8156863,
+            blue: 0.8745098,
+            alpha: 1.0,
+        ),
+        accent_indigo: (
+            red: 0.6313726,
+            green: 0.7529412,
+            blue: 0.92156863,
+            alpha: 1.0,
+        ),
+        accent_purple: (
+            red: 0.90588236,
+            green: 0.6117647,
+            blue: 0.99607843,
+            alpha: 1.0,
+        ),
+        accent_pink: (
+            red: 1.0,
+            green: 0.6117647,
+            blue: 0.69411767,
+            alpha: 1.0,
+        ),
+        accent_red: (
+            red: 0.99215686,
+            green: 0.6313726,
+            blue: 0.627451,
+            alpha: 1.0,
+        ),
+        accent_orange: (
+            red: 1.0,
+            green: 0.6784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        accent_yellow: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 1.0,
+        ),
+        accent_green: (
+            red: 0.57254905,
+            green: 0.8117647,
+            blue: 0.6117647,
+            alpha: 1.0,
+        ),
+        accent_warm_grey: (
+            red: 0.7921569,
+            green: 0.7294118,
+            blue: 0.7058824,
+            alpha: 1.0,
+        ),
+        ext_warm_grey: (
+            red: 0.60784316,
+            green: 0.5568628,
+            blue: 0.5411765,
+            alpha: 1.0,
+        ),
+        ext_orange: (
+            red: 1.0,
+            green: 0.6784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        ext_yellow: (
+            red: 0.99607843,
+            green: 0.85882354,
+            blue: 0.2509804,
+            alpha: 1.0,
+        ),
+        ext_blue: (
+            red: 0.28235295,
+            green: 0.7254902,
+            blue: 0.78039217,
+            alpha: 1.0,
+        ),
+        ext_purple: (
+            red: 0.8117647,
+            green: 0.49019608,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        ext_pink: (
+            red: 0.9764706,
+            green: 0.22745098,
+            blue: 0.5137255,
+            alpha: 1.0,
+        ),
+        ext_indigo: (
+            red: 0.24313726,
+            green: 0.53333336,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+    )
+  primary: |
+    (
+        base: (
+            red: 0.15292811,
+            green: 0.15292811,
+            blue: 0.15292808,
+            alpha: 1.0,
+        ),
+        component: (
+            base: (
+                red: 0.21220893,
+                green: 0.2122089,
+                blue: 0.2122089,
+                alpha: 1.0,
+            ),
+            hover: (
+                red: 0.29098803,
+                green: 0.290988,
+                blue: 0.290988,
+                alpha: 1.0,
+            ),
+            pressed: (
+                red: 0.36976713,
+                green: 0.36976713,
+                blue: 0.36976713,
+                alpha: 1.0,
+            ),
+            selected: (
+                red: 0.29098803,
+                green: 0.290988,
+                blue: 0.290988,
+                alpha: 1.0,
+            ),
+            selected_text: (
+                red: 0.35294122,
+                green: 0.7647059,
+                blue: 0.4745098,
+                alpha: 1.0,
+            ),
+            focus: (
+                red: 0.35294122,
+                green: 0.7647059,
+                blue: 0.4745098,
+                alpha: 1.0,
+            ),
+            divider: (
+                red: 0.7913618,
+                green: 0.7913618,
+                blue: 0.7913618,
+                alpha: 0.2,
+            ),
+            on: (
+                red: 0.7913618,
+                green: 0.7913618,
+                blue: 0.7913618,
+                alpha: 1.0,
+            ),
+            disabled: (
+                red: 0.21220893,
+                green: 0.2122089,
+                blue: 0.2122089,
+                alpha: 1.0,
+            ),
+            on_disabled: (
+                red: 0.5017854,
+                green: 0.50178534,
+                blue: 0.50178534,
+                alpha: 1.0,
+            ),
+            border: (
+                red: 0.7764706,
+                green: 0.7764706,
+                blue: 0.7764706,
+                alpha: 1.0,
+            ),
+            disabled_border: (
+                red: 0.7764706,
+                green: 0.7764706,
+                blue: 0.7764706,
+                alpha: 0.5,
+            ),
+        ),
+        divider: (
+            red: 0.31702772,
+            green: 0.31702772,
+            blue: 0.3170277,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.97342616,
+            green: 0.97342616,
+            blue: 0.97342604,
+            alpha: 1.0,
+        ),
+        small_widget: (
+            red: 0.20212594,
+            green: 0.20212597,
+            blue: 0.20212597,
+            alpha: 0.25,
+        ),
+    )
+  secondary: |
+    (
+        base: (
+            red: 0.20212594,
+            green: 0.20212597,
+            blue: 0.20212597,
+            alpha: 1.0,
+        ),
+        component: (
+            base: (
+                red: 0.23260304,
+                green: 0.23260307,
+                blue: 0.23260304,
+                alpha: 1.0,
+            ),
+            hover: (
+                red: 0.30934274,
+                green: 0.30934277,
+                blue: 0.30934274,
+                alpha: 1.0,
+            ),
+            pressed: (
+                red: 0.38608244,
+                green: 0.38608247,
+                blue: 0.38608244,
+                alpha: 1.0,
+            ),
+            selected: (
+                red: 0.30934274,
+                green: 0.30934277,
+                blue: 0.30934274,
+                alpha: 1.0,
+            ),
+            selected_text: (
+                red: 0.35294122,
+                green: 0.7647059,
+                blue: 0.4745098,
+                alpha: 1.0,
+            ),
+            focus: (
+                red: 0.35294122,
+                green: 0.7647059,
+                blue: 0.4745098,
+                alpha: 1.0,
+            ),
+            divider: (
+                red: 0.81693083,
+                green: 0.8169309,
+                blue: 0.8169309,
+                alpha: 0.2,
+            ),
+            on: (
+                red: 0.81693083,
+                green: 0.8169309,
+                blue: 0.8169309,
+                alpha: 1.0,
+            ),
+            disabled: (
+                red: 0.23260304,
+                green: 0.23260307,
+                blue: 0.23260304,
+                alpha: 1.0,
+            ),
+            on_disabled: (
+                red: 0.5247669,
+                green: 0.524767,
+                blue: 0.524767,
+                alpha: 1.0,
+            ),
+            border: (
+                red: 0.7764706,
+                green: 0.7764706,
+                blue: 0.7764706,
+                alpha: 1.0,
+            ),
+            disabled_border: (
+                red: 0.7764706,
+                green: 0.7764706,
+                blue: 0.7764706,
+                alpha: 0.5,
+            ),
+        ),
+        divider: (
+            red: 0.3174277,
+            green: 0.31742772,
+            blue: 0.3174277,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.7786347,
+            green: 0.7786347,
+            blue: 0.77863467,
+            alpha: 1.0,
+        ),
+        small_widget: (
+            red: 0.2532908,
+            green: 0.25329086,
+            blue: 0.2532908,
+            alpha: 0.25,
+        ),
+    )
+  shade: |
+    (
+        red: 0.0,
+        green: 0.0,
+        blue: 0.0,
+        alpha: 0.32,
+    )
+  spacing: |
+    (
+        space_none: 0,
+        space_xxxs: 4,
+        space_xxs: 8,
+        space_xs: 12,
+        space_s: 16,
+        space_m: 24,
+        space_l: 32,
+        space_xl: 48,
+        space_xxl: 64,
+        space_xxxl: 128,
+    )
+  success: |
+    (
+        base: (
+            red: 0.57254905,
+            green: 0.8117647,
+            blue: 0.6117647,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.5513726,
+            green: 0.74274516,
+            blue: 0.58274513,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.38039216,
+            green: 0.5,
+            blue: 0.4,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.5513726,
+            green: 0.74274516,
+            blue: 0.58274513,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.57254905,
+            green: 0.8117647,
+            blue: 0.6117647,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.28627452,
+            green: 0.40588236,
+            blue: 0.30588236,
+            alpha: 1.0,
+        ),
+        border: (
+            red: 0.57254905,
+            green: 0.8117647,
+            blue: 0.6117647,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.57254905,
+            green: 0.8117647,
+            blue: 0.6117647,
+            alpha: 0.5,
+        ),
+    )
+  success_button: |
+    (
+        base: (
+            red: 0.6745098,
+            green: 0.96862745,
+            blue: 0.8235294,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.61732244,
+            green: 0.85261655,
+            blue: 0.7365381,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.38030702,
+            green: 0.5273658,
+            blue: 0.45481685,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.61732244,
+            green: 0.85261655,
+            blue: 0.7365381,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.3882353,
+            green: 0.8156863,
+            blue: 0.8745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.3882353,
+            green: 0.8156863,
+            blue: 0.8745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.012919995,
+            green: 0.012919999,
+            blue: 0.012920027,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.000000000000000000000000000000000000000000036,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.6745098,
+            green: 0.96862745,
+            blue: 0.8235294,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.000000000000000000000000000000000000000000036,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.6745098,
+            green: 0.96862745,
+            blue: 0.8235294,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.6745098,
+            green: 0.96862745,
+            blue: 0.8235294,
+            alpha: 0.5,
+        ),
+    )
+  text_button: |
+    (
+        base: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        hover: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 0.2,
+        ),
+        pressed: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 0.5,
+        ),
+        selected: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 0.2,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 0.2,
+        ),
+        on: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        on_disabled: (
+            red: 0.17647061,
+            green: 0.38235295,
+            blue: 0.2372549,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 0.5,
+        ),
+    )
+  warning: |
+    (
+        base: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.86823535,
+            green: 0.79607844,
+            blue: 0.4007843,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.57843137,
+            green: 0.53333336,
+            blue: 0.28627452,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.86823535,
+            green: 0.79607844,
+            blue: 0.4007843,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.48431373,
+            green: 0.4392157,
+            blue: 0.19215687,
+            alpha: 1.0,
+        ),
+        border: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 0.5,
+        ),
+    )
+  warning_button: |
+    (
+        base: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.86823535,
+            green: 0.79607844,
+            blue: 0.4007843,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.57843137,
+            green: 0.53333336,
+            blue: 0.28627452,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.86823535,
+            green: 0.79607844,
+            blue: 0.4007843,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.35294122,
+            green: 0.7647059,
+            blue: 0.4745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 0.5,
+        ),
+    )
+  window_hint: None
+
+com.system76.CosmicTheme.Dark.Builder:
+  accent: |
+    Some((
+        red: 0.35294122,
+        green: 0.7647059,
+        blue: 0.4745098,
+    ))
+  active_hint: 1
+  bg_color: None
+  corner_radii: |
+    (
+        radius_0: (0.0, 0.0, 0.0, 0.0),
+        radius_xs: (2.0, 2.0, 2.0, 2.0),
+        radius_s: (8.0, 8.0, 8.0, 8.0),
+        radius_m: (8.0, 8.0, 8.0, 8.0),
+        radius_l: (8.0, 8.0, 8.0, 8.0),
+        radius_xl: (8.0, 8.0, 8.0, 8.0),
+    )
+  destructive: None
+  gaps: (0,8)
+  is_dark: true
+  is_frosted: false
+  neutral_tint: None
+  palette: Dark((name:"cosmic-dark",blue:(red:0.5803922,green:0.92156863,blue:0.92156863,alpha:1.0),red:(red:1.0,green:0.70980394,blue:0.70980394,alpha:1.0),green:(red:0.6745098,green:0.96862745,blue:0.8235294,alpha:1.0),yellow:(red:1.0,green:0.94509804,blue:0.61960787,alpha:1.0),gray_1:(red:0.105882354,green:0.105882354,blue:0.105882354,alpha:1.0),gray_2:(red:0.14901961,green:0.14901961,blue:0.14901961,alpha:1.0),gray_3:(red:0.1882353,green:0.1882353,blue:0.1882353,alpha:1.0),neutral_0:(red:0.0,green:0.0,blue:0.0,alpha:1.0),neutral_1:(red:0.105882354,green:0.105882354,blue:0.105882354,alpha:1.0),neutral_2:(red:0.1882353,green:0.1882353,blue:0.1882353,alpha:1.0),neutral_3:(red:0.2784314,green:0.2784314,blue:0.2784314,alpha:1.0),neutral_4:(red:0.36862746,green:0.36862746,blue:0.36862746,alpha:1.0),neutral_5:(red:0.46666667,green:0.46666667,blue:0.46666667,alpha:1.0),neutral_6:(red:0.5686275,green:0.5686275,blue:0.5686275,alpha:1.0),neutral_7:(red:0.67058825,green:0.67058825,blue:0.67058825,alpha:1.0),neutral_8:(red:0.7764706,green:0.7764706,blue:0.7764706,alpha:1.0),neutral_9:(red:0.8862745,green:0.8862745,blue:0.8862745,alpha:1.0),neutral_10:(red:1.0,green:1.0,blue:1.0,alpha:1.0),bright_green:(red:0.36862746,green:0.85882354,blue:0.54901963,alpha:1.0),bright_red:(red:1.0,green:0.627451,blue:0.5647059,alpha:1.0),bright_orange:(red:1.0,green:0.6392157,blue:0.49019608,alpha:1.0),ext_warm_grey:(red:0.60784316,green:0.5568628,blue:0.5411765,alpha:1.0),ext_orange:(red:1.0,green:0.6784314,blue:0.0,alpha:1.0),ext_yellow:(red:0.99607843,green:0.85882354,blue:0.2509804,alpha:1.0),ext_blue:(red:0.28235295,green:0.7254902,blue:0.78039217,alpha:1.0),ext_purple:(red:0.8117647,green:0.49019608,blue:1.0,alpha:1.0),ext_pink:(red:0.9764706,green:0.22745098,blue:0.5137255,alpha:1.0),ext_indigo:(red:0.24313726,green:0.53333336,blue:1.0,alpha:1.0),accent_blue:(red:0.3882353,green:0.8156863,blue:0.8745098,alpha:1.0),accent_red:(red:0.99215686,green:0.6313726,blue:0.627451,alpha:1.0),accent_green:(red:0.57254905,green:0.8117647,blue:0.6117647,alpha:1.0),accent_warm_grey:(red:0.7921569,green:0.7294118,blue:0.7058824,alpha:1.0),accent_orange:(red:1.0,green:0.6784314,blue:0.0,alpha:1.0),accent_yellow:(red:0.96862745,green:0.8784314,blue:0.38431373,alpha:1.0),accent_purple:(red:0.90588236,green:0.6117647,blue:0.99607843,alpha:1.0),accent_pink:(red:1.0,green:0.6117647,blue:0.69411767,alpha:1.0),accent_indigo:(red:0.6313726,green:0.7529412,blue:0.92156863,alpha:1.0)))
+  primary_container_bg: None
+  secondary_container_bg: None
+  spacing: (space_none:0,space_xxxs:4,space_xxs:8,space_xs:12,space_s:16,space_m:24,space_l:32,space_xl:48,space_xxl:64,space_xxxl:128)
+  success: None
+  text_tint: None
+  warning: None
+  window_hint: None
+
+com.system76.CosmicTheme.Light:
+  accent: |
+    (
+        base: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.093333334,
+            green: 0.32235295,
+            blue: 0.43529412,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.3882353,
+            green: 0.53137255,
+            blue: 0.6019608,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.093333334,
+            green: 0.32235295,
+            blue: 0.43529412,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.5,
+            green: 0.6431373,
+            blue: 0.7137255,
+            alpha: 1.0,
+        ),
+        border: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 0.5,
+        ),
+    )
+  accent_button: |
+    (
+        base: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.093333334,
+            green: 0.32235295,
+            blue: 0.43529412,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.3882353,
+            green: 0.53137255,
+            blue: 0.6019608,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.093333334,
+            green: 0.32235295,
+            blue: 0.43529412,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.8862745,
+            green: 0.8862745,
+            blue: 0.8862745,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 0.5,
+        ),
+    )
+  accent_text: None
+  active_hint: 1
+  background: |
+    (
+        base: (
+            red: 0.8666667,
+            green: 0.8666667,
+            blue: 0.8666667,
+            alpha: 1.0,
+        ),
+        component: (
+            base: (
+                red: 0.98669606,
+                green: 0.98669606,
+                blue: 0.98669595,
+                alpha: 1.0,
+            ),
+            hover: (
+                red: 0.8880264,
+                green: 0.8880264,
+                blue: 0.88802636,
+                alpha: 1.0,
+            ),
+            pressed: (
+                red: 0.7893569,
+                green: 0.7893569,
+                blue: 0.78935677,
+                alpha: 1.0,
+            ),
+            selected: (
+                red: 0.8880264,
+                green: 0.8880264,
+                blue: 0.88802636,
+                alpha: 1.0,
+            ),
+            selected_text: (
+                red: 0.0,
+                green: 0.28627452,
+                blue: 0.42745098,
+                alpha: 1.0,
+            ),
+            focus: (
+                red: 0.0,
+                green: 0.28627452,
+                blue: 0.42745098,
+                alpha: 1.0,
+            ),
+            divider: (
+                red: 0.17235574,
+                green: 0.1723558,
+                blue: 0.17235562,
+                alpha: 0.2,
+            ),
+            on: (
+                red: 0.17235574,
+                green: 0.1723558,
+                blue: 0.17235562,
+                alpha: 1.0,
+            ),
+            disabled: (
+                red: 0.98669606,
+                green: 0.98669606,
+                blue: 0.98669595,
+                alpha: 1.0,
+            ),
+            on_disabled: (
+                red: 0.5795259,
+                green: 0.57952595,
+                blue: 0.57952577,
+                alpha: 1.0,
+            ),
+            border: (
+                red: 0.1882353,
+                green: 0.1882353,
+                blue: 0.1882353,
+                alpha: 1.0,
+            ),
+            disabled_border: (
+                red: 0.1882353,
+                green: 0.1882353,
+                blue: 0.1882353,
+                alpha: 0.5,
+            ),
+        ),
+        divider: (
+            red: 0.710911,
+            green: 0.7109109,
+            blue: 0.7109109,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.08788813,
+            green: 0.08788807,
+            blue: 0.087887965,
+            alpha: 1.0,
+        ),
+        small_widget: (
+            red: 0.946989,
+            green: 0.9469891,
+            blue: 0.946989,
+            alpha: 0.25,
+        ),
+    )
+  button: |
+    (
+        base: (
+            red: 0.2784314,
+            green: 0.2784314,
+            blue: 0.2784314,
+            alpha: 0.25,
+        ),
+        hover: (
+            red: 0.23254903,
+            green: 0.23254903,
+            blue: 0.23254903,
+            alpha: 0.4,
+        ),
+        pressed: (
+            red: 0.44392157,
+            green: 0.44392157,
+            blue: 0.44392157,
+            alpha: 0.625,
+        ),
+        selected: (
+            red: 0.23254903,
+            green: 0.23254903,
+            blue: 0.23254903,
+            alpha: 0.4,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.17235574,
+            green: 0.1723558,
+            blue: 0.17235562,
+            alpha: 0.2,
+        ),
+        on: (
+            red: 0.17235574,
+            green: 0.1723558,
+            blue: 0.17235562,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.21198754,
+            green: 0.21198754,
+            blue: 0.21198754,
+            alpha: 0.34375,
+        ),
+        on_disabled: (
+            red: 0.14186415,
+            green: 0.14186418,
+            blue: 0.14186409,
+            alpha: 0.625,
+        ),
+        border: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 0.5,
+        ),
+    )
+  corner_radii: |
+    (
+        radius_0: (0.0, 0.0, 0.0, 0.0),
+        radius_xs: (2.0, 2.0, 2.0, 2.0),
+        radius_s: (8.0, 8.0, 8.0, 8.0),
+        radius_m: (8.0, 8.0, 8.0, 8.0),
+        radius_l: (8.0, 8.0, 8.0, 8.0),
+        radius_xl: (8.0, 8.0, 8.0, 8.0),
+    )
+  destructive: |
+    (
+        base: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.5952941,
+            green: 0.20941177,
+            blue: 0.2282353,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.7019608,
+            green: 0.46078432,
+            blue: 0.47254902,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.5952941,
+            green: 0.20941177,
+            blue: 0.2282353,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.8137255,
+            green: 0.57254905,
+            blue: 0.58431375,
+            alpha: 1.0,
+        ),
+        border: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 0.5,
+        ),
+    )
+  destructive_button: |
+    (
+        base: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.5952941,
+            green: 0.20941177,
+            blue: 0.2282353,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.7019608,
+            green: 0.46078432,
+            blue: 0.47254902,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.5952941,
+            green: 0.20941177,
+            blue: 0.2282353,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.8862745,
+            green: 0.8862745,
+            blue: 0.8862745,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 0.5,
+        ),
+    )
+  gaps: (0, 8)
+  icon_button: |
+    (
+        base: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        hover: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 0.2,
+        ),
+        pressed: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 0.5,
+        ),
+        selected: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 0.2,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 0.2,
+        ),
+        on: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        on_disabled: (
+            red: 0.09411765,
+            green: 0.09411765,
+            blue: 0.09411765,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 0.5,
+        ),
+    )
+  is_dark: false
+  is_frosted: false
+  is_high_contrast: false
+  link_button: |
+    (
+        base: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        hover: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        pressed: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        selected: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 0.2,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        on_disabled: (
+            red: 0.0,
+            green: 0.14313726,
+            blue: 0.21372549,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 0.5,
+        ),
+    )
+  name: "cosmic-light"
+  palette: |
+    (
+        name: "cosmic-light",
+        blue: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        red: (
+            red: 0.627451,
+            green: 0.14509805,
+            blue: 0.16862746,
+            alpha: 1.0,
+        ),
+        green: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 1.0,
+        ),
+        yellow: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        gray_1: (
+            red: 0.8666667,
+            green: 0.8666667,
+            blue: 0.8666667,
+            alpha: 1.0,
+        ),
+        gray_2: (
+            red: 0.9098039,
+            green: 0.9098039,
+            blue: 0.9098039,
+            alpha: 1.0,
+        ),
+        gray_3: (
+            red: 0.9529412,
+            green: 0.9529412,
+            blue: 0.9529412,
+            alpha: 1.0,
+        ),
+        neutral_0: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        neutral_1: (
+            red: 0.8862745,
+            green: 0.8862745,
+            blue: 0.8862745,
+            alpha: 1.0,
+        ),
+        neutral_2: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 1.0,
+        ),
+        neutral_3: (
+            red: 0.67058825,
+            green: 0.67058825,
+            blue: 0.67058825,
+            alpha: 1.0,
+        ),
+        neutral_4: (
+            red: 0.5686275,
+            green: 0.5686275,
+            blue: 0.5686275,
+            alpha: 1.0,
+        ),
+        neutral_5: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 1.0,
+        ),
+        neutral_6: (
+            red: 0.36862746,
+            green: 0.36862746,
+            blue: 0.36862746,
+            alpha: 1.0,
+        ),
+        neutral_7: (
+            red: 0.2784314,
+            green: 0.2784314,
+            blue: 0.2784314,
+            alpha: 1.0,
+        ),
+        neutral_8: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 1.0,
+        ),
+        neutral_9: (
+            red: 0.105882354,
+            green: 0.105882354,
+            blue: 0.105882354,
+            alpha: 1.0,
+        ),
+        neutral_10: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        bright_green: (
+            red: 0.0,
+            green: 0.34117648,
+            blue: 0.17254902,
+            alpha: 1.0,
+        ),
+        bright_red: (
+            red: 0.5372549,
+            green: 0.015686275,
+            blue: 0.09411765,
+            alpha: 1.0,
+        ),
+        bright_orange: (
+            red: 0.4745098,
+            green: 0.17254902,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        ext_warm_grey: (
+            red: 0.60784316,
+            green: 0.5568628,
+            blue: 0.5411765,
+            alpha: 1.0,
+        ),
+        ext_orange: (
+            red: 0.9843137,
+            green: 0.72156864,
+            blue: 0.42352942,
+            alpha: 1.0,
+        ),
+        ext_yellow: (
+            red: 0.96862745,
+            green: 0.8784314,
+            blue: 0.38431373,
+            alpha: 1.0,
+        ),
+        ext_blue: (
+            red: 0.41568628,
+            green: 0.7921569,
+            blue: 0.84705883,
+            alpha: 1.0,
+        ),
+        ext_purple: (
+            red: 0.8352941,
+            green: 0.54901963,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        ext_pink: (
+            red: 1.0,
+            green: 0.6117647,
+            blue: 0.8666667,
+            alpha: 1.0,
+        ),
+        ext_indigo: (
+            red: 0.58431375,
+            green: 0.76862746,
+            blue: 0.9882353,
+            alpha: 1.0,
+        ),
+        accent_blue: (
+            red: 0.0,
+            green: 0.32156864,
+            blue: 0.3529412,
+            alpha: 1.0,
+        ),
+        accent_red: (
+            red: 0.47058824,
+            green: 0.16078432,
+            blue: 0.18039216,
+            alpha: 1.0,
+        ),
+        accent_green: (
+            red: 0.09411765,
+            green: 0.33333334,
+            blue: 0.16078432,
+            alpha: 1.0,
+        ),
+        accent_warm_grey: (
+            red: 0.33333334,
+            green: 0.2784314,
+            blue: 0.25882354,
+            alpha: 1.0,
+        ),
+        accent_orange: (
+            red: 0.38431373,
+            green: 0.2509804,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        accent_yellow: (
+            red: 0.3254902,
+            green: 0.28235295,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        accent_purple: (
+            red: 0.40784314,
+            green: 0.12941177,
+            blue: 0.4862745,
+            alpha: 1.0,
+        ),
+        accent_pink: (
+            red: 0.5254902,
+            green: 0.015686275,
+            blue: 0.22745098,
+            alpha: 1.0,
+        ),
+        accent_indigo: (
+            red: 0.18039216,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+    )
+  primary: |
+    (
+        base: (
+            red: 0.946989,
+            green: 0.9469891,
+            blue: 0.9469889,
+            alpha: 1.0,
+        ),
+        component: (
+            base: (
+                red: 0.88150823,
+                green: 0.88150835,
+                blue: 0.8815081,
+                alpha: 1.0,
+            ),
+            hover: (
+                red: 0.8933574,
+                green: 0.8933575,
+                blue: 0.8933573,
+                alpha: 1.0,
+            ),
+            pressed: (
+                red: 0.90520656,
+                green: 0.9052067,
+                blue: 0.9052065,
+                alpha: 1.0,
+            ),
+            selected: (
+                red: 0.8933574,
+                green: 0.8933575,
+                blue: 0.8933573,
+                alpha: 1.0,
+            ),
+            selected_text: (
+                red: 0.0,
+                green: 0.28627452,
+                blue: 0.42745098,
+                alpha: 1.0,
+            ),
+            focus: (
+                red: 0.0,
+                green: 0.28627452,
+                blue: 0.42745098,
+                alpha: 1.0,
+            ),
+            divider: (
+                red: 0.09687374,
+                green: 0.09687372,
+                blue: 0.09687359,
+                alpha: 0.2,
+            ),
+            on: (
+                red: 0.09687374,
+                green: 0.09687372,
+                blue: 0.09687359,
+                alpha: 1.0,
+            ),
+            disabled: (
+                red: 0.88150823,
+                green: 0.88150835,
+                blue: 0.8815081,
+                alpha: 1.0,
+            ),
+            on_disabled: (
+                red: 0.489191,
+                green: 0.48919103,
+                blue: 0.48919085,
+                alpha: 1.0,
+            ),
+            border: (
+                red: 0.1882353,
+                green: 0.1882353,
+                blue: 0.1882353,
+                alpha: 1.0,
+            ),
+            disabled_border: (
+                red: 0.1882353,
+                green: 0.1882353,
+                blue: 0.1882353,
+                alpha: 0.5,
+            ),
+        ),
+        divider: (
+            red: 0.78626055,
+            green: 0.78626066,
+            blue: 0.7862605,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.14334676,
+            green: 0.14334682,
+            blue: 0.14334664,
+            alpha: 1.0,
+        ),
+        small_widget: (
+            red: 0.8945333,
+            green: 0.8945333,
+            blue: 0.8945333,
+            alpha: 0.25,
+        ),
+    )
+  secondary: |
+    (
+        base: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 1.0,
+        ),
+        component: (
+            base: (
+                red: 0.82977223,
+                green: 0.82977235,
+                blue: 0.8297721,
+                alpha: 1.0,
+            ),
+            hover: (
+                red: 0.746795,
+                green: 0.7467951,
+                blue: 0.7467949,
+                alpha: 1.0,
+            ),
+            pressed: (
+                red: 0.6638178,
+                green: 0.6638179,
+                blue: 0.6638177,
+                alpha: 1.0,
+            ),
+            selected: (
+                red: 0.746795,
+                green: 0.7467951,
+                blue: 0.7467949,
+                alpha: 1.0,
+            ),
+            selected_text: (
+                red: 0.0,
+                green: 0.28627452,
+                blue: 0.42745098,
+                alpha: 1.0,
+            ),
+            focus: (
+                red: 0.0,
+                green: 0.28627452,
+                blue: 0.42745098,
+                alpha: 1.0,
+            ),
+            divider: (
+                red: 0.061619133,
+                green: 0.06161908,
+                blue: 0.06161897,
+                alpha: 0.2,
+            ),
+            on: (
+                red: 0.061619133,
+                green: 0.06161908,
+                blue: 0.06161897,
+                alpha: 1.0,
+            ),
+            disabled: (
+                red: 0.82977223,
+                green: 0.82977235,
+                blue: 0.8297721,
+                alpha: 1.0,
+            ),
+            on_disabled: (
+                red: 0.4456957,
+                green: 0.44569573,
+                blue: 0.44569555,
+                alpha: 1.0,
+            ),
+            border: (
+                red: 0.1882353,
+                green: 0.1882353,
+                blue: 0.1882353,
+                alpha: 1.0,
+            ),
+            disabled_border: (
+                red: 0.1882353,
+                green: 0.1882353,
+                blue: 0.1882353,
+                alpha: 0.5,
+            ),
+        ),
+        divider: (
+            red: 0.62702733,
+            green: 0.62702733,
+            blue: 0.6270273,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 0.029254153,
+            green: 0.029254114,
+            blue: 0.02925403,
+            alpha: 1.0,
+        ),
+        small_widget: (
+            red: 0.85556674,
+            green: 0.85556674,
+            blue: 0.85556674,
+            alpha: 0.25,
+        ),
+    )
+  shade: |
+    (
+        red: 0.0,
+        green: 0.0,
+        blue: 0.0,
+        alpha: 0.08,
+    )
+  spacing: |
+    (
+        space_none: 0,
+        space_xxxs: 4,
+        space_xxs: 8,
+        space_xs: 12,
+        space_s: 16,
+        space_m: 24,
+        space_l: 32,
+        space_xl: 48,
+        space_xxl: 64,
+        space_xxxl: 128,
+    )
+  success: |
+    (
+        base: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.27843136,
+            green: 0.43843138,
+            blue: 0.30352944,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.50392157,
+            green: 0.6039216,
+            blue: 0.51960784,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.27843136,
+            green: 0.43843138,
+            blue: 0.30352944,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.6156863,
+            green: 0.71568626,
+            blue: 0.6313726,
+            alpha: 1.0,
+        ),
+        border: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 0.5,
+        ),
+    )
+  success_button: |
+    (
+        base: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.27843136,
+            green: 0.43843138,
+            blue: 0.30352944,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.50392157,
+            green: 0.6039216,
+            blue: 0.51960784,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.27843136,
+            green: 0.43843138,
+            blue: 0.30352944,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.8862745,
+            green: 0.8862745,
+            blue: 0.8862745,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.23137255,
+            green: 0.43137255,
+            blue: 0.2627451,
+            alpha: 0.5,
+        ),
+    )
+  text_button: |
+    (
+        base: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        hover: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 0.2,
+        ),
+        pressed: (
+            red: 0.7764706,
+            green: 0.7764706,
+            blue: 0.7764706,
+            alpha: 0.5,
+        ),
+        selected: (
+            red: 0.46666667,
+            green: 0.46666667,
+            blue: 0.46666667,
+            alpha: 0.2,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 0.2,
+        ),
+        on: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 0.0,
+        ),
+        on_disabled: (
+            red: 0.0,
+            green: 0.14313726,
+            blue: 0.21372549,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.1882353,
+            green: 0.1882353,
+            blue: 0.1882353,
+            alpha: 0.5,
+        ),
+    )
+  warning: |
+    (
+        base: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.5639216,
+            green: 0.41960785,
+            blue: 0.093333334,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.68235296,
+            green: 0.5921569,
+            blue: 0.3882353,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.5639216,
+            green: 0.41960785,
+            blue: 0.093333334,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 0.7941177,
+            green: 0.70392156,
+            blue: 0.5,
+            alpha: 1.0,
+        ),
+        border: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 0.5,
+        ),
+    )
+  warning_button: |
+    (
+        base: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        hover: (
+            red: 0.5639216,
+            green: 0.41960785,
+            blue: 0.093333334,
+            alpha: 1.0,
+        ),
+        pressed: (
+            red: 0.68235296,
+            green: 0.5921569,
+            blue: 0.3882353,
+            alpha: 1.0,
+        ),
+        selected: (
+            red: 0.5639216,
+            green: 0.41960785,
+            blue: 0.093333334,
+            alpha: 1.0,
+        ),
+        selected_text: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        focus: (
+            red: 0.0,
+            green: 0.28627452,
+            blue: 0.42745098,
+            alpha: 1.0,
+        ),
+        divider: (
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        on: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        ),
+        disabled: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        on_disabled: (
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 0.5,
+        ),
+        border: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 1.0,
+        ),
+        disabled_border: (
+            red: 0.5882353,
+            green: 0.40784314,
+            blue: 0.0,
+            alpha: 0.5,
+        ),
+    )
+  window_hint: None
+
+com.system76.CosmicTheme.Light.Builder:
+  accent: None
+  active_hint: 1
+  bg_color: None
+  corner_radii: |
+    (
+        radius_0: (0.0, 0.0, 0.0, 0.0),
+        radius_xs: (2.0, 2.0, 2.0, 2.0),
+        radius_s: (8.0, 8.0, 8.0, 8.0),
+        radius_m: (8.0, 8.0, 8.0, 8.0),
+        radius_l: (8.0, 8.0, 8.0, 8.0),
+        radius_xl: (8.0, 8.0, 8.0, 8.0),
+    )
+  destructive: None
+  gaps: (0,8)
+  is_frosted: false
+  neutral_tint: None
+  palette: Light((name:"cosmic-light",blue:(red:0.0,green:0.28627452,blue:0.42745098,alpha:1.0),red:(red:0.627451,green:0.14509805,blue:0.16862746,alpha:1.0),green:(red:0.23137255,green:0.43137255,blue:0.2627451,alpha:1.0),yellow:(red:0.5882353,green:0.40784314,blue:0.0,alpha:1.0),gray_1:(red:0.8666667,green:0.8666667,blue:0.8666667,alpha:1.0),gray_2:(red:0.9098039,green:0.9098039,blue:0.9098039,alpha:1.0),gray_3:(red:0.9529412,green:0.9529412,blue:0.9529412,alpha:1.0),neutral_0:(red:1.0,green:1.0,blue:1.0,alpha:1.0),neutral_1:(red:0.8862745,green:0.8862745,blue:0.8862745,alpha:1.0),neutral_2:(red:0.7764706,green:0.7764706,blue:0.7764706,alpha:1.0),neutral_3:(red:0.67058825,green:0.67058825,blue:0.67058825,alpha:1.0),neutral_4:(red:0.5686275,green:0.5686275,blue:0.5686275,alpha:1.0),neutral_5:(red:0.46666667,green:0.46666667,blue:0.46666667,alpha:1.0),neutral_6:(red:0.36862746,green:0.36862746,blue:0.36862746,alpha:1.0),neutral_7:(red:0.2784314,green:0.2784314,blue:0.2784314,alpha:1.0),neutral_8:(red:0.1882353,green:0.1882353,blue:0.1882353,alpha:1.0),neutral_9:(red:0.105882354,green:0.105882354,blue:0.105882354,alpha:1.0),neutral_10:(red:0.0,green:0.0,blue:0.0,alpha:1.0),bright_green:(red:0.0,green:0.34117648,blue:0.17254902,alpha:1.0),bright_red:(red:0.5372549,green:0.015686275,blue:0.09411765,alpha:1.0),bright_orange:(red:0.4745098,green:0.17254902,blue:0.0,alpha:1.0),ext_warm_grey:(red:0.60784316,green:0.5568628,blue:0.5411765,alpha:1.0),ext_orange:(red:0.9843137,green:0.72156864,blue:0.42352942,alpha:1.0),ext_yellow:(red:0.96862745,green:0.8784314,blue:0.38431373,alpha:1.0),ext_blue:(red:0.41568628,green:0.7921569,blue:0.84705883,alpha:1.0),ext_purple:(red:0.8352941,green:0.54901963,blue:1.0,alpha:1.0),ext_pink:(red:1.0,green:0.6117647,blue:0.8666667,alpha:1.0),ext_indigo:(red:0.58431375,green:0.76862746,blue:0.9882353,alpha:1.0),accent_blue:(red:0.0,green:0.32156864,blue:0.3529412,alpha:1.0),accent_red:(red:0.47058824,green:0.16078432,blue:0.18039216,alpha:1.0),accent_green:(red:0.09411765,green:0.33333334,blue:0.16078432,alpha:1.0),accent_warm_grey:(red:0.33333334,green:0.2784314,blue:0.25882354,alpha:1.0),accent_orange:(red:0.38431373,green:0.2509804,blue:0.0,alpha:1.0),accent_yellow:(red:0.3254902,green:0.28235295,blue:0.0,alpha:1.0),accent_purple:(red:0.40784314,green:0.12941177,blue:0.4862745,alpha:1.0),accent_pink:(red:0.5254902,green:0.015686275,blue:0.22745098,alpha:1.0),accent_indigo:(red:0.18039216,green:0.28627452,blue:0.42745098,alpha:1.0)))
+  primary_container_bg: None
+  secondary_container_bg: None
+  spacing: (space_none:0,space_xxxs:4,space_xxs:8,space_xs:12,space_s:16,space_m:24,space_l:32,space_xl:48,space_xxl:64,space_xxxl:128)
+  success: None
+  text_tint: None
+  warning: None
+  window_hint: None
+
+com.system76.CosmicTheme.Mode:
+  auto_switch: false
+  is_dark: true
+
+com.system76.CosmicTk:
+  apply_theme_global: true
+  icon_theme: "Papirus"
+  interface_font: |
+    (
+        family: "Inter",
+        weight: Normal,
+        stretch: Normal,
+        style: Normal,
+    )
+  monospace_font: |
+    (
+        family: "Noto Sans Mono",
+        weight: Normal,
+        stretch: Normal,
+        style: Normal,
+    )

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -1,0 +1,327 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.ghaf.graphics.cosmic;
+
+  inherit (import ../../../../lib/launcher.nix { inherit pkgs lib; }) rmDesktopEntries;
+
+  ghaf-powercontrol = pkgs.ghaf-powercontrol.override { ghafConfig = config.ghaf; };
+
+  ghaf-cosmic-config = import ./config/cosmic-config.nix {
+    inherit lib pkgs;
+  };
+
+  autostart = pkgs.writeShellApplication {
+    name = "autostart";
+
+    runtimeInputs = [
+      pkgs.systemd
+      pkgs.dbus
+      pkgs.glib
+    ];
+
+    text = ''
+      mkdir -p "$XDG_CONFIG_HOME/gtk-3.0" "$XDG_CONFIG_HOME/gtk-4.0"
+      [ ! -f "$XDG_CONFIG_HOME/gtk-3.0/settings.ini" ] && echo -ne "${gtk-settings}" > "$XDG_CONFIG_HOME/gtk-3.0/settings.ini"
+      [ ! -f "$XDG_CONFIG_HOME/gtk-4.0/settings.ini" ] && echo -ne "${gtk-settings}" > "$XDG_CONFIG_HOME/gtk-4.0/settings.ini"
+    '';
+  };
+
+  # Change papirus folder icons to grey
+  papirus-icon-theme-grey = pkgs.papirus-icon-theme.override {
+    color = "grey";
+  };
+
+  swayidleConfig = ''
+    timeout ${
+      toString (builtins.floor (300 * 0.8))
+    } 'notify-send -a System -u normal -t 10000 -i system "Automatic suspend" "The system will suspend soon due to inactivity."; brightnessctl -q -s; brightnessctl -q -m | { IFS=',' read -r _ _ _ brightness _ && [ "''${brightness%\%}" -le 25 ] || brightnessctl -q set 25% ;}' resume "brightnessctl -q -r || brightnessctl -q set 100%"
+    timeout ${toString 300} "loginctl lock-session" resume "brightnessctl -q -r || brightnessctl -q set 100%"
+    timeout ${toString (builtins.floor (300 * 1.5))} "wlopm --off \*" resume "wlopm --on \*"
+    timeout ${toString (builtins.floor (300 * 3))} "ghaf-powercontrol suspend"
+    after-resume "wlopm --on \*; brightnessctl -q -r || brightnessctl -q set 100%"
+    unlock "brightnessctl -q -r || brightnessctl -q set 100%"
+  '';
+
+  gtk-settings = ''
+    [Settings]
+    gtk-application-prefer-dark-theme=1
+    gtk-icon-theme-name=Papirus
+    gtk-cursor-theme-name=Pop
+    gtk-cursor-theme-size=24
+    gtk-button-images=1
+    gtk-menu-images=1
+    gtk-enable-event-sounds=1
+    gtk-enable-input-feedback-sounds=1
+    gtk-xft-antialias=1
+    gtk-xft-hinting=1
+    gtk-xft-hintstyle=hintslight
+    gtk-xft-rgba=rgb
+  '';
+
+in
+{
+  options.ghaf.graphics.cosmic = {
+    enable = lib.mkEnableOption "cosmic";
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.desktopManager.cosmic.enable = true;
+    services.displayManager.cosmic-greeter.enable = true;
+
+    # Login is handled by cosmic-greeter
+    ghaf.graphics.login-manager.enable = false;
+
+    # Override default power controls with ghaf-powercontrol
+    ghaf.graphics.power-manager.enable = true;
+
+    environment = {
+      systemPackages =
+        with pkgs;
+        [
+          papirus-icon-theme-grey
+          adwaita-icon-theme
+          pamixer
+          (import ../launchers-pkg.nix { inherit pkgs config; })
+          # Nix's evaluation order installs ghaf-cosmic-config after cosmic tools.
+          # Installing it before the cosmic tools would result in its configuration being overridden
+          # by the default configurations of the cosmic tools.
+          # If this behavior changes in the future, overlays for the relevant cosmic packages
+          # must be added to nixpkgs.overlays to enforce the desired configuration precedence.
+          ghaf-cosmic-config
+        ]
+        ++ (rmDesktopEntries [ ]);
+      sessionVariables = {
+        XDG_CONFIG_HOME = "$HOME/.config";
+        XDG_DATA_HOME = "$HOME/.local/share";
+        XDG_STATE_HOME = "$HOME/.local/state";
+        XDG_CACHE_HOME = "$HOME/.cache";
+        XDG_PICTURES_DIR = "$HOME/Pictures";
+        XDG_VIDEOS_DIR = "$HOME/Videos";
+        PULSE_SERVER = "audio-vm:${toString config.ghaf.services.audio.pulseaudioTcpControlPort}";
+        XCURSOR_THEME = "Pop";
+        XCURSOR_SIZE = 24;
+        GSETTINGS_SCHEMA_DIR = "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}/glib-2.0/schemas";
+        # Enable zwlr_data_control_manager_v1 protocol for COSMIC Utilities - Clipboard Manager to work
+        COSMIC_DATA_CONTROL_ENABLED = 1;
+      };
+      etc."xdg/user-dirs.defaults".text = ''
+        #DOWNLOAD=Downloads
+        #DOCUMENTS=Documents
+        #MUSIC=Music
+        #PICTURES=Pictures
+        #VIDEOS=Videos
+        #PUBLICSHARE=Public
+        #TEMPLATES=Templates
+        #DESKTOP=Desktop
+      '';
+      etc."swayidle/config".text = swayidleConfig;
+    };
+
+    # Needed for the greeter to query systemd-homed users correctly
+    systemd.services.cosmic-greeter-daemon.environment.LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [
+      pkgs.systemd
+    ]}";
+
+    security.pam.services = {
+      cosmic-greeter.rules.auth = {
+        systemd_home.order = 11399; # Re-order to allow either password _or_ fingerprint
+        fprintd.args = [ "maxtries=3" ];
+      };
+      greetd = {
+        fprintAuth = false; # User needs to enter password to decrypt home
+        rules = {
+          account.group_video = {
+            enable = true;
+            control = "requisite";
+            modulePath = "${pkgs.linux-pam}/lib/security/pam_succeed_if.so";
+            order = 10000;
+            args = [
+              "user"
+              "ingroup"
+              "video"
+            ];
+          };
+        };
+      };
+    };
+
+    services = {
+      greetd = {
+        enable = true;
+        settings.default_session =
+          let
+            greeter-autostart = pkgs.writeShellApplication {
+              name = "greeter-autostart";
+              runtimeInputs = [
+                pkgs.cosmic-comp
+                pkgs.cosmic-greeter
+                pkgs.brightnessctl
+              ];
+              text = ''
+                brightnessctl set 100%
+                cosmic-comp cosmic-greeter
+              '';
+            };
+          in
+          {
+            command = lib.mkForce ''${lib.getExe' pkgs.coreutils "env"} XCURSOR_THEME="''${XCURSOR_THEME:-Pop}" systemd-cat -t cosmic-greeter ${lib.getExe greeter-autostart}'';
+          };
+      };
+
+      seatd = {
+        enable = true;
+        group = "video";
+      };
+
+      # Allow video group to change brightness
+      udev.extraRules = ''
+        ACTION=="add", SUBSYSTEM=="backlight", RUN+="${pkgs.coreutils}/bin/chgrp video $sys$devpath/brightness", RUN+="${pkgs.coreutils}/bin/chmod a+w $sys$devpath/brightness"
+      '';
+    };
+
+    users.users.cosmic-greeter.extraGroups = [ "video" ];
+
+    systemd.user.services = {
+      autostart = {
+        enable = true;
+        description = "Ghaf autostart";
+        serviceConfig.ExecStart = "${lib.getExe autostart}";
+        partOf = [ "cosmic-session.target" ];
+        wantedBy = [ "cosmic-session.target" ];
+      };
+
+      audio-control = {
+        enable = true;
+        description = "Audio Control application";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "5";
+          ExecStart = ''
+            ${lib.getExe' pkgs.ghaf-audio-control "GhafAudioControlStandalone"} --pulseaudio_server=audio-vm:${toString config.ghaf.services.audio.pulseaudioTcpControlPort} --deamon_mode=true --indicator_icon_name=adjustlevels
+          '';
+        };
+        partOf = [ "cosmic-session.target" ];
+        wantedBy = [ "cosmic-session.target" ];
+      };
+
+      # Disable XDG autostart nm-applet, replace with our own service
+      "app-nm\\x2dapplet@autostart" = {
+        enable = false;
+      };
+
+      nm-applet = {
+        enable = true;
+        description = "Network Manager Applet";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "1";
+          Environment = "DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/dbusproxy_net.sock";
+          ExecStart = ''
+            ${lib.getExe' pkgs.networkmanagerapplet "nm-applet"} --indicator
+          '';
+        };
+        partOf = [ "cosmic-session.target" ];
+        wantedBy = [ "cosmic-session.target" ];
+      };
+
+      # We use existing blueman services and create overrides for both
+      blueman-applet = {
+        enable = true;
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "1";
+          ExecStart = [
+            ""
+            "${lib.getExe pkgs.bt-launcher} applet"
+          ];
+        };
+        partOf = [ "cosmic-session.target" ];
+        wantedBy = [ "cosmic-session.target" ];
+      };
+
+      blueman-manager = {
+        enable = true;
+        serviceConfig.ExecStart = [
+          ""
+          "${lib.getExe pkgs.bt-launcher}"
+        ];
+      };
+
+      swayidle = {
+        enable = true;
+        description = "Ghaf system idle handler";
+        path = with pkgs; [
+          brightnessctl
+          systemd
+          wlopm
+          ghaf-powercontrol
+          libnotify
+        ];
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${lib.getExe pkgs.swayidle} -w -C /etc/swayidle/config";
+        };
+        partOf = [ "ghaf-session.target" ];
+        wantedBy = [ "ghaf-session.target" ];
+      };
+    };
+
+    systemd.user.targets.ghaf-session = {
+      enable = true;
+      description = "Ghaf graphical session";
+      bindsTo = [ "cosmic-session.target" ];
+      after = [ "cosmic-session.target" ];
+      wantedBy = [ "cosmic-session.target" ];
+    };
+
+    # cosmic-ghaf - our own cosmic dconf profile
+    programs.dconf = {
+      enable = true;
+      profiles.cosmic-ghaf = {
+        databases = [
+          {
+            lockAll = false;
+            settings = {
+              "org/gnome/desktop/interface" = {
+                color-scheme = "prefer-dark";
+                cursor-theme = "Pop";
+                icon-theme = "Papirus";
+                clock-format = "24h";
+              };
+            };
+          }
+        ];
+      };
+    };
+
+    # Following are changes made to default COSMIC configuration done by services.desktopManager.cosmic
+    hardware.bluetooth.enable = lib.mkForce false;
+    # services.acpid.enable = lib.mkForce false;
+    services.gvfs.enable = lib.mkForce false;
+    services.avahi.enable = lib.mkForce false;
+    security.rtkit.enable = lib.mkForce false;
+    services.geoclue2.enable = lib.mkForce false;
+    networking.networkmanager.enable = lib.mkForce false;
+    services.gnome.gnome-keyring.enable = lib.mkForce false;
+    # services.upower.enable = lib.mkForce false;
+    services.pipewire.enable = lib.mkForce false;
+    services.playerctld.enable = true;
+    # Fails to replace adwaita cursor with Pop/Cosmic
+    # TODO: Investigate further
+    xdg.icons.fallbackCursorThemes = lib.mkDefault [
+      "Pop"
+      "Cosmic"
+      "Adwaita"
+    ];
+  };
+}

--- a/modules/desktop/graphics/default.nix
+++ b/modules/desktop/graphics/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./labwc.nix
     ./labwc.config.nix
+    ./cosmic
     ./launchers.nix
     ./ewwbar.nix
     ./fonts.nix

--- a/modules/desktop/graphics/fonts.nix
+++ b/modules/desktop/graphics/fonts.nix
@@ -7,14 +7,22 @@
   ...
 }:
 let
-  inherit (config.ghaf.graphics) labwc;
+  inherit (config.ghaf.graphics) labwc cosmic;
 in
 {
-  config = lib.mkIf labwc.enable {
-    fonts.packages = [
-      pkgs.inter
-      pkgs.nerd-fonts.fira-code
-      pkgs.hack-font
-    ];
+  config = lib.mkIf (labwc.enable || cosmic.enable) {
+    fonts.packages =
+      [
+        pkgs.inter
+      ]
+      ++ (
+        if labwc.enable then
+          [
+            pkgs.nerd-fonts.fira-code
+            pkgs.hack-font
+          ]
+        else
+          [ ]
+      );
   };
 }

--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -51,9 +51,8 @@ let
         # - On Wayland, GTK+ is known for not picking themes from settings.ini.
         # - We define GTK+ theme on Wayland using gsettings (e.g., `gsettings set org.gnome.desktop.interface ...`).
         mkdir -p "$XDG_CONFIG_HOME/gtk-3.0" "$XDG_CONFIG_HOME/gtk-4.0"
-
-        echo -e "${gtk-settings}" > "$XDG_CONFIG_HOME/gtk-3.0/settings.ini"
-        echo -e "${gtk-settings}" > "$XDG_CONFIG_HOME/gtk-4.0/settings.ini"
+        [ ! -f "$XDG_CONFIG_HOME/gtk-3.0/settings.ini" ] && echo -ne "${gtk-settings}" > "$XDG_CONFIG_HOME/gtk-3.0/settings.ini"
+        [ ! -f "$XDG_CONFIG_HOME/gtk-4.0/settings.ini" ] && echo -ne "${gtk-settings}" > "$XDG_CONFIG_HOME/gtk-4.0/settings.ini"
       ''
       + cfg.extraAutostart;
   };

--- a/modules/desktop/graphics/labwc.nix
+++ b/modules/desktop/graphics/labwc.nix
@@ -199,7 +199,7 @@ in
 
     systemd.user.targets.ghaf-session = {
       enable = true;
-      description = "Ghaf labwc session";
+      description = "Ghaf graphical session";
       unitConfig = {
         BindsTo = [ "graphical-session.target" ];
         After = [ "graphical-session-pre.target" ];

--- a/modules/microvm/common/waypipe.nix
+++ b/modules/microvm/common/waypipe.nix
@@ -106,10 +106,20 @@ in
           Restart = "always";
           RestartSec = "1";
           ExecStart =
-            if cfg.serverSocketPath != null then
-              "${pkgs.waypipe}/bin/waypipe --secctx \"${cfg.vm.name}\" ${waypipeBorder} -s ${cfg.serverSocketPath} client"
-            else
-              "${pkgs.waypipe}/bin/waypipe --vsock --secctx \"${cfg.vm.name}\" ${waypipeBorder} -s ${toString waypipePort} client";
+            let
+              titlePrefix = lib.optionalString (
+                config.ghaf.profiles.graphics.compositor == "cosmic"
+              ) ''--title-prefix "[${cfg.vm.name}-vm] "'';
+              secctx = "--secctx \"${cfg.vm.name}\"";
+              socketPath =
+                if cfg.serverSocketPath != null then
+                  "-s ${cfg.serverSocketPath} client"
+                else
+                  "--vsock -s ${toString waypipePort} client";
+            in
+            ''
+              ${pkgs.waypipe}/bin/waypipe ${titlePrefix} ${secctx} ${waypipeBorder} ${socketPath}
+            '';
         };
         startLimitIntervalSec = 0;
         partOf = [ "ghaf-session.target" ];

--- a/modules/microvm/host/shared-mem.nix
+++ b/modules/microvm/host/shared-mem.nix
@@ -218,13 +218,13 @@ in
                         {
                           enable = true;
                           description = "memsocket";
-                          after = [ "labwc.service" ];
                           serviceConfig = {
                             Type = "simple";
                             ExecStart = "${memsocket}/bin/memsocket -c ${cfg.clientSocketPath}";
                             Restart = "always";
                             RestartSec = "1";
                           };
+                          after = [ "ghaf-session.target" ];
                           wantedBy = [ "ghaf-session.target" ];
                         }
                       else

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -124,7 +124,7 @@ let
             services = {
               disks = {
                 enable = true;
-                fileManager = "${pkgs.pcmanfm}/bin/pcmanfm";
+                fileManager = lib.mkIf config.ghaf.graphics.labwc.enable "${pkgs.pcmanfm}/bin/pcmanfm";
               };
             };
             xdgitems.enable = true;
@@ -171,9 +171,14 @@ let
               '';
             };
 
-            # Suspend inside Qemu causes segfault
-            # See: https://gitlab.com/qemu-project/qemu/-/issues/2321
-            logind.lidSwitch = "ignore";
+            logind = {
+              lidSwitch = "ignore";
+              killUserProcesses = true;
+              extraConfig = ''
+                IdleAction=lock
+                UserStopDelaySec=0
+              '';
+            };
 
             # We dont enable services.blueman because it adds blueman desktop entry
             dbus.packages = [ pkgs.blueman ];

--- a/modules/profiles/graphics.nix
+++ b/modules/profiles/graphics.nix
@@ -9,7 +9,10 @@
 }:
 let
   cfg = config.ghaf.profiles.graphics;
-  compositors = [ "labwc" ];
+  compositors = [
+    "labwc"
+    "cosmic"
+  ];
   renderers = [
     "vulkan"
     "pixman"
@@ -93,6 +96,7 @@ in
     ghaf.graphics = {
       labwc.enable = cfg.compositor == "labwc";
       labwc.autolock.enable = cfg.idleManagement.enable;
+      cosmic.enable = cfg.compositor == "cosmic";
     };
   };
 }

--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -92,6 +92,15 @@
           ];
         }
         {
+          name = "Video Editor";
+          description = "Losslesscut Video Editor";
+          packages = [ pkgs.losslesscut-bin ];
+          icon = "losslesscut";
+          command = "losslesscut --enable-features=UseOzonePlatform --ozone-platform=wayland";
+        }
+      ]
+      ++ lib.optionals (config.ghaf.profiles.graphics.compositor != "cosmic") [
+        {
           name = "Text Editor";
           description = "Simple Text Editor";
           packages =
@@ -124,13 +133,6 @@
           packages = [ pkgs.xarchiver ];
           icon = "xarchiver";
           command = "xarchiver";
-        }
-        {
-          name = "Video Editor";
-          description = "Losslesscut Video Editor";
-          packages = [ pkgs.losslesscut-bin ];
-          icon = "losslesscut";
-          command = "losslesscut --enable-features=UseOzonePlatform --ozone-platform=wayland";
         }
       ];
     extraModules = [

--- a/modules/reference/desktop/applications.nix
+++ b/modules/reference/desktop/applications.nix
@@ -32,13 +32,6 @@ in
         }
 
         {
-          name = "File Manager";
-          description = "Organize & Manage Files";
-          icon = "system-file-manager";
-          command = "${pkgs.pcmanfm}/bin/pcmanfm";
-        }
-
-        {
           name = "Bluetooth Settings";
           description = "Manage Bluetooth Devices & Settings";
           icon = "bluetooth-48";
@@ -46,10 +39,18 @@ in
         }
 
         {
-          name = "Control Panel";
-          description = "Control Panel";
+          name = "Ghaf Control Panel";
+          description = "Ghaf Control Panel";
           icon = "utilities-tweak-tool";
           command = "${pkgs.ctrl-panel}/bin/ctrl-panel ${config.ghaf.givc.cliArgs}";
+        }
+      ]
+      ++ lib.optionals (config.ghaf.profiles.graphics.compositor != "cosmic") [
+        {
+          name = "File Manager";
+          description = "Organize & Manage Files";
+          icon = "system-file-manager";
+          command = "${pkgs.pcmanfm}/bin/pcmanfm";
         }
       ]
       ++ lib.optionals config.ghaf.reference.services.alpaca-ollama [

--- a/overlays/custom-packages/cosmic/cosmic-applets/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-applets/default.nix
@@ -1,0 +1,14 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# Add DBUS proxy socket for audio, network, and Bluetooth applets
+# Ref: https://github.com/pop-os/cosmic-applets
+{ prev }:
+prev.cosmic-applets.overrideAttrs (oldAttrs: {
+  postInstall =
+    oldAttrs.postInstall or ""
+    + ''
+      sed -i 's|^Exec=.*|Exec=env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/dbusproxy_net.sock cosmic-applet-network|' $out/share/applications/com.system76.CosmicAppletNetwork.desktop
+      sed -i 's|^Exec=.*|Exec=env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/dbusproxy_snd.sock cosmic-applet-audio|' $out/share/applications/com.system76.CosmicAppletAudio.desktop
+      sed -i 's|^Exec=.*|Exec=env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/dbusproxy_snd.sock cosmic-applet-bluetooth|' $out/share/applications/com.system76.CosmicAppletBluetooth.desktop
+    '';
+})

--- a/overlays/custom-packages/cosmic/cosmic-greeter/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-greeter/default.nix
@@ -1,0 +1,12 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# Disable network manager in cosmic-greeter
+# Ref: https://github.com/pop-os/cosmic-greeter/blob/master/Cargo.toml
+{ prev }:
+prev.cosmic-greeter.overrideAttrs (oldAttrs: {
+  cargoBuildFlags = (oldAttrs.cargoBuildFlags or [ ]) ++ [
+    "--no-default-features"
+    "--features"
+    "logind,upower"
+  ];
+})

--- a/overlays/custom-packages/cosmic/cosmic-session/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-session/default.nix
@@ -1,0 +1,10 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# Change the cosmic-session DCONF_PROFILE var to cosmic-ghaf
+# Ref: https://github.com/pop-os/cosmic-session/blob/master/Justfile
+{ prev }:
+prev.cosmic-session.overrideAttrs (oldAttrs: {
+  justFlags = builtins.map (
+    flag: if flag == "cosmic" then "cosmic-ghaf" else flag
+  ) oldAttrs.justFlags;
+})

--- a/overlays/custom-packages/cosmic/cosmic-settings/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-settings/default.nix
@@ -1,0 +1,13 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# Disable certain settings pages in cosmic-settings
+# Disabled pages: page-power, page-sound, page-users, page-display, page-legacy-applications
+# Ref: https://github.com/pop-os/cosmic-settings/blob/master/cosmic-settings/Cargo.toml
+{ prev }:
+prev.cosmic-settings.overrideAttrs (oldAttrs: {
+  cargoBuildFlags = (oldAttrs.cargoBuildFlags or [ ]) ++ [
+    "--no-default-features"
+    "--features"
+    "a11y,dbus-config,single-instance,wgpu,page-accessibility,page-about,page-bluetooth,page-date,page-default-apps,page-input,page-networking,page-region,page-window-management,page-workspaces,xdg-portal,wayland"
+  ];
+})

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -12,4 +12,8 @@
   tpm2-pkcs11 = import ./tpm2-pkcs11 { inherit prev; };
   papirus-icon-theme = import ./papirus-icon-theme { inherit prev; };
   libfm = import ./libfm { inherit prev; };
+  cosmic-applets = import ./cosmic/cosmic-applets { inherit prev; };
+  cosmic-greeter = import ./cosmic/cosmic-greeter { inherit prev; };
+  cosmic-session = import ./cosmic/cosmic-session { inherit prev; };
+  cosmic-settings = import ./cosmic/cosmic-settings { inherit prev; };
 })

--- a/packages/ghaf-powercontrol/package.nix
+++ b/packages/ghaf-powercontrol/package.nix
@@ -60,6 +60,7 @@ writeShellApplication {
 
       # Try wlopm without setting WAYLAND_DISPLAY first
       if eval "$cmd"; then
+        echo "Displays turned on successfully"
         return 0
       fi
 
@@ -102,12 +103,6 @@ writeShellApplication {
 
             # Switch on display on wakeup
             echo "Wake up detected, turning on displays..."
-            # Wait a little to ensure system is awake
-            sleep 1
-            # Sanity check turn off displays
-            try_toggle_displays false || true
-            # Turn on displays
-            # NOTE: This is a workaround for the issue where the display does not turn on after suspend
             try_toggle_displays true || true
           ''
         else

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -101,6 +101,7 @@ let
                 graphics = {
                   enable = true;
                   renderer = "gles2";
+                  compositor = "labwc";
                   idleManagement.enable = false;
                   # Disable suspend by default, not working as intended
                   allowSuspend = false;


### PR DESCRIPTION
<!--  
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors  
    SPDX-License-Identifier: CC-BY-SA-4.0  
-->

## Description of Changes

This PR introduces COSMIC as a new desktop environment option for Ghaf, replacing LabWC if enabled.
Notable changes:

1. **Integration of COSMIC DE (Alpha 6)** using NixOS options (available in `nixpkgs` as of April 2025).
2. **Dedicated COSMIC Nix configuration** in `cosmic.nix`:
   - Disables certain default features for compatibility with Ghaf.
   - Overrides first-party COSMIC packages to remove unsupported features in Ghaf.
   - Uses `swayidle` instead of COSMIC's idle manager.
3. **Ghaf-COSMIC system-wide desktop configuration** in `cosmic.config.yaml`:
   - `cosmic.config.yaml` is expanded into `/run/current-system/sw/share/cosmic` by `ghaf-cosmic-config` package.
   - Helper script `cosmic-config-to-yaml.sh` available to convert local `.config/cosmic` into YAML format for easier maintenance.
   -  `/run/current-system/sw/share/cosmic` - system default config
      `.config/cosmic` - user config
   - `/run/current-system/sw/share/cosmic` is used as the default config for fresh installations.
     Any changes made by the user after the initial installation will be saved in  `.config/cosmic` and prioritized over system defaults.
     This means the user can install Ghaf, log into Cosmic and proceed to change keybindings, desktop layout, etc. freely.
4. **Replacement of desktop utilities** with COSMIC-native applications:
   - File Manager: `pcmanfm` → `cosmic-files`
   - Archiving: `xarchiver` → context menu in `cosmic-files`
   - Text Editor: `gnome-text-editor` → `cosmic-edit`
   - Terminal: `foot` → `cosmic-term`
   - Screenshot: `grim`, `slurp` → `cosmic-screenshot`
5. **Apps launched via waypipe**:
   - Added VM name prefixes to app title bars to help identify application origin.
   - This is needed because colored app borders are not available in COSMIC at this time.
     For more info see **Known Issues** section. 

### Known Limitations / Issues

- COSMIC does not support forced Server Side Decorations:
  - This is in contrast to LabWC, which supports forcing system title bars and borders for all apps
  - Due to this limitation, the Ghaf-specific colored borders for apps running under different VMs are not supported
  - In an attempt to mitigate this, apps running over waypipe will now have a VM prefix in the title bar (if available) in the following format: `[vm name] <app title>`
    - Some apps have no way of using Server-Side Decorations and may not display the VM prefix in their own titlebar. In this case, users may not be able to tell which VM the app is running under.
- COSMIC does not yet support all common Wayland protocols (e.g. zwlr_virtual_pointer_manager_v1, etc.)
- COSMIC is still in relatively early development, with a Beta release planned some time in 2025.

### Not working
- Sticky Notes app
- Yubikey authentication
- Fingerprint login

### References

- [COSMIC Epoch repository](https://github.com/pop-os/cosmic-epoch)  
- [System76 COSMIC homepage](https://system76.com/cosmic/)  
- [nixos-cosmic flake](https://github.com/lilyinstarlight/nixos-cosmic) (No longer used as of April 2025)

## Related Issues / Tickets

<!-- Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to -->

## Checklist

- [x] Clear summary in PR description  
- [x] Detailed and meaningful commit message(s)  
- [x] Commits are logically organized and squashed if appropriate  
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed  
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/  
- [ ] Author has run `make-checks` and it passes  
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)  
- [x] Author has added reviewers and removed PR draft status  

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`  
- [ ] Orin NX `aarch64`  
- [x] Lenovo X1 `x86_64`  
- [x] Dell Latitude `x86_64`  

### Installation Method
- [x] Requires full re-installation  
- [ ] Can be updated with `nixos-rebuild ... switch`  
- [x] Other:  Can **technically** be updated via `nixos-rebuild ... switch` but not recommended.

### Test Steps To Verify:

https://github.com/kajusnau/ghaf/tree/ghaf-cosmic-enabled can be used.
This branch has cosmic already enabled by default, replacing labwc.

#### COSMIC:
1. Build Ghaf with COSMIC enabled:
```
modules/profiles/graphics.nix
#34: default = "cosmic"
```
2. Boot into Ghaf
3. Verify the desktop environment loads correctly and login works.
4. Confirm the Ghaf COSMIC configuration (`cosmic.config.yaml`) is applied:
   - Ghaf desktop background image visible
   - The application Dock on the bottom of the screen displays only the following items: App Library, File Manager, Terminal, Cosmic Settings.
   - (Optional) For a more thorough check, run the following as the logged in user:
   ```
   tree -l /run/current-system/sw/share/cosmic/ | sed -E "s/(ghaf-cosmic-config)/$(printf '\033[1;31m')\1$(printf '\033[0m')/g"
   ```
   The output should not show any symlinks that **aren't** from `ghaf-cosmic-config` package. 
5. Check functionality of replaced utilities (file manager, terminal, etc.).
6. Feel free to test any other aspects you find relevant or interesting — there are no **mandatory** tests, but all testing is appreciated.

#### LabWC:
1. Build Ghaf with COSMIC disabled (default behavior)
2. Ensure LabWC runs as expected with no regression, notably:
   - Verify udiskie applet works
   - VM name prefixes are **not** added to virtual apps running in LabWC
   - Text Editor, Xarchiver, and File Manager apps are available as before