### PR TITLE
bugfix: fix Falcon AI app not starting, rework package

### DIFF
--- a/modules/reference/desktop/applications.nix
+++ b/modules/reference/desktop/applications.nix
@@ -9,6 +9,9 @@
 let
   cfg = config.ghaf.reference.desktop.applications;
   inherit (lib) mkIf mkEnableOption;
+  falcon-launcher = pkgs.falcon-launcher.override {
+    inherit (pkgs) ghaf-artwork;
+  };
 in
 {
   options.ghaf.reference.desktop.applications = {
@@ -58,7 +61,7 @@ in
           name = "Falcon AI";
           description = "Your local large language model, developed by TII";
           icon = "${pkgs.ghaf-artwork}/icons/falcon-icon.svg";
-          command = "${pkgs.alpaca}/bin/alpaca";
+          command = "${pkgs.falcon-launcher}/bin/falcon-launcher";
         }
       ]
       ++ lib.optionals config.ghaf.reference.programs.windows-launcher.enable (

--- a/modules/reference/services/ollama/ollama.nix
+++ b/modules/reference/services/ollama/ollama.nix
@@ -3,7 +3,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
@@ -19,7 +18,20 @@ in
     services.ollama = {
       enable = true;
       openFirewall = true;
-      host = "127.0.0.1";
+      # Use Alpaca's default managed instance port
+      # This will force Alpaca to use the system's Ollama instance
+      port = 11435;
+    };
+
+    # Set the OLLAMA_HOST env var so Ollama is always accessible
+    environment.sessionVariables.OLLAMA_HOST = "${config.services.ollama.host}:${toString config.services.ollama.port}";
+
+    systemd.services.ollama = {
+      serviceConfig = {
+        TimeoutStartSec = "5h";
+        Restart = "always";
+        RestartSec = "5s";
+      };
     };
 
     ghaf = optionalAttrs (builtins.hasAttr "storagevm" config.ghaf) {
@@ -29,91 +41,6 @@ in
           mode = "u=rwx,g=,o=";
         }
       ];
-    };
-
-    environment.systemPackages = [
-      (pkgs.writeShellApplication {
-        name = "load-falcon";
-        runtimeInputs = with pkgs; [
-          libnotify
-          ollama
-        ];
-        text = ''
-          if [ "''${1:-}" == "--check" ]; then
-             if ollama show falcon2; then
-                echo "falcon2 model is installed"
-                exit 0
-             fi
-
-             if [ -f /tmp/falcon-download ]; then
-               if [ "$(cat /tmp/falcon-download)" == "1" ]; then
-                  echo "falcon2 model is currently being installed"
-                  exit 0
-               fi
-             fi
-
-             echo "falcon2 model is not installed"
-             exit 1
-          fi
-
-          function cleanup() {
-             echo 0 > /tmp/falcon-download
-          }
-
-          trap cleanup SIGINT
-
-          if ! ollama show falcon2; then
-             notify-send -i ${pkgs.ghaf-artwork}/icons/falcon-icon.svg 'Falcon AI' 'Downloading the latest falcon2 model. This may take a while...'
-             echo 1 > /tmp/falcon-download
-          else
-             echo "falcon2 model is already installed"
-             exit 0
-          fi
-
-          if ollama pull falcon2:latest; then
-            notify-send -i ${pkgs.ghaf-artwork}/icons/falcon-icon.svg 'Falcon AI' 'The falcon model has been downloaded successfully. You may now try it out!'
-          else
-            notify-send -i ${pkgs.ghaf-artwork}/icons/falcon-icon.svg 'Falcon AI' 'Failed to download the falcon model. Please try again later.'
-          fi
-
-          cleanup
-        '';
-      })
-    ];
-
-    # This forces Alpaca to use the systemd ollama daemon instead of spawning
-    # its own.
-    system.userActivationScripts.alpaca-configure = {
-      text = ''
-        [[ "$UID" != ${toString config.ghaf.users.loginUser.uid} ]] && exit 0
-        source ${config.system.build.setEnvironment}
-        mkdir -p $HOME/.config/com.jeffser.Alpaca
-        cat <<EOF > $HOME/.config/com.jeffser.Alpaca/server.json
-        {
-          "remote_url": "http://localhost:11434",
-          "remote_bearer_token": "",
-          "run_remote": true,
-          "local_port": 11435,
-          "run_on_background": false,
-          "powersaver_warning": true,
-          "model_tweaks": {
-                "temperature": 0.7,
-                "seed": 0,
-                "keep_alive": 5
-          },
-          "ollama_overrides": {},
-          "idle_timer": 0
-        }
-        EOF
-      '';
-    };
-
-    systemd.services.ollama = {
-      serviceConfig = {
-        TimeoutStartSec = "5h";
-        Restart = "always";
-        RestartSec = "5s";
-      };
     };
   };
 }

