### PR TITLE
fix(desktop): adjust ghaf-launcher env vars

### DIFF
--- a/modules/desktop/graphics/labwc.config.nix
+++ b/modules/desktop/graphics/labwc.config.nix
@@ -317,8 +317,6 @@ let
     gtk-theme-name=${cfg.gtk.theme}
     gtk-icon-theme-name=${cfg.gtk.iconTheme}
     gtk-font-name=${cfg.gtk.fontName} ${cfg.gtk.fontSize}
-    gtk-button-images=1
-    gtk-menu-images=1
     gtk-enable-event-sounds=1
     gtk-enable-input-feedback-sounds=1
     gtk-xft-antialias=1
@@ -622,7 +620,9 @@ in
           Type = "simple";
           EnvironmentFile = "-/etc/locale.conf";
           ExecCondition = "${display-connected}/bin/display-connected";
-          ExecStart = "${pkgs.nwg-drawer}/bin/nwg-drawer -r -nofs -nocats -s ${drawerStyle}";
+          ExecStart = ''
+            ${lib.getExe pkgs.bash} -c "PATH=/run/current-system/sw/bin:$PATH ${lib.getExe pkgs.nwg-drawer} -r -nofs -nocats -s ${drawerStyle}"
+          '';
           Restart = "always";
           RestartSec = "1";
         };


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

1. **Add /run/current-system/sw/bin to nwg-drawer PATH:**
   - This change allows nwg-drawer to properly run applications via their .desktop files even if the full path to the binary is not provided in Exec=
   - With this change, if a particular package, added via `environment.systemPackages` has its own .desktop entry, nwg-drawer will be able to launch it without issues.
   - The reason this change is needed is because we start nwg-drawer as a user service. By default, it seems to inherit the service manager's PATH, which does not include /run/current-system/sw/bin.  

2. **Minor adjustment to default gtk settings files, removing unsupported properties**

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
Testing is not necessary, as this change should not affect existing functionality and it doesn't add anything new yet.
That being said, a sanity check can be performed:
1. Find the process ID of nwg-drawer via `ps aux | grep nwg-drawer`
3. Check the PATH env var for the nwg-drawer process: `cat /proc/[PROC-ID-HERE]/environ | tr '\0' '\n' | grep PATH --color=auto`
4. PATH should contain `/run/current-system/sw/bin`
