### PR TITLE
fix: adding usb quirks for some of eth-to-usb adapters

### DIFF
--- a/modules/hardware/common/default.nix
+++ b/modules/hardware/common/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./usb/external-devices.nix
     ./usb/vhotplug.nix
+    ./usb/quirks.nix
     ./devices.nix
     ./input.nix
     ./kernel.nix

--- a/modules/hardware/common/usb/quirks.nix
+++ b/modules/hardware/common/usb/quirks.nix
@@ -1,0 +1,34 @@
+# Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.ghaf.hardware.usb.quirks;
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    ;
+  # https://github.com/eihqnh/.nixconfig/blob/a685389652c3df60b1ece49125f3e2db993aeebf/common.nix#L102
+  # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/7.7_release_notes/kernel_parameters_changes
+  quirks = [
+    "2357:0601:k" # TP-Link’s USB 3.0 Ethernet adapters (AX88179 chipset)
+    "0bda:8153:k" # Realtek Semiconductor Corp. RTL8153 Gigabit Ethernet Adapter
+  ];
+
+in
+{
+  options.ghaf.hardware.usb.quirks = {
+    enable = mkEnableOption "quirks for USB devices";
+  };
+
+  config = mkIf cfg.enable {
+
+    boot.kernelParams = [
+      "usbcore.quirks=${lib.concatStringsSep "," quirks}"
+    ];
+
+  };
+}

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -32,6 +32,7 @@ in
         tpm2.enable = true;
         usb = {
           vhotplug.enable = true;
+          quirks.enable = true;
         };
       };
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -20,6 +20,7 @@ in
   imports = [
     #TODO: fix me
     ../../../../hardware/common/usb/vhotplug.nix
+    ../../../../hardware/common/usb/quirks.nix
   ];
   options.ghaf.hardware.nvidia.orin = {
     # Enable the Orin boards
@@ -84,6 +85,7 @@ in
       ];
     };
 
+    ghaf.hardware.usb.quirks.enable = true;
     ghaf.hardware.usb.vhotplug = {
       enable = true;
       rules = [


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
There is an issue with the handling of Link Power Management for USB Ethernet adapters. That's why I added the USB quirks.

**Open questions:**
1) Test team has tested **TP-Link’s USB 3.0 Ethernet adapters (AX88179 chipset)** and the **Realtek Semiconductor Corp. RTL8153 Gigabit Ethernet Adapter**. However, we cannot confirm whether this issue will also occur with other Ethernet-USB adapters from different manufacturers, as the quirks are device-specific. Would it be beneficial to implement a feature in the vhotplug app that adds quirks dynamically for all Ethernet-USB adapters?
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets
[SSRCSP-6557](https://jira.tii.ae/browse/SSRCSP-6557)
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. [SSRCSP-6557](https://jira.tii.ae/browse/SSRCSP-6557)

