### PR TITLE
display: Drop x-igd-opregion device arg

### DIFF
--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7230.nix
@@ -59,8 +59,6 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "46aa";
-        # opregion is required for type-c display to work
-        qemu.deviceExtraArgs = "x-igd-opregion=on";
         # Detected kernel driver: i915
         # Detected kernel modules: i915
       }

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330.nix
@@ -63,8 +63,6 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "9a49";
-        # opregion is required for type-c display to work
-        qemu.deviceExtraArgs = "x-igd-opregion=on";
         # Detected kernel driver: i915
         # Detected kernel modules: i915
       }

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-2-in-1-gen-9.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-2-in-1-gen-9.nix
@@ -54,8 +54,6 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "7d45";
-        # opregion is required for type-c display to work
-        qemu.deviceExtraArgs = "x-igd-opregion=on";
       }
     ];
     kernelConfig = {

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen10.nix
@@ -44,8 +44,6 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "46a6";
-        # opregion is required for type-c display to work
-        qemu.deviceExtraArgs = "x-igd-opregion=on";
       }
     ];
     kernelConfig = {

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -46,8 +46,6 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "a7a1";
-        # opregion is required for type-c display to work
-        qemu.deviceExtraArgs = "x-igd-opregion=on";
       }
     ];
     kernelConfig = {

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen12.nix
@@ -47,7 +47,6 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "7d45";
-        qemu.deviceExtraArgs = "x-igd-opregion=on";
       }
       {
         # Communication controller [0780]: Intel Corporation Device [8086:7e70] (rev 20)

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen13.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen13.nix
@@ -53,8 +53,6 @@
         path = "0000:00:02.0";
         vendorId = "8086";
         productId = "64a0";
-        # opregion is required for type-c display to work
-        qemu.deviceExtraArgs = "x-igd-opregion=on";
       }
     ];
     kernelConfig = {


### PR DESCRIPTION


<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
x-igd-opregion is now enabled by default in Qemu. The Type-C display now works without the explicit Qemu opregion argument, so the extra device configuration is no longer needed.

More details in https://github.com/qemu/qemu/commit/16cbb43302a228f804c067992f6f61787934f3e9

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Type-C and HDMI connections should function seamlessly with external displays for all applicable targets.
