### PR TITLE
Enabling fail2ban module

### DIFF
--- a/modules/common/firewall/attack-mitigation.nix
+++ b/modules/common/firewall/attack-mitigation.nix
@@ -1,0 +1,28 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.ghaf.firewall.attack-mitigation;
+in
+{
+  options.ghaf.firewall.attack-mitigation = {
+
+    enable = lib.mkEnableOption "Attack mitigation features integrated into the firewall";
+    rateLimitSSH = lib.mkEnableOption "Rate-limiting to mitigate SSH syn flood attacks";
+  };
+
+  config = mkIf cfg.enable {
+    # ssh syn flood protection
+    ghaf.firewall.tcpBlacklistRules = mkIf cfg.rateLimitSSH [
+      {
+        port = lib.head config.services.openssh.ports;
+        trackingSize = 100;
+        burstNum = 5;
+        maxPacketFreq = "30/minute"; # maximum 30 new ssh connection request/minute
+      }
+    ];
+  };
+}

--- a/modules/common/firewall/default.nix
+++ b/modules/common/firewall/default.nix
@@ -7,5 +7,6 @@
   imports = [
     ./kernel-modules.nix
     ./firewall.nix
+    ./attack-mitigation.nix
   ];
 }

--- a/modules/common/security/default.nix
+++ b/modules/common/security/default.nix
@@ -6,6 +6,7 @@
     ./apparmor
     ./audit
     ./pwquality.nix
+    ./fail2ban.nix
     ./ssh-tarpit
   ];
 }

--- a/modules/common/security/fail2ban.nix
+++ b/modules/common/security/fail2ban.nix
@@ -1,0 +1,86 @@
+# Copyright 2024-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.fail2ban;
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    types
+    mkOption
+    ;
+in
+{
+  options.ghaf.security.fail2ban = {
+    enable = mkEnableOption "the fail2ban";
+    sshd-jail-fwmark = mkOption {
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "sshd custom jail";
+          fwMarkNum = mkOption {
+            type = types.str;
+            default = "70";
+            description = "Firewall mark number to apply to banned IPs when using iptables-ipset-mark.";
+          };
+          blacklistName = mkOption {
+            type = types.strMatching "^[a-zA-Z]{1,31}$";
+            default = "sshBlacklist";
+            description = ''
+              Blacklist name for fail2ban
+            '';
+          };
+        };
+      };
+      default = { };
+      description = "Configuration for the SSHD Fail2Ban jail using firewall marks.";
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    services.fail2ban = {
+      enable = true;
+      extraPackages = [ pkgs.ipset ];
+      bantime = "30m";
+      maxretry = 3;
+      bantime-increment.enable = true;
+      bantime-increment.factor = "2";
+      jails = {
+        # sshd is jailed by default
+        sshd.settings = {
+          enabled = true;
+          banaction =
+            if cfg.sshd-jail-fwmark.enable then
+              "iptables-ipset-mark"
+            else
+              "iptables-ipset-proto6-allports[name=${cfg.sshd-jail-fwmark.blacklistName},blocktype=DROP]";
+        };
+
+      };
+    };
+
+    # Only provide custom action file if user selects iptables-ipset-mark
+    environment.etc = mkIf cfg.sshd-jail-fwmark.enable {
+      "fail2ban/action.d/iptables-ipset-mark.conf".text = ''
+        [INCLUDES]
+        before = iptables-ipset-proto6-allports.conf
+
+        [Definition]
+        rule-jump = -m set --match-set <ipmset> src -j MARK --set-mark ${cfg.sshd-jail-fwmark.fwMarkNum}
+
+        [Init]
+        chain = PREROUTING
+        ipmset = f2b-${cfg.sshd-jail-fwmark.blacklistName}
+        iptables = iptables -t raw <lockingopt>
+
+      '';
+    };
+
+  };
+}

--- a/modules/development/ssh.nix
+++ b/modules/development/ssh.nix
@@ -10,5 +10,13 @@ in
     enable = mkEnableOption "ssh daemon";
   };
 
-  config = mkIf cfg.enable { services.openssh.enable = true; };
+  config = mkIf cfg.enable {
+
+    services.openssh.enable = true;
+
+    ghaf.firewall.attack-mitigation = {
+      enable = true;
+      rateLimitSSH = true;
+    };
+  };
 }

--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -123,6 +123,9 @@ let
                   name = "${vm.name}";
                 };
                 logging.client.enable = configHost.ghaf.logging.enable;
+
+                security.fail2ban.enable = configHost.ghaf.development.ssh.daemon.enable;
+
               };
 
               # SSH is very picky about the file permissions and ownership and will

--- a/modules/microvm/sysvms/adminvm.nix
+++ b/modules/microvm/sysvms/adminvm.nix
@@ -65,6 +65,9 @@ let
                 inherit (configHost.ghaf.logging) enable;
               };
             };
