### PR TITLE
Bump: Update microvm.nix module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,17 +360,16 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1755802472,
-        "narHash": "sha256-GPrRlKMrvNkW4NGQl0DtXHvT+tQUha0ImnwduFlTGzc=",
+        "lastModified": 1757518086,
+        "narHash": "sha256-qUJFqN9KGhh2nh4ksaFGfGNIuL7p+8PstjtODLbWuSk=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "beb47425bd866f606129c631c98b6288f7596e78",
+        "rev": "f6e7494efa2b17deb2a69a45932d34dc205bd3bb",
         "type": "github"
       },
       "original": {
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "beb47425bd866f606129c631c98b6288f7596e78",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -125,8 +125,7 @@
 
     # For building and managing VMs
     microvm = {
-      #TODO: bug in the darwin enable that removed qemu_kvm
-      url = "github:microvm-nix/microvm.nix/beb47425bd866f606129c631c98b6288f7596e78";
+      url = "github:microvm-nix/microvm.nix";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Updated the microvm.nix module to utilize qemu_kvm for Linux hosts fix.

More details in https://github.com/microvm-nix/microvm.nix/pull/406

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. System should boot to GUI.
