### PR TITLE
feat(desktop): add gpu screen recording with kb shortcut

### DIFF
--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -23,6 +23,17 @@ let
     inherit lib pkgs;
     secctx = cfg.securityContext;
     inherit (cfg) panelApplets;
+    extraShortcuts = lib.optionals cfg.screen-recorder.enable [
+      {
+        modifiers = [
+          "Ctrl"
+          "Shift"
+          "Alt"
+        ];
+        key = "r";
+        command = "ghaf-screen-record";
+      }
+    ];
   };
 
   autostart = pkgs.writeShellApplication {
@@ -191,6 +202,14 @@ in
         If unset, COSMIC will attempt to automatically detect a suitable render device.
       '';
     };
+
+    screen-recorder = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether to enable screen recording capabilities using gpu-screen-recorder.";
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -200,6 +219,8 @@ in
     ghaf.graphics.login-manager.enable = true;
     # Override default power controls with ghaf-powercontrol
     ghaf.graphics.power-manager.enable = true;
+
+    ghaf.graphics.screen-recorder.enable = cfg.screen-recorder.enable;
 
     environment = {
       systemPackages = with pkgs; [
@@ -246,7 +267,7 @@ in
           #DOCUMENTS=Documents
           #MUSIC=Music
           PICTURES=Pictures
-          #VIDEOS=Videos
+          VIDEOS=Videos
           #PUBLICSHARE=Public
           #TEMPLATES=Templates
           #DESKTOP=Desktop
@@ -387,7 +408,6 @@ in
 
     services.gvfs.enable = lib.mkForce false;
     services.avahi.enable = lib.mkForce false;
-    security.rtkit.enable = lib.mkForce false;
     services.gnome.gnome-keyring.enable = lib.mkForce false;
     services.power-profiles-daemon.enable = lib.mkForce false;
     # Fails to build in cross-compilation for Orins
@@ -397,15 +417,12 @@ in
     # but we add it here so cosmic-osd doesn't consume too much CPU
     # ref https://github.com/pop-os/cosmic-osd/issues/70
     services.pipewire = {
-      enable = !graphicsProfileCfg.proxyAudio;
+      enable = true;
 
       # Disable audio backends
       alsa.enable = false;
       pulse.enable = !graphicsProfileCfg.proxyAudio;
       jack.enable = false;
-
-      # Disable the session manager
-      wireplumber.enable = false;
     };
     services.playerctld.enable = true;
   };

--- a/modules/desktop/graphics/default.nix
+++ b/modules/desktop/graphics/default.nix
@@ -11,5 +11,6 @@
     ./login-manager.nix
     ./power-manager.nix
     ./boot.nix
+    ./screen-recorder.nix
   ];
 }

