### PR TITLE
Microvm boot order

### DIFF
--- a/modules/givc/guivm.nix
+++ b/modules/givc/guivm.nix
@@ -31,6 +31,10 @@ in
         addr = hosts.${hostName}.ipv4;
         port = "9000";
       };
+      services = [
+        "reboot.target"
+        "poweroff.target"
+      ];
       admin = lib.head config.ghaf.givc.adminConfig.addresses;
       tls.enable = config.ghaf.givc.enableTls;
       enableUserTlsAccess = true;

--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -246,8 +246,8 @@ in
     systemd.services.vhotplug = {
       enable = true;
       description = "vhotplug";
-      wantedBy = [ "microvms.target" ];
-      after = [ "microvms.target" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "local-fs.target" ];
       serviceConfig = {
         Type = "simple";
         Restart = "always";

--- a/modules/microvm/host/boot.nix
+++ b/modules/microvm/host/boot.nix
@@ -1,0 +1,261 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.microvm-boot;
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkForce
+    mkOption
+    types
+    attrNames
+    filterAttrs
+    foldl'
+    removeSuffix
+    optionals
+    optionalAttrs
+    ;
+  inherit (config.ghaf.networking) hosts;
+  inherit (config.ghaf.virtualization.microvm) appvm;
+
+  # Filter system and enabled app VMs
+  appVms = attrNames (filterAttrs (_: vm: vm.enable) appvm.vms);
+  sysVms = map (name: removeSuffix "-vm" name) (
+    attrNames (filterAttrs (_: vm: vm.config.config.ghaf.type == "system-vm") config.microvm.vms)
+  );
+
+  # Boot priority mapping for app VMs
+  bootPriorityMap = {
+    low = [ "system-login.target" ]; # Start after user session is initialized
+    medium = [ "system-ui.target" ]; # Start after gui-vm is ready
+    high = [ "local-fs.target" ]; # Start at the same time as system VMs
+  };
+
+  # Function to evaluate boot dependency for a VM
+  evalBootPriority =
+    name:
+    if (cfg.uiEnabled && (lib.hasAttr name appvm.vms)) then
+      bootPriorityMap.${appvm.vms.${name}.bootPriority}
+    else
+      [ "local-fs.target" ];
+
+  # Functions to configure systemd service dependencies
+  mkServiceDependencies =
+    group: service-prefix:
+    foldl' (
+      result: name:
+      result
+      // {
+        "${service-prefix}${name}-vm" = {
+          serviceConfig.Slice = "system-${group}-${name}.slice";
+          requiredBy = [ "microvms.target" ];
+          requires = [ "local-fs.target" ];
+          after = evalBootPriority name;
+        };
+      }
+    ) { } (if group == "sysvms" then sysVms else appVms);
+
+  mkAppVmDependencies = service: mkServiceDependencies "appvms" service;
+  mkSysVmDependencies = service: mkServiceDependencies "sysvms" service;
+  mkVmDependencies = service: (mkSysVmDependencies service) // (mkAppVmDependencies service);
+
+  # Function to create slice hierarchy for system and app VMs
+  mkSliceGroup =
+    group:
+    (
+      {
+        # Create parent slice for system and app VMs
+        "system-${group}" = {
+          sliceConfig = optionalAttrs cfg.uiEnabled {
+            CPUAccounting = true;
+            IOAccounting = true;
+            CPUWeight = if (group == "sysvms") then 10000 else "idle";
+            IOWeight = if (group == "sysvms") then 10000 else 1;
+          };
+        };
+      }
+      // (foldl' (result: name: result // { "system-${group}-${name}" = { }; }) { } (
+        if group == "sysvms" then sysVms else appVms
+      ))
+    );
+  mkSliceGroups = (mkSliceGroup "sysvms") // (mkSliceGroup "appvms");
+
+  # Reset resource constraints for system and app VMs
+  reset-resources = pkgs.writeShellApplication {
+    name = "reset-resources";
+    runtimeInputs = [
+      pkgs.systemd
+      pkgs.coreutils
+    ];
+    text = ''
+      systemctl set-property --runtime system-sysvms.slice CPUWeight= IOWeight=
+      systemctl set-property --runtime system-appvms.slice CPUWeight= IOWeight=
+      systemctl daemon-reload
+    '';
+  };
+
+  # Wait for user login and ghaf-session to be active
+  loginTarget = {
+    labwc = "ghaf-session.target";
+    cosmic = "xdg-desktop-portal.service";
+  };
+
+  wait-for-user = pkgs.writeShellApplication {
+    name = "wait-for-user";
+    runtimeInputs = [
+      pkgs.systemd
+    ];
+    text = ''
+      set +e # don't exit on error
+      echo "Waiting for user to login..."
+      state="inactive"
+      until [ "$state" == "active" ]; do
+        sleep 1
+        state=$(${pkgs.systemd}/bin/loginctl show-user ${toString config.ghaf.users.loginUser.uid} -P State 2>/dev/null)
+      done
+      echo "User is now active"
+      echo "Waiting for user-session to be active..."
+      state="inactive"
+      until [ "$state" == "active" ]; do
+        state=$(systemctl --user is-active ${
+          loginTarget.${config.ghaf.profiles.graphics.compositor}
+        } --machine=${toString config.ghaf.users.loginUser.uid}@.host)
+        sleep 1
+      done
+      echo "user-session is now active"
+    '';
+  };
+in
+{
+  options.ghaf.microvm-boot = {
+    enable = mkEnableOption "ghaf-specific microvm boot order";
+    debug = mkEnableOption "resource tracing of the ghaf-specific microvm boot order";
+    uiEnabled = mkOption {
+      type = types.bool;
+      default = config.ghaf.virtualization.microvm.guivm.enable && config.ghaf.givc.enable;
+      description = "Enable microvm boot order for GUI targets";
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+
+      # Systemd boot targets
+      systemd.targets =
+        {
+          # Override microvm.nix's default target (default is VMs with autostart)
+          microvms = {
+            wants = mkForce (map (name: "microvm@${name}.service") (attrNames config.microvm.vms));
+          };
+        }
+        // optionalAttrs cfg.uiEnabled {
+          system-ui = {
+            description = "System UI target";
+            wantedBy = [ "microvms.target" ];
+            requires = [ "wait-for-ui.service" ];
+            after = [ "wait-for-ui.service" ];
+          };
+          system-login = {
+            description = "System Login target";
+            wantedBy = [ "microvms.target" ];
+            requires = [ "wait-for-login.service" ];
+            after = [ "wait-for-login.service" ];
+          };
+        };
+
+      # Slice groups for system- and app VMs
+      systemd.slices = mkSliceGroups;
+
+      # Systemd service dependencies
+      systemd.services =
+        mkVmDependencies "microvm@"
+        // mkVmDependencies "microvm-virtiofsd@"
+        // mkAppVmDependencies "vsockproxy-"
+        // mkAppVmDependencies "ghaf-mem-manager-"
+        // optionalAttrs cfg.uiEnabled {
+
+          # Wait for gui-vm to reach multi-user.target. Times out after 60 seconds
+          wait-for-ui = {
+            description = "Wait for GuiVM startup";
+            after = [ "givc-key-setup.service" ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = ''
+                ${pkgs.wait-for-unit}/bin/wait-for-unit \
+                ${hosts.admin-vm.ipv4} 9001 \
+                gui-vm \
+                greetd.service \
+                60
+              '';
+              RemainAfterExit = true;
+            };
+          };
+
+          # Service to wait for user login to gui-vm. Resets boot resource constraints
+          # after user has logged in and ghaf-session is active. Times out after 120 seconds
+          wait-for-login = {
+            description = "Wait for user login to gui-vm";
+            after = [
+              "givc-key-setup.service"
+              "system-ui.target"
+            ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = ''
+                ${pkgs.wait-for-unit}/bin/wait-for-unit \
+                ${hosts.admin-vm.ipv4} 9001 \
+                gui-vm \
+                user-login.service \
+                120
+              '';
+              ExecStartPost = "${reset-resources}/bin/reset-resources";
+              RemainAfterExit = true;
+            };
+          };
+        };
+
+      ghaf.virtualization.microvm.guivm.extraModules = optionals cfg.uiEnabled [
+        {
+          # Allow systemd units to be monitored via givc
+          givc.sysvm.services = [
+            "greetd.service"
+            "user-login.service"
+          ];
+
+          # Wait until user logs in and ghaf-session is active
+          systemd.services.user-login = {
+            description = "Wait for ghaf-session to be active";
+            wantedBy = [ "multi-user.target" ];
+            after = [ "greetd.service" ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStartPre = "${wait-for-user}/bin/wait-for-user";
+              ExecStart = "/bin/sh -c exit"; # no-op
+              RemainAfterExit = true;
+            };
+          };
+        }
+      ];
+    })
+
+    # Enable systemd-bootchart if debug is enabled
+    (mkIf cfg.debug {
+      systemd.services.systemd-bootchart = {
+        description = "Trace microvm boot with systemd-bootchart";
+        wantedBy = [ "local-fs.target" ];
+        after = [ "local-fs.target" ];
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkgs.systemd-bootchart}/lib/systemd/systemd-bootchart -r -n 1500";
+        };
+      };
+    })
+  ];
+}

