### PR TITLE
Fix ctrl-panel VM starting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757402219,
-        "narHash": "sha256-EoDW8zFAyA0a2m3T0dSeFtyghdbINpZlYSV4sN0aYJ4=",
+        "lastModified": 1758180565,
+        "narHash": "sha256-IxmECgMs/j/fVSbx1tESJVdu82cT27WwTSS7cgH03d8=",
         "owner": "tiiuae",
         "repo": "ghaf-ctrl-panel",
-        "rev": "ad99a2074f32f98dac9919096d673fcd4694f33f",
+        "rev": "52d01dedafbe5e650e2fd2e77afff6a0225650e5",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757683017,
-        "narHash": "sha256-hLxS6SD36nVqagZdHDSHNLzvTPlDhwZv9Ca82BUQa3Y=",
+        "lastModified": 1758118765,
+        "narHash": "sha256-M0aK5uII9NqtxbL7nm/NMtHNNRqxHkem5FBz/bY3lZ8=",
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "d1299d566bb443070b16dff1930be47d4c8d1479",
+        "rev": "a499977643d0013ad93369311157fa3f878e3eb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Fix VM controls in ctrl-panel to allow starting a VM after it has been shut down.
Also fix issue, where VM/service controls became insensitive in some scenarios.

https://github.com/tiiuae/ghaf-givc/pull/205
https://github.com/tiiuae/ghaf-ctrl-panel/pull/104

### Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7215

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:

1. open ghaf control panel
2. choose an app vm from left hand side tree, for example chrome-vm
3. choose stop from VM controls drop down
4. wait for the status to update to "stopped"
5. choose start from VM controls drop down
6. wait for the status to update to "running"
7. verify that app (for example, chrome) can be started from menu
