### PR TITLE
fix(logging): stop losing admin-vm logs across offline reboots

### DIFF
--- a/modules/microvm/common/storagevm.nix
+++ b/modules/microvm/common/storagevm.nix
@@ -145,6 +145,8 @@ in
           (mkIf cfg.preserveLogs {
             directories = [
               "/var/log/journal"
+            ]
+            ++ optionals (!config.ghaf.logging.server.enable) [
               "/var/lib/private/alloy"
             ]
             ++ optionals config.security.auditd.enable [

--- a/modules/microvm/sysvms/adminvm.nix
+++ b/modules/microvm/sysvms/adminvm.nix
@@ -92,16 +92,6 @@ let
                 mountPoint = "/etc/common";
                 proto = "virtiofs";
               }
-            ]
-            ++ lib.optionals config.ghaf.logging.enable [
-              {
-                # Creating a persistent log-store which is mapped on ghaf-host
-                # This is only to preserve logs state across adminvm reboots
-                tag = "log-store";
-                source = "/persist/storagevm/admin-vm/var/lib/private/alloy";
-                mountPoint = "/var/lib/private/alloy";
-                proto = "virtiofs";
-              }
             ];
 
             writableStoreOverlay = lib.mkIf config.ghaf.development.debug.tools.enable "/nix/.rw-store";


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Fixes loss of `admin-vm` logs when they are generated while the Internet is down and the VM reboots before connectivity returns. 

The root cause was that we were persisting Alloy’s state (`/var/lib/private/alloy`) on `admin-vm`, which includes the `loki.source.journal cursor`. The source advanced its cursor pre-reboot even though some entries had not yet reached `loki.write` (where the WAL append happens). After reboot, the persisted cursor skipped those entries, so nothing was resent.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7024

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
1. Boot a fresh ghaf image on Lenovo-X1 without internet (eth cable) connection
2. Create user account, log in, open terminal
3. `cat /etc/common/device-id` (and write down the id)
4. `ssh ghaf@admin-vm`
5. `sudo logger --priority=user.info --tag=myjob "logtest0 - admin"`
6. Reboot the laptop
7. Connect to internet, verify the connection by 'ping google.com' from terminal
8. `ssh ghaf@admin-vm`
9. `sudo logger --priority=user.info --tag=myjob "logtest1 - admin"`
10. Log in to grafana https://ghaflogs.vedenemo.dev/explore
11. Select filters: machine = device-id / host = admin-vm / Line contains: logtest
12. Select time frame (upper right corner) to cover steps from 4 (e.g. Last 15 minutes)
13. Hit "Run query"
14. Grafana lists both log lines:
`logtest0 - admin` `logtest1 - admin`