### PR TITLE
Add VM CPU and memory graphs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748249571,
-        "narHash": "sha256-d9dJCbu2IkvHUO/vANdZ06CtZX3IyzTJ9GlGV8NHN64=",
+        "lastModified": 1749518014,
+        "narHash": "sha256-F6eUtfReTsbh3eXiXiIHbvfHEfsvmrZTHnC4CPmJkQA=",
         "owner": "tiiuae",
         "repo": "ghaf-ctrl-panel",
-        "rev": "7b0ca382d83b7671c7685caf61af3ae357807ae9",
+        "rev": "a39dafd79a8b09602da300f61aa40dae24b52f00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Pull in ctrl-panel changes that implement CPU and memory monitoring for individual VMs: https://github.com/tiiuae/ghaf-ctrl-panel/pull/56

The monitor windows can be opened from settings / information page, from the action menu for VMs.

Also pulls in improvements for the audio settings.

### Type of Change
- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

SSRCSP-6308

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:

 1. Open control panel
 2. Navigate to settings page, information subpage
 3. choose "monitor" from sub-menu for chrome VM
 4. launch chrome
 5. observe graphs, both should show rising values
 6. repeat 3-5 for other VMs as appropriate
 7. open audio subpage
 8. change audio settings externally
 9. observe audio settings changing in ctrl-panel