### PR TITLE
audit: add Nix-specific rules

### DIFF
--- a/modules/common/security/audit/default.nix
+++ b/modules/common/security/audit/default.nix
@@ -37,6 +37,11 @@ in
       default = importAuditRules "common";
       description = "Common audit rules for host and guests";
     };
+    enableVerboseCommon = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Include verbose Common audit rules";
+    };
     enableStig = mkOption {
       type = types.bool;
       default = false;
@@ -46,6 +51,11 @@ in
       type = types.bool;
       default = false;
       description = "Enable OSPP rules";
+    };
+    enableVerboseOspp = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Include verbose OSPP rules";
     };
     host = {
       enable = mkOption {
@@ -88,6 +98,7 @@ in
 
     ghaf.systemd.withAudit = true;
     security.auditd.enable = true;
+    ghaf.security.audit.enableOspp = mkIf cfg.enableVerboseOspp true;
 
     security.audit = {
       enable = true;

--- a/modules/common/security/audit/rules/host.nix
+++ b/modules/common/security/audit/rules/host.nix
@@ -1,6 +1,16 @@
 # Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 _: [
+  # NixOS specific rules
+  # Nix profiles & system generations (symlink flips = important)
+  "-w /nix/var/nix/profiles -p wa -k nix_profiles"
+  # Nix DB & state (writes signal store mutation); keep scope tight to avoid volume
+  "-w /nix/var/nix/db -p wa -k nix_db"
+  # GC (pinning/unpinning)
+  "-w /nix/var/nix/gc.lock -p wa -k nix_gc_lock"
+  # The current system symlink and profile links (generation switches)
+  "-w /run/current-system -p wa -k nix_system"
+  "-w /nix/var/nix/profiles/system -p wa -k nix_system"
 
   # 40-local.rules
   ## Put your own watches after this point

--- a/modules/reference/appvms/zathura.nix
+++ b/modules/reference/appvms/zathura.nix
@@ -12,6 +12,7 @@
     cores = 1;
     bootPriority = "low";
     borderColor = "#122263";
+
     applications = [
       {
         name = "PDF Viewer";
@@ -27,12 +28,20 @@
         ];
       }
     ];
+
     extraModules = [
       {
         # This vm should be stateless so nothing stored between boots
         ghaf.storagevm.enable = lib.mkForce false;
+
         # Handle PDF and image open requests
         ghaf.xdghandlers.enable = true;
+
+        # Let systemd use default ordering for audit-rules instead of early-boot
+        systemd.services.audit-rules = {
+          unitConfig.DefaultDependencies = lib.mkForce true;
+          before = lib.mkForce [ ];
+        };
       }
     ];
   };

--- a/modules/reference/personalize/authorizedSshKeys.nix
+++ b/modules/reference/personalize/authorizedSshKeys.nix
@@ -36,6 +36,7 @@
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGJSuGlmQ/iMu7JGL7L4jVT3d+o4MiOsuh0e1ZVkBUKq gayathri@tii.ae"
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINlIpJ9Q1oW1KiFBa12N5K/ecGVeGSBbcD8M9ZjA0TYe kajus.naujokaitis@unikie.com"
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPE/CgI8MXyHiiUyt7BXWjQG1pb25b4N3als/dKKPZyD samuli@nixos"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJpTkKsWyFQxWKwL22fghfJnLaOhUtZLlF9h2gdWcoJz everton.dematos@tii.ae"
 
         # For ghaf-installer automated testing:
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAolaKCuIUBQSBFGFZI1taNX+JTAr8edqUts7A6k2Kv7"


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Enhances NixOS audit coverage, aligns with Anduril NixOS STIG guidance, removes overlapping/erroring rules, and adds opt-in verbose toggles.

### Key Updates
- Nix-specific coverage
  - Exec rules for `nix-daemon` and `nix` (execve/execveat).
  - Path watches for `nix`, `nix-store`, `nix-shell`, `nix-build`, `nix-collect-garbage`, and `nixos-rebuild`.
  - Watches for `/etc/nix`, `/etc/nixos`, and `nix-daemon` unit/socket paths.
  - Host-level watches for Nix profiles, DB/state, GC lock, and system generation symlinks.
- STIG alignment
  - Incorporated rules from [https://stigviewer.com/stigs/anduril_nixos](https://stigviewer.com/stigs/anduril_nixos?utm_source=chatgpt.com). Trimmed duplicates/overlaps
- Verbose options
  - `ghaf.security.audit.enableVerboseCommon`
  - `ghaf.security.audit.enableVerboseOspp`

### Performance Insights
#### Storage 
- Write rate (KiB/s) is measured by monitoring the `audit.log` files.
  - Each scenario was run 3×. The following table presents the average of the three runs with different configurations (i.e., scenarios) for two phases: (i) booting, (ii) idle (~10 min)

| **Scenario** | **Common rules** | **Common-Verbose** | **OSPP** | **OSPP-Verbose** | **STIG** | **#Rules** | **Boot avg (KiB/s)** | **Idle avg (KiB/s)** |
|-|-|-|-|-|-|-|-|-|
| net-vm-S1   | ✅ | ❌ | ❌ | ❌ | ❌ | 43 | 5.7757 | 0.0742 |
| net-vm-S2   | ✅ | ✅ | ❌ | ❌ | ❌ | 45 | 138.1898 | 1.3372 |
| net-vm-S3    | ✅ | ❌ | ✅ | ❌ | ❌ | 82 | 5.7824 | 0.1698 |
| net-vm-S4    | ✅ | ❌ | ❌ | ✅ | ❌ | 83 | 21.0952 | 0.1552 |
| net-vm-S5    | ✅ | ❌| ❌ | ❌| ✅ | 60 | 6.4002 | 0.107 |
| host-vm-S1   | ✅ | ❌ | ❌ | ❌ | ❌ | 47 | 2.4155 | 0.2051 |
| host-vm-S2   | ✅ | ✅ | ❌ | ❌ | ❌ | 49 | 116.2952 | 2.3102 |
| host-vm-S3   | ✅ | ❌ | ✅ | ❌ | ❌ | 86 | 2.1979 | 0.2053 |
| host-vm-S4   | ✅ | ❌ | ❌ | ✅ | ❌ | 87 | 2.6081 | 0.2065 |
| host-vm-S5   | ✅ | ❌| ❌ | ❌| ✅ | 64 | 2.8714 | 0.2053 |

#### Memory and CPU
- Measured on `auditd.service` during idle (~10 min).
  - Memory: average of systemd cgroup `MemoryCurrent` and peak from `MemoryPeak`.
  - CPU: average % over the same window, computed from deltas of the main PID’s utime+stime (i.e., `cpu_pct`).

| **Scenario** | **Common rules** | **Common-Verbose** | **OSPP** | **OSPP-Verbose** | **STIG** | **#Rules** | **Memory avg (MiB)** | **Memory peak (MiB)** | **CPU (%)** |
|-|-|-|-|-|-|-|-|-|-|
| net-vm-S1   | ✅ | ❌ | ❌ | ❌ | ❌ | 43 | 0.76 | 3.66 | 0.01 |
| net-vm-S2   | ✅ | ✅ | ❌ | ❌ | ❌ | 45 | 3.20 | 5.65 | 0.02 |
| net-vm-S3    | ✅ | ❌ | ✅ | ❌ | ❌ | 82 | 0.89 | 3.18 | 0.01 |
| net-vm-S4    | ✅ | ❌ | ❌ | ✅ | ❌ | 83 | 5.92 | 9.34 | 0.19 |
| net-vm-S5    | ✅ | ❌| ❌ | ❌| ✅ | 60 | 0.77 | 3.36 | 0.01 |
| host-vm-S1   | ✅ | ❌ | ❌ | ❌ | ❌ | 47 | 1.96 | 3.15 | 0.01 |
| host-vm-S2   | ✅ | ✅ | ❌ | ❌ | ❌ | 49 | 12.62 | 13.46 | 0.02 |
| host-vm-S3   | ✅ | ❌ | ✅ | ❌ | ❌ | 86 | 2.16 | 2.65 | 0.01 |
| host-vm-S4   | ✅ | ❌ | ❌ | ✅ | ❌ | 87 | 10.23 | 13.85 | 0.11 |
| host-vm-S5   | ✅ | ❌| ❌ | ❌| ✅ | 64 | 1.99 | 2.42 | 0.01 |

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
1. To enable audit you can use either the `extras` (`#lenovo-x1-extras-debug`) - audit will be enabled by default - or set this flag to true (https://github.com/everton-dematos/ghaf/blob/pr_audit_logging/modules/reference/profiles/mvp-user-trial.nix#L102)
2. The rules will be available in all the VMs. The `ghaf-host` will have a few more rules, as it has specific rules for host (https://github.com/everton-dematos/ghaf/blob/pr_audit_logging/modules/common/security/audit/rules/host.nix)
3. To enable specific set of rules (i.e., `enableVerboseCommon`, `enableStig`, `enableOspp`, `enableVerboseOspp`), it is mandatory to set it as `true`, as follows:
```
# Optional hardening:
ghaf.security.audit.enableStig = true;
ghaf.security.audit.enableOspp = true;

# Noisy diagnostics (opt-in):
ghaf.security.audit.enableVerboseCommon = true;
ghaf.security.audit.enableVerboseOspp = true;
```
4. After boot, verify that `auditd.service` and `audit-rules.service` are up and running by `systemctl status <service>`
4. List the loaded rules by `sudo auditctl -l`
5. Monitor `/var/log/audit/` files
