### PR TITLE
vhotplug: Add option to prepend rules

### DIFF
--- a/modules/hardware/common/usb/vhotplug.nix
+++ b/modules/hardware/common/usb/vhotplug.nix
@@ -188,10 +188,20 @@ in
       '';
     };
 
-    extraRules = mkOption {
+    prependRules = mkOption {
       description = ''
         List of extra udev rules to be added to the system. Uses the same format as vhotplug.rules,
-        and is appended to the default rules. This is useful for adding rules for additional VMs while
+        and is prepended to the default rules. This is helpful for setting rules where the order of
+        USB device detection matters for additional VMs, while still maintaining the default rules.
+      '';
+      type = types.listOf types.attrs;
+      default = [ ];
+    };
+
+    postpendRules = mkOption {
+      description = ''
+        List of extra udev rules to be added to the system. Uses the same format as vhotplug.rules,
+        and is postpened to the default rules. This is useful for adding rules for additional VMs while
         keeping the ghaf defaults.
       '';
       type = types.listOf types.attrs;
@@ -229,7 +239,9 @@ in
       KERNEL=="event*", GROUP="kvm"
     '';
 
-    environment.etc."vhotplug.conf".text = builtins.toJSON { vms = cfg.rules ++ cfg.extraRules; };
+    environment.etc."vhotplug.conf".text = builtins.toJSON {
+      vms = cfg.prependRules ++ cfg.rules ++ cfg.postpendRules;
+    };
 
     systemd.services.vhotplug = {
       enable = true;


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
This patch will add support to the vhotplug module, allowing it to prepend rules. This feature is useful when the order of USB device detection is important for additional VMs.

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Detection of USB devices should work fine.
