### PR TITLE
Enable hwdb in systemd

### DIFF
--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -60,6 +60,7 @@ let
         withUserDb = cfg.withHomed;
         withUtmp = cfg.withJournal || cfg.withAudit;
         inherit (cfg) withSysupdate;
+        inherit (cfg) withHwdb;
       }
       // lib.optionalAttrs (lib.strings.versionAtLeast pkgs.systemdMinimal.version "255.0") {
         withVmspawn = cfg.withMachines;
@@ -346,6 +347,12 @@ in
       description = "Enable systemd debug functionality.";
       type = types.bool;
       default = false;
+    };
+
+    withHwdb = mkOption {
+      description = "Enable systemd hwdb functionality.";
+      type = types.bool;
+      default = true;
     };
 
     logLevel = mkOption {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

Some USB devices currently appear without friendly names because hwdb in systemd is not enabled. This change enables hwdb, ensuring that all devices have readable names from fields such as ID_PRODUCT_FROM_DATABASE and ID_MODEL_FROM_DATABASE.

Enabling hwdb also adds hardware-specific properties, rules and device quirks which might be particularly useful for input devices (e.g., keyboards, mice and gamepads).

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:

Run `lsusb` on host and `vhotplugcli usb list`. Verify that all devices have friendly names.
In the current main, some devices only show their vid and pid without a descriptive name.
