### PR TITLE
Fix Sticky Notes segfault in Cosmic

### DIFF
--- a/modules/common/systemd/hardened-configs/greetd.nix
+++ b/modules/common/systemd/hardened-configs/greetd.nix
@@ -18,7 +18,7 @@
   ProtectControlGroups = true;
   RestrictNamespaces = true;
   LockPersonality = true;
-  MemoryDenyWriteExecute = true;
+  MemoryDenyWriteExecute = false;
   RestrictRealtime = true;
   RestrictSUIDSGID = true;
   SystemCallArchitectures = "native";


### PR DESCRIPTION
Sticky Notes was attempting to execute gjs-console from memory, but this action was denied due to memory execution restrictions inherited from the parent process (greetd). This resulted in a segmentation fault.

This commit removes the restrictive setting, allowing gjs-console to execute as expected and resolving the crash.

Tested on top of pr #1206.

<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Boot into cosmic desktop and run sticky note application from cli.
