### PR TITLE
waypipe: preliminary support for XWayland inside app-VMs

### DIFF
--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -27,7 +27,9 @@ let
       # A list of applications for the GIVC service
       givcApplications = map (app: {
         name = app.givcName;
-        command = "${config.ghaf.givc.appPrefix}/run-waypipe ${config.ghaf.givc.appPrefix}/${app.command}";
+        command = "${config.ghaf.givc.appPrefix}/run-waypipe${
+          if app.supportXWayland then " -X" else ""
+        } ${config.ghaf.givc.appPrefix}/${app.command}";
         args = app.givcArgs;
       }) vm.applications;
       # Packages and extra modules from all applications defined in the appvm
@@ -271,6 +273,11 @@ in
                         type = types.str;
                         description = "The command to run the application";
                         default = null;
+                      };
+                      supportXWayland = mkOption {
+                        description = "Whether or not to support XWayland through a sub-compositor.";
+                        type = types.bool;
+                        default = false;
                       };
                       extraModules = mkOption {
                         description = "Additional modules required for the application";


### PR DESCRIPTION


<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

For applications that require an X11 interface, a full Wayland compositor (labwc) will be created inside the app-VM. This is because xwayland doesn't work directly with waypipe, as this isn't a supported use-case.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`: yes
- [x] Other: Include the application snippet below in one of the app-vms (such as chrome-vm).

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Add an application that only supports X11 and not Wayland sessions, one example is `cantor`. This can be added in any application VM (e.g. chrome-vm):
   ```nix
        {
          name = "Cantor";
          description = "A random X11-only application for testing";
          packages = [
            pkgs.cantor
          ];
          icon = "cantor";
          supportXWayland = true;
          command = "cantor";
        }
   ```
2. Rebuild, and launch that application. The window will have the 'labwc' in the title due to the sub-compositor. The application might not behave like a native window on the desktop, and applications will be confined within the box only. 
