### PR TITLE
bugfix: add temporary watchdog service for high-CPU processes

### DIFF
--- a/modules/desktop/graphics/cosmic/config/cosmic-config.nix
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.nix
@@ -113,6 +113,9 @@ pkgs.stdenv.mkDerivation rec {
     cp ${panelAppletsWingsConfig} $out/share/cosmic/com.system76.CosmicPanel.Panel/v1/plugins_wings
   '';
 
+  # TODO: remove audio-volume-change playback when upstream hardcoded path is fixed
+  # Also add pipewire (pa-play) to system packages
+  # ref https://github.com/pop-os/cosmic-osd/blob/master/src/components/app.rs#L747
   postInstall = ''
     substituteInPlace $out/share/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions \
     --replace-fail 'VolumeLower: ""' 'VolumeLower: "pamixer --unmute --decrease 5 && ${pkgs.pulseaudio}/bin/paplay ${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo/audio-volume-change.oga"' \


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Add temporary watchdog service to monitor known problematic high-cpu usage processes:**
   - The service runs on session start for 5 minutes
   - If an offending process is found to exceed the maximum threshold CPU usage, all offending processes are killed
   - The killed processes are automatically restarted by `cosmic-session`
   - Known offenders: `cosmic-applet-audio`, `cosmic-osd`
   - ref. https://github.com/pop-os/cosmic-osd/issues/70

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
**NOTE:** Perform the following test at least 3 times to confirm the behavior is consistent
1. Install Ghaf from scratch (this bug appears mostly on fresh installs)
2. Boot and log into the system
3. Observe `htop` and `journalctl --user-unit=cosmic-cpu-watchdog.service`
   - `cosmic-applet-audio` and `cosmic-osd` should appear in htop consuming more than 80% of CPU resources
   - The offending processes should be killed by `cosmic-cpu-watchdog` within ~2 minutes, the watchdog should then exit