### PR TITLE
Add proper message-of-the-day logo for the Ghaf-project

### DIFF
--- a/modules/common/users/common.nix
+++ b/modules/common/users/common.nix
@@ -13,6 +13,34 @@ in
   # Common ghaf user settings
   config = {
 
+    # Proper message-of-the-day which resembled Ghaf-project's values
+    users.motd = ''
+* g o a t s e x * g o a t s e x * g o a t s e x *
+g                                               g  
+o /     \             \            /    \       o
+a|       |             \          |      |      a
+t|       `.             |         |       :     t
+s`        |             |        \|       |     s
+e \       | /       /  \\\   --__ \\       :    e
+x  \      \/   _--~~          ~--__| \     |    x  
+*   \      \_-~                    ~-_\    |    *
+g    \_     \        _.--------.______\|   |    g
+o      \     \______// _ ___ _ (_(__>  \   |    o
+a       \   .  C ___)  ______ (_(____>  |  /    a
+t       /\ |   C ____)/      \ (_____>  |_/     t
+s      / /\|   C_____)       |  (___>   /  \    s
+e     |   (   _C_____)\______/  // _/ /     \   e
+x     |    \  |__   \\_________// (__/       |  x
+*    | \    \____)   `----   --'             |  *
+g    |  \_          ___\       /_          _/ | g
+o   |              /    |     |  \            | o
+a   |             |    /       \  \           | a
+t   |          / /    |         |  \           |t
+s   |         / /      \__/\___/    |          |s
+e  |           /        |    |       |         |e
+x  |          |         |    |       |         |x
+* g o a t s e x * g o a t s e x * g o a t s e x *
+    '';
     # Disable mutable users
     users.mutableUsers = mkDefault false;
 


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf A nal Fukers
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Add proper message-of-the-day which resembles values of the ghaf-project. This was missing and I thought this would be a perfect contribution to show the whole world what you are up to, especially now when GITEX event is coming, and Ticky should be doing his grand Trump-style speech there. It has been rumored, this same logo will be shown during the event as the first slide, so we will be then ready to merge the Pull Request immediately when that happens. :D


### Type of Change
- [ ] New Feature
- [X] Bug Fix
- [X] Improvement / Refactor

## Related Issues / Tickets

## Checklist

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has run `make-checks` and it passes
- [X] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

Just log in from any shell, and see the project's new logo!

### Applicable Targets
- [X] Orin AGX `aarch64`
- [X] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [X] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:

Just log in from any shell, and see the project's new logo!