### PR TITLE
Fix for SSRCSP-6902 (blueman-applet failure)

### DIFF
--- a/modules/givc/audiovm.nix
+++ b/modules/givc/audiovm.nix
@@ -32,7 +32,7 @@ in
       };
       tls.enable = config.ghaf.givc.enableTls;
       admin = lib.head config.ghaf.givc.adminConfig.addresses;
-      socketProxy = [
+      socketProxy = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
         {
           transport = {
             name = guivmName;

--- a/modules/givc/guivm.nix
+++ b/modules/givc/guivm.nix
@@ -38,28 +38,29 @@ in
       admin = lib.head config.ghaf.givc.adminConfig.addresses;
       tls.enable = config.ghaf.givc.enableTls;
       enableUserTlsAccess = true;
-      socketProxy = [
-        {
-          transport = {
-            name = netvmName;
-            addr = hosts.${netvmName}.ipv4;
-            port = "9010";
-            protocol = "tcp";
-          };
-          socket = "/tmp/dbusproxy_net.sock";
-        }
-      ]
-      ++ lib.optionals config.ghaf.givc.audiovm.enable [
-        {
-          transport = {
-            name = audiovmName;
-            addr = hosts.${audiovmName}.ipv4;
-            port = "9011";
-            protocol = "tcp";
-          };
-          socket = "/tmp/dbusproxy_snd.sock";
-        }
-      ];
+      socketProxy =
+        lib.optionals (builtins.elem netvmName config.ghaf.common.vms) [
+          {
+            transport = {
+              name = netvmName;
+              addr = hosts.${netvmName}.ipv4;
+              port = "9010";
+              protocol = "tcp";
+            };
+            socket = "/tmp/dbusproxy_net.sock";
+          }
+        ]
+        ++ lib.optionals (builtins.elem audiovmName config.ghaf.common.vms) [
+          {
+            transport = {
+              name = audiovmName;
+              addr = hosts.${audiovmName}.ipv4;
+              port = "9011";
+              protocol = "tcp";
+            };
+            socket = "/tmp/dbusproxy_snd.sock";
+          }
+        ];
     };
     ghaf.security.audit.extraRules = [
       "-w /etc/givc/ -p wa -k givc-${hostName}"

--- a/modules/givc/netvm.nix
+++ b/modules/givc/netvm.nix
@@ -34,7 +34,7 @@ in
       hwidService = true;
       tls.enable = config.ghaf.givc.enableTls;
       admin = lib.head config.ghaf.givc.adminConfig.addresses;
-      socketProxy = [
+      socketProxy = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
         {
           transport = {
             name = guivmName;


### PR DESCRIPTION

<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Fixed socketProxy issue which caused blueman-applet failure 
Generalized socketProxy configuration
Fixes SSRCSP-6902
Config config.ghaf.givc.<vmname>.enable is private to the vm, it can not be used in a vm to check status of other vm.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Test status of blueman-applet service.
2. Test audio
