### PR TITLE
vhotplug: Enable type-c display for x86_64 variants

### DIFF
--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -47,6 +47,10 @@ let
           subclass = 6;
           description = "Mass Storage - SCSI (USB drives)";
         }
+        {
+          class = 17;
+          description = "USB-C alternate modes supported by device";
+        }
       ];
       evdevPassthrough = {
         enable = cfg.enableEvdevPassthrough;

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
@@ -93,6 +93,8 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "46aa";
+        # opregion is required for type-c display to work
+        qemu.deviceExtraArgs = "x-igd-opregion=on";
         # Detected kernel driver: i915
         # Detected kernel modules: i915
       }

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-71.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-71.nix
@@ -94,6 +94,8 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "9a49";
+        # opregion is required for type-c display to work
+        qemu.deviceExtraArgs = "x-igd-opregion=on";
         # Detected kernel driver: i915
         # Detected kernel modules: i915
       }

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-72.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-72.nix
@@ -94,6 +94,8 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "9a49";
+        # opregion is required for type-c display to work
+        qemu.deviceExtraArgs = "x-igd-opregion=on";
         # Detected kernel driver: i915
         # Detected kernel modules: i915
       }

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -77,6 +77,8 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "46a6";
+        # opregion is required for type-c display to work
+        qemu.deviceExtraArgs = "x-igd-opregion=on";
       }
     ];
     kernelConfig = {

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -84,6 +84,8 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "a7a1";
+        # opregion is required for type-c display to work
+        qemu.deviceExtraArgs = "x-igd-opregion=on";
       }
     ];
     kernelConfig = {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
We need to pass usb class to vhotplug and opregion to gui-vm so that it can detect type-c display.

As we are doing GPU pasthrough to `gui-vm` qemu we need pass video BIOS table (VBT) info from UEFI to
`gui-vm` qemu for which qemu need to access `x-igd-opregion` memory region, hence enabling the same.

More details https://github.com/qemu/qemu/blob/master/docs/igd-assign.txt

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Type C display on Lenovo X1 and Dell Latitude should work with this change.
