### PR TITLE
New demo tower hardware with RTX 5080

### DIFF
--- a/modules/desktop/graphics/login-manager.nix
+++ b/modules/desktop/graphics/login-manager.nix
@@ -55,6 +55,10 @@ in
       '';
     };
 
+    systemd.services.greetd.serviceConfig = {
+      RestartSec = "1";
+    };
+
     users.users.greeter.extraGroups = [ "video" ];
   };
 }

--- a/modules/desktop/nvidia-gpu/default.nix
+++ b/modules/desktop/nvidia-gpu/default.nix
@@ -42,6 +42,14 @@ in
         if you separately disable offload rendering.
       '';
     };
+    openDrivers = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to use the open source drivers instead of the nvidia
+        proprietary drivers, e.g., for Blackwell architectures.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -55,21 +63,17 @@ in
 
       nvidia = {
         modesetting.enable = lib.mkDefault true;
-
         gsp.enable = true;
+        open = cfg.openDrivers;
+        nvidiaSettings = true;
+        package = config.boot.kernelPackages.nvidiaPackages.production; # beta; # was stable
 
+        dynamicBoost.enable = cfg.enable && cfg.withIntegratedGPU;
         # TODO: test enabling these to resume from sleep/suspend states
         powerManagement.enable = false;
         # TODO: this may fix screen tearing but if not needed it can cause more issues
         # than it actually fixes. so leave it to off by default
         forceFullCompositionPipeline = false;
-        # TODO: testing the open drivers recommended by nvidia, fails to load the cuda modules
-        # and hence fails vaapi support
-        open = false; # true;
-        nvidiaSettings = true;
-        package = config.boot.kernelPackages.nvidiaPackages.beta; # was stable
-
-        dynamicBoost.enable = cfg.enable && cfg.withIntegratedGPU;
       };
     };
 

--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -14,117 +14,125 @@ let
     types
     mkIf
     literalExpression
+    optionals
     ;
 
