### PR TITLE
Restore default shortcut for lock screen

### DIFF
--- a/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
@@ -173,6 +173,7 @@ com.system76.CosmicSettings.Shortcuts:
         (modifiers: [Super, Alt], key: "Escape"): Terminate,
         (modifiers: [Super, Shift], key: "Escape"): System(LogOut),
         (modifiers: [Super, Ctrl], key: "Escape"): Debug,
+        (modifiers: [Super], key: "Escape"): System(LockScreen),
         (modifiers: [Super], key: "l"): System(LockScreen),
         (modifiers: [Alt], key: "F4"): Close,
 


### PR DESCRIPTION

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
- Cosmic default shortcut for lock screen is 'Super' + 'Escape' and the same is displayed in power applet.
- The power applet always shows the default shortcut, which is hardcoded in app.
- The shortcut is restored to default to avoid confusion.
- Addresses the issue: SSRCSP-6879

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Press 'Super' + 'Escape' to lock screen
