### PR TITLE
Input devices: remove hardcoded evdevs

### DIFF
--- a/modules/hardware/common/devices.nix
+++ b/modules/hardware/common/devices.nix
@@ -75,18 +75,10 @@ in
       };
 
       guivmVirtioInputHostEvdevModule = {
-        microvm.qemu.extraArgs =
-          builtins.concatMap
-            (d: [
-              "-device"
-              "virtio-input-host-pci,evdev=${d}"
-            ])
-            (
-              config.ghaf.hardware.definition.input.keyboard.evdev
-              ++ config.ghaf.hardware.definition.input.mouse.evdev
-              ++ config.ghaf.hardware.definition.input.touchpad.evdev
-              ++ config.ghaf.hardware.definition.input.misc.evdev
-            );
+        microvm.qemu.extraArgs = builtins.concatMap (d: [
+          "-device"
+          "virtio-input-host-pci,evdev=${d}"
+        ]) config.ghaf.hardware.definition.input.misc.evdev;
       };
     };
   };

--- a/modules/hardware/common/input.nix
+++ b/modules/hardware/common/input.nix
@@ -3,26 +3,8 @@
 #
 { config, lib, ... }:
 let
-  inherit (builtins) toString typeOf;
-  inherit (lib) concatImapStrings concatMapStringsSep;
-
+  inherit (lib) concatMapStringsSep;
   cfg = config.ghaf.hardware.definition;
