### PR TITLE
Add security context indicator to COSMIC

### DIFF
--- a/modules/desktop/graphics/cosmic/config/cosmic-config.nix
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.nix
@@ -3,9 +3,29 @@
 {
   lib,
   pkgs,
+  secctx,
   ...
 }:
 
+let
+  securityContextConfig = pkgs.writeText "cosmic_security_context" ''
+    (
+      border_size: ${toString secctx.borderWidth},
+      rules:
+      [
+        ${lib.concatStrings (
+          map (rule: ''
+            (
+              sandbox_engine: "waypipe",
+              app_id: "${rule.identifier}",
+              border_color: "${rule.color}",
+            ),
+          '') secctx.rules
+        )}
+      ],
+    )
+  '';
+in
 pkgs.stdenv.mkDerivation rec {
   pname = "ghaf-cosmic-config";
   version = "0.1";
@@ -38,6 +58,7 @@ pkgs.stdenv.mkDerivation rec {
     mkdir -p $out/share/cosmic
     cp -rf cosmic-unpacked/* $out/share/cosmic/
     rm -rf cosmic-unpacked
+    cp ${securityContextConfig} $out/share/cosmic/com.system76.CosmicComp/v1/security_context
   '';
 
   postInstall = ''

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -15,6 +15,7 @@ let
 
   ghaf-cosmic-config = import ./config/cosmic-config.nix {
     inherit lib pkgs;
+    secctx = cfg.securityContext;
   };
 
   autostart = pkgs.writeShellApplication {
@@ -69,6 +70,39 @@ in
 {
   options.ghaf.graphics.cosmic = {
     enable = lib.mkEnableOption "cosmic";
+
+    securityContext = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          borderWidth = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 4;
+            description = "Default border width";
+          };
+
+          rules = lib.mkOption {
+            type = lib.types.listOf (
+              lib.types.submodule {
+                options = {
+                  identifier = lib.mkOption {
+                    type = lib.types.str;
+                    description = "The identifier attached to the security context";
+                  };
+                  color = lib.mkOption {
+                    type = lib.types.str;
+                    example = "#006305";
+                    description = "Window border color";
+                  };
+                };
+              }
+            );
+            default = [ ];
+            description = "List of security contexts rules";
+          };
+        };
+      };
+      description = "Security context settings";
+    };
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -117,6 +117,12 @@ let
                   color = vm.borderColor;
                 }) (lib.attrsets.mapAttrsToList (name: vm: { inherit name; } // vm) enabledVms);
               };
+              cosmic = {
+                securityContext.rules = map (vm: {
+                  identifier = vm.name;
+                  color = vm.borderColor;
+                }) (lib.attrsets.mapAttrsToList (name: vm: { inherit name; } // vm) enabledVms);
+              };
             };
 
             # Logging

--- a/overlays/custom-packages/cosmic/cosmic-comp/0001-Add-security-context-indicator.patch
+++ b/overlays/custom-packages/cosmic/cosmic-comp/0001-Add-security-context-indicator.patch
@@ -1,0 +1,337 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+From df8f3b5c969475ed76a414e8b6f4e8ef8d0a1f53 Mon Sep 17 00:00:00 2001
+From: Yuri Nesterov <yuriy.nesterov@unikie.com>
+Date: Fri, 2 May 2025 20:43:32 +0300
+Subject: [PATCH] Add security context indicator
+
+---
+ cosmic-comp-config/src/lib.rs         | 24 ++++++++++++
+ src/shell/layout/floating/mod.rs      | 56 ++++++++++++++++++++++++++-
+ src/shell/mod.rs                      | 14 ++++++-
+ src/shell/workspace.rs                |  4 +-
+ src/wayland/handlers/xdg_shell/mod.rs | 23 +++++++++++
+ 5 files changed, 117 insertions(+), 4 deletions(-)
+
+diff --git a/cosmic-comp-config/src/lib.rs b/cosmic-comp-config/src/lib.rs
+index a6b772a..7e27234 100644
+--- a/cosmic-comp-config/src/lib.rs
++++ b/cosmic-comp-config/src/lib.rs
+@@ -49,6 +49,7 @@ pub struct CosmicCompConfig {
+     /// The threshold before windows snap themselves to output edges
+     pub edge_snap_threshold: u32,
+     pub accessibility_zoom: ZoomConfig,
++    pub security_context: SecurityContextConfig,
+ }
+ 
+ impl Default for CosmicCompConfig {
+@@ -81,6 +82,7 @@ impl Default for CosmicCompConfig {
+             descale_xwayland: false,
+             edge_snap_threshold: 0,
+             accessibility_zoom: ZoomConfig::default(),
++            security_context: SecurityContextConfig::default(),
+         }
+     }
+ }
+@@ -150,3 +152,25 @@ pub enum ZoomMovement {
+     Centered,
+     Continuously,
+ }
++
++#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
++pub struct SecurityContextRule {
++    pub app_id: String,
++    pub sandbox_engine: String,
++    pub border_color: String,
++}
++
++#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
++pub struct SecurityContextConfig {
++    pub border_size: u8,
++    pub rules: Vec<SecurityContextRule>,
++}
++
++impl Default for SecurityContextConfig {
++    fn default() -> SecurityContextConfig {
++        SecurityContextConfig {
++            border_size: 4,
++            rules: Vec::new(),
++        }
++    }
++}
+\ No newline at end of file
+diff --git a/src/shell/layout/floating/mod.rs b/src/shell/layout/floating/mod.rs
+index 9ec3f01..d111282 100644
+--- a/src/shell/layout/floating/mod.rs
++++ b/src/shell/layout/floating/mod.rs
+@@ -21,6 +21,7 @@ use smithay::{
+     output::Output,
+     utils::{IsAlive, Logical, Point, Rectangle, Scale, Size},
+     wayland::seat::WaylandFocus,
++    wayland::security_context::SecurityContext,
+ };
+ 
+ use crate::{
+@@ -44,6 +45,8 @@ use crate::{
+     wayland::handlers::xdg_shell::popup::get_popup_toplevel,
+ };
+ 
++use cosmic_comp_config::SecurityContextConfig;
++
+ mod grabs;
+ pub use self::grabs::*;
+ 
+@@ -58,6 +61,7 @@ pub struct FloatingLayout {
+     hovered_stack: Option<(CosmicMapped, Rectangle<i32, Local>)>,
+     dirty: AtomicBool,
+     pub theme: cosmic::Theme,
++    pub security_context_config: SecurityContextConfig,
+ }
+ 
+ #[derive(Debug)]
+@@ -262,9 +266,14 @@ impl TiledCorners {
+ }
+ 
+ impl FloatingLayout {
+-    pub fn new(theme: cosmic::Theme, output: &Output) -> FloatingLayout {
++    pub fn new(
++        theme: cosmic::Theme,
++        output: &Output,
++        security_context_config: SecurityContextConfig,
++    ) -> FloatingLayout {
+         let mut layout = Self {
+             theme,
++            security_context_config,
+             ..Default::default()
+         };
+         layout.space.map_output(output, (0, 0));
+@@ -1584,6 +1593,39 @@ impl FloatingLayout {
+                 }
+             }
+ 
++            // Security context indicator
++            if elem.is_window() {
++                let surface = elem.active_window();
++
++                if let Some(security_context) = surface.user_data().get::<SecurityContext>() {
++                    let sandbox_engine = security_context
++                        .sandbox_engine
++                        .as_deref()
++                        .unwrap_or_default();
++                    let app_id = security_context.app_id.as_deref().unwrap_or_default();
++                    let border_color = self
++                        .security_context_config.rules
++                        .iter()
++                        .find(|config| {
++                            config.sandbox_engine == sandbox_engine && config.app_id == app_id
++                        })
++                        .map(|config| config.border_color.clone());
++
++                    if let Some(color) = border_color {
++                        let element = IndicatorShader::focus_element(
++                            renderer,
++                            Key::Window(Usage::FocusIndicator, elem.key()),
++                            geometry,
++                            self.security_context_config.border_size,
++                            output_scale,
++                            alpha,
++                            self.hex_to_rgb_f32(&color).unwrap_or_default(),
++                        );
++                        window_elements.insert(0, element.into());
++                    }
++                }
++            }
++
+             elements.extend(window_elements);
+         }
+ 
+@@ -1594,4 +1636,16 @@ impl FloatingLayout {
+         let g = self.theme.cosmic().gaps;
+         (g.0 as i32, g.1 as i32)
+     }
++
++    fn hex_to_rgb_f32(&self, hex: &str) -> Option<[f32; 3]> {
++        if hex.len() != 7 || !hex.starts_with('#') {
++            return None;
++        }
++
++        let r = u8::from_str_radix(&hex[1..3], 16).ok()?;
++        let g = u8::from_str_radix(&hex[3..5], 16).ok()?;
++        let b = u8::from_str_radix(&hex[5..7], 16).ok()?;
++
++        Some([r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0])
++    }
+ }
+diff --git a/src/shell/mod.rs b/src/shell/mod.rs
+index b4f6562..1758755 100644
+--- a/src/shell/mod.rs
++++ b/src/shell/mod.rs
+@@ -14,6 +14,7 @@ use crate::wayland::{handlers::data_device, protocols::workspace::WorkspaceCapab
+ use cosmic_comp_config::{
+     workspace::{WorkspaceLayout, WorkspaceMode},
+     TileBehavior, ZoomConfig, ZoomMovement,
++    SecurityContextConfig
+ };
+ use cosmic_protocols::workspace::v1::server::zcosmic_workspace_handle_v1::TilingState;
+ use cosmic_settings_config::shortcuts::action::{Direction, FocusDirection, ResizeDirection};
+@@ -336,6 +337,7 @@ pub struct WorkspaceSet {
+     pub sticky_layer: FloatingLayout,
+     pub minimized_windows: Vec<MinimizedWindow>,
+     pub workspaces: Vec<Workspace>,
++    pub security_context_config: SecurityContextConfig,
+ }
+ 
+ fn create_workspace(
+@@ -345,6 +347,7 @@ fn create_workspace(
+     active: bool,
+     tiling: bool,
+     theme: cosmic::Theme,
++    security_context_config: SecurityContextConfig,
+ ) -> Workspace {
+     let workspace_handle = state
+         .create_workspace(
+@@ -362,7 +365,7 @@ fn create_workspace(
+         state.add_workspace_state(&workspace_handle, WState::Active);
+     }
+     state.set_workspace_capabilities(&workspace_handle, WorkspaceCapabilities::Activate);
+-    Workspace::new(workspace_handle, output.clone(), tiling, theme.clone())
++    Workspace::new(workspace_handle, output.clone(), tiling, theme.clone(), security_context_config)
+ }
+ 
+ fn move_workspace_to_group(
+@@ -432,9 +435,10 @@ impl WorkspaceSet {
+         idx: usize,
+         tiling_enabled: bool,
+         theme: cosmic::Theme,
++        security_context_config: SecurityContextConfig,
+     ) -> WorkspaceSet {
+         let group_handle = state.create_workspace_group();
+-        let sticky_layer = FloatingLayout::new(theme.clone(), output);
++        let sticky_layer = FloatingLayout::new(theme.clone(), output, security_context_config.clone());
+ 
+         WorkspaceSet {
+             previously_active: None,
+@@ -447,6 +451,7 @@ impl WorkspaceSet {
+             minimized_windows: Vec::new(),
+             workspaces: Vec::new(),
+             output: output.clone(),
++            security_context_config: security_context_config.clone(),
+         }
+     }
+ 
+@@ -557,6 +562,7 @@ impl WorkspaceSet {
+             false,
+             self.tiling_enabled,
+             self.theme.clone(),
++            self.security_context_config.clone(),
+         );
+         workspace_set_idx(
+             state,
+@@ -630,6 +636,7 @@ pub struct Workspaces {
+     autotile: bool,
+     autotile_behavior: TileBehavior,
+     theme: cosmic::Theme,
++    security_context_config: SecurityContextConfig,
+ }
+ 
+ impl Workspaces {
+@@ -642,6 +649,7 @@ impl Workspaces {
+             autotile: config.cosmic_conf.autotile,
+             autotile_behavior: config.cosmic_conf.autotile_behavior,
+             theme,
++            security_context_config: config.cosmic_conf.security_context.clone(),
+         }
+     }
+ 
+@@ -669,6 +677,7 @@ impl Workspaces {
+                     self.sets.len(),
+                     self.autotile,
+                     self.theme.clone(),
++                    self.security_context_config.clone(),
+                 )
+             });
+         workspace_state.add_group_output(&set.group, &output);
+@@ -881,6 +890,7 @@ impl Workspaces {
+                                     false,
+                                     config.cosmic_conf.autotile,
+                                     self.theme.clone(),
++                                    config.cosmic_conf.security_context.clone(),
+                                 ),
+                             );
+                         }
+diff --git a/src/shell/workspace.rs b/src/shell/workspace.rs
+index f386caa..d12e2bd 100644
+--- a/src/shell/workspace.rs
++++ b/src/shell/workspace.rs
+@@ -69,6 +69,7 @@ use super::{
+     layout::tiling::{Data, MinimizedTilingState, NodeDesc},
+     CosmicMappedRenderElement, CosmicSurface, ResizeDirection, ResizeMode,
+ };
++use cosmic_comp_config::SecurityContextConfig;
+ 
+ const FULLSCREEN_ANIMATION_DURATION: Duration = Duration::from_millis(200);
+ 
+@@ -238,9 +239,10 @@ impl Workspace {
+         output: Output,
+         tiling_enabled: bool,
+         theme: cosmic::Theme,
++        security_context_config: SecurityContextConfig,
+     ) -> Workspace {
+         let tiling_layer = TilingLayout::new(theme.clone(), &output);
+-        let floating_layer = FloatingLayout::new(theme, &output);
++        let floating_layer = FloatingLayout::new(theme, &output, security_context_config.clone());
+         let output_name = output.name();
+ 
+         Workspace {
+diff --git a/src/wayland/handlers/xdg_shell/mod.rs b/src/wayland/handlers/xdg_shell/mod.rs
+index c8695e2..90305d9 100644
+--- a/src/wayland/handlers/xdg_shell/mod.rs
++++ b/src/wayland/handlers/xdg_shell/mod.rs
+@@ -5,6 +5,7 @@ use crate::{
+         element::CosmicWindow, grabs::ReleaseMode, CosmicMapped, CosmicSurface, ManagedLayer,
+         PendingWindow,
+     },
++    state::ClientState,
+     utils::prelude::*,
+     wayland::protocols::toplevel_info::{toplevel_enter_output, toplevel_enter_workspace},
+ };
+@@ -19,6 +20,7 @@ use smithay::{
+     reexports::{
+         wayland_protocols::xdg::shell::server::xdg_toplevel,
+         wayland_server::protocol::{wl_output::WlOutput, wl_seat::WlSeat},
++        wayland_server::Resource,
+     },
+     utils::{Logical, Point, Serial},
+     wayland::{
+@@ -47,7 +49,28 @@ impl XdgShellHandler for State {
+     fn new_toplevel(&mut self, surface: ToplevelSurface) {
+         let mut shell = self.common.shell.write().unwrap();
+         let seat = shell.seats.last_active().clone();
++
+         let window = CosmicSurface::from(surface);
++
++        // Get security context data and add it to the user data
++        if let Some(client) = window.wl_surface().unwrap().client() {
++            let client_data = self
++                .common
++                .display_handle
++                .backend_handle()
++                .get_client_data(client.id().clone())
++                .ok();
++
++            if let Some(security_context) = client_data
++                .as_ref()
++                .and_then(|data| data.downcast_ref::<ClientState>())
++                .and_then(|data| data.security_context.as_ref()) {
++                window
++                    .user_data()
++                    .get_or_insert_threadsafe(|| security_context.clone());
++            }
++        }
++
+         shell.pending_windows.push(PendingWindow {
+             surface: window,
+             seat,
+-- 
+2.43.0
+

--- a/overlays/custom-packages/cosmic/cosmic-comp/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-comp/default.nix
@@ -1,0 +1,6 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ prev }:
+prev.cosmic-comp.overrideAttrs (oldAttrs: {
+  patches = oldAttrs.patches ++ [ ./0001-Add-security-context-indicator.patch ];
+})

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -17,4 +17,5 @@
   cosmic-greeter = import ./cosmic/cosmic-greeter { inherit prev; };
   cosmic-session = import ./cosmic/cosmic-session { inherit prev; };
   cosmic-settings = import ./cosmic/cosmic-settings { inherit prev; };
+  cosmic-comp = import ./cosmic/cosmic-comp { inherit prev; };
 })


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This adds an initial version of a patch to the COSMIC compositor that enables setting different window frame colors based on the security context attached to the Wayland connection. This allows applications running in different AppVMs to have different window frame colors similar to how it works in Labwc.

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Build a Lenovo X1 image with COSMIC enabled (`lenovo-x1-gen11-cosmic-debug`).
2. Run different application and make sure they have correct window frame colors.
