### PR TITLE
Bump control panel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753755172,
-        "narHash": "sha256-t2JBVgRyD31wFMNRVtt6HO12KDWzHuZUuZYVCDuvNT8=",
+        "lastModified": 1754042132,
+        "narHash": "sha256-1FDWgpeOTfXDKUrUfUlTACzEDoNuSV+2M2T/Qv/6IiQ=",
         "owner": "tiiuae",
         "repo": "ghaf-ctrl-panel",
-        "rev": "3eaa8fc1e314d21d22a8bab8edbc5d9bcdcaa1aa",
+        "rev": "7d192dfedfc071700106320d6b6ebbca07477894",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Pull in new version of control panel, which replaces the tabbed view of services with a tree-like view.

Monitoring graphs for VMs are now shown when a VM is selected from the tree.

Also removes most of non-functioning or overlapping settings.

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [X] Improvement / Refactor

## Related Issues / Tickets

https://github.com/tiiuae/ghaf-ctrl-panel/pull/71
https://jira.tii.ae/browse/SSRCSP-6777

## Checklist

- [X] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:

Start control panel, observe VMs and services shown as a tree, with `ghaf-host` as a root. When host or a VM is selected, cpu and memory graphs should be shown. Non-functioning entries under `Settings`-tab should be gone.