### PR TITLE
feat: Kernel version option for NVIDIA Orin NX/AGX targets

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746516549,
-        "narHash": "sha256-Pm5ROyHeCRD75/Yadh5E+QqHFRbE/Lx6FcKLCL+SExk=",
+        "lastModified": 1747039537,
+        "narHash": "sha256-RC27FVnlwM7so1lMRP7mnZcs+twcMbc7Z/a0P3cX94c=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "a0767c3e5cced4bfc93631e7c35cef9a7c88de53",
+        "rev": "956a952392cd03243ff380e09d464021f8e6c6b7",
         "type": "github"
       },
       "original": {

--- a/modules/reference/hardware/jetpack/agx-netvm-wlan-pci-passthrough.nix
+++ b/modules/reference/hardware/jetpack/agx-netvm-wlan-pci-passthrough.nix
@@ -46,9 +46,9 @@ in
       }
     ];
 
-    boot.kernelPatches = [
+    boot.kernelPatches = lib.mkIf (config.ghaf.hardware.nvidia.orin.kernelVersion == "upstream-6-6") [
       {
-        name = lib.debug.traceVal "vfio-true";
+        name = "vfio-true";
         patch = ./0001-ARM-SMMU-drivers-return-always-true-for-IOMMU_CAP_CA.patch;
       }
     ];

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -45,6 +45,12 @@ in
       type = types.str;
       default = "devkit";
     };
+
+    kernelVersion = mkOption {
+      description = "Kernel version";
+      type = types.str;
+      default = "bsp-default";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -53,7 +59,7 @@ in
       som = if ((cfg.somType == "agx") || (cfg.somType == "agx64")) then "orin-agx" else "orin-nx";
       carrierBoard = "${cfg.carrierBoard}";
       modesetting.enable = true;
-
+      kernel.version = "${cfg.kernelVersion}";
       flashScriptOverrides = lib.optionalAttrs ((cfg.somType == "agx") || (cfg.somType == "agx64")) {
         flashArgs = lib.mkForce [
           "-r"

--- a/modules/reference/hardware/jetpack/nx-netvm-ethernet-pci-passthrough.nix
+++ b/modules/reference/hardware/jetpack/nx-netvm-ethernet-pci-passthrough.nix
@@ -52,9 +52,9 @@ in
       }
     ];
 
-    boot.kernelPatches = [
+    boot.kernelPatches = lib.mkIf (config.ghaf.hardware.nvidia.orin.kernelVersion == "upstream-6-6") [
       {
-        name = lib.debug.traceVal "vfio-true";
+        name = "vfio-true";
         patch = ./0001-ARM-SMMU-drivers-return-always-true-for-IOMMU_CAP_CA.patch;
       }
     ];

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -4,7 +4,6 @@
 {
   imports = [
     inputs.devshell.flakeModule
-    ./devshell/kernel.nix
   ];
   perSystem =
     {

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -66,6 +66,7 @@ let
                 nx.enableNetvmEthernetPCIPassthrough = som == "nx";
                 # Currntly we have mostly xavier nx based carrier boards
                 carrierBoard = if som == "nx" then "xavierNXdevkit" else "devkit";
+                kernelVersion = "upstream-6-6";
               };
 
               hardware.nvidia = {


### PR DESCRIPTION
Jetpack-nixos (tiiuae fork) supports kernel version select between "bsp-default" and "upstream-6-6". Upstream kernel only works with Jetson 36.X BSP. Commit also updates Jetpack-nixos flake lock.

NVIDIA Orin NX/AGX keeps using upstream 6.6. kernel.

<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions
Define kernel version option. For example 
`kernelVersion = "upstream-6-6"`
or 
`kernelVersion = "bsp-default"`
or
If not explicitly defined then "bsp-default" is selected.

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
If `kernelVersion = "upstream-6-6"` 
   -> `uname -a` should print `Linux ghaf-host 6.6.75 ...`
if `kernelVersion = "bsp-default"` 
   -> `uname -a` should print `Linux ghaf-host 5.15.148 ...`
if kernelVersion is NOT defined
   -> `uname -a` should print `Linux ghaf-host 5.15.148 ...`