### PR TITLE
feat: power manager module, refactor ghaf-powercontrol

### DIFF
--- a/modules/desktop/graphics/default.nix
+++ b/modules/desktop/graphics/default.nix
@@ -8,6 +8,7 @@
     ./ewwbar.nix
     ./fonts.nix
     ./login-manager.nix
+    ./power-manager.nix
     ./boot.nix
   ];
 }

--- a/modules/desktop/graphics/power-manager.nix
+++ b/modules/desktop/graphics/power-manager.nix
@@ -1,0 +1,148 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# This module overrides logind power management using ghaf-powercontrol.
+# The specific operations overriden are:
+# - Suspend
+# - Shutdown
+# - Reboot
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.ghaf.graphics.power-manager;
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+    ;
+
+  ghaf-powercontrol = pkgs.ghaf-powercontrol.override { ghafConfig = config.ghaf; };
+
+  logindSuspendListener = pkgs.writeShellApplication {
+    # This listener monitors systemd's suspend signals and delays the suspend process
+    # While the process is delayed, we use ghaf-powercontrol to handle the suspend operation instead
+    # TODO: Investigate if suspension can be cancelled entirely if caught. Some notes on that:
+    # - `--mode=block` does not work, as it will block suspension entirely and no signal will be sent
+    # - `--mode=delay` works, but the system will still suspend after the delay
+    name = "logind-suspend-listener";
+    runtimeInputs = [
+      pkgs.dbus
+      pkgs.systemd
+      ghaf-powercontrol
+    ];
+    text = ''
+      systemd-inhibit --what=sleep --who="ghaf-powercontrol" \
+        --why="Handling ghaf suspend" --mode=delay \
+          dbus-monitor --system "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'" | \
+            while read -r line; do
+              if echo "$line" | grep -q "boolean true"; then
+                echo "Found prepare for sleep signal"
+                echo "Suspending via ghaf-powercontrol"
+                ghaf-powercontrol suspend
+              fi
+            done
+    '';
+  };
+
+  logindShutdownListener = pkgs.writeShellApplication {
+    # This listener monitors systemd's shutdown/reboot signals and delays the process
+    # While the process is delayed, we use ghaf-powercontrol to handle the shutdown/reboot operation instead
+    name = "logind-shutdown-listener";
+    runtimeInputs = [
+      pkgs.dbus
+      pkgs.systemd
+      ghaf-powercontrol
+    ];
+    text = ''
+      systemd-inhibit --what=shutdown --who="ghaf-powercontrol" \
+        --why="Handling ghaf shutdown/reboot" --mode=delay \
+          dbus-monitor --system "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForShutdownWithMetadata'" | \
+            while read -r line; do
+              if echo "$line" | grep -q "boolean true"; then
+                echo "Found prepare for shutdown signal. Checking type..."
+                while read -r subline; do
+                    if echo "$subline" | grep -q "reboot"; then
+                        echo "Found type: reboot"
+                        echo "Rebooting via ghaf-powercontrol"
+                        ghaf-powercontrol reboot
+                    elif echo "$subline" | grep -q "poweroff"; then
+                        echo "Found type: power-off"
+                        echo "Powering off via ghaf-powercontrol"
+                        ghaf-powercontrol poweroff
+                    fi
+                done
+              fi
+            done
+    '';
+  };
+in
+{
+  options.ghaf.graphics.power-manager = {
+    enable = mkOption {
+      description = ''
+        Override logind power management using ghaf-powercontrol
+      '';
+      type = types.bool;
+      default = false;
+    };
+    enableSuspendListener = mkOption {
+      description = ''
+        Enable the suspend signal listener service
+      '';
+      type = types.bool;
+      default = true;
+    };
+
+    enableShutdownListener = mkOption {
+      description = ''
+        Enable the shutdown/reboot signal listener service
+      '';
+      type = types.bool;
+      default = true;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services = {
+      logind-shutdown-listener = mkIf cfg.enableShutdownListener {
+        enable = true;
+        description = "Ghaf logind shutdown listener";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "5";
+          ExecStart = "${lib.getExe logindShutdownListener}";
+        };
+        partOf = [ "graphical.target" ];
+        wantedBy = [ "graphical.target" ];
+      };
+
+      logind-suspend-listener = mkIf cfg.enableSuspendListener {
+        # Currently system continues to suspend even after ghaf-powercontrol suspend is called
+        # If running on host:
+        #   - Might result in two suspension requests in a row
+        # If running on VM:
+        #   - Will result in `ghaf-powercontrol suspend` first. If woken up see next point
+        #   - Will result in a non-functional VM suspend, which gets cancelled almost immediately
+        #   - End result - System suspends, wakes up, attempts to suspend again but wakes up immediately
+        # NOTE:
+        # As a system service, this will run as root
+        # This means ghaf-powercontrol will run as root and therefore fail to
+        # find and turn off the display as part of the suspension procedures
+        enable = true;
+        description = "Ghaf logind suspend listener";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "5";
+          ExecStart = "${lib.getExe logindSuspendListener}";
+        };
+        partOf = [ "graphical.target" ];
+        wantedBy = [ "graphical.target" ];
+      };
+    };
+  };
+}

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -102,6 +102,8 @@ let
                   enable = true;
                   renderer = "gles2";
                   idleManagement.enable = false;
