### PR TITLE
docs: fix the flake init template attribute

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -24,7 +24,7 @@ import {
 } from "@astrojs/starlight/components";
 
 <Card title="Get Started">
-  <Code lang="sh" code="nix flake init -t github:tiiuae/ghaf#boilerplate" />
+  <Code lang="sh" code="nix flake init -t github:tiiuae/ghaf#target-boilerplate" />
   <LinkButton
     href="/ghaf/overview/"
     variant="secondary"


### PR DESCRIPTION
When following the "Getting Started" on the project home page, the command fails to a missing attribute. Update the template name to a valid template target.

<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [X] Other: `nix build .#doc`

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Navigate to https://ghaf.tii.ae/ - try running the command on Getting Started-box. Fails to 
`error: flake 'github:tiiuae/ghaf' does not provide attribute 'templates.boilerplate' or 'boilerplate'`
2. Apply the patch, rebuild the docs: `nix build .#doc`
3. Open the index.html on the updated docs and run the (updated) command -> initializes a flake from the template.
