### PR TITLE
firefox: Make in to a reference program

### DIFF
--- a/modules/desktop/nvidia-gpu/vaapi.nix
+++ b/modules/desktop/nvidia-gpu/vaapi.nix
@@ -37,7 +37,6 @@ in
         experiment.
 
       '';
-
     };
 
     maxInstances = lib.mkOption {
@@ -48,31 +47,6 @@ in
 
         Sometimes useful for graphics cards with little VRAM.
       '';
-    };
-
-    # TODO: Add the same for the chrome browser
-    firefox = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = config.programs.firefox.enable;
-        description = ''
-          Configure Firefox to used the vaapi driver for video decoding.
-
-          Note that this requires disabling the [RDD
-          sandbox](https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html#data-decoder-rdd-process).
-        '';
-      };
-
-      av1Support = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to enable av1 support.
-
-          This will not work on Turing (e.g. Geforce 2xxx) and
-          earlier, and is therefore disabled by default there.
-        '';
-      };
     };
   };
 
@@ -85,23 +59,11 @@ in
           NVD_BACKEND = "direct";
           LIBVA_DRIVER_NAME = "nvidia";
         }
-        // lib.optionalAttrs (cfg.maxInstances != null) { NVD_MAX_INSTANCES = toString cfg.maxInstances; }
-        // lib.optionalAttrs cfg.firefox.enable { MOZ_DISABLE_RDD_SANDBOX = "1"; };
+        // lib.optionalAttrs (cfg.maxInstances != null) { NVD_MAX_INSTANCES = toString cfg.maxInstances; };
     };
 
     hardware.graphics.extraPackages = [
       pkgs.nvidia-vaapi-driver
     ];
-
-    programs.firefox.preferences = lib.mkIf cfg.firefox.enable {
-      "media.ffmpeg.vaapi.enabled" = true;
-      "media.rdd-ffmpeg.enabled" = true;
-      "media.av1.enabled" = cfg.firefox.av1Support;
-      #TODO: enable when the 137 release notes show which flags to show
-      #"media.hevc.enabled" = true;
-      #"dom.media.webcodecs.h265.enabled" = true;
-      "gfx.x11-egl.force-enabled" = true;
-      "widget.dmabuf.force-enabled" = true;
-    };
   };
 }

--- a/modules/reference/programs/default.nix
+++ b/modules/reference/programs/default.nix
@@ -7,5 +7,6 @@
     ./google-chrome.nix
     ./windows-launcher.nix
     ./element-desktop.nix
+    ./firefox.nix
   ];
 }

--- a/modules/reference/programs/firefox.nix
+++ b/modules/reference/programs/firefox.nix
@@ -1,0 +1,44 @@
+# Copyright 2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.ghaf.reference.programs.firefox;
+in
+{
+  options.ghaf.reference.programs.firefox = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = config.programs.firefox.enable;
+      description = ''
+        Configure Firefox to used the vaapi driver for video decoding.
+
+        Note that this requires disabling the [RDD
+        sandbox](https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html#data-decoder-rdd-process).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.firefox.preferences = lib.mkIf cfg.firefox.enable {
+      "media.ffmpeg.vaapi.enabled" = true;
+      "media.rdd-ffmpeg.enabled" = true;
+      "media.av1.enabled" = true;
+      "media.hevc.enabled" = true;
+      "dom.media.webcodecs.h265.enabled" = true;
+      "gfx.x11-egl.force-enabled" = true;
+      "widget.dmabuf.force-enabled" = true;
+      "gfx.webrender.all" = true;
+      "media.hrdware-video-decoding.force-enabled" = true;
+    };
+
+    # Disable the RDD sandbox
+    # See https://firefox-source-docs.mozilla.org/dom/ipc/process_model.html#data-decoder-rdd-process
+    environment.variables = {
+      MOZ_DISABLE_RDD_SANDBOX = "1";
+    };
+  };
+}


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Move from the Nvidia namespace to the reference programs, allows the settings to be shared across different GPU families.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
