### PR TITLE
net-vm,gui-vm: Enhance xdg-dbus-proxy with system bus D-Bus proxy

### DIFF
--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -370,7 +370,6 @@ in
           Type = "simple";
           Restart = "always";
           RestartSec = "1";
-          Environment = mkIf graphicsProfileCfg.networkManager.applet.useDbusProxy "DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/dbusproxy_net.sock";
           ExecStart = ''
             ${lib.getExe' pkgs.networkmanagerapplet "nm-applet"} --indicator
           '';

--- a/modules/givc/guivm.nix
+++ b/modules/givc/guivm.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -74,9 +75,48 @@ in
         }
       ];
     };
+    systemd.services.dbus-proxy = {
+      enable = true;
+      description = "DBus proxy for Network Manager ${guivmName}";
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        RestartSec = "10s";
+        Environment = "DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/dbusproxy_net.sock";
+        ExecStart = "${pkgs.dbus-proxy}/bin/dbus-proxy --source-bus-name org.freedesktop.NetworkManager --source-object-path /org/freedesktop/NetworkManager --proxy-bus-name org.freedesktop.NetworkManager --source-bus-type session --target-bus-type system";
+      };
+      startLimitIntervalSec = 0;
+      wantedBy = [ "multi-user.target" ];
+    };
+    services.dbus.packages = [
+      (pkgs.writeTextFile {
+        name = "dproxy-dbus-policy";
+        text = ''
+          <!DOCTYPE busconfig PUBLIC
+            "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+            "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+          <busconfig>
+            <!-- grant root the ability to own org.freedesktop.NetworkManager.* -->
+            <policy user="root">
+              <allow own="org.freedesktop.NetworkManager"/>
+            </policy>
+            <!-- grant everybody access to the org.freedesktop.NetworkManager.* -->
+            <policy context="default">
+              <allow send_destination="org.freedesktop.NetworkManager.*"/>
+              <allow send_interface="org.freedesktop.NetworkManager.*"/>
+              <allow send_type="method_call"/>
+            </policy>
+          </busconfig>
+        '';
+        destination = "/share/dbus-1/system.d/dproxy.conf";
+      })
+    ];
     ghaf.security.audit.extraRules = [
       "-w /etc/givc/ -p wa -k givc-${hostName}"
       "-w /run/givc/ -p wa -k givc-${hostName}"
+    ];
+    environment.systemPackages = [
+      pkgs.dbus-proxy
     ];
   };
 }

--- a/modules/givc/netvm.nix
+++ b/modules/givc/netvm.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -61,14 +62,17 @@ in
         user = config.ghaf.users.proxyUser.name;
         socket = "/tmp/dbusproxy_net.sock";
         policy = {
-          own = [
-            "org.freedesktop.NetworkManager.*"
+          talk = [
+            "org.freedesktop.NetworkManager"
           ];
         };
       };
     };
     ghaf.security.audit.extraRules = [
       "-w /etc/givc/ -p wa -k givc-${hostName}"
+    ];
+    environment.systemPackages = [
+      pkgs.xdg-dbus-proxy
     ];
   };
 }

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -5,6 +5,7 @@
   flake.overlays.own-pkgs-overlay = final: _prev: {
     audit-rules = final.callPackage ./pkgs-by-name/audit-rules/package.nix { };
     dendrite-pinecone = final.callPackage ./pkgs-by-name/dendrite-pinecone/package.nix { };
+    dbus-proxy = final.callPackage ./pkgs-by-name/dbus-proxy/package.nix { };
     element-gps = final.python3Packages.callPackage ./python-packages/element-gps/package.nix { };
     falcon-launcher = final.callPackage ./falcon-launcher/package.nix { };
     flash-script = final.callPackage ./pkgs-by-name/flash-script/package.nix { };

--- a/packages/pkgs-by-name/dbus-proxy/package.nix
+++ b/packages/pkgs-by-name/dbus-proxy/package.nix
@@ -1,0 +1,36 @@
+# Copyright 2022-2023 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  stdenv,
+  fetchFromGitHub,
+  pkgs,
+  ...
+}:
+stdenv.mkDerivation {
+  name = "dbus-proxy";
+
+  src = fetchFromGitHub {
+    owner = "tiiuae";
+    repo = "DBus_proxy";
+    rev = "e88fe9d03b08ba4d0b5aecef48efa5d7dfd537e8";
+    sha256 = "sha256-qEMwdeD2lj3VGH1DAAhcbu5m6EX9qsd/jd5QtjN8zh4=";
+  };
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [ pkgs.glib ];
+
+  sourceRoot = "source";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install ./dbus-proxy $out/bin/dbus-proxy
+  '';
+
+  meta = {
+    description = "DBus proxy";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION


<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
    Switch nm-applet from private xdg-dbus-proxy to system bus connection.
    Previously nm-applet used its own bus with xdg-dbus-proxy in net-vm.
    Now uses local dbus-proxy service on gui-vm system bus instead.
-->

## Description of Changes
**D-Bus Proxy Changes for Ghaf**

**What Changed**

**net-vm:**
Updated xdg-proxy-config to expose NetworkManager's D-Bus interface to other VMs
**gui-vm:**
Added dbus-proxy service that:
Connects to net-vm's NetworkManager
Claims NetworkManager's name on local system bus
Exchanges all D-Bus traffic between nm-applet and NetworkManager
**Connection:**
Reused existing socket connections between VMs
No new security holes or connections needed
**nm-applet:**
Now connects to local system bus instead of trying to reach net-vm directly
Works normally without knowing NetworkManager is in another VM
**Why It Works**
The proxy makes NetworkManager in net-vm appear as if it's running locally in gui-vm. nm-applet talks to what it thinks is a local NetworkManager, but the proxy in background forwards everything to net-vm.
This keeps the network isolated in net-vm while letting users control it from gui-vm.

### Type of Change
- [X] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [X] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
**Boot Ghaf**
Verify both net-vm and gui-vm start successfully
Check dbus-proxy service is running in gui-vm: systemctl status dbus-proxy.service

**Log in and verify nm-applet**
Check nm-applet icon appears in system tray
Click icon - menu should show available networks
Connect to a WiFi network (verify password prompt works)
Disconnect from network
Toggle WiFi on/off
Check "Connection Information" displays correct IP/DNS details
Verify network changes reflect immediately in icon

**Test resilience**
Logout, login
Verify nm-applet reconnects
Restart net-vm: sudo systemctl restart microvm@net-vm.service (on host)
Verify it reconnects once net-vm is back (waiting period may be around 10-20 secs)
Restart nm-apple servicet: systemctl --user restart nm-applet.service (under logged in user)
Should reconnect without proxy restart
