### PR TITLE
Update vhotplug to support new config format and external API

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,17 +234,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1757567943,
-        "narHash": "sha256-mdYISYtn74IYJu52Ep9pjywnYhdWaxELI8MiGh7FVVg=",
+        "lastModified": 1757697234,
+        "narHash": "sha256-aISdrjIjYgy8V60LcgFCt2KbXR1spdKF5tkHt9vgCDI=",
         "owner": "tiiuae",
         "repo": "ghafpkgs",
-        "rev": "7127f73cd9962d4ad28c024c57ee23fa487926df",
+        "rev": "f465691dd491e3a21f5a6e32e435ce3fb0d95525",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
         "repo": "ghafpkgs",
-        "rev": "7127f73cd9962d4ad28c024c57ee23fa487926df",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
 
     # A set of useful nix packages and utilities for ghaf
     ghafpkgs = {
-      url = "github:tiiuae/ghafpkgs/7127f73cd9962d4ad28c024c57ee23fa487926df";
+      url = "github:tiiuae/ghafpkgs";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -89,12 +89,12 @@ in
       enable = true;
       rules = [
         {
-          name = "NetVM";
-          qmpSocket = "/var/lib/microvms/net-vm/net-vm.sock";
-          usbPassthrough = [
+          description = "Devices for NetVM";
+          targetVm = "net-vm";
+          allow = [
             {
-              class = 2;
-              subclass = 6;
+              interfaceClass = 2;
+              interfaceSubclass = 6;
               description = "Communications - Ethernet Networking";
             }
             {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This updates vhotplug to the version with the new config format, which allows selecting multiple VMs for a single device.
It also adds support for the external API over VSOCK, which is required for the frontend GUI app.
No new functionality is added in this PR, but it is a prerequisite for the PR with the USB management app from Ganga.


<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
Overall USB hotplug testing is required to make sure this doesn’t introduce any regressions.
