### PR TITLE
Add tls_config support to alloy server

### DIFF
--- a/modules/microvm/sysvms/adminvm.nix
+++ b/modules/microvm/sysvms/adminvm.nix
@@ -63,6 +63,13 @@ let
             logging = {
               server = {
                 inherit (configHost.ghaf.logging) enable;
+                tls = {
+                  caFile = null;
+                  certFile = "/etc/givc/cert.pem";
+                  keyFile = "/etc/givc/key.pem";
+                  serverName = "loki.ghaflogs.vedenemo.dev";
+                  minVersion = "TLS12";
+                };
               };
             };
 


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Enable mTLS support for the Alloy log forwarder when sending logs to Loki. Improvements can be listed as follows:
- Supports per-target mTLS profiles (custom CA, SNI, min TLS version, and client cert/key), enabling easy personalization for different SIEMs or gateways with their own PKI and policy requirements.
- Allows using a custom CA (internal PKI), which is typical in SIEM environments and zero-trust networks.
- Client identity available (mTLS-ready).
- Transport is TLS-encrypted with explicit policy (no silent downgrade).

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Check if the logs are being uploaded to remote server (e.g., Grafana)
2. On `admin-vm`, run the following command to dump a live graph of all running Alloy components: `curl -s http://127.0.0.1:12345/api/v0/web/components`
3. Look for the `loki.write` block labeled `remote`. You should see: `referencesTo` includes `local.file.tls_cert` and `local.file.tls_key` (and `local.file.tls_ca` if you set a custom CA). This confirms the `tls_config` is wired in.
