### PR TITLE
feat(boot): enable graphical boot on guivm, fix darp11 graphical boot

### DIFF
--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -91,7 +91,7 @@ in
         givc.host.enable = true;
         graphics.boot = {
           enable = true; # Enable graphical boot on host
-          waitForService = lib.optionalString config.ghaf.virtualization.microvm.guivm.enable "system-ui.target";
+          renderer = "simpledrm"; # Force simpledrm framebuffer for graphical boot on host
         };
         services = {
           power-manager = {

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -104,6 +104,10 @@ let
 
             # Create launchers for regular apps running in the GUIVM and virtualized ones if GIVC is enabled
             graphics = {
+              boot = {
+                enable = true; # Enable graphical boot on gui-vm
+                renderer = "gpu"; # Use GPU for graphical boot in gui-vm
+              };
               launchers = guivmLaunchers ++ lib.optionals config.ghaf.givc.enable virtualLaunchers;
               labwc = {
                 autolock.enable = lib.mkDefault config.ghaf.graphics.labwc.autolock.enable;

--- a/modules/reference/hardware/system76/definitions/system76-darp11-b.nix
+++ b/modules/reference/hardware/system76/definitions/system76-darp11-b.nix
@@ -62,9 +62,8 @@
     ];
     kernelConfig = {
       stage1.kernelModules = [
-        "xe"
+        "i915"
       ];
-      stage2.kernelModules = [ ];
       kernelParams = [
         "earlykms"
       ];


### PR DESCRIPTION
## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

1. Graphical boot config overhaul:
   - Added more nix options to configure Ghaf graphical boot: `theme, renderer, splashDelay, deviceTimeout, debug`
2. Enabled graphical boot on guivm
   - The splash screen should show up as soon as the gpu is attached and initialized on guivm
3. Fixed black screen boot on system76 darp11-b

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Shutdown the target system after deploying this patch
2. Power on the system
3. Observe and verify the following boot process:
   - Firmware/NixOS generation selection
   - Host boot splash screen with Ghaf logo
   - Black screen (guivm started, gpu is being initialized)
   - Guivm boot splash screen with Ghaf logo
   - Black screen (greetd starting)
   - Login screen
4. Verify boot process is fixed on system76 darp11-b
