### PR TITLE
New features and bug fixes for login user

### DIFF
--- a/modules/common/security/default.nix
+++ b/modules/common/security/default.nix
@@ -5,5 +5,6 @@
     ./sshkeys.nix
     ./apparmor
     ./audit
+    ./pwquality.nix
   ];
 }

--- a/modules/common/security/pwquality.nix
+++ b/modules/common/security/pwquality.nix
@@ -1,0 +1,88 @@
+# Copyright 2024-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.ghaf.security.pwquality;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    types
+    ;
+  creditVal =
+    val:
+    if val < 0 then
+      throw "pwquality value must not be negative: ${builtins.toString val}"
+    else if val == 0 then
+      "0"
+    else
+      "-" + builtins.toString val;
+in
+{
+  options.ghaf.security.pwquality = {
+    enable = mkEnableOption "Password quality check.";
+
+    minLength = mkOption {
+      description = ''
+        Minimum password length.
+      '';
+      type = types.int;
+      default = 8;
+    };
+
+    minDigit = mkOption {
+      description = ''
+        Minimum number of digits required in password.
+      '';
+      type = types.int;
+      default = 1;
+    };
+
+    minUppercase = mkOption {
+      description = ''
+        Minimum number of uppercase letters required in password.
+      '';
+      type = types.int;
+      default = 1;
+    };
+
+    minLowercase = mkOption {
+      description = ''
+        Minimum number of lowercase letters required in password.
+      '';
+      type = types.int;
+      default = 1;
+    };
+
+    minSpecialChar = mkOption {
+      description = ''
+        Minimum number of special letters required in password.
+      '';
+      type = types.int;
+      default = 1;
+    };
+
+    rememberOld = mkOption {
+      description = ''
+        Number of old password to remember to avoid repetetion.
+      '';
+      type = types.int;
+      default = 2;
+    };
+
+  };
+  config = mkIf cfg.enable {
+    environment.etc."security/pwquality.conf".text = ''
+      minlen = ${builtins.toString config.ghaf.security.pwquality.minLength}
+      dcredit = ${creditVal config.ghaf.security.pwquality.minDigit}
+      ucredit = ${creditVal config.ghaf.security.pwquality.minUppercase}
+      lcredit = ${creditVal config.ghaf.security.pwquality.minLowercase}
+      ocredit = ${creditVal config.ghaf.security.pwquality.minSpecialChar}
+      remember = ${builtins.toString config.ghaf.security.pwquality.rememberOld} 
+    '';
+  };
+}

--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -48,6 +48,7 @@ let
         inherit (cfg) withNss;
         withOomd = true;
         withPam = true;
+        withPasswordQuality = !cfg.withDebug;
         inherit (cfg) withPolkit;
         inherit (cfg) withResolved;
         inherit (cfg) withRepart;

--- a/modules/common/users/desktop.nix
+++ b/modules/common/users/desktop.nix
@@ -45,17 +45,7 @@ let
         default = 800000;
       };
       fidoAuth = mkEnableOption "FIDO authentication for the login user.";
-      createRecoveryKey = mkOption {
-        description = ''
-          Create recovery key for the login user.
-          Options: "yes" or "no". Defaults to "no".
-        '';
-        type = types.enum [
-          "yes"
-          "no"
-        ];
-        default = "no";
-      };
+      createRecoveryKey = mkEnableOption "Recovery key for the login user";
     };
   };
 
@@ -250,9 +240,10 @@ in
                   --real-name="$REALNAME" \
                   --skel=/etc/skel \
                   --storage=luks \
-                  --recovery-key=${cfg.loginUser.createRecoveryKey} \
+                  --recovery-key=${lib.boolToString cfg.loginUser.createRecoveryKey} \
                   --luks-pbkdf-type=argon2id \
                   --fs-type=btrfs \
+                  --enforce-password-policy=true \
                   --fido2-device="$FIDO_SUPPORT" \
                   --drop-caches=true \
                   --nosuid=true \

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -53,12 +53,14 @@ let
           ];
 
           ghaf = {
+            security.pwquality.enable = true;
             # Profiles
             profiles = {
               debug.enable = lib.mkDefault config.ghaf.profiles.debug.enable;
               graphics.enable = true;
             };
             users.loginUser = {
+              createRecoveryKey = true;
               enable = true;
               fidoAuth = true;
             };


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Added options for password quality check.
- Added option to generate recovery key.
- Repeat the prompt if 'user name' or 'user full name' is empty.
- Fixed [SSRCSP-6972](https://jira.tii.ae/browse/SSRCSP-6972)

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Password quality check and recovery key features are not available in `debug` build. Either test with `release` build or enable the features in 'debug' build using the patch below:

```
diff --git a/modules/common/systemd/base.nix b/modules/common/systemd/base.nix
index d9dd986a..400f8baf 100644
--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -48,7 +48,7 @@ let
         inherit (cfg) withNss;
         withOomd = true;
         withPam = true;
-        withPasswordQuality = !cfg.withDebug;
+        withPasswordQuality = cfg.withDebug;
         inherit (cfg) withPolkit;
         inherit (cfg) withResolved;
         inherit (cfg) withRepart;
diff --git a/modules/microvm/sysvms/guivm.nix b/modules/microvm/sysvms/guivm.nix
index 24ab23d1..bbe41fa7 100644
--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -53,6 +53,8 @@ let
           ];
 
           ghaf = {
+            security.pwquality.enable = true;
+            users.loginUser.createRecoveryKey = true;
             # Profiles
             profiles = {
               debug.enable = lib.mkDefault config.ghaf.profiles.debug.enable;

```

2. Empty `user name` and `full name` can be tested in debug build.
Just press `return` key when prompted for `user name` or `full name`.
