### PR TITLE
Orin NX/AGX: Switch from nvidia bsp 5.15 kernel to upstream 6.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,11 +337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743071390,
-        "narHash": "sha256-rHwJ9EVWg9lf4GSt+EhHhjkRMIsMMsCIAhUFHBdGmc0=",
+        "lastModified": 1743370486,
+        "narHash": "sha256-3/QrkE5ndeTqJOJjv6Z/3W7wStQe/Rxw5IwBoIeU9gQ=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "e6a2a3d19f19843c8fe7ad503da01e0fe91e0f5d",
+        "rev": "6e543867b2d1f429de88275658d7638c67df4389",
         "type": "github"
       },
       "original": {

--- a/modules/reference/hardware/jetpack/0001-ARM-SMMU-drivers-return-always-true-for-IOMMU_CAP_CA.patch
+++ b/modules/reference/hardware/jetpack/0001-ARM-SMMU-drivers-return-always-true-for-IOMMU_CAP_CA.patch
@@ -1,0 +1,51 @@
+From e6aafcc52da833711957a600ab75b0f5064a532c Mon Sep 17 00:00:00 2001
+From: Tanel Dettenborn <tanel@ssrc.tii.ae>
+Date: Wed, 12 Mar 2025 14:37:16 +0200
+Subject: [PATCH] ARM-SMMU drivers return always true for
+ IOMMU_CAP_CACHE_COHERENCY capability
+
+Signed-off-by: Tanel Dettenborn <tanel@ssrc.tii.ae>
+---
+ drivers/iommu/arm/arm-smmu/arm-smmu.c | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/iommu/arm/arm-smmu/arm-smmu.c b/drivers/iommu/arm/arm-smmu/arm-smmu.c
+index 42c5012ba8aa..964cf4131acb 100644
+--- a/drivers/iommu/arm/arm-smmu/arm-smmu.c
++++ b/drivers/iommu/arm/arm-smmu/arm-smmu.c
+@@ -1315,13 +1315,30 @@ static bool arm_smmu_capable(struct device *dev, enum iommu_cap cap)
+ 	switch (cap) {
+ 	case IOMMU_CAP_CACHE_COHERENCY:
+ 		/*
++		 * Start: Original comment and code!
++		 *
+ 		 * It's overwhelmingly the case in practice that when the pagetable
+ 		 * walk interface is connected to a coherent interconnect, all the
+ 		 * translation interfaces are too. Furthermore if the device is
+ 		 * natively coherent, then its translation interface must also be.
++		 *
++		 * return cfg->smmu->features & ARM_SMMU_FEAT_COHERENT_WALK ||
++		 *	 device_get_dma_attr(dev) == DEV_DMA_COHERENT;
++		 *
++		 * End: Original comment and code!
+ 		 */
+-		return cfg->smmu->features & ARM_SMMU_FEAT_COHERENT_WALK ||
+-			device_get_dma_attr(dev) == DEV_DMA_COHERENT;
++
++		/*
++		 * Speicific change (hack) is for Nvidia Orin AGX/NX. Their
++		 * SMMUs does not support SMMU coherent walk and therefore
++		 * vfio-pci passthrough would not work. It requires coherent walk.
++		 * In other words SMMU-node should contain dma-coherent property.
++		 *
++		 * Eventhough NVIDIA SMMU node does not contain dma-coherent then
++		 * returning true for IOMMU_CAP_CACHE_COHERENCY, because it has
++		 * worked *fine*. Obviously it might introduces unseen issues.
++		 */
++		return true;
+ 	case IOMMU_CAP_NOEXEC:
+ 	case IOMMU_CAP_DEFERRED_FLUSH:
+ 		return true;
+-- 
+2.47.2
+

--- a/modules/reference/hardware/jetpack/agx-netvm-wlan-pci-passthrough.nix
+++ b/modules/reference/hardware/jetpack/agx-netvm-wlan-pci-passthrough.nix
@@ -42,6 +42,13 @@ in
       }
     ];
 
+    boot.kernelPatches = [
+      {
+        name = lib.debug.traceVal "vfio-true";
+        patch = ./0001-ARM-SMMU-drivers-return-always-true-for-IOMMU_CAP_CA.patch;
+      }
+    ];
+
     boot.kernelParams = [
       "vfio-pci.ids=10ec:c822,10ec:c82f"
       "vfio_iommu_type1.allow_unsafe_interrupts=1"

--- a/modules/reference/hardware/jetpack/nx-netvm-ethernet-pci-passthrough.nix
+++ b/modules/reference/hardware/jetpack/nx-netvm-ethernet-pci-passthrough.nix
@@ -52,6 +52,13 @@ in
       }
     ];
 
+    boot.kernelPatches = [
+      {
+        name = lib.debug.traceVal "vfio-true";
+        patch = ./0001-ARM-SMMU-drivers-return-always-true-for-IOMMU_CAP_CA.patch;
+      }
+    ];
+
     boot.kernelParams = [
       "vfio-pci.ids=10ec:8168"
       "vfio_iommu_type1.allow_unsafe_interrupts=1"

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -64,6 +64,8 @@ let
                 somType = som;
                 agx.enableNetvmWlanPCIPassthrough = som == "agx";
                 nx.enableNetvmEthernetPCIPassthrough = som == "nx";
+                # Currntly we have mostly xavier nx based carrier boards
+                carrierBoard = if som == "nx" then "xavierNXdevkit" else "devkit";
               };
 
               hardware.nvidia = {


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes
Nvidia Orin NX/AGX currently uses kernel from Nvidia Jetson 36.4.3 BSP. Jetson 36.4.3 BSP support "bring yout own kernel"-feature. In other words it has a support(/guide) for upstream kernel. Pull request introduces following changes:
- Orin NX: Making Xavier NX devkit as a default carrier board.
- Patch for kernel vfio-pci driver (comment in patch).
- _nix flake update jetpack-nixos_:  Contains updates, which relates to kernel 6.6

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [x] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
  - [ ] Tested on Dell Latitude `x86_64`
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
  - [x] AGX
  - [x] NX
  - [ ] x86_64
- [x] Is this a new feature
  - [x] List the test steps to verify:
No specific steps, but everything should work as it has been worked. Only visible change should be host kernel and it should be 6.6.75.
- [ ] If it is an improvement how does it impact existing functionality?
