### PR TITLE
Rebase: Flash script as build result

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -53,5 +53,21 @@ nixpkgs.lib.extend (
         in
         lib.elem system platforms
       );
+
+    genPkgWithFlashScript =
+      pkg: system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      pkgs.linkFarm "ghaf-image" [
+        {
+          name = "image";
+          path = pkg;
+        }
+        {
+          name = "flash-script";
+          path = pkgs.callPackage ./packages/flash { };
+        }
+      ];
   }
 )

--- a/lib.nix
+++ b/lib.nix
@@ -66,7 +66,7 @@ nixpkgs.lib.extend (
         }
         {
           name = "flash-script";
-          path = pkgs.callPackage ./packages/flash { };
+          path = pkgs.callPackage ./packages/pkgs-by-name/flash-script/package.nix { };
         }
       ];
   }

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -151,7 +151,11 @@ in
       map (t: lib.nameValuePair t.name t.hostConfiguration) targets
     );
     packages = {
-      x86_64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+      x86_64-linux = builtins.listToAttrs (
+        map (
+          t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package "x86_64-linux")
+        ) targets
+      );
     };
   };
 }

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -239,6 +239,8 @@ in
     nixosConfigurations = builtins.listToAttrs (
       map (t: lib.nameValuePair t.name t.hostConfiguration) targets
     );
-    packages.${system} = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+    packages.${system} = builtins.listToAttrs (
+      map (t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package system)) targets
+    );
   };
 }

--- a/targets/laptop/laptop-installer-builder.nix
+++ b/targets/laptop/laptop-installer-builder.nix
@@ -10,7 +10,6 @@
 }:
 let
   system = "x86_64-linux";
-
   mkLaptopInstaller =
     name: imagePath: extraModules:
     let
@@ -64,49 +63,5 @@ let
       name = "${name}-installer";
       package = hostConfiguration.config.system.build.isoImage;
     };
-
-  # Define the installer function
-  installer = generation: variant:
-    let
-      name = "lenovo-x1-${generation}-${variant}";
-      imagePath = self.packages.x86_64-linux."${name}" + "/image/disk1.raw.zst";
-    in
-      mkLaptopInstaller name imagePath [];
-
-  # List of targets
-  targets = [
-    (installer "gen10" "debug")
-    (installer "gen11" "debug")
-    (installer "gen12" "debug")
-    (installer "gen10" "release")
-    (installer "gen11" "release")
-    (installer "gen12" "release")
-  ];
-
-  # Function to bundle image and flash script
-  genPkgWithFlashScript =
-    pkg:
-    let
-      pkgs = import self.inputs.nixpkgs { inherit system; };
-    in
-    pkgs.linkFarm "ghaf-image" [
-      {
-        name = "image";
-        path = pkg;
-      }
-      {
-        name = "flash-script";
-        path = pkgs.callPackage ../../packages/flash { };
-      }
-    ];
 in
-{
-  flake = {
-    nixosConfigurations = builtins.listToAttrs (
-      map (t: lib.nameValuePair t.name t.hostConfiguration) targets
-    );
-    packages.${system} = builtins.listToAttrs (
-      map (t: lib.nameValuePair t.name (genPkgWithFlashScript t.package)) targets
-    );
-  };
-}
+mkLaptopInstaller

--- a/targets/laptop/laptop-installer-builder.nix
+++ b/targets/laptop/laptop-installer-builder.nix
@@ -10,6 +10,7 @@
 }:
 let
   system = "x86_64-linux";
+
   mkLaptopInstaller =
     name: imagePath: extraModules:
     let
@@ -63,5 +64,49 @@ let
       name = "${name}-installer";
       package = hostConfiguration.config.system.build.isoImage;
     };
+
+  # Define the installer function
+  installer = generation: variant:
+    let
+      name = "lenovo-x1-${generation}-${variant}";
+      imagePath = self.packages.x86_64-linux."${name}" + "/image/disk1.raw.zst";
+    in
+      mkLaptopInstaller name imagePath [];
+
+  # List of targets
+  targets = [
+    (installer "gen10" "debug")
+    (installer "gen11" "debug")
+    (installer "gen12" "debug")
+    (installer "gen10" "release")
+    (installer "gen11" "release")
+    (installer "gen12" "release")
+  ];
+
+  # Function to bundle image and flash script
+  genPkgWithFlashScript =
+    pkg:
+    let
+      pkgs = import self.inputs.nixpkgs { inherit system; };
+    in
+    pkgs.linkFarm "ghaf-image" [
+      {
+        name = "image";
+        path = pkg;
+      }
+      {
+        name = "flash-script";
+        path = pkgs.callPackage ../../packages/flash { };
+      }
+    ];
 in
-mkLaptopInstaller
+{
+  flake = {
+    nixosConfigurations = builtins.listToAttrs (
+      map (t: lib.nameValuePair t.name t.hostConfiguration) targets
+    );
+    packages.${system} = builtins.listToAttrs (
+      map (t: lib.nameValuePair t.name (genPkgWithFlashScript t.package)) targets
+    );
+  };
+}

--- a/targets/microchip-icicle-kit/flake-module.nix
+++ b/targets/microchip-icicle-kit/flake-module.nix
@@ -76,7 +76,11 @@ in
       map (t: lib.nameValuePair t.name t.hostConfiguration) targets
     );
     packages = {
-      x86_64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+      x86_64-linux = builtins.listToAttrs (
+        map (
+          t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package "x86_64-linux")
+        ) targets
+      );
     };
   };
 }

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -202,9 +202,17 @@ in
     );
 
     packages = {
-      aarch64-linux = builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) targets);
+      aarch64-linux = builtins.listToAttrs (
+        map (
+          t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package "aarch64-linux")
+        ) targets
+      );
       x86_64-linux =
-        builtins.listToAttrs (map (t: lib.nameValuePair t.name t.package) crossTargets)
+        builtins.listToAttrs (
+          map (
+            t: lib.nameValuePair t.name (self.outputs.lib.genPkgWithFlashScript t.package "x86_64-linux")
+          ) crossTargets
+        )
         // builtins.listToAttrs (
           map (
             t: lib.nameValuePair "${t.name}-flash-script" t.hostConfiguration.pkgs.nvidia-jetpack.flashScript


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Bundle flash-script with image build. For example:

```
nix build .#lenovo-x1-carbon-gen11-debug
```

Will no produce

```
result/
  flash-script/bin/flash-script
  image/disk1.raw.zst
```

Instead of only the image.

### Type of Change
- [x] Improvement / Refactor

## Related Issues / Tickets

https://github.com/tiiuae/ghaf/pull/927

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