+                  # Disable suspend by default, not working as intended
+                  allowSuspend = false;
                 };
                 release.enable = variant == "release";
                 debug.enable = variant == "debug";


### PR DESCRIPTION
This PR introduces a new `power-manager` module to override default logind power management and refactors `ghaf-powercontrol` for improved functionality and robustness.

<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

**1. Add power-manager module:**
   - Implement suspend signal interception and handling.
   - Implement shutdown/reboot signal interception and handling.
   - Suspend and shutdown/reboot listener services can be enabled individually through nix options.
   - Use `ghaf-powercontrol` to override power state management.

The power-manager module provides better control over system power management by intercepting logind signals and using `ghaf-powercontrol` for custom handling of suspend, shutdown, and reboot operations.
With this module enabled, the user should be able to simply call `systemctl suspend/poweroff/reboot`, regardless of whether the DE is running on the host or in a VM.
This module is expected to be first used in COSMIC (#1104)
This PR also reduces the scope of the COSMIC PR.

**2. Refactor ghaf-powercontrol:**
   - Refactor to handle any Wayland compositor by iterating over available `wayland-[0-9]` sockets.
   - Fix premature exit during suspend if `wlopm` fails.

## Known issues/Notes using `power-manager` module:
- Suspension limitations:
  - Currently, the system continues to suspend even after `ghaf-powercontrol suspend` is called.
  - If running on a host:
    - This might result in two suspension requests in a row.
  - If running on a VM:
    - `ghaf-powercontrol suspend` will execute first, then, if woken up by the user:
    - a non-functional VM suspend, which gets cancelled almost immediately
    - The end result is that the system suspends, and, if woken up by the user, attempts to suspend again, but wakes up immediately.
- Root execution:
  - `power-manager` module adds system services which run as root.
  - This means `ghaf-powercontrol`, which is called by these services, will also run as root, which may cause it to fail to find and turn off the display as part of the suspension procedures.
  This might result in the display showing a static image while the system is suspended

## Testing instructions
As power-manager is not enabled by default, only `ghaf-powercontrol` is affected by this PR. Therefore testing should:
1. Verify no regression can be observed in power control behavior:
   - Suspend, shutdown, and reboot all function as before wherever `ghaf-powercontrol` is used (e.g. LabWC ewwbar, swayidle autosuspend, etc.)

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Lenovo X1 `x86_64`
  - [ ] Tested on Jetson Orin NX or AGX `aarch64`
  - [ ] Tested on Polarfire `riscv64`
  - [ ] Tested on Dell Latitude `x86_64`
- [ ] Author has run `make-checks` and it passes
- [x] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [x] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
  - [x] AGX
  - [x] NX
  - [x] x86_64
- [x] Is this a new feature
  - [ ] List the test steps to verify:
- [x] If it is an improvement how does it impact existing functionality?
  - Minor bugfix in `ghaf-powercontrol`
