### PR TITLE
crazyflie: add the usb passthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ghaf-host.qcow2
 linux-*/
 gcroot/
 .pre-commit-config.yaml
+.aider*

--- a/modules/hardware/common/usb/external-devices.nix
+++ b/modules/hardware/common/usb/external-devices.nix
@@ -28,6 +28,24 @@ _: {
         vendorId = "045e";
         productId = "0b12";
       }
+      # Crazyradio (normal operation)
+      {
+        name = "crazyradio0";
+        vendorId = "1915";
+        productId = "7777";
+      }
+      # Crazyradio bootloader
+      {
+        name = "crazyradio1";
+        vendorId = "1915";
+        productId = "0101";
+      }
+      # Crazyflie (over USB)
+      {
+        name = "crazyflie0";
+        vendorId = "0483";
+        productId = "5740";
+      }
     ];
   };
 }


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Add the usb passthrough for the crazyflie and the crazyflie specific network dongle.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
