### PR TITLE
Update vhotplug to fix issues with multiple devices with the same VID/PID

### DIFF
--- a/overlays/custom-packages/qemu/default.nix
+++ b/overlays/custom-packages/qemu/default.nix
@@ -15,6 +15,7 @@ prev.qemu_kvm.overrideAttrs (
     patches = prev.patches ++ [
       ./acpi-devices-passthrough-qemu-8.1.patch
       ./0001-ivshmem-flat-memory-support.patch
+      ./usb-host-enable-autoscan-for-bus-addr.patch
     ];
   })
   // {

--- a/overlays/custom-packages/qemu/usb-host-enable-autoscan-for-bus-addr.patch
+++ b/overlays/custom-packages/qemu/usb-host-enable-autoscan-for-bus-addr.patch
@@ -1,0 +1,46 @@
+From 88687c9939c5d744b1f7224d77943099b659ab17 Mon Sep 17 00:00:00 2001
+From: Yuri Nesterov <yuriy.nesterov@unikie.com>
+Date: Wed, 9 Apr 2025 22:24:52 +0300
+Subject: [PATCH] usb-host: enable autoscan for bus+addr to survive host
+ suspend/resume
+
+Currently, there is a special case for USB devices added using the
+hostbus= and hostaddr= properties to avoid adding them to the hotplug
+watchlist, since the address changes every time the device is plugged
+in. However, when the host system goes into suspend and then resumes,
+those devices are disconnected from the guest with the "no device"
+error but their address stays the same. Enabling autoscan and adding
+them to the watchlist allows them to be reconnected to guest after host
+suspend/resume.
+
+Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>
+---
+ hw/usb/host-libusb.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/hw/usb/host-libusb.c b/hw/usb/host-libusb.c
+index 691bc881fb..5c1e740bd7 100644
+--- a/hw/usb/host-libusb.c
++++ b/hw/usb/host-libusb.c
+@@ -1242,12 +1242,14 @@ static void usb_host_realize(USBDevice *udev, Error **errp)
+                        s->match.bus_num, s->match.addr);
+             return;
+         }
+-    } else {
+-        s->needs_autoscan = true;
+-        QTAILQ_INSERT_TAIL(&hostdevs, s, next);
+-        usb_host_auto_check(NULL);
+     }
+ 
++    /* Enabling autoscan for all match types allows all attached devices,
++     * including those added by bus+addr, to survive host suspend/resume */
++    s->needs_autoscan = true;
++    QTAILQ_INSERT_TAIL(&hostdevs, s, next);
++    usb_host_auto_check(NULL);
++
+     s->exit.notify = usb_host_exit_notifier;
+     qemu_add_exit_notifier(&s->exit);
+ }
+-- 
+2.43.0
+

--- a/packages/python-packages/vhotplug/package.nix
+++ b/packages/python-packages/vhotplug/package.nix
@@ -24,8 +24,8 @@ buildPythonApplication {
   src = fetchFromGitHub {
     owner = "tiiuae";
     repo = "vhotplug";
-    rev = "dc91f43d90da24782bd32cfc5a79afc9fe74d9e6";
-    hash = "sha256-qyLEUNoXHzj5BjUV0i7YjWA9U206J/BGwgvLkni0kIs=";
+    rev = "6fa43f4e64ab130632a3f88eaf3d53108a0cc3b5";
+    hash = "sha256-B0VQ+sJhmU77UOf87SWu2rVrKJq8kweXYkBd0A21Ipo=";
   };
 
   meta = {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
This fixes an issue with hot-plugging that can potentially cause a race condition and system crash.

When the system is booted from a USB SSD drive, it remains connected to the host because vhotplug detects it as a boot device and doesn't pass it to the GUIVM. When a second USB drive is connected, it gets passed to the GUIVM. If the user then unplugs it, the vhotplug service tries to remove it from the GUIVM but at the same time QEMU tries to find the device by VID/PID and reconnect it. If both drives are the same model, QEMU finds the boot drive and connect it to the GUIVM causing a system crash.

This issue is difficult to reproduce because in most cases the vhotplug service removes the drive from the GUIVM faster than QEMU can detect and reconnect it. However, Samuli managed to consistently reproduce the crash.

To fix the issue, the updated version of vhotplug uses the device bus and address which are unique to each device.

This change is also required for any scenario involving multiple identical USB devices of any type as relying on VID/PID doesn't allow to distinguish between them reliably.

The only drawback to this approach is that devices passed using bus and address are not automatically reconnected after a system suspend/resume cycle. A small QEMU patch has been created to resolve this.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

SSRCSP-6350

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

Testing instructions are in SSRCSP-6350.

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [x] Other: 
A reboot might be needed when updated using nixos-rebuild.

### Test Steps To Verify:
1. Check that regular hot-plugging scenarios still work as expected.
2. Check that system doesn't crash using test steps from SSRCSP-6350.
