### PR TITLE
refactor(desktop): remove sticky notes from cosmic, switch to oculante img viewer

### DIFF
--- a/modules/microvm/common/xdghandlers.nix
+++ b/modules/microvm/common/xdghandlers.nix
@@ -35,7 +35,7 @@ let
       #!${pkgs.runtimeShell}
       file="$1"
       echo "XDG open image: $file"
-      ${config.ghaf.givc.appPrefix}/run-waypipe ${config.ghaf.givc.appPrefix}/pqiv -i "$file"
+      ${config.ghaf.givc.appPrefix}/run-waypipe ${config.ghaf.givc.appPrefix}/oculante "$file"
       rm "$file"
     '';
   };
@@ -47,9 +47,9 @@ in
 
   config = lib.mkIf (cfg.enable && config.ghaf.givc.enable) {
 
-    environment.systemPackages = [
-      pkgs.zathura
-      pkgs.pqiv
+    environment.systemPackages = with pkgs; [
+      zathura
+      oculante
     ];
 
     # Set up GIVC applications for XDG scripts

--- a/modules/reference/desktop/applications.nix
+++ b/modules/reference/desktop/applications.nix
@@ -28,13 +28,6 @@ in
         }
 
         {
-          name = "Sticky Notes";
-          description = "Sticky Notes on your Desktop";
-          icon = "${pkgs.sticky-notes}/share/icons/hicolor/scalable/apps/com.vixalien.sticky.svg";
-          command = "${pkgs.sticky-notes}/bin/com.vixalien.sticky";
-        }
-
-        {
           name = "Bluetooth Settings";
           description = "Manage Bluetooth Devices & Settings";
           icon = "bluetooth-48";
@@ -54,6 +47,14 @@ in
           description = "Organize & Manage Files";
           icon = "system-file-manager";
           command = "${pkgs.pcmanfm}/bin/pcmanfm";
+        }
+
+        # com.vixalien.sticky segfaults in COSMIC DE
+        {
+          name = "Sticky Notes";
+          description = "Sticky Notes on your Desktop";
+          icon = "${pkgs.sticky-notes}/share/icons/hicolor/scalable/apps/com.vixalien.sticky.svg";
+          command = "${pkgs.sticky-notes}/bin/com.vixalien.sticky";
         }
       ]
       ++ lib.optionals config.ghaf.reference.services.alpaca-ollama [


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->


## Description of Changes

1. **Removed Sticky Notes From COSMIC DE:**
   - Sticky notes app behaves inconsistently in Cosmic, e.g. failing to launch due to segfaults
   - Tried some other sticky notes apps on Cosmic, but couldn't find one that runs nicely

2. **Switched Default Image Viewer [Pqiv](https://github.com/phillipberndt/pqiv) -> [Oculante](https://github.com/woelper/oculante):**
   - pqiv seems to prefer X11 over Wayland, which causes some rendering issues in Cosmic (and possibly labwc)
   - Switched to Oculante, a fast image viewer written in Rust with better Wayland support
   - Added more default image mimetypes [supported by Oculante](https://github.com/woelper/oculante/blob/master/res/oculante.desktop)
 
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Save several types of images in some Shares directory or otherwise
   - recommend previously supported types like jpg, png, and some new ones, like webp
   - easiest method is to download some images via chrome
   - different image types can be created via online image converters
   - for a full reference of supported image types, check https://github.com/woelper/oculante/blob/master/res/oculante.desktop
2. Try to open the images through a file manager by double clicking them
3. Try to manipulate and interact with the images in Oculante
   - No specific instructions but all basic operations should be supported as before, e.g. zooming, moving, etc.