-
-  # Helper function to create udev rules for input devices
-  generateUdevRules =
-    devlink: deviceList:
-    concatImapStrings (
-      i: d:
-      if (typeOf d) == "list" then
-        ''${
-          concatMapStringsSep "\n" (
-            sd:
-            ''SUBSYSTEM=="input", ATTRS{name}=="${sd}", KERNEL=="event*", GROUP="kvm", SYMLINK+="${devlink}${toString (i - 1)}"''
-          ) d
-        }''\n''
-      else
-        ''SUBSYSTEM=="input", ATTRS{name}=="${d}", KERNEL=="event*", GROUP="kvm", SYMLINK+="${devlink}${toString (i - 1)}"''\n''
-    ) deviceList;
 in
 {
   config = {
@@ -32,12 +14,6 @@ in
 
     # Host udev rules for input devices
     services.udev.extraRules = ''
-      # Keyboard
-      ${generateUdevRules "keyboard" cfg.input.keyboard.name}
-      # Mouse
-      ${generateUdevRules "mouse" cfg.input.mouse.name}
-      # Touchpad
-      ${generateUdevRules "touchpad" cfg.input.touchpad.name}
       # Misc
       ${lib.strings.concatMapStringsSep "\n" (
         d: ''SUBSYSTEM=="input", ATTRS{name}=="${d}", GROUP="kvm"''

--- a/modules/reference/hardware/alienware/alienware-m18.nix
+++ b/modules/reference/hardware/alienware/alienware-m18.nix
@@ -22,32 +22,6 @@
 
   # Input devices
   input = {
-    keyboard = {
-      name = [
-        "AT Translated Set 2 keyboard"
-        "DELL Technologies Keyboard"
-      ];
-      evdev = [
-        "/dev/keyboard0"
-        "/dev/keyboard1"
-      ];
-    };
-
-    mouse = {
-      name = [ "PS/2 Generic Mouse" ];
-      evdev = [ "/dev/mouse0" ];
-    };
-
-    touchpad = {
-      name = [
-        [
-          "VEN_04F3:00 04F3:328A Touchpad"
-          "VEN_06CB:00 06CB:CEFB Touchpad"
-        ]
-      ];
-      evdev = [ "/dev/touchpad0" ];
-    };
-
     misc = {
       name = [
         # "Dell WMI hotkeys" "HDA NVidia HDMI/DP,pcm=8" "HDA NVidia HDMI/DP,pcm=9" "Video Bus" "sof-hda-dsp Headphone Mic" "sof-hda-dsp HDMI/DP,pcm=3" "sof-hda-dsp HDMI/DP,pcm=4" "Lid Switch" "sof-hda-dsp HDMI/DP,pcm=5" "Power Button" "Sleep Button" "Intel HID events" "Intel HID 5 button array" "HDA NVidia HDMI/DP,pcm=3" "HDA NVidia HDMI/DP,pcm=7"

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
@@ -20,35 +20,6 @@
 
   # Input devices
   input = {
-    keyboard = {
-      name = [ "AT Translated Set 2 keyboard" ];
-      evdev = [ "/dev/keyboard0" ];
-    };
-
-    mouse = {
-      name = [
-        "PS/2 Generic Mouse"
-        "SYNAPTICS Synaptics HIDUSB TouchPad V1.05 Mouse"
-      ];
-      evdev = [
-        "/dev/mouse0"
-        "/dev/mouse1"
-      ];
-    };
-
-    touchpad = {
-      name = [
-        "SYNAPTICS Synaptics HIDUSB TouchPad V1.05 Touchpad"
-        "EETI8082:00 0EEF:C004"
-        "EETI8082:00 0EEF:C004 Stylus"
-      ];
-      evdev = [
-        "/dev/touchpad0"
-        "/dev/touchpad1"
-        "/dev/touchpad2"
-      ];
-    };
-
     misc = {
       name = [
         # "Intel HID events" "Dell WMI hotkeys" "Video Bus" "HDA Intel PCH Headphone Mic" "HDA Intel PCH HDMI/DP,pcm=3" "HDA Intel PCH HDMI/DP,pcm=7" "HDA Intel PCH HDMI/DP,pcm=8" "HDA Intel PCH HDMI/DP,pcm=9" "Intel HID 5 button array" "Lid Switch" "Power Button" "Sleep Button"

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-71.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-71.nix
@@ -20,33 +20,6 @@
 
   # Input devices
   input = {
-    keyboard = {
-      name = [
-        "AT Translated Set 2 keyboard"
-        "DELL0A9E:00 214A:0028 Keyboard"
-      ];
-      evdev = [
-        "/dev/keyboard0"
-        "/dev/keyboard1"
-      ];
-    };
-
-    mouse = {
-      name = [
-        "DELL0A9E:00 214A:0028 Mouse"
-        "PS/2 Generic Mouse"
-      ];
-      evdev = [
-        "/dev/mouse0"
-        "/dev/mouse1"
-      ];
-    };
-
-    touchpad = {
-      name = [ "CUST0000:00 0EEF:C003" ];
-      evdev = [ "/dev/touchpad0" ];
-    };
-
     misc = {
       name = [
         # "Lid Switch" "Video Bus" "HDA Intel PCH Headphone Mic" "HDA Intel PCH HDMI/DP,pcm=3" "HDA Intel PCH HDMI/DP,pcm=7" "HDA Intel PCH HDMI/DP,pcm=8" "HDA Intel PCH HDMI/DP,pcm=9" "Power Button" "Sleep Button" "Intel HID events" "Intel HID 5 button array" "Dell WMI hotkeys"

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-72.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330-72.nix
@@ -20,33 +20,6 @@
 
   # Input devices
   input = {
-    keyboard = {
-      name = [
-        "AT Translated Set 2 keyboard"
-        "DELL0A9E:00 214A:0028 Keyboard"
-      ];
-      evdev = [
-        "/dev/keyboard0"
-        "/dev/keyboard1"
-      ];
-    };
-
-    mouse = {
-      name = [
-        "DELL0A9E:00 214A:0028 Mouse"
-        "PS/2 Generic Mouse"
-      ];
-      evdev = [
-        "/dev/mouse0"
-        "/dev/mouse1"
-      ];
-    };
-
-    touchpad = {
-      name = [ "CUST0000:00 0EEF:C003" ];
-      evdev = [ "/dev/touchpad0" ];
-    };
-
     misc = {
       name = [
         # "Lid Switch" "Video Bus" "HDA Intel PCH Headphone Mic" "HDA Intel PCH HDMI/DP,pcm=3" "HDA Intel PCH HDMI/DP,pcm=7" "HDA Intel PCH HDMI/DP,pcm=8" "HDA Intel PCH HDMI/DP,pcm=9" "Power Button" "Sleep Button" "Intel HID events" "Intel HID 5 button array" "Dell WMI hotkeys"

--- a/modules/reference/hardware/demo-tower/demo-tower.nix
+++ b/modules/reference/hardware/demo-tower/demo-tower.nix
@@ -22,21 +22,6 @@
 
   # Input devices
   input = {
-    keyboard = {
-      name = [ ];
-      evdev = [ ];
-    };
-
-    mouse = {
-      name = [ ];
-      evdev = [ ];
-    };
-
-    touchpad = {
-      name = [ ];
-      evdev = [ ];
-    };
-
     misc = {
       name = [
         # "HDA NVidia HDMI/DP,pcm=3" "HDA NVidia HDMI/DP,pcm=7" "HDA NVidia HDMI/DP,pcm=8" "HDA NVidia HDMI/DP,pcm=9" "Generic USB Audio Consumer Control" "Generic USB Audio" "Power Button"

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -21,35 +21,6 @@
   };
 
   input = {
-    keyboard = {
-      name = [ "AT Translated Set 2 keyboard" ];
-      evdev = [ "/dev/input/by-path/platform-i8042-serio-0-event-kbd" ];
-    };
-
-    mouse = {
-      name = [
-        [
-          "ELAN067B:00 04F3:31F8 Mouse"
-          "SYNA8016:00 06CB:CEB3 Mouse"
-        ]
-        "TPPS/2 Elan TrackPoint"
-      ];
-      evdev = [
-        "/dev/mouse0"
-        "/dev/mouse1"
-      ];
-    };
-
-    touchpad = {
-      name = [
-        [
-          "ELAN067B:00 04F3:31F8 Touchpad"
-          "SYNA8016:00 06CB:CEB3 Touchpad"
-        ]
-      ];
-      evdev = [ "/dev/touchpad0" ];
-    };
-
     misc = {
       name = [ "ThinkPad Extra Buttons" ];
       evdev = [ "/dev/input/by-path/platform-thinkpad_acpi-event" ];

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -23,40 +23,6 @@
   };
 
   input = {
-    keyboard = {
-      name = [ "AT Translated Set 2 keyboard" ];
-      evdev = [ "/dev/input/by-path/platform-i8042-serio-0-event-kbd" ];
-    };
-
-    mouse = {
-      name = [
-        [
-          "ELAN067C:00 04F3:31F9 Mouse"
-          "SYNA8016:00 06CB:CEB3 Mouse"
-          "ELAN067B:00 04F3:31F8 Mouse"
-          "SYNA8017:00 06CB:CEB2 Mouse"
-        ]
-        "TPPS/2 Elan TrackPoint"
-      ];
-      evdev = [
-        "/dev/mouse0"
-        "/dev/mouse1"
-      ];
-    };
-
-    touchpad = {
-      name = [
-        [
-          "ELAN067C:00 04F3:31F9 Touchpad"
-          "SYNA8016:00 06CB:CEB3 Touchpad"
-          "ELAN067B:00 04F3:31F8 Touchpad"
-          "SYNA8017:00 06CB:CEB2 Touchpad"
-          "ELAN901C:00 04F3:2C4E Touchpad"
-        ]
-      ];
-      evdev = [ "/dev/touchpad0" ];
-    };
-
     misc = {
       name = [ "ThinkPad Extra Buttons" ];
       evdev = [ "/dev/input/by-path/platform-thinkpad_acpi-event" ];

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
@@ -22,33 +22,6 @@
   };
 
   input = {
-    keyboard = {
-      name = [ "AT Translated Set 2 keyboard" ];
-      evdev = [ "/dev/input/by-path/platform-i8042-serio-0-event-kbd" ];
-    };
-
-    mouse = {
-      name = [
-        [
-          "ELAN06D5:00 04F3:32B7 Mouse"
-        ]
-        "TPPS/2 Elan TrackPoint"
-      ];
-      evdev = [
-        "/dev/mouse0"
-        "/dev/mouse1"
-      ];
-    };
-
-    touchpad = {
-      name = [
-        [
-          "ELAN06D5:00 04F3:32B7 Touchpad"
-        ]
-      ];
-      evdev = [ "/dev/touchpad0" ];
-    };
-
     misc = {
       name = [ "ThinkPad Extra Buttons" ];
       evdev = [ "/dev/input/by-path/platform-thinkpad_acpi-event" ];


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Remove hardcoded input devices from hardware definition. The input devices should be handled correctly by vhotplug.
This should simplify the hardware definition, and remove the need to specify multiple input devices.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. For all reference laptop hardware, verify that all input devices (touchpad, trackpoint, touchscreen, and keyboard) work as before
2. (optional) Check that input devices are picked up by vhotplug (`journalctl -b0 -u vhotplug.service` on the host)
