### PR TITLE
fix(bluetooth): remove bluetooth from host

### DIFF
--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -159,6 +159,7 @@ let
     ])
     ++ (lib.optionals (!cfg.withBluetooth) [
       "bluetooth.target"
+      "bluetooth.service"
     ])
     ++ (lib.optionals (!cfg.withDebug) [
       ## Units kept with debug

--- a/modules/common/systemd/hardened-configs/bluetooth.nix
+++ b/modules/common/systemd/hardened-configs/bluetooth.nix
@@ -1,15 +1,12 @@
 # Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  #  ProtectProc = lib.mkForce "noaccess";
   ProcSubset = "pid";
   ProtectHome = true;
   ProtectSystem = "full";
   PrivateTmp = true;
   PrivateMounts = true;
   UMask = 77;
-  # ProtectKernelTunables = lib.mkForce true;
-  #ProtectKernelModules = lib.mkForce true;
   ProtectKernelLogs = true;
   KeyringMode = "private";
   ProtectHostname = true;
@@ -47,14 +44,12 @@
     "CAP_NET_ADMIN"
     "CAP_NET_RAW"
     "CAP_SYS_RESOURCE"
-    "CAP_AUDIT_WRITE"
   ];
   CapabilityBoundingSet = [
     "CAP_NET_BIND_SERVICE"
     "CAP_NET_ADMIN"
     "CAP_NET_RAW"
     "CAP_SYS_RESOURCE"
-    "CAP_AUDIT_WRITE"
   ];
   SystemCallArchitectures = "native";
   SystemCallFilter = [
@@ -62,13 +57,13 @@
     "~@timer"
     "~@pkey"
     "~@debug"
-    "~@cpu_emulation"
+    "~@cpu-emulation"
     "~@mount"
     "~@ipc"
     "~@resources"
     "~@memlock"
     "~@keyring"
-    "~@raw_io"
+    "~@raw-io"
     "~@clock"
     "~@aio"
     "~@setuid"

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
@@ -14,7 +14,7 @@
       "iommu=pt"
       "acpi_backlight=vendor"
       "acpi_osi=linux"
-      "module_blacklist=i915,xe,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl"
+      "module_blacklist=i915,xe,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,bluetooth,btusb"
     ];
   };
 

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330.nix
@@ -15,6 +15,7 @@
       "acpi_backlight=vendor"
       "acpi_osi=linux"
       #"module_blacklist=e1000e,i2c_i801,i915,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,spi_intel_pci"
+      "module_blacklist=bluetooth,btusb"
     ];
   };
 

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-2-in-1-gen-9.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-2-in-1-gen-9.nix
@@ -17,7 +17,7 @@
       "acpi_backlight=vendor"
       "acpi_osi=linux"
       #"module_blacklist=i2c_i801,i915,iwlwifi,snd_hda_intel,snd_sof_pci_intel_mtl,spi_intel_pci,xe"
-      "module_blacklist=i915,xe,snd_pcm" # Prevent i915,xe,snd_pcm modules from being accidentally used by host
+      "module_blacklist=i915,xe,snd_pcm,bluetooth,btusb" # Prevent i915,xe,snd_pcm modules from being accidentally used by host
     ];
   };
 

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -14,7 +14,7 @@
     kernelConfig.kernelParams = [
       "intel_iommu=on,sm_on"
       "iommu=pt"
-      "module_blacklist=i915,snd_pcm" # Prevent i915,snd_pcm module from being accidentally used by host
+      "module_blacklist=i915,snd_pcm,bluetooth,btusb" # Prevent i915,snd_pcm module from being accidentally used by host
       "acpi_backlight=vendor"
       "acpi_osi=linux"
     ];

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -16,7 +16,7 @@
     kernelConfig.kernelParams = [
       "intel_iommu=on,sm_on"
       "iommu=pt"
-      "module_blacklist=i915,xe,snd_pcm" # Prevent i915,xe,snd_pcm modules from being accidentally used by host
+      "module_blacklist=i915,xe,snd_pcm,bluetooth,btusb" # Prevent i915,xe,snd_pcm modules from being accidentally used by host
       "acpi_backlight=vendor"
       "acpi_osi=linux"
     ];

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
@@ -15,7 +15,7 @@
     kernelConfig.kernelParams = [
       "intel_iommu=on,sm_on"
       "iommu=pt"
-      "module_blacklist=i915,xe,snd_pcm,mei_me" # Prevent kernel modules from being accidentally used by host
+      "module_blacklist=i915,xe,snd_pcm,mei_me,bluetooth,btusb" # Prevent kernel modules from being accidentally used by host
       "acpi_backlight=vendor"
       "acpi_osi=linux"
     ];

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen13.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen13.nix
@@ -16,7 +16,7 @@
       "iommu=pt"
       "acpi_backlight=vendor"
       "acpi_osi=linux"
-      "module_blacklist=i915,xesnd_hda_intel,snd_sof_pci_intel_lnl,spi_intel_pci,xe"
+      "module_blacklist=i915,xesnd_hda_intel,snd_sof_pci_intel_lnl,spi_intel_pci,xe,bluetooth,btusb"
     ];
   };
 


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Prevent bluetooth and btusb kernel modules loaded in the host, and fix some config errors.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