--- a/overlays/custom-packages/alpaca/default.nix
+++ b/overlays/custom-packages/alpaca/default.nix
@@ -1,0 +1,17 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# 5.3.0 introduced a breaking change, preventing the app from starting
+# 6.0.0+ promises to fix the issue, but not yet available as of April 14 2025
+# Refs:
+# https://github.com/Jeffser/Alpaca/issues/626
+{ prev }:
+prev.alpaca.overrideAttrs (_oldAttrs: {
+  version = "5.2.0";
+
+  src = prev.fetchFromGitHub {
+    owner = "Jeffser";
+    repo = "Alpaca";
+    tag = "5.2.0";
+    hash = "sha256-uUGsdHrqzA5fZ4LNtX04H4ue9n4JQrkTYW2PCCFYFHc=";
+  };
+})

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -5,6 +5,7 @@
 # packages.
 #
 (final: prev: {
+  alpaca = import ./alpaca { inherit prev; };
   element-desktop = import ./element-desktop { inherit prev; };
   gtklock = import ./gtklock { inherit prev; };
   labwc = import ./labwc { inherit prev; };

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -7,6 +7,7 @@
     dendrite-pinecone = final.callPackage ./pkgs-by-name/dendrite-pinecone/package.nix { };
     element-gps = final.python3Packages.callPackage ./python-packages/element-gps/package.nix { };
     element-web = final.callPackage ./pkgs-by-name/element-web/package.nix { };
+    falcon-launcher = final.callPackage ./pkgs-by-name/falcon-launcher/package.nix { };
     flash-script = final.callPackage ./pkgs-by-name/flash-script/package.nix { };
     gala = final.callPackage ./pkgs-by-name/gala/package.nix { };
     ghaf-build-helper = final.callPackage ./pkgs-by-name/ghaf-build-helper/package.nix { };

--- a/packages/pkgs-by-name/falcon-launcher/package.nix
+++ b/packages/pkgs-by-name/falcon-launcher/package.nix
@@ -1,0 +1,110 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  writeShellApplication,
+  libnotify,
+  ollama,
+  alpaca,
+  ghaf-artwork ? null,
+  curl,
+}:
+writeShellApplication {
+  name = "falcon-launcher";
+  bashOptions = [ "errexit" ];
+  runtimeInputs = [
+    libnotify
+    ollama
+    alpaca
+    curl
+  ];
+  text = ''
+    DOWNLOAD_FLAG="/tmp/falcon-download"
+    LLM_NAME="falcon3:10b"
+    LLM_FRIENDLY_NAME="Falcon 3"
+    FALCON_AI_ICON_PATH=${
+      if ghaf-artwork != null then "${ghaf-artwork}/icons/falcon-icon.svg" else "falcon-icon"
+    }
+    NOTIFICATION_ID=
+    TMP_LOG=
+
+    cleanup() {
+        echo 0 > "$DOWNLOAD_FLAG"
+        rm "$TMP_LOG" 2>/dev/null
+    }
+
+    trap cleanup EXIT
+
+    # If Falcon2 model is already installed, launch Alpaca
+    if ollama show "$LLM_NAME" &>/dev/null; then
+        echo "$LLM_NAME is already installed"
+        alpaca
+        exit 0
+    fi
+
+    # If download is already ongoing, wait for it to finish
+    if [[ -f "$DOWNLOAD_FLAG" && "$(cat "$DOWNLOAD_FLAG")" == "1" ]]; then
+        echo "$LLM_NAME is currently being installed..."
+        exit 0
+    else
+        # Start new download
+        echo 1 > "$DOWNLOAD_FLAG"
+        NOTIFICATION_ID=$(notify-send -i "$FALCON_AI_ICON_PATH" "Downloading $LLM_FRIENDLY_NAME" "The app will open once the download is complete" --print-id)
+    fi
+
+    # Temp file to capture full Ollama pull output
+    TMP_LOG=$(mktemp)
+
+    # Check for connectivity to Ollama's model registry
+    if ! curl --connect-timeout 3 -I https://ollama.com 2>&1; then
+      notify-send --replace-id="$NOTIFICATION_ID" \
+          -i "$FALCON_AI_ICON_PATH" \
+          "No Internet Connection" "Cannot download $LLM_FRIENDLY_NAME\nCheck your connection and try again"
+      exit 1
+    fi
+
+    echo "Downloading $LLM_FRIENDLY_NAME ..."
+    last_percent=""
+    ollama pull "$LLM_NAME" 2>&1 | tee "$TMP_LOG" | while read -r line; do
+        if [[ $line =~ ([0-9]{1,3})% ]]; then
+            percent="''${BASH_REMATCH[1]}"
+            # Skip updating same percentage
+            [[ "$percent" == "$last_percent" ]] && continue
+            last_percent="$percent"
+            NOTIFICATION_ID=$(notify-send --print-id --replace-id="$NOTIFICATION_ID" \
+                -u critical \
+                -h int:value:"$percent" \
+                -i "$FALCON_AI_ICON_PATH" \
+                "Downloading $LLM_FRIENDLY_NAME  $percent%" \
+                "The app will open once the download is complete")
+        fi
+    done
+
+    status=''${PIPESTATUS[0]}
+
+    # Final notification
+    if [[ $status -eq 0 ]]; then
+        echo "Download completed successfully"
+        notify-send --replace-id="$NOTIFICATION_ID" \
+            -i "$FALCON_AI_ICON_PATH" \
+            "Download complete" \
+            "The application will now open"
+        alpaca
+        exit 0
+    else
+        echo "Download failed with status $status"
+        error_msg=$(tail -n 1 "$TMP_LOG")
+        notify-send --replace-id="$NOTIFICATION_ID" \
+            -i "$FALCON_AI_ICON_PATH" \
+            "Failed to download $LLM_FRIENDLY_NAME" \
+            "Error occurred:\n''${error_msg}"
+    fi
+  '';
+
+  meta = {
+    description = "Script to setup and/or launch the Falcon LLM chat";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Fix Alpaca not launching bug by downgrading Alpaca 5.3.0 -> 5.2.0**
   - Alpaca was recently upgraded to 5.3.0 via a flake bump
   - 5.3.0 has a known issue ([ref1](https://github.com/Jeffser/Alpaca/issues/703) [ref2](https://github.com/Jeffser/Alpaca/issues/626)), where the app might not start or start with functionality missing.
   - Possible solutions are upgrading to 6.0.0+ or downgrading back to 5.2.0
   See notes below for more info why downgrade was preferred.

2. **Rework Falcon AI launcher package behavior:**
   - Introduced new `falcon-launcher` package
   - Removed obsolete `load-falcon` package
   - `falcon-launcher` is responsible for downloading the Falcon LLM and/or launching Alpaca ("Falcon AI" app)
   - Opening "Falcon AI" from the App Library results in the following:
      - If Falcon LLM is not present:
        - Download will start and download progress will be displayed as a system notification
        - Starting another instance will do nothing
        - Once download is complete the notification will update and the Alpaca ("Falcon AI") app will open
      - If Falcon LLM is present:
        - Alpaca ("Falcon AI") app will open

3. **Fixed a bug where Falcon LLM would not be available in Falcon AI app**
   - This was due to Alpaca using its own managed Ollama instance.
   - Alpaca now explicitly tries to start its' own managed Ollama instance on an IP that is already used by the systemd Ollama service
   The result is that Alpaca's managed Ollama instance is not started - instead, the systemd service is used.

4. **Changed to Falcon 3 LLM by default ([falcon3:10b](https://ollama.com/library/falcon3:10b))**

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Notes
Alpaca 6.0.0+ promises to address the launching bug and other issues, but upgrading is not straight-forward at this time.
6.0.0+ has a Python dependency `markitdown`, which is severely outdated in `nixpkgs`.
There is currently [on-going work](https://github.com/NixOS/nixpkgs/pull/397554) in `nixpkgs` to move away from `markitdown` in favor of `markdownify`, but no clear resolution yet.
As such, in our use case, it's easier to downgrade to known working Alpaca 5.2.0.

~Another concern is that when Alpaca 6.0.0+ is available in `nixpkgs`, server settings via JSON, [as we do in Ghaf](https://github.com/tiiuae/ghaf/blob/4a6dcda0e6ec1994dd82d6a00f76e899a81f9724/modules/reference/services/ollama/ollama.nix#L91) will no longer be supported - https://github.com/Jeffser/Alpaca/releases/tag/6.0.3.
This means we will likely have to slightly refactor Alpaca/Ollama configuration in Ghaf.~

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

[SSRCSP-6482](https://jira.tii.ae/browse/SSRCSP-6482)

https://github.com/Jeffser/Alpaca/issues/703
https://github.com/Jeffser/Alpaca/issues/626
https://github.com/Jeffser/Alpaca/releases/tag/6.0.3
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
Not launching bug:
1. Try to launch Falcon AI app, either through terminal or App Library
2. Falcon AI app launches on first try, no need to open twice or more times

Refactor:
Try to launch Falcon AI app while Falcon LLM is not yet present on the system
1. To make sure Falcon LLM is not present, run the following as the logged in user in Ghaf: `ollama rm falcon3:10b`
2. Try to launch Falcon AI app
4. Observe the Download status notification, verify the notification updates correctly
5. Verify app opens once download is complete
6. Verify app works as expected, Falcon LLM is available immediately
7. Close the app
8. Try to launch Falcon AI app again, this time no download should occur, Falcon AI app should start immediately
9. (Optional) Try to start multiple instances of Falcon AI app while Falcon LLM is not present on the system
  There should only be one Download status notification, no additional processes should start.