### PR TITLE
power: allow system vms to shutdown gracefully, preserve audio on shutdown

### DIFF
--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -95,7 +95,20 @@ in
         "app-vm"
       ];
     };
+    gracefulShutdown = mkOption {
+      type = types.bool;
+      default = config.ghaf.givc.enable;
+      defaultText = "config.ghaf.givc.enable";
+      description = ''
+        If true, the microvm ExecStop logic for this VM will be overridden
+        with the host-managed graceful shutdown, which starts the guest's
+        poweroff.target and waits for the VM process to exit.
 
+        This option only has effect if the power manager module is enabled
+        on the host:
+        `ghaf.services.power-manager.host.enable = true;`
+      '';
+    };
   };
   config = {
 

--- a/modules/common/services/audio.nix
+++ b/modules/common/services/audio.nix
@@ -14,11 +14,20 @@ let
     mkEnableOption
     mkOption
     types
+    mkMerge
+    optionalAttrs
+    hasAttr
     ;
 in
 {
   options.ghaf.services.audio = {
     enable = mkEnableOption "Enable audio service for audio VM";
+    debug = mkOption {
+      type = types.bool;
+      default = config.ghaf.profiles.debug.enable;
+      defaultText = "config.ghaf.profiles.debug.enable";
+      description = "Enable debug logs for pipewire and wireplumber";
+    };
     pulseaudioTcpPort = mkOption {
       type = types.int;
       default = 4713;
@@ -87,88 +96,37 @@ in
       };
     };
 
-    # Start pipewire on system boot
-    systemd.services.pipewire.wantedBy = [ "multi-user.target" ];
-
-    systemd.services."initialize-audio-profile" =
+    systemd.services =
       let
-        initialize-audio-profile = pkgs.writeShellApplication {
-          name = "initialize-audio-profile";
-          runtimeInputs = [
-            pkgs.pulseaudio
-            pkgs.jq
-          ];
-          text = ''
-            function setProfile() {
-              if [[ -n "$1" ]] && [[ -n "$2" ]]; then
-                echo "Setting audio device profile: ($1 - $2)"
-                pactl set-card-profile "$1" "$2"
-              fi
-            }
-
-            function findAudioProfiles() {
-              local audio_device_name active_profile profile_list
-              if [[ -n "$1" ]]; then
-                audio_device_name=$(jq --raw-output --argjson index "$1" '.[$index].name' <<< "$pactl_data")
-                active_profile=$(jq --raw-output --argjson index "$1" '.[$index].active_profile ' <<< "$pactl_data")
-                if [[ -n "$audio_device_name" ]]; then
-                  echo "Found the default audio device: $audio_device_name"
-                  profile_list=$(jq --raw-output --argjson index "$1" '.[$index].profiles | keys[]' <<< "$pactl_data")
-                  echo "With profiles: $profile_list"
-                  while IFS= read -r profile; do
-                    setProfile "$audio_device_name" "$profile"
-                  done <<< "$profile_list"
-
-                  echo "Reset the original active profile."
-                  if [[ -n "$active_profile" ]]; then
-                    setProfile "$audio_device_name" "$active_profile"
-                  fi
-                fi
-              fi
-            }
-
-            pactl_data=$(pactl --format=json list cards)
-            if [[ -z "$pactl_data" ]]; then
-              pulse_address="''${PULSE_SERVER:-localhost}"
-              echo "Error connecting to Pulseaudio service at: \"$pulse_address\""
-              exit 1
-            fi
-
-            default_device_id=$(pactl --format=json info short | jq '.default_sink_name | split(".") | .[1:-1] | join(".")')
-            echo "Default audio device name: $default_device_id";
-
-            audio_device_count=$(jq '. | length' <<< "$pactl_data")
-            echo "Audio device count: $audio_device_count"
-
-            for ((index = 0; index < audio_device_count; index++)); do
-              device_id=$(jq --argjson index $index '.[$index].name | split(".") | .[1:] | join(".")' <<< "$pactl_data")
-              echo "Found audio device with id: $device_id"
-              if [[ "$device_id" == "$default_device_id" ]]; then
-                findAudioProfiles "$index"
-              fi
-            done
-          '';
-        };
+        debugLevel = if cfg.debug then "3" else "1";
       in
       {
-        enable = false;
-        description = "Initialize default audio device profiles";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "pipewire.target" ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          Environment = "PULSE_SERVER=tcp:localhost:${toString cfg.pulseaudioTcpControlPort}";
-          ExecStart = "${initialize-audio-profile}/bin/initialize-audio-profile";
-          Restart = "on-failure";
-          RestartSec = "1";
+        pipewire = {
+          wantedBy = [ "multi-user.target" ];
+          environment.PIPEWIRE_DEBUG = debugLevel;
         };
+        wireplumber.environment.WIREPLUMBER_DEBUG = debugLevel;
       };
 
-    # Open TCP port for the pipewire pulseaudio socket
-    ghaf.firewall.allowedTCPPorts = [
-      cfg.pulseaudioTcpPort
-      cfg.pulseaudioTcpControlPort
+    ghaf = mkMerge [
+      {
+        # Open TCP port for the pipewire pulseaudio socket
+        firewall.allowedTCPPorts = with cfg; [
+          pulseaudioTcpPort
+          pulseaudioTcpControlPort
+        ];
+      }
+      # Enable persistent storage for pipewire state to restore settings on boot
+      (optionalAttrs (hasAttr "storagevm" config.ghaf) {
+        storagevm.directories = [
+          {
+            directory = "/var/lib/pipewire";
+            user = "pipewire";
+            group = "pipewire";
+            mode = "0700";
+          }
+        ];
+      })
     ];
   };
 }


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Added pipewire state dir to persistent storage:**
   - Allows audio state to be saved between reboots

2. **Added gracefulShutdown option to Ghaf common options:**
   - Enabled by default
   - Only affects system-vms
   - If enabled, tells power-manager module to handle shutdown gracefully instead of using microvm's built-in shutdown logic

3. **Power manager module changes:**
   - Host power manager module config now includes overriding microvm's default `ExecStop` behavior for system VMs
   - With this change, when the host is shutting down or a system-vm shutdown is requested, the host will start the respective vm's poweroff.target, which, in turn, will allow the VM to gracefully shutdown
   - The host will wait until the VM process is fully stopped before proceeding with shutdown, or send SIGTERM to the VM if `TimeoutStopSec` is elapsed
     

With these changes, the general shutdown process is as follows:

1. User issues gui-vm shutdown request
2. gui-vm starts shutdown procedures, part of which is signaling the host to shutdown
3. Host receives shutdown signal from gui-vm, starts shutdown procedures
4. Host shutdown procedures tell its' active services to stop via their `ExecStop` binaries
5. All system VMs running under the host will run their `ExecStop` binaries, which now include starting `poweroff.target` on the respective VM
6. Once all `microvm@` services are stopped, host will continue shutting down.

Additionally, these changes allow the display backlight state in gui-vm to be properly stored on shutdown and restored on the next boot.

**Some notes:**
- _After_ this PR, if changes to gui-vm are detected, `nixos-rebuild switch` will attempt to stop `microvm@gui-vm.service`, which, in turn, will trigger the host to shutdown. This is **intended and not unexpected** behavior, although not perfect. My recommendation is to use `nixos-rebuild boot` instead.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch` power-cycle recommended before testing
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
Test backlight and audio state restoration:
1. Boot into Ghaf and login
7. Adjust volume and brightness to some values you can easily remember
8. Reboot or shutdown the system
9. Boot into Ghaf and login
10. Verify volume and brightness values are restored

Test (any) system vm shutdown
`audio-vm` is a good choice here
1. Boot into Ghaf, no need to login
2. Open two separate terminals, both in ghaf-host
3. In the first, run `journalctl -f -u microvm@<sysvm-name>.service`
4. In the second, run `sudo systemctl stop microvm@<sysvm-name>.service`
5. Observe the shutdown process in the first terminal
11. Verify the VM shutdown successfully with `systemctl status microvm@<sysvm-name>.service` - there should be no non-zero exit codes in the execution of `ExecStop` 
