### PR TITLE
overlays: intel-gpu-tools: Dynamic iGPU detection

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -145,3 +145,8 @@ SPDX-FileCopyrightText = "Copyright (C) 2007 Free Software Foundation, Inc."
 path = [
   "overlays/custom-packages/gtklock/*.patch"
 ]
+
+[[annotations]]
+SPDX-License-Identifier = "MIT"
+SPDX-FileCopyrightText = "igt-gpu-tools contributors"
+path = "overlays/custom-packages/intel-gpu-tools/feat-dynamically-detect-iGPU-PCI-address-at-runtime.patch"

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -17,4 +17,5 @@
   cosmic-settings = import ./cosmic/cosmic-settings { inherit prev; };
   cosmic-comp = import ./cosmic/cosmic-comp { inherit prev; };
   xdg-desktop-portal-cosmic = import ./cosmic/xdg-desktop-portal-cosmic { inherit prev; };
+  intel-gpu-tools = import ./intel-gpu-tools { inherit prev; };
 })

--- a/overlays/custom-packages/intel-gpu-tools/default.nix
+++ b/overlays/custom-packages/intel-gpu-tools/default.nix
@@ -1,0 +1,7 @@
+# Copyright 2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{ prev }:
+prev.intel-gpu-tools.overrideAttrs {
+  patches = [ ./feat-dynamically-detect-iGPU-PCI-address-at-runtime.patch ];
+}

--- a/overlays/custom-packages/intel-gpu-tools/feat-dynamically-detect-iGPU-PCI-address-at-runtime.patch
+++ b/overlays/custom-packages/intel-gpu-tools/feat-dynamically-detect-iGPU-PCI-address-at-runtime.patch
@@ -1,0 +1,46 @@
+From 063ac77d7ae304e55dccc08c1eaa65cdd8d63c19 Mon Sep 17 00:00:00 2001
+From: Vunny Sodhi <vunny.sodhi@unikie.com>
+Date: Tue, 12 Aug 2025 16:16:27 +0300
+Subject: [PATCH] feat: dynamically detect iGPU PCI address at runtime
+
+Replace hardcoded IGPU_PCI macro with a runtime function that uses
+to detect the full PCI address of the iGPU. Ensures correct domain
+format (e.g., 0000:00:02.0) and allows the code to adapt to different
+hardware configurations without recompilation.
+---
+ tools/intel_gpu_top.c | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/tools/intel_gpu_top.c b/tools/intel_gpu_top.c
+index 54e71e559..3b28b0c6a 100644
+--- a/tools/intel_gpu_top.c
++++ b/tools/intel_gpu_top.c
+@@ -346,7 +346,25 @@ static int engine_cmp(const void *__a, const void *__b)
+ 		return a->instance - b->instance;
+ }
+ 
+-#define IGPU_PCI "0000:00:02.0"
++static const char *get_igpu_pci(void) {
++    static char pci_addr[64] = "0000:00:02.0"; // default fallback
++
++    FILE *fp = popen("lspci -D | grep -i 'VGA compatible controller' | awk '{print $1}'", "r");
++    if (fp == NULL) {
++        perror("popen failed");
++        return pci_addr; // fallback
++    }
++
++    if (fgets(pci_addr, sizeof(pci_addr), fp) != NULL) {
++        // Remove trailing newline
++        pci_addr[strcspn(pci_addr, "\n")] = '\0';
++    }
++    pclose(fp);
++
++    return pci_addr;
++}
++
++#define IGPU_PCI get_igpu_pci()
+ #define is_igpu_pci(x) (strcmp(x, IGPU_PCI) == 0)
+ #define is_igpu(x) (strcmp(x, "i915") == 0)
+ 
+-- 
+2.50.1


### PR DESCRIPTION
## Description of Changes

Adds an overlay to intel-gpu-tools that applies 0001-feat-dynamically-detect-iGPU-PCI-address-at-runtime.patch to enable runtime detection of the iGPU PCI address.

This patch can be treated as **workaround** until we have proper way of PCI address assigned in VMs.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. It should fix below error of `intel_gpu_top` not running with latest Kernel `6.15.8` for `gui-vm`
```
[root@gui-vm:~]# intel_gpu_top 
Failed to detect engines! (No such file or directory)
(Kernel 4.16 or newer is required for i915 PMU support.)
```
