### PR TITLE
ARP protection

### DIFF
--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -54,6 +54,14 @@ in
           description = "Extra host entries that override or extend the generated ones.";
           default = { };
         };
+        enableStaticArp = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Enable static ARP entries for all hosts, and prevent any ARP traffic being sent or received
+            on the internal network. This is useful to prevent ARP spoofing attacks between VMs.
+          '';
+        };
       };
       hardware = {
         nics = mkOption {

--- a/modules/common/firewall/kernel-modules.nix
+++ b/modules/common/firewall/kernel-modules.nix
@@ -134,7 +134,6 @@ in
           IP_NF_TARGET_NETMAP = module;
           IP_NF_TARGET_REDIRECT = module;
           IP_NF_TARGET_REJECT = module;
-
         };
       }
     ];

--- a/modules/common/services/wifi.nix
+++ b/modules/common/services/wifi.nix
@@ -9,6 +9,7 @@
 let
   cfg = config.ghaf.services.wifi;
   inherit (lib) mkIf mkForce mkEnableOption;
+  inherit (config.ghaf.networking) hosts;
 in
 {
   options.ghaf.services.wifi = {
@@ -21,7 +22,7 @@ in
       networkmanager = {
         enable = true;
         wifi.powersave = true;
-        unmanaged = [ "ethint0" ];
+        unmanaged = [ hosts.${config.networking.hostName}.interfaceName ];
       };
     };
 

--- a/modules/microvm/sysvms/idsvm/mitmproxy/default.nix
+++ b/modules/microvm/sysvms/idsvm/mitmproxy/default.nix
@@ -8,10 +8,9 @@
 }:
 let
   cfg = config.ghaf.virtualization.microvm.idsvm.mitmproxy;
+  inherit (config.ghaf.networking) hosts;
   mitmproxyport = 8080;
   mitmwebUIport = 8081;
-  inherit (config.ghaf.networking) hosts;
-
 in
 {
   options.ghaf.virtualization.microvm.idsvm.mitmproxy = {
@@ -91,7 +90,7 @@ in
         prerouting.nat = [
           # Redirect http(s) traffic to mitmproxy.
           "-i ${
-            toString hosts."ids-vm".interfaceName
+            hosts.${config.networking.hostName}.interfaceName
           } -p tcp -m multiport --dports 80,443 -j REDIRECT --to-port ${toString mitmproxyport}"
         ]
         ++ lib.optional cfg.webUIEnabled "-p tcp --dport ${toString mitmwebUIport} -j DNAT --to-destination 127.0.0.1:${toString mitmwebUIport}";

--- a/modules/reference/services/chromecast/chromecast-config.nix
+++ b/modules/reference/services/chromecast/chromecast-config.nix
@@ -3,6 +3,7 @@
 { config, lib, ... }:
 let
   inherit (lib) optionalAttrs hasAttrByPath;
+  inherit (config.ghaf.networking) hosts;
   isHost = hasAttrByPath [
     "hardware"
     "devices"
@@ -12,6 +13,6 @@ in
   config.ghaf.reference.services.chromecast = optionalAttrs isHost {
     enable = lib.mkDefault false;
     externalNic = (lib.head config.ghaf.hardware.definition.network.pciDevices).name;
-    internalNic = "ethint0";
+    internalNic = hosts.${config.networking.hostName}.interfaceName;
   };
 }

--- a/modules/reference/services/dendrite-pinecone/dendrite-config.nix
+++ b/modules/reference/services/dendrite-pinecone/dendrite-config.nix
@@ -7,6 +7,7 @@
 }:
 let
   inherit (lib) optionalAttrs hasAttrByPath;
+  inherit (config.ghaf.networking) hosts;
   isHost = hasAttrByPath [
     "hardware"
     "devices"
@@ -16,7 +17,7 @@ in
   config.ghaf.reference.services.dendrite-pinecone = optionalAttrs isHost {
     enable = lib.mkDefault false;
     externalNic = (lib.head config.ghaf.hardware.definition.network.pciDevices).name;
-    internalNic = "ethint0";
+    internalNic = hosts.${config.networking.hostName}.interfaceName;
     serverIpAddr = config.ghaf.networking.hosts."comms-vm".ipv4;
   };
 }


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Enable static ARP in the internal network, to prevent ARP spoofing and
subsequent MITM attacks.

- additional firewall (ebtables) rules on internal bridge, filtering out
  arp traffic; and required kernel modules
- sysctl settings to configure arp behaviour on bridge and vm internal
  interfaces
- splitting host networking configuration, allowing to later remove host
  networking without removing the internal bridge
- adding static entries for all known hosts
- adding flag for external host networking, allowing to not activate
  interfaces on the host by default and disable internal host nat


### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Confirm ARP spoofing works on current main
2. (optional) run `sudo arp net-vm` in chrome-vm before and during spoofing to see MAC address change
3. Apply patch and confirm ARP spoofing does not work (broadcast traffic will still be visible)
4. (optional) run `sudo arp net-vm` in chrome-vm before and during spoofing to see no MAC address change
5. Check for any network performance impact

Instructions:
```
ssh ghaf@zathura-vm
sudo su
nix-shell -p bettercap
arp -s 192.168.100.1 02:ad:00:00:00:01
iptables -P FORWARD ACCEPT

bettercap
> net.probe on
> set arp.spoof.targets 192.168.100.102
> arp.spoof on
> net.sniff on
```

Then open chrome browser on desktop, go to a website and observe traffic in zathura-vm. 
