### PR TITLE
x86: Sample remote signing implementation for UEFI Secure Boot using jsign and Vault

### DIFF
--- a/modules/partitioning/verity-repart.nix
+++ b/modules/partitioning/verity-repart.nix
@@ -8,6 +8,7 @@
 }:
 let
   cfg = config.ghaf.partitioning.verity;
+  inherit (pkgs.stdenv.hostPlatform) efiArch;
 in
 {
 
@@ -19,10 +20,11 @@ in
       partitions = {
         "00-esp" = {
           contents = {
-            "/".source = pkgs.runCommand "esp-contents" { } ''
-              mkdir -p $out/EFI/BOOT
-              cp ${config.system.build.uki}/${config.system.boot.loader.ukiFile} $out/EFI/BOOT/BOOTX64.EFI
-            '';
+            "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source = 
+              "${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
+
+            "/EFI/Linux/${config.system.boot.loader.ukiFile}".source = 
+              "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
           };
           repartConfig = {
             Type = "esp";

--- a/overlays/lib/make-iso9660-image.sh
+++ b/overlays/lib/make-iso9660-image.sh
@@ -1,0 +1,147 @@
+# original file: nixpkgs/nixos/lib/make-iso9660-image.sh
+set -x
+
+# Remove the initial slash from a path, since genisofs likes it that way.
+stripSlash() {
+    res="$1"
+    if test "${res:0:1}" = /; then res=${res:1}; fi
+}
+
+# Escape potential equal signs (=) with backslash (\=)
+escapeEquals() {
+    echo "$1" | sed -e 's/\\/\\\\/g' -e 's/=/\\=/g'
+}
+
+# Queues an file/directory to be placed on the ISO.
+# An entry consists of a local source path (2) and
+# a destination path on the ISO (1).
+addPath() {
+    target="$1"
+    source="$2"
+    echo "$(escapeEquals "$target")=$(escapeEquals "$source")" >> $out/pathlist
+}
+
+stripSlash "$bootImage"; bootImage="$res"
+
+
+if test -n "$bootable"; then
+
+    # The -boot-info-table option modifies the $bootImage file, so
+    # find it in `contents' and make a copy of it (since the original
+    # is read-only in the Nix store...).
+    for ((i = 0; i < ${#targets[@]}; i++)); do
+        stripSlash "${targets[$i]}"
+        if test "$res" = "$bootImage"; then
+            echo "copying the boot image ${sources[$i]}"
+            cp "${sources[$i]}" boot.img
+            chmod u+w boot.img
+            sources[$i]=boot.img
+        fi
+    done
+
+    isoBootFlags="-eltorito-boot ${bootImage}
+                  -eltorito-catalog .boot.cat
+                  -no-emul-boot -boot-load-size 4 -boot-info-table
+                  --sort-weight 1 /isolinux" # Make sure isolinux is near the beginning of the ISO
+fi
+
+if test -n "$usbBootable"; then
+    usbBootFlags="-isohybrid-mbr ${isohybridMbrImage}"
+fi
+
+if test -n "$efiBootable"; then
+    efiBootFlags="-eltorito-alt-boot
+                  -e $efiBootImage
+                  -no-emul-boot
+                  -isohybrid-gpt-basdat"
+fi
+
+mkdir -p $out/iso
+
+touch $out/pathlist
+
+
+# Add the individual files.
+for ((i = 0; i < ${#targets[@]}; i++)); do
+    stripSlash "${targets[$i]}"
+    addPath "$res" "${sources[$i]}"
+done
+
+
+# Add the closures of the top-level store objects.
+for i in $(< $closureInfo/store-paths); do
+    addPath "${i:1}" "$i"
+done
+
+# If needed, build a squashfs and add that
+if [[ -n "$squashfsCommand" ]]; then
+    (out="nix-store.squashfs" eval "$squashfsCommand")
+    addPath "nix-store.squashfs" "nix-store.squashfs"
+fi
+
+# Also include a manifest of the closures in a format suitable for
+# nix-store --load-db.
+if [[ ${#objects[*]} != 0 ]]; then
+    cp $closureInfo/registration nix-path-registration
+    addPath "nix-path-registration" "nix-path-registration"
+fi
+
+
+# Add symlinks to the top-level store objects.
+for ((n = 0; n < ${#objects[*]}; n++)); do
+    object=${objects[$n]}
+    symlink=${symlinks[$n]}
+    if test "$symlink" != "none"; then
+        mkdir -p $(dirname ./$symlink)
+        ln -s $object ./$symlink
+        addPath "$symlink" "./$symlink"
+    fi
+done
+
+# daed2280-b91e-42c0-aed6-82c825ca41f3 is an arbitrary namespace, to prevent
+# independent applications from generating the same UUID for the same value.
+# (the chance of that being problematic seem pretty slim here, but that's how
+# version-5 UUID's work)
+guid=$(uuid -v 5 daed2280-b91e-42c0-aed6-82c825ca41f3 $out | tr -d -)
+echo "$guid" > $out/gpt_disk_guid
+
+xorriso="xorriso
+ -boot_image any gpt_disk_guid="$guid"
+ -volume_date all_file_dates =$SOURCE_DATE_EPOCH
+ -as mkisofs
+ -iso-level 3
+ -volid ${volumeID}
+ -appid nixos
+ -publisher nixos
+ -graft-points
+ -full-iso9660-filenames
+ -joliet
+ ${isoBootFlags}
+ ${usbBootFlags}
+ ${efiBootFlags}
+ -r
+ -path-list $out/pathlist
+ --sort-weight 0 /
+"
+
+echo "$xorriso" > "$out/xorriso.cmd"
+if [[ -n "$squashfsCommand" ]]; then
+    # (out="nix-store.squashfs" eval "$squashfsCommand")
+    echo "$squashfsCommand" > "$out/mksquashfs.cmd"
+fi
+
+$xorriso -output $out/iso/$isoName
+
+if test -n "$compressImage"; then
+    echo "Compressing image..."
+    zstd -T$NIX_BUILD_CORES --rm $out/iso/$isoName
+fi
+
+mkdir -p $out/nix-support
+echo $system > $out/nix-support/system
+
+if test -n "$compressImage"; then
+    echo "file iso $out/iso/$isoName.zst" >> $out/nix-support/hydra-build-products
+else
+    echo "file iso $out/iso/$isoName" >> $out/nix-support/hydra-build-products
+fi

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -19,6 +19,7 @@
       final.callPackage ./pkgs-by-name/globalprotect-openconnect/package.nix
         { };
     hardware-scan = final.callPackage ./pkgs-by-name/hardware-scan/package.nix { };
+    jsign = final.callPackage ./pkgs-by-name/jsign/package.nix { };
     ghaf-installer = final.callPackage ./pkgs-by-name/ghaf-installer/package.nix { };
     kernel-hardening-checker =
       final.python3Packages.callPackage ./python-packages/kernel-hardening-checker/package.nix

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -28,6 +28,7 @@
     memsocket = final.callPackage ./pkgs-by-name/memsocket/package.nix { };
     open-normal-extension = final.callPackage ./pkgs-by-name/open-normal-extension/package.nix { };
     qemuqmp = final.python3Packages.callPackage ./python-packages/qemuqmp/package.nix { };
+    sign-disk-image = final.callPackage ./pkgs-by-name/sign-disk-image/package.nix { };
     rtl8126 = final.callPackage ./pkgs-by-name/rtl8126/package.nix { };
     vhotplug = final.python3Packages.callPackage ./python-packages/vhotplug/package.nix { };
     vinotify = final.python3Packages.callPackage ./python-packages/vinotify/package.nix { };

--- a/packages/pkgs-by-name/jsign/package.nix
+++ b/packages/pkgs-by-name/jsign/package.nix
@@ -11,7 +11,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-+ZErUCTbAI4uzhZGVQ5+awi4N4hnL3RD6SuoNdiXxBs=";
   };
 
-  mvnHash = "sha256-SPBodhd8Ta8iK9UD+xIeaJvZAcVEA86gUUDf4VXlXNk=";
+  mvnHash = "sha256-k/04IHQ90OxSlOzstCTe2QhddZNpqPFsTqkVLjLHArM=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/packages/pkgs-by-name/jsign/package.nix
+++ b/packages/pkgs-by-name/jsign/package.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub, jre, makeWrapper, maven }:
+
+maven.buildMavenPackage rec {
+  pname = "jsign";
+  version = "7.1";
+
+  src = fetchFromGitHub {
+    owner = "ebourg";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-+ZErUCTbAI4uzhZGVQ5+awi4N4hnL3RD6SuoNdiXxBs=";
+  };
+
+  mvnHash = "sha256-SPBodhd8Ta8iK9UD+xIeaJvZAcVEA86gUUDf4VXlXNk=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # some tests fail trying to make HTTP requests to unreachable domains
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/jsign
+    install -Dm644 jsign/target/jsign-${version}.jar $out/share/jsign
+
+    makeWrapper ${jre}/bin/java $out/bin/jsign \
+      --add-flags "-jar $out/share/jsign/jsign-${version}.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Java implementation of Microsoft Authenticode for signing Windows executables, installers & scripts";
+    homepage = "https://github.com/ebourg/jsign";
+    license = licenses.asl20;
+  };
+}

--- a/packages/pkgs-by-name/sign-disk-image/package.nix
+++ b/packages/pkgs-by-name/sign-disk-image/package.nix
@@ -1,0 +1,26 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  writeShellApplication,
+  coreutils,
+  jsign,
+  vault,
+  sbsigntool
+}:
+writeShellApplication {
+  name = "sign-disk-image";
+  runtimeInputs = [
+    coreutils
+    jsign
+    vault
+    sbsigntool
+  ];
+  text = builtins.readFile ./sign_disk_image.sh;
+  meta = {
+    description = "Secure Boot signing script for plain disk image";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/packages/pkgs-by-name/sign-disk-image/prepare_vault.sh
+++ b/packages/pkgs-by-name/sign-disk-image/prepare_vault.sh
@@ -1,0 +1,30 @@
+## Commands to bootstrap an empty Hashicorp Vault instance and generate UEFI Secure Boot keys, prior to running sign_disk_image.sh
+##
+## A test Vault instance can be started locally
+## docker run --cap-add=IPC_LOCK -e 'VAULT_LOCAL_CONFIG={"storage": {"file": {"path": "/vault/file"}}, "listener": [{"tcp": { "address": "0.0.0.0:8200", "tls_disable": true}}], "default_lease_ttl": "168h", "max_lease_ttl": "720h", "ui": true}' -p 8200:8200 hashicorp/vault server
+
+export VAULT_ADDR='http://127.0.0.1:8200' # Production setup should use TLS
+
+vault operator init -key-shares=1 -key-threshold=1
+# ...save unseal key and root token...
+
+vault operator unseal
+vault login
+
+# > Success! You are now authenticated. The token information displayed below
+# > is already stored in the token helper. You do NOT need to run "vault login"
+# > again. Future Vault requests will automatically use this token.
+
+vault secrets enable transit
+
+vault write -f transit/keys/PK type=rsa-4096
+vault write -f transit/keys/KEK type=rsa-4096
+vault write -f transit/keys/db type=rsa-4096
+
+vault secrets enable pki
+vault secrets tune -max-lease-ttl=365d pki
+
+vault write pki/roles/root allow_any_name=true server_flag=false client_flag=false code_signing_flag=true key_usage=''
+
+vault write pki/keys/generate/internal key_name=ca-key
+vault write pki/root/generate/internal issuer_name=new-ca key_ref=ca-key ttl=365d common_name="Vault CA"

--- a/packages/pkgs-by-name/sign-disk-image/sign_disk_image.sh
+++ b/packages/pkgs-by-name/sign-disk-image/sign_disk_image.sh
@@ -1,0 +1,113 @@
+set -eu -o pipefail
+set -x
+
+
+LOOPDEV=''
+
+function cleanup() {
+  set +e
+  sudo umount boot
+  sudo umount rootfs
+  set -e
+  if [[ -n "$LOOPDEV" ]]; then
+    sudo losetup -d "$LOOPDEV"
+  fi
+  rmdir boot rootfs
+}
+trap cleanup SIGINT
+
+if [[ "$1" == clean ]]; then
+  cleanup
+  exit
+fi
+
+if ! type vault; then
+  echo "vault binary not found"
+  exit 1
+fi
+
+if ! type jsign; then
+  echo "jsign binary not found"
+  exit 1
+fi
+
+IMAGE="$1"
+if [[ ! -f "$IMAGE" ]]; then
+  echo "Argument must be a path to a raw disk image (ex: disk1.raw)"
+  echo "zstd compressed output images should be decompressed first"
+  exit 1
+fi
+
+## Retrieve CA cert and public keys from Vault
+
+export VAULT_ADDR='http://127.0.0.1:8200'
+if [[ ! -v VAULT_TOKEN || -z $VAULT_TOKEN ]]; then
+  echo "VAULT_TOKEN environment variable is not set. Will not be able to connect to Vault instance"
+  exit 1
+fi
+
+mkdir keys
+KEYDIR=$(realpath ./keys)
+pushd "$KEYDIR"
+  vault read -field=certificate pki/issuer/new-ca > CA.crt
+
+  vault write -f -field=csr transit/keys/PK/csr > PK.csr
+  vault write -f -field=csr transit/keys/KEK/csr > KEK.csr
+  vault write -f -field=csr transit/keys/db/csr > db.csr
+
+  vault write -field=certificate pki/issuer/new-ca/sign/root csr="$(cat PK.csr)" common_name="UEFI-PK" ttl="30d" > PK.crt
+  vault write -field=certificate pki/issuer/new-ca/sign/root csr="$(cat KEK.csr)" common_name="UEFI-KEK" ttl="30d" > KEK.crt
+  vault write -field=certificate pki/issuer/new-ca/sign/root csr="$(cat db.csr)" common_name="UEFI-db" ttl="30d" > db.crt
+
+  # key enroll in Lenovo BIOS only accepts DER format
+  openssl x509 -in PK.crt -outform der -out PK.cer
+  openssl x509 -in KEK.crt -outform der -out KEK.cer
+  openssl x509 -in db.crt -outform der -out db.cer
+
+  echo '' | cat db.crt - CA.crt > dbchain.pem
+popd
+
+
+## Mount disk image partitions
+
+LOOPDEV=$(sudo losetup --show --partscan -f "$IMAGE")
+echo "Loop device at $LOOPDEV"
+
+ESP=$(sudo fdisk -l "$LOOPDEV" | grep 'EFI System' | cut -d' ' -f1)
+ROOTFS=$(sudo fdisk -x "$LOOPDEV" | grep root | cut -d' ' -f1)
+echo "$ESP: ESP partition" 
+echo "$ROOTFS: root partition"
+
+mkdir -vp boot rootfs
+
+sudo mount -o loop "$ESP" boot
+## Not needed for signing
+## could implement sanity checks, for example that UKI cmdline 
+## points to the right nix store path
+# sudo mount -o loop "$ROOTFS" rootfs
+
+
+## Sign UKI and systemd loader
+
+cp boot/EFI/BOOT/BOOTX64.efi "$KEYDIR/BOOTX64.efi"
+cp boot/EFI/Linux/nixos.efi "$KEYDIR/nixos.efi"
+
+pushd "$KEYDIR"
+  jsign remove BOOTX64.efi
+  jsign remove nixos.efi
+  jsign --storetype HASHICORPVAULT --keystore "$VAULT_ADDR/v1/transit" --storepass "$VAULT_TOKEN" --alias db:1 --certfile db.crt BOOTX64.efi
+  jsign --storetype HASHICORPVAULT --keystore "$VAULT_ADDR/v1/transit" --storepass "$VAULT_TOKEN" --alias db:1 --certfile db.crt nixos.efi
+
+  sbverify --cert db.crt BOOTX64.efi
+  sbverify --cert db.crt nixos.efi
+popd
+
+sudo cp -v "$KEYDIR/BOOTX64.efi" boot/EFI/BOOT/BOOTX64.efi
+sudo cp -v "$KEYDIR/nixos.efi" boot/EFI/Linux/nixos.efi
+
+## Copy Secure Boot keys to ESP
+
+sudo mkdir -vp boot/EFI/keys
+sudo cp -v "$KEYDIR"/*.cer boot/EFI/keys
+
+cleanup

--- a/packages/pkgs-by-name/sign-installer/package.nix
+++ b/packages/pkgs-by-name/sign-installer/package.nix
@@ -1,0 +1,27 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  writeShellApplication,
+  coreutils,
+  squashfsTools,
+  zstd,
+  sign-disk-image
+}:
+writeShellApplication {
+  name = "sign-installer";
+  runtimeInputs = [
+    coreutils
+    squashfsTools
+    zstd
+    sign-disk-image
+  ];
+  text = builtins.readFile ./sign_installer_iso.sh;
+  checkPhase = "true";
+  meta = {
+    description = "Secure Boot signing script for ISO installer";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/packages/pkgs-by-name/sign-installer/sign_installer_iso.sh
+++ b/packages/pkgs-by-name/sign-installer/sign_installer_iso.sh
@@ -1,0 +1,80 @@
+set -eu -o pipefail
+set -x
+
+
+function cleanup() {
+  set +e
+  sudo umount merged
+  sudo umount baseroot
+  sudo umount iso
+  rmdir iso baseroot merged
+  sudo rm -r --preserve-root=all upper workdir squashfs-root
+  rm pathlist disk1.raw.zst nix-store.squashfs xorriso.cmd
+  set -e
+}
+trap cleanup SIGINT
+
+if [[ "$1" == clean ]]; then
+  cleanup
+  exit
+fi
+
+
+if [[ ! -v VAULT_TOKEN || -z $VAULT_TOKEN ]]; then
+  echo "VAULT_TOKEN environment variable is not set. Will not be able to connect to Vault instance"
+  exit 1
+fi
+
+export VAULT_ADDR='http://127.0.0.1:8200'
+err=0
+vault status || err=$?
+if [[ $err -ne 0 ]]; then
+  echo "Vault is sealed"
+  exit 1
+fi
+
+NIXBUILD=$(realpath "$1")
+if [[ ! -d "$NIXBUILD" ]]; then
+  echo "Argument must be the path to the Nix build output (ex: ghaf/result/) that contains ghaf.iso"
+  exit 2
+fi
+
+# cp "$NIXBUILD/iso/ghaf.iso" "$TMPDIR"
+# cp "$NIXBUILD/pathlist" .
+cp -v "$NIXBUILD/xorriso.cmd" .
+
+# Extract the installer nix store
+mkdir iso
+sudo mount -t iso9660 -o ro "$NIXBUILD/iso/ghaf.iso" iso
+
+# Extract the Ghaf disk image from the squashed nix store
+DISK_PATH=$(unsquashfs -lc iso/nix-store.squashfs '*ghaf-host-disko-images/disk1.raw.zst' | sed 's|squashfs-root/||')
+if [[ -z "$DISK_PATH" ]]; then
+  # repart was used in place of disko
+  DISK_PATH=$(unsquashfs -lc iso/nix-store.squashfs '*-ghaf-*/ghaf_*.raw.zst' | sed 's|squashfs-root/||')
+fi
+unsquashfs iso/nix-store.squashfs "$DISK_PATH"
+
+# Decompress the image and sign it
+TMPDIR=$(mktemp -d -p .)
+zstd -d "squashfs-root/$DISK_PATH" -o "$TMPDIR/disk1.img"
+pushd "$TMPDIR"
+  sign-disk-image disk1.img
+popd
+zstd --compress "$TMPDIR/disk1.img" -o disk1.raw.zst
+
+# Packing up...
+# Recreate a squashfs with the signed image
+mkdir baseroot
+sudo mount -t squashfs iso/nix-store.squashfs baseroot
+mkdir upper workdir merged
+sudo mount -t overlay -o lowerdir=baseroot,upperdir=upper,workdir=workdir overlay merged
+sudo cp -v disk1.raw.zst "merged/$DISK_PATH"
+mksquashfs merged/* nix-store-mod.squashfs -no-hardlinks -keep-as-directory -all-root -b 1048576 -comp zstd -Xcompression-level 3 -root-mode 0755
+mv -v nix-store-mod.squashfs nix-store.squashfs
+
+# Make the iso
+xorrisocmd=$(cat xorriso.cmd | awk '{ printf $0 }')
+$xorrisocmd -output ghaf-signed.iso
+
+cleanup

--- a/packages/pkgs-by-name/sign-installer/sign_installer_iso_example.md
+++ b/packages/pkgs-by-name/sign-installer/sign_installer_iso_example.md
@@ -1,0 +1,13 @@
+The following are sample commands to illustrate the process of signing the Ghaf installer ISO for Secure Boot.
+
+The idea is to progressively unpack the layers of the CD iso until we reach the raw NixOS disk image. At this point we
+can sign it with the `sign_disk_image.sh` script and recreate the installer by doing the steps in reverse.
+
+```shell
+# This contains a patch to output the make-iso-image pathlist in the derivation
+nix build .#lenovo-x1-carbon-gen11-debug-installer
+cd ..
+mkdir temp
+cd temp
+nix run ../ghaf#sign-installer ../ghaf/result/
+```

--- a/targets/laptop/laptop-installer-builder.nix
+++ b/targets/laptop/laptop-installer-builder.nix
@@ -62,7 +62,9 @@ let
     {
       inherit hostConfiguration;
       name = "${name}-installer";
-      package = hostConfiguration.config.system.build.isoImage;
+      package = hostConfiguration.config.system.build.isoImage.overrideAttrs {
+        buildCommandPath = ../../overlays/lib/make-iso9660-image.sh;
+      };
     };
 in
 mkLaptopInstaller


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This is a sample implementation of remotely signing binaries for the purpose of enabling UEFI Secure Boot on x86 targets. It comes in the form of shell scripts that live outside the main Ghaf image and are designed to be called after `nix build`.

The signing step is expected to take place separately from the nix build process. The input is an ISO or raw disk image produced by running `nix build` and it outputs an identical image except for the binaries present in the EFI System Partition which have been signed.

The main goal is to enable Secure Boot using keys stored in a remote instance (HSM, Cloud key vault, etc.). This pull request has been developed with HashiCorp Vault as an example of a key storage solution. Compatibility with other providers is possible by changing the way that certificates for the UEFI keys are retrieved and selecting a different jsign backend.

Summary of changes:
- nix package for the [jsign](https://ebourg.github.io/jsign/) tool
- add scripts to sign an image using a remote Vault instance
- add a script that sets up a Vault instance for testing (`prepare_vault.sh`)

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status
- [x] Tested on Lenovo X1 `x86_64` gen 11

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Requires changing BIOS settings

### Test Steps To Verify:

#### Preparation steps
A Vault instance is assumed to be running. Otherwise, you can use Docker and the included `prepare_vault.sh` script to bring up a local test instance:

```
$ docker run --cap-add=IPC_LOCK -e 'VAULT_LOCAL_CONFIG={"storage": {"file": {"path": "/vault/file"}}, "listener": [{"tcp": { "address": "0.0.0.0:8200", "tls_disable": true}}], "default_lease_ttl": "168h", "max_lease_ttl": "720h", "ui": true}' -p 8200:8200 hashicorp/vault server
```
```
$ ./packages/pkgs-by-name/sign-disk-image/prepare_vault.sh
```

#### Signing

1. Build an iso image: `nix build .#lenovo-x1-gen11-hardening-debug-installer`

> We use the hardening profile because its boot partition contains a UKI.

2. Create an empty folder where the output will be placed and run the `sign-installer` script
```
cd ..
mkdir temp
cd temp
export VAULT_TOKEN='...your login token...'
nix run ../ghaf#sign-installer ../ghaf/result/
```
3. Flash the resulting image (`ghaf-signed.iso`) to a Lenovo x86 device as usual
4. Enter the BIOS settings and perform the following steps:
  - enter Security -> Secure Boot -> Key Management
  - enroll the PK, KEK and db certificates (the BIOS should automatically find them on the disk)
  - enable Secure Boot
  - save changes and reboot
5. The device should boot correctly. Run `bootctl` as root to check the Secure Boot status.