--- a/modules/desktop/graphics/screen-recorder.nix
+++ b/modules/desktop/graphics/screen-recorder.nix
@@ -1,0 +1,96 @@
+# Copyright 2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.graphics.screen-recorder;
+
+  ghaf-screen-record = pkgs.writeShellApplication {
+    name = "ghaf-screen-record";
+
+    runtimeInputs = with pkgs; [
+      gpu-screen-recorder
+      libnotify
+      killall
+      xdg-utils
+    ];
+
+    text = ''
+      # If gpu-screen-recorder is already running, stop it and exit
+      if killall -SIGINT -q gpu-screen-recorder; then
+          action=$(notify-send -h byte:urgency:0 -t 5000 -h "string:image-path:gpu-screen-recorder" -A "open=open" \
+              -a "GPU Screen Recorder" "Screen recording stopped" "Screen recording saved to $HOME/Videos")
+          # User clicked the notification
+          if [ "$action" = "open" ]; then
+              xdg-open "$HOME/Videos" &
+          fi
+          exit 0
+      fi
+
+      # Create output filename
+      video="$HOME/Videos/ghaf-screen-capture_$(date +"%Y-%m-%d_%H-%M-%S").mp4"
+
+      # Start recording
+      if gpu-screen-recorder \
+          -w portal \
+          -c mp4 \
+          -k h264 \
+          -ac opus \
+          -f 60 \
+          -cursor yes \
+          -restore-portal-session yes \
+          -cr limited \
+          -encoder gpu \
+          -q very_high \
+          -a device:default_output \
+          -o "$video" &
+      then
+          notify-send -h byte:urgency:0 -t 5000 -h "string:image-path:gpu-screen-recorder" -a "GPU Screen Recorder" \
+              "Screen recording started" "Use CTRL+SHIFT+ALT+R to stop recording"
+      else
+          notify-send -h byte:urgency:0 -t 5000 -h "string:image-path:gpu-screen-recorder" -a "GPU Screen Recorder" \
+              "Screen recording failed" "Failed to start screen recording"
+          exit 1
+      fi
+    '';
+  };
+in
+{
+  options.ghaf.graphics.screen-recorder = {
+    enable = lib.mkEnableOption "Whether to enable screen recording capabilities using gpu-screen-recorder.";
+  };
+
+  config = lib.mkIf cfg.enable {
+    # OBS is another option to capture the screen in Cosmic
+    # Other options include Kooha and Wayfarer, but are misbehaving as of Cosmic Alpha 7
+    # due to issues with the xdg-desktop-portal-cosmic implementation
+    # ref. https://github.com/SeaDve/Kooha/issues/311
+    # programs.obs-studio.enable = true;
+
+    # XDG desktop portal screen capture requires pipewire and wireplumber to be enabled
+    services.pipewire = {
+      enable = true;
+      wireplumber.enable = true;
+    };
+
+    environment.systemPackages = with pkgs; [
+      gpu-screen-recorder
+      # UI for gpu-screen-recorder
+      gpu-screen-recorder-gtk
+
+      # Script to start/stop screen recording
+      ghaf-screen-record
+    ];
+
+    assertions = [
+      {
+        assertion = pkgs.stdenv.isx86_64;
+        message = "GPU screen recording is only supported on x86_64";
+      }
+    ];
+  };
+}

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -52,6 +52,7 @@ in
           "com.system76.CosmicAppletTiling"
           "com.system76.CosmicAppletPower"
         ];
+        screen-recorder.enable = false;
       };
 
       reference.programs.windows-launcher.enable = true;


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Added Ghaf screen recorder module:**
   - Module declared in `modules/desktop/graphics/screen-recorder.nix`
   - Enabling the module does the following:
     - Enables pipewire and wireplumber services on the target (necessary for xdg-desktop-portal screen capture)
     - Adds `gpu-screen-recorder`, `gpu-screen-recorder-gtk`, and `ghaf-screen-record` to `environment.systemPackages`
   - `ghaf-screen-record`:
     - Acts as a simple way to start/stop screen recording by running the script
     - Attempts to record the screen by using xdg-desktop-portal screen capture with pipewire
     - Recordings are saved at `$HOME/VIdeos`
     - Notifications are displayed for screen capture start, stop, errors.
       Clicking the "Recording stopped" notification opens the default file browser at `$HOME/VIdeos`
2. **Added extraShortcuts option to cosmic config:**
   - Can be used to add extra default keyboard shortcuts to run commands
   - Each extra shortcut can be set to a specific combination of modifiers (Alt, Shift etc.) and keys
3. **Added default Ghaf screen recording keyboard shortcut**
   - **CTRL+SHIFT+ALT+R** is the default shortcut to start/stop screen recording
   - The keyboard shortcut simply runs the previously mentioned `ghaf-screen-record` script


Ref.
https://git.dec05eba.com/gpu-screen-recorder/about/

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`  gpu-screen-recorder only available on x86
- [ ] Orin NX `aarch64`    gpu-screen-recorder only available on x86
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Boot into Ghaf, wait for the desktop panel to be visible (to ensure notifications are ready to be displayed)
2. Open two separate terminal windows, and run `nvtop` and `htop` respectively
3. Use the new keyboard shortcut **CTRL+SHIFT+ALT+R** to start a screen recording
4. Verify a notification shows up at the top, indicating that the screen recording has started
5. Allow the screen recording to capture your display in the window that appears soon after
6. Verify GPU and CPU usage in `nvtop` and `htop` - GPU usage should increase, CPU usage should increase by ~15-20% only
7. Record for ~10 seconds, or any given time, while doing something on the desktop
8. Stop the recording with the keyboard shortcut **CTRL+SHIFT+ALT+R**
9. Verify a notification shows up at the top, indicating the recording has stopped and the file was saved
10. Click the notification or navigate to `$HOME/Videos` manually and find the video file
11. View the recording
12. Verify GPU and CPU usage in `nvtop` and `htop` - GPU usage should drop down to 0%, CPU usage should be decreased as well

