### PR TITLE
bugfix: adjust backlight brightness before login

### DIFF
--- a/modules/desktop/graphics/cosmic/config/cosmic-config.nix
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.nix
@@ -76,7 +76,9 @@ pkgs.stdenv.mkDerivation rec {
     --replace "None" "Path(\"${pkgs.ghaf-artwork}/ghaf-desert-sunset.jpg\")"
     substituteInPlace $out/share/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions \
     --replace-fail 'VolumeLower: ""' 'VolumeLower: "pamixer --unmute --decrease 5 && ${pkgs.pulseaudio}/bin/paplay ${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo/audio-volume-change.oga"' \
-    --replace-fail 'VolumeRaise: ""' 'VolumeRaise: "pamixer --unmute --increase 5 && ${pkgs.pulseaudio}/bin/paplay ${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo/audio-volume-change.oga"'
+    --replace-fail 'VolumeRaise: ""' 'VolumeRaise: "pamixer --unmute --increase 5 && ${pkgs.pulseaudio}/bin/paplay ${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo/audio-volume-change.oga"' \
+    --replace-fail 'BrightnessUp: ""' 'BrightnessUp: "${lib.getExe pkgs.brightnessctl} set +5% > /dev/null 2>&1"' \
+    --replace-fail 'BrightnessDown: ""' 'BrightnessDown: "${lib.getExe pkgs.brightnessctl} set 5%- > /dev/null 2>&1"'
   '';
 
   meta = with lib; {

--- a/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
@@ -259,9 +259,11 @@ com.system76.CosmicSettings.Shortcuts:
         /// Opens the application library
         AppLibrary: "cosmic-app-library",
         /// Decreases screen brightness
-        BrightnessDown: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness",
+        // BrightnessDown: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness",
+        BrightnessDown: "",
         /// Increases screen brightness
-        BrightnessUp: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness",
+        // BrightnessUp: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness",
+        BrightnessUp: "",
         /// Switch between input sources
         InputSourceSwitch: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon InputSourceSwitch",
         /// Opens the home folder in a system default file browser

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -9,8 +9,6 @@
 let
   cfg = config.ghaf.graphics.cosmic;
 
-  inherit (import ../../../../lib/launcher.nix { inherit pkgs lib; }) rmDesktopEntries;
-
   ghaf-powercontrol = pkgs.ghaf-powercontrol.override { ghafConfig = config.ghaf; };
 
   ghaf-cosmic-config = import ./config/cosmic-config.nix {
@@ -127,22 +125,19 @@ in
     ghaf.graphics.power-manager.enable = true;
 
     environment = {
-      systemPackages =
-        with pkgs;
-        [
-          papirus-icon-theme-grey
-          adwaita-icon-theme
-          ghaf-wallpapers
-          pamixer
-          (import ../launchers-pkg.nix { inherit pkgs config; })
-          # Nix's evaluation order installs ghaf-cosmic-config after cosmic tools.
-          # Installing it before the cosmic tools would result in its configuration being overridden
-          # by the default configurations of the cosmic tools.
-          # If this behavior changes in the future, overlays for the relevant cosmic packages
-          # must be added to nixpkgs.overlays to enforce the desired configuration precedence.
-          ghaf-cosmic-config
-        ]
-        ++ (rmDesktopEntries [ ]);
+      systemPackages = with pkgs; [
+        papirus-icon-theme-grey
+        adwaita-icon-theme
+        ghaf-wallpapers
+        pamixer
+        (import ../launchers-pkg.nix { inherit pkgs config; })
+        # Nix's evaluation order installs ghaf-cosmic-config after cosmic tools.
+        # Installing it before the cosmic tools would result in its configuration being overridden
+        # by the default configurations of the cosmic tools.
+        # If this behavior changes in the future, overlays for the relevant cosmic packages
+        # must be added to nixpkgs.overlays to enforce the desired configuration precedence.
+        ghaf-cosmic-config
+      ];
       sessionVariables = {
         XDG_CONFIG_HOME = "$HOME/.config";
         XDG_DATA_HOME = "$HOME/.local/share";


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Minor bugfix to Cosmic config to allow adjusting backlight brightness before user session is started.
This functionality might be useful in cases where previous brightness settings cannot be restored by `systemd-backlight@` service, and the brightness ends up being too low or even completely off in login screen.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Boot into Ghaf but do not log in
2. Try changing backlight brightness via the F5/F6 keyboard shortcuts
3. Log in
4. Try changing backlight brightness via the F5/F6 keyboard shortcuts, there should be no regression
