### PR TITLE
feat(cosmic): propagate locale changes

### DIFF
--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -6,7 +6,12 @@
 #
 # ghaf.common: Interface to share ghaf configs from host to VMs
 #
-{ config, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   inherit (builtins) attrNames;
   inherit (lib)
@@ -144,17 +149,16 @@ in
     documentation.nixos.enable = false;
     ##### Remove to here
 
-    i18n.supportedLocales = [
-      "C.UTF-8/UTF-8"
-      "en_US.UTF-8/UTF-8"
-      "ar_AE.UTF-8/UTF-8"
+    environment.systemPackages = [
+      pkgs.isocodes
     ];
-    environment.extraInit = ''
-      if [ -f /etc/locale.conf ]; then
-          . /etc/locale.conf
-          export LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION LC_ALL
-      fi
-    '';
 
+    environment.pathsToLink = [
+      "/share/iso-codes"
+    ];
+
+    i18n.defaultLocale = "en_US.UTF-8";
+
+    i18n.extraLocales = "all";
   };
 }

--- a/modules/common/services/default.nix
+++ b/modules/common/services/default.nix
@@ -13,5 +13,6 @@
     ./wifi.nix
     ./xpadneo.nix
     ./yubikey.nix
+    ./locale.nix
   ];
 }

--- a/modules/common/services/locale.nix
+++ b/modules/common/services/locale.nix
@@ -1,0 +1,75 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkEnableOption mkIf;
+  useGivc = config.ghaf.givc.enable;
+  cfg = config.ghaf.services.locale;
+
+  ghafLocaleListener = pkgs.writeShellApplication {
+    name = "ghaf-locale-listener";
+    runtimeInputs = with pkgs; [
+      dbus
+      systemd
+      givc-cli
+      gawk
+    ];
+    # locale1 is a system service, this script should be run as a system service
+    # Propagate locale changes from the gui-vm to givc-cli
+    text = ''
+      # shellcheck disable=SC2016
+      busctl monitor org.freedesktop.locale1 | stdbuf -oL awk '
+        /^$/ {
+          if (in_block && found_locale && locale_str != "") {
+            print locale_str
+          }
+          in_block = 0
+          found_locale = 0
+          locale_str = ""
+        }
+        /PropertiesChanged/ { in_block = 1 }
+        /"Locale"/ {
+          if (in_block) found_locale = 1
+        }
+        /^ *STRING/ {
+          if (found_locale && match($0, /"[^"]+"/)) {
+            line = substr($0, RSTART+1, RLENGTH-2)
+            if (line ~ /^(LANG|LC_[^=]+)=/) {
+              locale_str = (locale_str == "" ? line : locale_str ";" line)
+            }
+          }
+        }' |  while IFS= read -r line; do
+              locale_settings="''${line//;/ }"
+              echo "Applying locale settings: ''$line"
+
+              echo "''$locale_settings" | xargs givc-cli ${config.ghaf.givc.cliArgs} set-locale || echo "Failed to apply locale settings: \"''$locale_settings\""
+              done
+    '';
+  };
+in
+{
+  options.ghaf.services.locale = {
+    enable = mkEnableOption "Propagate locale changes from the system to givc-cli";
+  };
+
+  config = mkIf (cfg.enable && useGivc) {
+    systemd.services = {
+      ghaf-locale-listener = {
+        enable = true;
+        description = "Ghaf locale listener";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${lib.getExe ghafLocaleListener}";
+        };
+        partOf = [ "graphical.target" ];
+        wantedBy = [ "graphical.target" ];
+      };
+    };
+  };
+}

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -136,6 +136,8 @@ let
 
               timezone.enable = true;
 
+              locale.enable = true;
+
               disks = {
                 enable = true;
                 fileManager = lib.mkIf config.ghaf.graphics.labwc.enable "${pkgs.pcmanfm}/bin/pcmanfm";


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Add a simple service to propagate gui-vm locale changes to givc, only if givc is available, similar to #1252** 
   - This change will allow Cosmic Settings app "Region and Language" page to work as it should in Ghaf, when the next Cosmic Epoch release is out

### Notes:
~givc `set-locale` command doesn't support variable assignment (e.g. `LANG=en_US.UTF-8`)
Due to this, changing the locale also implicitly changes the LANG in [givc under the hood](https://github.com/tiiuae/ghaf-givc/blob/main/modules/pkgs/localelistener/controller.go#L42). This may need to be adjusted in givc at some point down the line.~
givc now supports locale macro assignments with [PR 130](https://github.com/tiiuae/ghaf-givc/pull/130)

**The "Time & Language > Region & Language" cosmic settings page will not work properly until the next Cosmic release, unless step #1 from the Testing Instructions is done**

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->
https://github.com/tiiuae/ghaf-givc/pull/130

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. If new Cosmic release is not out yet (as of Aug 12), manually override cosmic-settings package src and cargoDeps attributes  in **overlays/custom-packages/cosmic/cosmic-settings/default.nix**, the resulting file should look like this:
  ```
  ...
{ prev }:
(prev.cosmic-settings.overrideAttrs (_oldAttrs: rec {
  src = prev.fetchFromGitHub {
    owner = "kajusnau";
    repo = "cosmic-settings";
    rev = "locale-rs-patch";
    hash = "sha256-OhEXI0Jl/X9GrHqZoKEBOU819r06HJeOR2rXwwS/blk=";
  };
  cargoDeps = prev.rustPlatform.fetchCargoVendor {
    inherit src;
    hash = "sha256-zTUv/duWE6HYraK9874u1xd8TA7POKim0RCzaLtryLk=";
  };
  cargoBuildNoDefaultFeatures = true;
  cargoBuildFeatures = [
  ...
  ```
2. Build and boot into Ghaf
3. Adjust the region via the Cosmic settings app (language adjustments don't work, it's a nix config option)
4. Reboot and verify the region changes persist - e.g. if you changed the region to fi_FI.UTF-8 then you should see the date in Finnish format in the top panel of the desktop.