### PR TITLE
Dell 7230 wrong pointing devices and guivm fix

### DIFF
--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -76,7 +76,7 @@ let
               withResolved = true;
               withTimesyncd = true;
               withDebug = config.ghaf.profiles.debug.enable;
-              withHardenedConfigs = true;
+              withHardenedConfigs = false;
             };
 
             givc.guivm.enable = true;

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
@@ -32,7 +32,6 @@
       ];
       evdev = [
         "/dev/mouse0"
-        "/dev/mouse1"
       ];
     };
 
@@ -43,7 +42,6 @@
         "EETI8082:00 0EEF:C004 Stylus"
       ];
       evdev = [
-        "/dev/touchpad0"
         "/dev/touchpad1"
         "/dev/touchpad2"
       ];


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
The Dell Lattitude 7230 tablet is not working as a target and the system fails to display the graphical screen. Examined the issue and noticed four major issues: 

1. /dev/mouse1 is not available, can't passthrough
2. /dev/touchpad0 is not available, can't passthrough
3. GUI VM Storage not accessible /persist/storage/homes/gui-vm-home.img owned by nscd:kvm  -> Change to microvm:kvm skipped this error
4. /persist/storage/homes fail to have net-vm-home.img and other vm images.

Solution for these are 
1. Remove the device
2. Remove the device
3. Due to hardened config
4. Due to hardened config

The first two are fixed in this PR. Unfortunately the 3rd and 4th issues are related to systemd.withHardenedConfigs being enabled. We will set systemd.withHardenedConfigs to false. But **gui_vm needs to be checked in detail for systemd.withHardenedConfigs for a better fix**. 

### Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets
https://jira.tii.ae/browse/SSRCSP-6461

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [X] Dell Latitude `x86_64`

### Installation Method
- [X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Follow build instructions of Lenovo Lattitude 7230 tablet target to build image
2. Boot the device with that image
3. Ghaf boots up with graphical interface and functioning normally