### PR TITLE
intel-gpu: Cleanup the intel setup configuration

### DIFF
--- a/modules/desktop/intel-gpu/default.nix
+++ b/modules/desktop/intel-gpu/default.nix
@@ -21,15 +21,13 @@ in
       # hardware.graphics since NixOS 24.11
       enable = true;
       extraPackages = with pkgs; [
-        intel-media-driver # LIBVA_DRIVER_NAME=iHD
-        intel-vaapi-driver # LIBVA_DRIVER_NAME=i965 (older but might work better for Firefox/Chromium)
-        libvdpau-va-gl
+        intel-media-driver # For Broadwell (2014) or newer processors, use LIBVA_DRIVER_NAME=iHD
+        vpl-gpu-rt # QSV on 11th gen or newer
       ];
     };
 
-    # TODO: to check if i965 is indeed better
     environment.sessionVariables = {
       LIBVA_DRIVER_NAME = "iHD";
-    }; # Force intel-media-driver
+    }; # Force to use intel-media-driver
   };
 }

--- a/modules/reference/programs/firefox.nix
+++ b/modules/reference/programs/firefox.nix
@@ -32,7 +32,7 @@ in
       "gfx.x11-egl.force-enabled" = true;
       "widget.dmabuf.force-enabled" = true;
       "gfx.webrender.all" = true;
-      "media.hrdware-video-decoding.force-enabled" = true;
+      "media.hardware-video-decoding.force-enabled" = true;
     };
 
     # Disable the RDD sandbox


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
As we are supporting newer generations of Intel platforms, we no longer need i965 configuration. Even if we forcefully try to use i965 configuration hardware codecs doesn't enumerate, verified using vainfo command.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. vainfo works
2.  glmark2-wayland use Render/3D engine.
3.  Video playback should use Video engine. 
