### PR TITLE
Changes to the VM target

### DIFF
--- a/modules/givc/guivm.nix
+++ b/modules/givc/guivm.nix
@@ -48,6 +48,8 @@ in
           };
           socket = "/tmp/dbusproxy_net.sock";
         }
+      ]
+      ++ lib.optionals config.ghaf.givc.audiovm.enable [
         {
           transport = {
             name = audiovmName;

--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -111,7 +111,7 @@ let
 
                 # Services
                 waypipe = {
-                  enable = true;
+                  inherit (vm.waypipe) enable;
                   inherit vm;
                 }
                 // optionalAttrs configHost.ghaf.shm.enable {
@@ -355,6 +355,11 @@ in
               useTunneling = lib.mkEnableOption "Use Pulseaudio tunneling";
             };
             vtpm.enable = lib.mkEnableOption "vTPM support in the virtual machine";
+            waypipe.enable = mkOption {
+              description = "Enable waypipe for this VM";
+              type = types.bool;
+              default = true;
+            };
             bootPriority = mkOption {
               description = ''
                 Boot priority of the AppVM.

--- a/modules/microvm/modules.nix
+++ b/modules/microvm/modules.nix
@@ -185,23 +185,25 @@ in
       netvm.extraModules =
         optionals cfg.netvm.enable [
           serviceModules.logging
+          serviceModules.givc
           commonModule
+          managedUserAccounts
         ]
         ++ optionals (cfg.netvm.enable && fullVirtualization) [
           deviceModules.netvmPCIPassthroughModule
           kernelConfigs.netvm
           firmwareModule
           serviceModules.wifi
-          serviceModules.givc
           serviceModules.audit
           referenceServiceModule
-          managedUserAccounts
         ];
       # Audiovm modules
       audiovm.extraModules =
         optionals cfg.audiovm.enable [
           serviceModules.logging
+          serviceModules.givc
           commonModule
+          managedUserAccounts
         ]
         ++ optionals (cfg.audiovm.enable && fullVirtualization) [
           deviceModules.audiovmPCIPassthroughModule
@@ -210,16 +212,16 @@ in
           qemuModules.audiovm
           serviceModules.audio
           serviceModules.audit
-          serviceModules.givc
           serviceModules.bluetooth
           serviceModules.xpadneo
-          managedUserAccounts
         ];
       # Guivm modules
       guivm.extraModules =
         optionals cfg.guivm.enable [
           serviceModules.logging
+          serviceModules.givc
           commonModule
+          managedUserAccounts
         ]
         ++ optionals (cfg.guivm.enable && fullVirtualization) [
           deviceModules.guivmPCIPassthroughModule
@@ -230,35 +232,31 @@ in
           serviceModules.graphics
           serviceModules.fprint
           serviceModules.yubikey
-          serviceModules.givc
           serviceModules.audit
           referenceServiceModule
-          managedUserAccounts
         ];
 
       # Adminvm modules
       adminvm.extraModules =
         optionals cfg.adminvm.enable [
           serviceModules.logging
+          serviceModules.givc
           commonModule
+          managedUserAccounts
         ]
         ++ optionals (cfg.adminvm.enable && fullVirtualization) [
-          serviceModules.givc
-          managedUserAccounts
           serviceModules.audit
-
         ];
       # Appvm modules
       appvm.extraModules =
         optionals cfg.appvm.enable [
           serviceModules.logging
+          serviceModules.givc
           commonModule
+          managedUserAccounts
         ]
         ++ optionals (cfg.appvm.enable && fullVirtualization) [
-          serviceModules.givc
-          managedUserAccounts
           serviceModules.audit
-
         ];
       # Idsvm modules
       idsvm.extraModules = optionals cfg.idsvm.enable [

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -55,6 +55,11 @@ let
                 appvms.enable = true;
               };
 
+              givc = {
+                enable = withGraphics;
+                debug = true;
+              };
+
               host.networking.enable = true;
 
               # Enable all the default UI applications


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This PR contains some adjustments that were made to the `vm` target while working on the TPM storage feature. We are posting them in a PR in case there is interest to merge parts into upstream. Changes include:

- added a non-graphical qemu target for testing Ghaf on machines without a display output
- increased the resources allocated to qemu host
- set the `useNixStoreImage` option, which disables mounting the top-level nix store inside the qemu ghaf-host with an overlay. This was causing issues because it is then mounted the same way inside the microvm. A temporary disk image is now created when starting the ghaf-host with a copy of the nix store.
- enabled a few reference VMs for testing
- a VMware disk image can also be created instead of qemu (useful on MacOS)

We found this setup helpful to experiment with host services, inter-vm communication, or the TPM. However device passthrough is still not implemented for this qemu target (I think it could be done by running hardware-scan inside qemu and assigning the PCI indexes).

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [x] QEMU virtual machine `x86_64`

### Test Steps To Verify:

`nix run .#vm-debug` or `nix run .#vm-debug-nogui`