-  defaultRules = [
-    {
-      name = "GUIVM";
-      qmpSocket = "/var/lib/microvms/gui-vm/gui-vm.sock";
-      usbPassthrough = [
+  defaultRules =
+    [
+      {
+        name = "GUIVM";
+        qmpSocket = "/var/lib/microvms/gui-vm/gui-vm.sock";
+        usbPassthrough = [
+          {
+            class = 3;
+            protocol = 1;
+            description = "HID Keyboard";
+          }
+          {
+            class = 3;
+            protocol = 2;
+            description = "HID Mouse";
+          }
+          {
+            class = 11;
+            description = "Chip/SmartCard (e.g. YubiKey)";
+          }
+          {
+            class = 224;
+            subclass = 1;
+            protocol = 1;
+            description = "Bluetooth";
+            disable = true;
+          }
+          {
+            class = 8;
+            subclass = 6;
+            description = "Mass Storage - SCSI (USB drives)";
+          }
+          {
+            class = 17;
+            description = "USB-C alternate modes supported by device";
+          }
+        ];
+        evdevPassthrough = {
+          enable = cfg.enableEvdevPassthrough;
+          inherit (cfg) pcieBusPrefix;
+        };
+      }
+      {
+        name = "NetVM";
+        qmpSocket = "/var/lib/microvms/net-vm/net-vm.sock";
+        usbPassthrough = [
+          {
+            class = 2;
+            subclass = 6;
+            description = "Communications - Ethernet Networking";
+          }
+          {
+            vendorId = "0b95";
+            productId = "1790";
+            description = "ASIX Elec. Corp. AX88179 UE306 Ethernet Adapter";
+          }
+        ];
+      }
+      {
+        name = "AudioVM";
+        qmpSocket = "/var/lib/microvms/audio-vm/audio-vm.sock";
+        usbPassthrough = [
+          {
+            class = 1;
+            description = "Audio";
+          }
+        ];
+      }
+    ]
+    ++ optionals
+      (
+        config.ghaf.virtualization.microvm.appvm.enable
+        && config.ghaf.virtualization.microvm.appvm.vms.chrome.enable
+      )
+      [
         {
-          class = 3;
-          protocol = 1;
-          description = "HID Keyboard";
-        }
-        {
-          class = 3;
-          protocol = 2;
-          description = "HID Mouse";
-        }
-        {
-          class = 11;
-          description = "Chip/SmartCard (e.g. YubiKey)";
-        }
-        {
-          class = 224;
-          subclass = 1;
-          protocol = 1;
-          description = "Bluetooth";
-          disable = true;
-        }
-        {
-          class = 8;
-          subclass = 6;
-          description = "Mass Storage - SCSI (USB drives)";
-        }
-        {
-          class = 17;
-          description = "USB-C alternate modes supported by device";
-        }
-      ];
-      evdevPassthrough = {
-        enable = cfg.enableEvdevPassthrough;
-        inherit (cfg) pcieBusPrefix;
-      };
-    }
-    {
-      name = "NetVM";
-      qmpSocket = "/var/lib/microvms/net-vm/net-vm.sock";
-      usbPassthrough = [
-        {
-          class = 2;
-          subclass = 6;
-          description = "Communications - Ethernet Networking";
-        }
-        {
-          vendorId = "0b95";
-          productId = "1790";
-          description = "ASIX Elec. Corp. AX88179 UE306 Ethernet Adapter";
-        }
-      ];
-    }
-
-    {
-      name = "ChromeVM";
-      qmpSocket = "/var/lib/microvms/chrome-vm/chrome-vm.sock";
-      usbPassthrough = [
-        {
-          class = 14;
-          description = "Video (USB Webcams)";
-          ignore = [
+          name = "ChromeVM";
+          qmpSocket = "/var/lib/microvms/chrome-vm/chrome-vm.sock";
+          usbPassthrough = [
             {
-              # Ignore Lenovo X1 camera since it is attached to the business-vm
-              # Finland SKU
-              vendorId = "04f2";
-              productId = "b751";
-              description = "Lenovo X1 Integrated Camera";
-            }
-            {
-              # Ignore Lenovo X1 camera since it is attached to the business-vm
-              # Uae 1st SKU
-              vendorId = "5986";
-              productId = "2145";
-              description = "Lenovo X1 Integrated Camera";
-            }
-            {
-              # Ignore Lenovo X1 camera since it is attached to the business-vm
-              # UAE #2 SKU
-              vendorId = "30c9";
-              productId = "0052";
-              description = "Lenovo X1 Integrated Camera";
-            }
-            {
-              # Ignore Lenovo X1 gen 12 camera since it is attached to the business-vm
-              # Finland SKU
-              vendorId = "30c9";
-              productId = "005f";
-              description = "Lenovo X1 Integrated Camera";
+              class = 14;
+              description = "Video (USB Webcams)";
+              ignore = [
+                {
+                  # Ignore Lenovo X1 camera since it is attached to the business-vm
+                  # Finland SKU
+                  vendorId = "04f2";
+                  productId = "b751";
+                  description = "Lenovo X1 Integrated Camera";
+                }
+                {
+                  # Ignore Lenovo X1 camera since it is attached to the business-vm
+                  # Uae 1st SKU
+                  vendorId = "5986";
+                  productId = "2145";
+                  description = "Lenovo X1 Integrated Camera";
+                }
+                {
+                  # Ignore Lenovo X1 camera since it is attached to the business-vm
+                  # UAE #2 SKU
+                  vendorId = "30c9";
+                  productId = "0052";
+                  description = "Lenovo X1 Integrated Camera";
+                }
+                {
+                  # Ignore Lenovo X1 gen 12 camera since it is attached to the business-vm
+                  # Finland SKU
+                  vendorId = "30c9";
+                  productId = "005f";
+                  description = "Lenovo X1 Integrated Camera";
+                }
+              ];
             }
           ];
         }
       ];
-    }
-    {
-      name = "AudioVM";
-      qmpSocket = "/var/lib/microvms/audio-vm/audio-vm.sock";
-      usbPassthrough = [
-        {
-          class = 1;
-          description = "Audio";
-        }
-      ];
-    }
-  ];
 in
 {
   options.ghaf.hardware.usb.vhotplug = {

--- a/modules/reference/hardware/flake-module.nix
+++ b/modules/reference/hardware/flake-module.nix
@@ -48,7 +48,16 @@
         ];
       }
     ];
-
+    hardware-tower-5080.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      {
+        ghaf.hardware.definition = import ./tower-5080/tower-5080.nix;
+        ghaf.hardware.tpm2.enable = lib.mkForce false;
+        ghaf.virtualization.microvm.guivm.extraModules = [
+          (import ./tower-5080/extra-config.nix)
+        ];
+      }
+    ];
     hardware-lenovo-x1-carbon-gen10.imports = [
       inputs.self.nixosModules.hardware-x86_64-workstation
       {

--- a/modules/reference/hardware/tower-5080/extra-config.nix
+++ b/modules/reference/hardware/tower-5080/extra-config.nix
@@ -1,0 +1,19 @@
+# Copyright 2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  pkgs,
+  ...
+}:
+{
+  ghaf.graphics.nvidia-setup = {
+    enable = true;
+    openDrivers = true;
+  };
+
+  microvm.qemu.extraArgs = [
+    "-drive"
+    "file=${pkgs.OVMF.fd}/FV/OVMF_CODE.fd,if=pflash,unit=0,readonly=true"
+    "-drive"
+    "file=${pkgs.OVMF.fd}/FV/OVMF_VARS.fd,if=pflash,unit=1,readonly=true"
+  ];
+}

--- a/modules/reference/hardware/tower-5080/tower-5080.nix
+++ b/modules/reference/hardware/tower-5080/tower-5080.nix
@@ -1,0 +1,177 @@
+# Copyright 2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  # System name
+  name = "Micro-Star International Co., Ltd. 2.0";
+
+  # List of system SKUs covered by this configuration
+  skus = [
+    "Default string MS-7E06"
+  ];
+
+  type = "desktop";
+
+  # Host configuration
+  host = {
+    kernelConfig.kernelParams = [
+      "intel_iommu=on,sm_on"
+      "iommu=pt"
+      "acpi_backlight=vendor"
+      "acpi_osi=linux"
+      "module_blacklist=nouveau,snd,snd_hda_intel,igc,iwlwifi,bluetooth"
+    ];
+  };
+
+  # Input devices
+  input = {
+    misc = {
+      name = [
+        # "LiteOn Lenovo Calliope USB Keyboard" "HDA NVidia HDMI/DP,pcm=7" "HDA NVidia HDMI/DP,pcm=8" "HDA NVidia HDMI/DP,pcm=9" "HDA Intel PCH Rear Mic" "HDA Intel PCH Front Mic" "HDA Intel PCH Line" "HDA Intel PCH Line Out Front" "HDA Intel PCH Line Out Surround" "HDA Intel PCH Line Out CLFE" "HDA Intel PCH Line Out Side" "LiteOn Lenovo Calliope USB Keyboard System Control" "HDA Intel PCH Front Headphone" "HDA Intel PCH HDMI/DP,pcm=3" "HDA Intel PCH HDMI/DP,pcm=7" "HDA Intel PCH HDMI/DP,pcm=8" "HDA Intel PCH HDMI/DP,pcm=9" "LiteOn Lenovo Calliope USB Keyboard Consumer Control" "Sleep Button" "Power Button" "Video Bus" "HDA NVidia HDMI/DP,pcm=3"
+      ];
+      evdev = [
+        # /dev/input/by-id/usb-LiteOn_Lenovo_Calliope_USB_Keyboard-event-kbd /dev/input/by-path/pci-0000:00:14.0-usb-0:11:1.0-event-kbd /dev/input/by-path/pci-0000:00:14.0-usbv2-0:11:1.0-event-kbd /dev/input/by-path/pci-0000:00:14.0-usb-0:11:1.1-event /dev/input/by-id/usb-LiteOn_Lenovo_Calliope_USB_Keyboard-event-if01 /dev/input/by-path/pci-0000:00:14.0-usbv2-0:11:1.1-event /dev/input/by-path/pci-0000:00:14.0-usbv2-0:11:1.1-event /dev/input/by-id/usb-LiteOn_Lenovo_Calliope_USB_Keyboard-event-if01 /dev/input/by-path/pci-0000:00:14.0-usb-0:11:1.1-event
+      ];
+    };
+  };
+
+  # Main disk device
+  disks = {
+    disk1.device = "/dev/nvme0n1";
+  };
+
+  # Network devices for passthrough to netvm
+  network = {
+    pciDevices = [
+      {
+        # Network controller: Intel Corporation Raptor Lake-S PCH CNVi WiFi (rev 11)
+        name = "wlp0s5f0";
+        path = "0000:00:14.3";
+        vendorId = "8086";
+        productId = "7a70";
+        # Detected kernel driver: iwlwifi
+        # Detected kernel modules: iwlwifi
+      }
+      {
+        # Ethernet controller: Intel Corporation Ethernet Controller I226-V (rev 04)
+        name = "eth0";
+        path = "0000:04:00.0";
+        vendorId = "8086";
+        productId = "125c";
+        # Detected kernel driver: igc
+        # Detected kernel modules: igc
+      }
+    ];
+    kernelConfig = {
+      # Kernel modules are indicative only, please investigate with lsmod/modinfo
+      stage1.kernelModules = [ ];
+      stage2.kernelModules = [
+        "iwlwifi"
+        "igc"
+      ];
+      kernelParams = [ ];
+    };
+  };
+
+  # GPU devices for passthrough to guivm
+  gpu = {
+    pciDevices = [
+      {
+        # VGA compatible controller: NVIDIA Corporation GB203 [GeForce RTX 5080] (rev a1)
+        name = "gpu0-0";
+        path = "0000:01:00.0";
+        vendorId = "10de";
+        productId = "2c02";
+        # Detected kernel driver:
+        # Detected kernel modules: nvidiafb,nouveau
+      }
+      {
+        # Audio device: NVIDIA Corporation Device 22e9 (rev a1)
+        name = "gpu0-1";
+        path = "0000:01:00.1";
+        vendorId = "10de";
+        productId = "22e9";
+        # Detected kernel driver: snd_hda_intel
+        # Detected kernel modules: snd_hda_intel
+      }
+    ];
+    kernelConfig = {
+      stage1.kernelModules = [
+        "nvidia"
+        "nvidia_drm"
+        "nvidia_uvm"
+        "nvidia_modeset"
+      ];
+      kernelParams = [
+        "module_blacklist=nouveau"
+      ];
+    };
+  };
+
+  # Audio device for passthrough to audiovm
+  audio = {
+    pciDevices = [
+      {
+        # ISA bridge: Intel Corporation Raptor Lake LPC/eSPI Controller (rev 11)
+        name = "snd0-0";
+        path = "0000:00:1f.0";
+        vendorId = "8086";
+        productId = "7a04";
+        # Detected kernel driver:
+        # Detected kernel modules:
+      }
+      {
+        # Serial bus controller: Intel Corporation Raptor Lake SPI (flash) Controller (rev 11)
+        name = "snd0-1";
+        path = "0000:00:1f.5";
+        vendorId = "8086";
+        productId = "7a24";
+        # Detected kernel driver: intel-spi
+        # Detected kernel modules: spi_intel_pci
+      }
+      {
+        # Audio device: Intel Corporation Raptor Lake High Definition Audio Controller (rev 11)
+        name = "snd0-2";
+        path = "0000:00:1f.3";
+        vendorId = "8086";
+        productId = "7a50";
+        # Detected kernel driver: snd_hda_intel
+        # Detected kernel modules: snd_hda_intel,snd_soc_avs,snd_sof_pci_intel_tgl
+      }
+      {
+        # SMBus: Intel Corporation Raptor Lake-S PCH SMBus Controller (rev 11)
+        name = "snd0-3";
+        path = "0000:00:1f.4";
+        vendorId = "8086";
+        productId = "7a23";
+        # Detected kernel driver: i801_smbus
+        # Detected kernel modules: i2c_i801
+      }
+    ];
+    kernelConfig = {
+      # Kernel modules are indicative only, please investigate with lsmod/modinfo
+      stage1.kernelModules = [ ];
+      stage2.kernelModules = [
+        "i2c_i801"
+        "snd_hda_intel"
+        "snd_soc_avs"
+        "snd_sof_pci_intel_tgl"
+        "spi_intel_pci"
+      ];
+      kernelParams = [ ];
+    };
+  };
+
+  # USB devices for passthrough
+  usb = {
+    internal = [
+      {
+        name = "bt0";
+        vendorId = "8087";
+        productId = "0033";
+      }
+    ];
+    external = [
+      # Add external USB devices here
+    ];
+  };
+}

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -127,6 +127,16 @@ let
         };
       }
     ]))
+    (laptop-configuration "tower-5080" "debug" (withCommonModules [
+      self.nixosModules.hardware-tower-5080
+      {
+        ghaf = {
+          reference.profiles.mvp-user-trial.enable = true;
+          partitioning.disko.enable = true;
+          profiles.graphics.idleManagement.enable = false;
+        };
+      }
+    ]))
     (laptop-configuration "lenovo-x1-gen11-cosmic" "debug" (withCommonModules [
       self.nixosModules.hardware-lenovo-x1-carbon-gen11
       {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Add new demo tower hardware and target with Nvidia RTX 5080. Tested with FMO, all functionality appears to work with exception of boot with cables in nvidia card. To be updated.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. No testing required. 