--- a/modules/microvm/sysvms/audiovm.nix
+++ b/modules/microvm/sysvms/audiovm.nix
@@ -134,7 +134,7 @@ in
 
   config = lib.mkIf cfg.enable {
     microvm.vms."${vmName}" = {
-      autostart = true;
+      autostart = !config.ghaf.microvm-boot.enable;
       inherit (inputs) nixpkgs;
       config = audiovmBaseConfiguration // {
         imports = audiovmBaseConfiguration.imports ++ cfg.extraModules;

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -322,7 +322,7 @@ in
 
   config = lib.mkIf cfg.enable {
     microvm.vms."${vmName}" = {
-      autostart = true;
+      autostart = !config.ghaf.microvm-boot.enable;
       inherit (inputs) nixpkgs;
       config = guivmBaseConfiguration // {
         boot.kernelPackages =

--- a/modules/microvm/sysvms/netvm.nix
+++ b/modules/microvm/sysvms/netvm.nix
@@ -143,7 +143,7 @@ in
 
   config = lib.mkIf cfg.enable {
     microvm.vms."${vmName}" = {
-      autostart = true;
+      autostart = !config.ghaf.microvm-boot.enable;
       restartIfChanged = false;
       inherit (inputs) nixpkgs;
       config = netvmBaseConfiguration // {

--- a/modules/reference/appvms/gala.nix
+++ b/modules/reference/appvms/gala.nix
@@ -9,6 +9,7 @@
   gala = {
     ramMb = 1536;
     cores = 2;
+    bootPriority = "low";
     borderColor = "#027d7b";
     applications = [
       {

--- a/modules/reference/appvms/zathura.nix
+++ b/modules/reference/appvms/zathura.nix
@@ -10,6 +10,7 @@
   zathura = {
     ramMb = 512;
     cores = 1;
+    bootPriority = "low";
     borderColor = "#122263";
     applications = [
       {

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -31,6 +31,7 @@
     vhotplug = final.python3Packages.callPackage ./python-packages/vhotplug/package.nix { };
     vinotify = final.python3Packages.callPackage ./python-packages/vinotify/package.nix { };
     vsockproxy = final.callPackage ./pkgs-by-name/vsockproxy/package.nix { };
+    wait-for-unit = final.callPackage ./pkgs-by-name/wait-for-unit/package.nix { };
     windows-launcher = final.callPackage ./pkgs-by-name/windows-launcher/package.nix { };
   };
 }

--- a/packages/pkgs-by-name/wait-for-unit/package.nix
+++ b/packages/pkgs-by-name/wait-for-unit/package.nix
@@ -1,0 +1,68 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  writeShellApplication,
+  grpcurl,
+  jq,
+}:
+writeShellApplication {
+  name = "wait-for-unit";
+
+  runtimeInputs = [
+    grpcurl
+    jq
+  ];
+
+  text = ''
+    # Assert root
+    [[ $(id -u) -ne 0 ]] && echo "Please run as root." && exit 1
+
+    # Usage
+    if [ "$#" -ne 5 ]; then
+      echo "Usage: $0 <admin service ip> <admin service port> <vm-name> <unit-name> <timeout in seconds>"
+      exit 1
+    fi
+
+    # Check if key/certificates exist
+    [[ ! -f /etc/givc/ca-cert.pem ]] && echo "CA certificate not found." && exit 1
+    [[ ! -f /etc/givc/cert.pem ]] && echo "Client certificate not found." && exit 1
+    [[ ! -f /etc/givc/key.pem ]] && echo "Client key not found." && exit 1
+
+    # Function to fetch the unit status
+    ADDR="$1:$2"
+    VM="$3"
+    UNIT="$4"
+    args=(
+      "-cacert" "/etc/givc/ca-cert.pem"
+      "-cert" "/etc/givc/cert.pem"
+      "-key" "/etc/givc/key.pem"
+      "-d" "{\"VmName\":\"$VM\",\"UnitName\":\"$UNIT\"}"
+      "$ADDR"
+      "admin.AdminService.GetUnitStatus"
+    )
+    TIMEOUT="$5"
+    SECONDS=0
+
+    # Wait until the unit is running
+    echo "Waiting for unit '$UNIT' in VM '$VM' ..."
+    while [ $SECONDS -lt "$TIMEOUT" ]; do
+      if status_response="$(grpcurl "''${args[@]}" 2>/dev/null)"; then
+        active_status=$(echo "$status_response" | jq -rj '.ActiveState')
+        sub_status=$(echo "$status_response" | jq -rj '.SubState')
+        [[ "$active_status" == "active" && ("$sub_status" == "active" || "$sub_status" == "running" || "$sub_status" == "exited") ]] && exit 0
+      else
+        echo "Waiting to get status for unit '$UNIT' in VM '$VM' ..."
+      fi
+      sleep 0.5
+    done
+    echo "Timeout reached: Unit '$UNIT' in VM '$VM' did not reach the desired state within $TIMEOUT seconds. Exit gracefully."
+  '';
+
+  meta = {
+    description = "Script to query a systemd unit status across VMs.";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Add custom microvm boot-order for ghaf to delay appvms startup to reserve resources for system-vms during boot.
This custom boot sequence is only enabled iff the gui-vm is enabled.

Features:
- remove the previous sleep for appvms by adding a wait-unit command to monitor the status of a service or target within a VM
- disable microvms autostart feature for net-vm, gui-vm, audio-vm, and app-vms, if enabled
- disable automatic restart of microvm@<vm> service. This allows to shutdown a machine internally (e.g., poweroff.target)

### Boot Targets

Appvms now have a boot priority flag that determines when they start booting; high, medium, low. Default is **medium**, with the following boot triggers:

| Trigger | Default | Appvm Priority | 
| ------- | ------- | ------- | 
| local-fs.target (host) | System VMs | high |
| greetd.target (guivm) | App VMs | medium |
| loginTarget** (guivm) | other | low |

** `ghaf-session.target` for labwc, `xdg-desktop-portal.service` for cosmic (slowest service as of now)

### Notes

**This patch does not aim to improve boot time or resource usage.** While minor improvements are noticeable, the main objective is to re-order the boot flow to allow system-vms to boot without significant appvm impact. In turn, the gui-vm should display the login-screen faster. The full boot from start menu to opening an application, without delay at the login screen, should pretty much match the previous (or be slightly faster).

Example boot CPU/IO profile without this boot order
![image](https://github.com/user-attachments/assets/c198ec64-c143-4110-b9d5-d86453252cd0)

Example boot CPU/IO  profile with this change
![image](https://github.com/user-attachments/assets/f4198bb8-c656-48ad-940d-a942be5f08cf)

Example measurements

Boot-to-Login: Time from starting the boot entry to the password/login screen showing
Login-to-Desktop: Time from login screen to desktop (top bar loaded)
Desktop-to-Chrome: Time from loaded desktop to started chrome application

|  | Boot-to-Login | Login-to-Desktop |  Desktop-to-Chrome | Total |
| ------- | ------- | ------- | ------- | ------- |
| Before Patch | 43 | 17 | 8 | 68 |
| | 44 | 16 | 8 | 68 |
| | 45 | 18 | 8 | 71 |
|  |  |  |  |  |
| After Patch |  31 | 22 | 12 | 65 |
| | 30 | 20 | 14 | 64 |
| | 31 | 18 | 14 | 63 |

If there is any user delay during login, the subsequent timing will be shorter.

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify that all VMs boot successfully with patch
2. Verify that all functionality works as with mainline
3. Compare boot with previous. Recommend to comment out the enable in `microvm-host.nix`, to still get systemd-bootcharts
```
microvm-boot = {
  #inherit (config.ghaf.virtualization.microvm.guivm) enable;
  debug = config.ghaf.profiles.debug.enable;
};
```
4. (Optional) analyze systemd bootchart
To copy a bootchart: `scp -J root@<ip of ghaf machine> root@ghaf-host:/run/log/*.svg .`
