### PR TITLE
Fixing logs duplication on remote

### DIFF
--- a/modules/common/logging/client.nix
+++ b/modules/common/logging/client.nix
@@ -1,6 +1,10 @@
 # Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 let
   cfg = config.ghaf.logging.client;
   inherit (config.ghaf.logging) listener;

--- a/modules/microvm/common/storagevm.nix
+++ b/modules/microvm/common/storagevm.nix
@@ -149,6 +149,7 @@ in
           (mkIf cfg.preserveLogs {
             directories = [
               "/var/log/journal"
+              "/var/lib/private/alloy"
             ]
             ++ optionals config.security.auditd.enable [
               "/var/log/audit"


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This PR fixes an issue where, after enabling log persistence, the same logs were re-uploaded to the remote Grafana server on every system reboot. 

The root cause was that Alloy's `positions.yml` file (i.e., which tracks the read offsets in the journal to avoid reprocessing logs) was not being persisted. Since Alloy runs with `DynamicUser=true`, this file resides in `/var/lib/private/alloy`. 

This change ensures that the correct `positions.yml`is persisted across reboots to prevent duplicate log ingestion.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Apply this change.
2. Generate test logs using the following example commands:
   ```bash
   [ghaf@admin-vm:~]$ sudo logger --priority=user.info --tag=myjob "test log logger INFO - admin"
   [ghaf@chrome-vm:~]$ sudo systemd-cat -t myjob echo "test log - chrome"
3. Open Grafana and verify that the logs appear as expected.
4. Reboot the system.
5. After the system is back up, monitor Grafana again.
6. Verify that the previously ingested logs are not re-uploaded. Only new logs generated after the reboot should appear.
7. After a few reboots, you should see something like the following in Grafana (filtered by "test log" and "Rebooting"), without duplicated entries:
   ```bash
   1754477862653  2025-08-06T10:57:42.653Z  Rebooting via ghaf-powercontrol
   1754477784432  2025-08-06T10:56:24.432Z  test log - chrome
   1754477544854  2025-08-06T10:52:24.854Z  Rebooting via ghaf-powercontrol
   1754477469543  2025-08-06T10:51:09.543Z  test log - zathura
   1754477443832  2025-08-06T10:50:43.832Z  test log logger INFO - admin
8. Verify that the log still exists locally after reboot:
   ```bash
   [ghaf@chrome-vm:~]$ journalctl -o json-pretty | awk '/test log/{show=1} show && /^\}/ {print; show=0} show'
9. Something like this should appear:
   ```bash
   	"MESSAGE" : "test log - chrome",
	"_COMM" : "echo",
	"_HOSTNAME" : "chrome-vm",
	"_SYSTEMD_OWNER_UID" : "1001",
	"_SYSTEMD_SLICE" : "user-1001.slice",
	"_STREAM_ID" : "95dfffa4227943eda456fba44c2e6e77",
	"_SYSTEMD_USER_SLICE" : "-.slice",
	"_SYSTEMD_UNIT" : "session-2.scope",
	"SYSLOG_IDENTIFIER" : "myjob",
	"_MACHINE_ID" : "22e74ff9140f4c92baa1f278e193569d",
	"_AUDIT_SESSION" : "2",
	"__SEQNUM" : "2137",
	"_GID" : "0",
	"_SYSTEMD_CGROUP" : "/user.slice/user-1001.slice/session-2.scope",
	"_SYSTEMD_SESSION" : "2",
	"_BOOT_ID" : "21d86e6732974b54a3564e1fd538891a",
	"PRIORITY" : "6",
	"_TRANSPORT" : "stdout"
