### PR TITLE
bump: use the latest ghafpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760962771,
-        "narHash": "sha256-eE+2r0jOt2ePiD36JsReJGQfwUnDNC5GFJOPwt9Vjmc=",
+        "lastModified": 1761125875,
+        "narHash": "sha256-Xn98t+2W2rm4/QL48Ca4be7RV+iQOn9WiUM18SkkBcA=",
         "owner": "tiiuae",
         "repo": "ci-test-automation",
-        "rev": "b4ae6847e9f8b52abaf177e4712f5b8ea854efad",
+        "rev": "0bb9b970e58ccf43d6c41a468c4e9100144f49fd",
         "type": "github"
       },
       "original": {
@@ -223,22 +223,22 @@
           "flake-parts"
         ],
         "flake-root": "flake-root_2",
+        "git-hooks-nix": [
+          "git-hooks-nix"
+        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "pre-commit-hooks-nix": [
-          "git-hooks-nix"
         ],
         "treefmt-nix": [
           "treefmt-nix"
         ]
       },
       "locked": {
-        "lastModified": 1761026514,
-        "narHash": "sha256-xt0uvfZPXDuHJqzgUbHBl1o5KQS5jNSPoOvQ88/UXus=",
+        "lastModified": 1761196524,
+        "narHash": "sha256-wBGkkcxc0QUERdkUVBIAP5zc33AX4NuAwfRaK0IjLSA=",
         "owner": "tiiuae",
         "repo": "ghafpkgs",
-        "rev": "f86f3ee0d3148d292d829686cad023eda3caf183",
+        "rev": "a10d6ea04920329cba5f3ab445be68f9a186d0d2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";
         treefmt-nix.follows = "treefmt-nix";
-        pre-commit-hooks-nix.follows = "git-hooks-nix";
+        git-hooks-nix.follows = "git-hooks-nix";
         flake-compat.follows = "flake-compat";
         crane.follows = "givc/crane";
         devshell.follows = "devshell";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
-# SPDX-License-Identifier: Apache-2.0
-
-[tool.ruff]
-line-length = 88
-target-version = "py312"
-lint.select = ["E", "F", "I", "U", "N", "RUF", "A"]
-lint.ignore = ["E501", "A003"]


### PR DESCRIPTION
Use the latest version of ghafpkgs

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
