### PR TITLE
Enable TLS for alloy client to server

### DIFF
--- a/modules/microvm/sysvms/adminvm.nix
+++ b/modules/microvm/sysvms/adminvm.nix
@@ -64,11 +64,16 @@ let
               server = {
                 inherit (configHost.ghaf.logging) enable;
                 tls = {
-                  caFile = null;
+                  remoteCAFile = null;
                   certFile = "/etc/givc/cert.pem";
                   keyFile = "/etc/givc/key.pem";
                   serverName = "loki.ghaflogs.vedenemo.dev";
                   minVersion = "TLS12";
+
+                  terminator = {
+                    backendPort = 3101;
+                    verifyClients = true;
+                  };
                 };
               };
             };


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Switch Alloy clients to `https` and add `tls_config` (CA/cert/key, TLS ≥1.2) delivered via systemd `LoadCredential`. 
- On `admin-vm`, keep Alloy behind `stunnel`, which terminates TLS and enforces mTLS on the public port. 
- The `stunnel` was used as a lightweight, low-dep TLS terminator vs heavier proxies.

Before, there was no encryption in the `alloy` client to server communication:

<img width="1290" height="475" alt="Screenshot from 2025-10-03 15-53-07" src="https://github.com/user-attachments/assets/f6d7f29f-2b92-471a-a93f-7a3f43e22f21" />

After this patch:

<img width="1290" height="475" alt="Screenshot from 2025-10-03 15-55-35" src="https://github.com/user-attachments/assets/0ee7ddf9-de32-4ad1-99ef-119085b844cf" />

- The `stunnel` service performance was measured for 10 minutes after boot:
  - Average CPU usage:   0.04%
  - Max CPU usage:       1.18% at t=26s
  - Average Memory:      4.25 MiB
  - Max Memory:          7.57 MiB at t=2s
<img width="1244" height="658" alt="stunnel_metrics_stunnel_20251003_104729" src="https://github.com/user-attachments/assets/580e9e85-b7b4-4c16-bdf4-75c10248cb4a" />


### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Check if the logs are being uploaded to remote server (e.g., Grafana)
2. The alloy service in both clients (all VMs except admin-vm), and server (admin-vm) should be working fine: `systemctl status alloy.service `
3. The admin-vm should have the `stunnel` service working fine: `systemctl status stunnel.service`
4. (Optional) It is possible to add the `tshark` package to a specific VM to record the traffic and analyze the output `pcap` file:
- For example, we can add  `++ [ pkgs.wireshark-cli ]` into `gui-vm` - https://github.com/tiiuae/ghaf/blob/main/modules/microvm/sysvms/guivm.nix#L209
- Then, it is possible to monitor, from `gui-vm`, the logs being sent to `admin-vm`: `sudo tshark -i any -p -s 0 -f 'tcp port 9999 and host 192.168.100.5' \
  -a duration:300 \
  -w /tmp/loki_to_adminvm_$(date +%Y%m%d_%H%M%S).pcapng`
- You can use wireshark to analyze the output pcap