+
+            security.fail2ban.enable = configHost.ghaf.development.ssh.daemon.enable;
+
           };
 
           system.stateVersion = lib.trivial.release;

--- a/modules/microvm/sysvms/audiovm.nix
+++ b/modules/microvm/sysvms/audiovm.nix
@@ -73,6 +73,9 @@ let
               };
             };
             logging.client.enable = configHost.ghaf.logging.enable;
+
+            security.fail2ban.enable = configHost.ghaf.development.ssh.daemon.enable;
+
           };
 
           environment = {

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -148,6 +148,9 @@ let
               };
             };
             xdgitems.enable = true;
+
+            security.fail2ban.enable = config.ghaf.development.ssh.daemon.enable;
+
           };
 
           services = {

--- a/modules/microvm/sysvms/netvm.nix
+++ b/modules/microvm/sysvms/netvm.nix
@@ -74,6 +74,14 @@ let
               };
             };
             logging.client.enable = config.ghaf.logging.enable;
+
+            security = {
+              fail2ban.enable = config.ghaf.development.ssh.daemon.enable;
+              ssh-tarpit = {
+                inherit (config.ghaf.development.ssh.daemon) enable;
+                listenAddress = config.ghaf.networking.hosts.${vmName}.ipv4;
+              };
+            };
           };
 
           time.timeZone = config.time.timeZone;
@@ -92,10 +100,6 @@ let
               allowedTCPPorts = [ dnsPort ];
               allowedUDPPorts = [ dnsPort ];
             };
-          ghaf.security.ssh-tarpit = {
-            enable = lib.mkForce config.ghaf.development.ssh.daemon.enable;
-            listenAddress = config.ghaf.networking.hosts.${vmName}.ipv4;
-          };
 
           microvm = {
             # Optimize is disabled because when it is enabled, qemu is built without libusb

--- a/tests/firewall/default.nix
+++ b/tests/firewall/default.nix
@@ -78,14 +78,29 @@ pkgs.nixosTest {
       inherit users security;
       imports = [
         ../../modules/common/firewall
+        ../../modules/common/security/fail2ban.nix
+        ../../modules/common/security/ssh-tarpit
       ];
       virtualisation.vlans = [
         1 # 192.168.1.x
         100 # 192.168.100.x
       ];
-
+      services.openssh.enable = true;
       systemd.services.firewall.serviceConfig = fw-service-cfg;
+      ghaf.security.fail2ban = {
+        enable = true;
+        sshd-jail-fwmark = {
+          enable = true;
+          fwMarkNum = "70";
+        };
 
+      };
+      ghaf.security = {
+        ssh-tarpit = {
+          enable = true;
+          listenAddress = addrs.netvm-internal;
+        };
+      };
       ghaf.firewall = {
         enable = true;
         allowedTCPPorts = [ 22 ];


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
* Fail2Ban is enabled on all VMs to protect against SSH brute-force attacks. 
* A custom jail is configured to redirect SSH connections from banned IPs to the ssh-tarpit server on the net-vm, slowing down attackers by deliberately delaying their connections. 
* On all other VMs, packets from banned IPs are dropped immediately.
* VMs allow a maximum of 5 ICMP request packets (ping)  in a single burst per minute for each IP address.
* SSH sync flood protection has been activated for every VM. (  maximum 30 new ssh connection requests/minute)
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
**Scenario - 1 (External Network - Netvm)** 
1. Regression test for network-related services
2. Check endless-go in net-vm whether it is activated with `systemctl status endless-go`
3. Attempt to establish an SSH connection, but enter the password incorrectly more than three times.
4.  Check the blacklist on the net-vm by using the command `ipset list f2b-blacklist`. You should see the attacker's IP address listed in the members section.
5. Try to make an SSH connection again from the attacker's device. The connection should hang.  

**Scenario - 2 (VM - VM)** 
1. Attempt to establish a VM-to-VM SSH connection, such as comms-vm to gui-vm, but enter the password incorrectly more than three times.
2.  Check the blacklist on the gui-vm by using the command `ipset list f2b-blacklist`. You should see the comms-vm IP address listed in the members section.
3. Try to make an SSH connection again from the comms-vm to gui-vm. The connection should hang.
4. You can also try other combinations. (chrome-vm to admin-vm)

**Scenario - 3 (SSH sync flood protection, Icmp flood protection)**
1. Ping the VMs; however, you cannot send more than five pings in a single burst. You can ping them once every minute.
2. Launch an attack(VM-to-VM or External Network-to-Netvm) using the command `hping3 -S -p 22 -i u10000 -c 35 ${VmIp}`
3. Check the blacklist on the victim VM with ipset list BLACKLIST. You should see attacker's IP in the members section.

**Note: The device under test must be in its default state before each test scenario.(Can be rebooted)**