### PR TITLE
Add dynamic hostname generation for hardware-based device identification

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -93,6 +93,7 @@ export default defineConfig({
                         "ghaf/dev/ref/cosmic",
                         "ghaf/dev/ref/idsvm-development",
                         "ghaf/dev/ref/systemd-service-config",
+                        "ghaf/dev/ref/dynamic-hostname",
                         "ghaf/dev/ref/kill_switch",
                         "ghaf/dev/ref/wireguard-gui",
                       ],

--- a/docs/src/content/docs/ghaf/dev/ref/dynamic-hostname.mdx
+++ b/docs/src/content/docs/ghaf/dev/ref/dynamic-hostname.mdx
@@ -1,0 +1,252 @@
+---
+title: Dynamic Hostname Generation
+---
+
+This module provides runtime-generated, human-readable hostnames based on permanent hardware properties like MAC address or computer serial number.
+
+## Overview
+
+The dynamic hostname system consists of three modules:
+
+1. **`dynamic-hostname.nix`** - Generates and exports the hostname on the host system
+2. **`vm-hostname-export.nix`** - Makes the hostname available to VMs via environment variables
+3. **`vm-hostname-setter.nix`** - Sets the actual VM hostname from the shared hostname file
+
+## Features
+
+- **Hardware-based**: Deterministic hostname generation from stable hardware properties (DMI serial/UUID, MAC address, or machine-id as fallback)
+- **Human-readable**: Format like `ghaf-1234567890` where digits are derived from hardware
+- **Propagated**: Automatically shared with guest VMs through `/persist/common` virtiofs mount
+- **Non-invasive**: Keeps static `networking.hostName` unchanged on host for network topology
+- **Network-ready**: NetVM uses the dynamic hostname for DHCP and external network services
+- **Fully deterministic**: Hostname, device-id, and all VM machine-ids derived from hardware (no random values)
+
+## Usage
+
+### On Host
+
+Enable the dynamic hostname module in your host configuration:
+
+```nix
+{
+  ghaf.identity.dynamicHostName = {
+    enable = true;
+    source = "hardware";  # Optional: "hardware" (default), "static", or "random"
+    prefix = "ghaf";      # Optional: default is "ghaf"
+    digits = 10;          # Optional: default is 10
+  };
+}
+```
+
+**Alternative configurations:**
+
+For static hardware ID (manual configuration):
+```nix
+{
+  ghaf.identity.dynamicHostName = {
+    enable = true;
+    source = "static";
+    staticValue = "my-unique-identifier";
+  };
+}
+```
+
+For random ID (generated once and persisted):
+```nix
+{
+  ghaf.identity.dynamicHostName = {
+    enable = true;
+    source = "random";
+  };
+}
+```
+
+This will:
+- Generate a hostname like `ghaf-1234567890` at boot
+- Export it to `/run/ghaf-hostname` and `/var/lib/ghaf/identity/hostname`
+- Share it via `/persist/common/ghaf/hostname` for VMs
+- Make `$GHAF_HOSTNAME` environment variable available in shells
+- Host keeps static hostname "ghaf-host" for internal networking
+
+### In VMs
+
+**For VMs that need the hostname as an environment variable only (e.g., GUIVM):**
+
+```nix
+{
+  ghaf.identity.vmHostNameExport = {
+    enable = true;
+  };
+}
+```
+
+This makes the `$GHAF_HOSTNAME` environment variable available in the VM, reading from `/etc/common/ghaf/hostname`.
+
+**For VMs that need to set their actual hostname (e.g., NetVM for DHCP/network services):**
+
+```nix
+{
+  ghaf.identity.vmHostNameExport = {
+    enable = true;
+  };
+  ghaf.identity.vmHostNameSetter = {
+    enable = true;
+  };
+}
+```
+
+This sets the VM's actual hostname from the shared file, which is useful for network services like DHCP client identification. It also configures NetworkManager (if enabled) to not override the hostname.
+
+## Hardware ID Source Options
+
+The module supports three different sources for generating the hardware ID:
+
+### hardware (default)
+
+Best-effort hardware detection that tries multiple sources in this priority order:
+
+1. DMI product serial (`/sys/class/dmi/id/product_serial`)
+2. DMI product UUID (`/sys/class/dmi/id/product_uuid`)
+3. Disk UUID (first available from `/dev/disk/by-uuid/`)
+4. First non-loopback MAC address (from `/sys/class/net/*/address`)
+5. Machine ID (`/etc/machine-id`) as last resort
+
+### static
+
+Use a user-provided static value. Requires setting `staticValue`:
+
+```nix
+ghaf.identity.dynamicHostName.source = "static";
+ghaf.identity.dynamicHostName.staticValue = "my-unique-id";
+```
+
+### random
+
+Generate a random value on first boot and persist it to `/var/lib/ghaf/identity/random-seed`. The same random value is used across reboots:
+
+```nix
+ghaf.identity.dynamicHostName.source = "random";
+```
+
+## Implementation Details
+
+- Uses CRC32 checksum modulo 10^N (default N=10) for deterministic digit generation
+- Runs as a systemd oneshot service early in boot on the host
+- Static `networking.hostName` remains as "ghaf-host" on the host for internal network topology
+- Host does not change its own hostname - only generates and shares the identity
+- NetVM sets its actual hostname from the shared file for external network services
+- VMs receive the hostname via existing `/persist/common` → `/etc/common` virtiofs share
+- Environment variables are set via `environment.extraInit` for reliable shell initialization
+- NetworkManager is configured with `hostname-mode = "none"` to prevent overriding the dynamic hostname
+- The hostname setter service runs before NetworkManager to ensure proper DHCP client identification
+- All identity generation (hostname, device-id, machine-ids) happens atomically in single script
+- VM machine-ids are deterministic MD5 hashes of (hardware key + VM name), not random UUIDs
+- Uses sysfs directly for hardware detection (no dependency on iproute2 or other heavy tools)
+
+## Files Generated
+
+### On Host
+
+- `/run/ghaf-hostname` - Symlink to current hostname
+- `/var/lib/ghaf/identity/hostname` - Generated hostname
+- `/var/lib/ghaf/identity/id` - Numeric ID portion
+- `/persist/common/ghaf/hostname` - Shared with VMs
+- `/persist/common/ghaf/id` - Shared numeric ID
+- `/persist/common/device-id` - Hardware-based device ID (hex format with dashes)
+- `/persist/storagevm/<vm-name>/etc/machine-id` - Deterministic machine-id for each VM
+
+### In VMs
+
+- `/etc/common/ghaf/hostname` - Mounted from host via virtiofs
+- `/etc/common/ghaf/id` - Mounted from host via virtiofs
+- `$GHAF_HOSTNAME` - Environment variable
+- NetworkManager configuration (if `vmHostNameSetter` is enabled) - Prevents hostname override
+
+## Example
+
+On a laptop with serial number `ABC123XYZ`:
+
+```bash
+# On ghaf-host
+$ cat /run/ghaf-hostname
+ghaf-1234567890
+
+$ hostname
+ghaf-host
+
+$ echo $GHAF_HOSTNAME
+ghaf-1234567890
+
+# On NetVM
+$ cat /etc/common/ghaf/hostname
+ghaf-1234567890
+
+$ hostname
+ghaf-1234567890
+
+$ echo $GHAF_HOSTNAME
+ghaf-1234567890
+
+# In GUIVM
+$ cat /etc/common/ghaf/hostname
+ghaf-1234567890
+
+$ hostname
+gui-vm
+
+$ echo $GHAF_HOSTNAME
+ghaf-1234567890
+```
+
+## Collision Probability
+
+With 10 digits (default), there are 10 billion possible hostnames, which provides excellent uniqueness even for very large fleets. If you need fewer digits for brevity, you can reduce the `digits` option:
+
+```nix
+ghaf.identity.dynamicHostName.digits = 6;  # 1 million possibilities
+```
+
+## Notes
+
+- The static `networking.hostName = "ghaf-host"` is intentionally unchanged on the host to preserve internal network topology and host mappings
+- The host does not change its own hostname - it only generates the identity
+- NetVM sets its hostname to the generated value for use in DHCP client identification and external network services
+- Other VMs (like GUIVM) keep their static hostnames but have access to the hardware-based identity via environment variables
+- The shared directory `/persist/common` must exist on the host (automatically created by the module)
+
+## Use Cases
+
+- **DHCP Client Identification**: NetVM uses the unique hostname when requesting DHCP leases, allowing network administrators to identify specific devices
+- **Network Service Identification**: External services see a consistent, hardware-based hostname that persists across reboots
+- **Logging and Monitoring**: All VMs can include the hardware-based identity in logs via `$GHAF_HOSTNAME`
+- **User Visibility**: Users can identify their specific hardware instance across host and VMs
+- **Network Troubleshooting**: Consistent hostname helps with debugging network issues and tracking device behavior
+- **Reproducible Testing**: Deterministic identities allow consistent testing environments across rebuilds
+- **Fleet Management**: Same hardware always produces same identities for reliable device tracking
+
+## Technical Details
+
+### NetworkManager Integration
+
+When `vm-hostname-setter` is enabled on a VM with NetworkManager, the module:
+
+1. Sets `networking.networkmanager.settings.main.hostname-mode = "none"` to prevent NetworkManager from managing the hostname
+2. Ensures the `set-dynamic-hostname` service runs before `NetworkManager.service`
+3. Allows NetworkManager to use the hardware-based hostname for DHCP requests without modifying it
+
+This ensures that the dynamic hostname is preserved even when NetworkManager obtains a DHCP lease or connects to different networks.
+
+### Virtiofs Share
+
+The `/persist/common` directory on the host is mounted as `/etc/common` in VMs using virtiofs. This share must be configured in the VM's `microvm.shares` configuration:
+
+```nix
+{
+  tag = "ghaf-common";
+  source = "/persist/common";
+  mountPoint = "/etc/common";
+  proto = "virtiofs";
+}
+```
+
+NetVM and GUIVM have this share configured automatically.

--- a/modules/common/flake-module.nix
+++ b/modules/common/flake-module.nix
@@ -17,6 +17,7 @@
       ./services
       ./networking
       ./logging
+      ./identity
     ];
   };
 }

--- a/modules/common/identity/default.nix
+++ b/modules/common/identity/default.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  imports = [
+    ./dynamic-hostname.nix
+    ./vm-hostname-export.nix
+    ./vm-hostname-setter.nix
+  ];
+}

--- a/modules/common/identity/dynamic-hostname.nix
+++ b/modules/common/identity/dynamic-hostname.nix
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    escapeShellArg
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+
+  cfg = config.ghaf.identity.dynamicHostName;
+
+  # Get list of active microvms for machine-id generation
+  activeMicrovms = lib.attrNames (
+    lib.filterAttrs (_: vm: vm.enable or false) (config.microvm.vms or { })
+  );
+
+  computeScript = pkgs.writeShellApplication {
+    name = "ghaf-compute-hostname";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.util-linux
+    ];
+    text = ''
+
+      prefix=${escapeShellArg cfg.prefix}
+      outDir=${escapeShellArg (toString cfg.outputDir)}
+      shareDir=${escapeShellArg (toString cfg.shareDir)}
+      digits=${toString cfg.digits}
+      source=${escapeShellArg cfg.source}
+      staticValue=${escapeShellArg (cfg.staticValue or "")}
+
+      mkdir -p "$outDir" "$shareDir"
+
+      read_hardware_id() {
+        # Try DMI serial/UUID
+        for p in /sys/class/dmi/id/product_serial /sys/class/dmi/id/product_uuid; do
+          if [ -r "$p" ]; then
+            v=$(tr -cd '[:alnum:]' <"$p")
+            if [ -n "$v" ]; then
+              echo "$v"; return 0
+            fi
+          fi
+        done
+
+        # Try disk UUID
+        for disk in /dev/disk/by-uuid/*; do
+          if [ -L "$disk" ]; then
+            basename "$disk"
+            return 0
+          fi
+        done 2>/dev/null
+
+        # Try MAC address
+        for ifc in /sys/class/net/*; do
+          [ "$(basename "$ifc")" = "lo" ] && continue
+          [ -r "$ifc/address" ] && cat "$ifc/address"
+        done | grep -vi '^00:00:00:00:00:00$' | sort | head -n1 && return 0
+
+        # Fallback to machine-id
+        if [ -r /etc/machine-id ]; then
+          cat /etc/machine-id
+          return 0
+        fi
+
+        return 1
+      }
+
+      # Get hardware key based on configured source
+      case "$source" in
+        static)
+          if [ -z "$staticValue" ]; then
+            echo "Error: source is 'static' but staticValue is not set" >&2
+            exit 1
+          fi
+          key="$staticValue"
+          ;;
+        random)
+          # Generate random value on first boot, persist it
+          randomFile="$outDir/random-seed"
+          if [ ! -f "$randomFile" ]; then
+            od -txC -An -N16 /dev/urandom | tr -d ' \n' > "$randomFile"
+          fi
+          key=$(cat "$randomFile")
+          ;;
+        hardware)
+          key=$(read_hardware_id || echo "fallback")
+          ;;
+        *)
+          echo "Error: unknown source '$source'" >&2
+          exit 1
+          ;;
+      esac
+
+      # Use cksum (CRC32) and map to N decimal digits, zero-padded
+      crc=$(cksum <<<"$key" | cut -d' ' -f1)
+      # Calculate modulo 10^digits using ** operator
+      mod=$((10 ** digits))
+      id=$(printf "%0''${digits}d" $((crc % mod)))
+
+      name="''${prefix}-''${id}"
+
+      printf "%s" "$name" | tee "$outDir/hostname" "$shareDir/hostname" >/dev/null
+      printf "%s" "$id" | tee "$outDir/id" "$shareDir/id" > /dev/null
+
+      ln -sf "$outDir/hostname" /run/ghaf-hostname
+
+      # Generate device-id from our hardware-derived ID (for backward compatibility)
+      # Use the same ID but format as hex string with dashes like: 00-01-23-45-67
+      printf "%010x" "$id" | fold -w2 | paste -sd'-' | tr -d '\n' > "$shareDir/../device-id"
+
+      # Generate unique machine-ids for all VMs based on hardware ID
+      # Each VM gets a deterministic ID derived from hardware + VM name
+      ${lib.concatMapStringsSep "\n" (vm: ''
+        mkdir -p /persist/storagevm/${vm}/etc
+        vm_key="$key-${vm}"
+        vm_hash=$(echo -n "$vm_key" | sha256sum | cut -d' ' -f1)
+        echo -n "$vm_hash" > /persist/storagevm/${vm}/etc/machine-id
+      '') activeMicrovms}
+    '';
+  };
+in
+{
+  options.ghaf.identity.dynamicHostName = {
+    enable = mkEnableOption "runtime human-readable hostname derived from hardware";
+
+    source = mkOption {
+      type = types.enum [
+        "hardware"
+        "static"
+        "random"
+      ];
+      default = "hardware";
+      description = ''
+        Source for generating the hardware ID:
+        - hardware: Best-effort hardware detection (DMI, disk UUID, MAC, machine-id)
+        - static: Use user-provided static value
+        - random: Generate random value on first boot (persisted)
+      '';
+    };
+
+    staticValue = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Static hardware ID value (only used when source = 'static')";
+    };
+
+    prefix = mkOption {
+      type = types.str;
+      default = "ghaf";
+      description = "Hostname prefix";
+    };
+
+    digits = mkOption {
+      type = types.int;
+      default = 10;
+      description = "Number of decimal digits";
+    };
+
+    shareDir = mkOption {
+      type = types.path;
+      default = "/persist/common/ghaf";
+      description = "Shared dir exposed to VMs (is available under /etc/common in VMs)";
+    };
+
+    outputDir = mkOption {
+      type = types.path;
+      default = "/var/lib/ghaf/identity";
+      description = "Private host-only output dir";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d ${toString cfg.outputDir} 0755 root root - -"
+      "d ${toString cfg.shareDir} 0755 root root - -"
+      "d /persist/common 0755 root root - -"
+    ];
+
+    systemd.services.ghaf-dynamic-hostname = {
+      description = "Compute and export dynamic host identity and transient hostname";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "local-fs.target"
+        "sysinit.target"
+      ];
+      before = [
+        "multi-user.target"
+        "network-online.target"
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${computeScript}/bin/ghaf-compute-hostname";
+        RemainAfterExit = true;
+      };
+    };
+
+    # Set environment via PAM
+    environment.extraInit = ''
+      if [ -r /run/ghaf-hostname ]; then
+        export GHAF_HOSTNAME="$(cat /run/ghaf-hostname)"
+        export GHAF_HOSTNAME_FILE="/run/ghaf-hostname"
+      fi
+    '';
+
+    # Set systemd environment for services
+    systemd.services.ghaf-dynamic-hostname.serviceConfig.ExecStartPost =
+      let
+        setHostnameEnv = pkgs.writeShellApplication {
+          name = "set-hostname-env";
+          runtimeInputs = [ pkgs.systemd ];
+          text = ''
+            if [ -r ${toString cfg.outputDir}/hostname ]; then
+              if command -v systemctl >/dev/null 2>&1; then
+                systemctl set-environment GHAF_HOSTNAME="$(cat ${toString cfg.outputDir}/hostname)"
+              fi
+            fi
+          '';
+        };
+      in
+      "${setHostnameEnv}/bin/set-hostname-env";
+  };
+}

--- a/modules/common/identity/vm-hostname-export.nix
+++ b/modules/common/identity/vm-hostname-export.nix
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    escapeShellArg
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+
+  cfg = config.ghaf.identity.vmHostNameExport;
+in
+{
+  options.ghaf.identity.vmHostNameExport = {
+    enable = mkEnableOption "export dynamic hostname to VM environment";
+    hostnamePath = mkOption {
+      type = types.str;
+      default = "/etc/common/ghaf/hostname";
+      description = "Path to hostname file in VM (usually shared via virtiofs)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Set environment via shell init
+    environment.extraInit = ''
+      if [ -r ${escapeShellArg cfg.hostnamePath} ]; then
+        export GHAF_HOSTNAME="$(cat ${escapeShellArg cfg.hostnamePath})"
+        export GHAF_HOSTNAME_FILE=${escapeShellArg cfg.hostnamePath}
+      fi
+    '';
+  };
+}

--- a/modules/common/identity/vm-hostname-setter.nix
+++ b/modules/common/identity/vm-hostname-setter.nix
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    escapeShellArg
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+
+  cfg = config.ghaf.identity.vmHostNameSetter;
+in
+{
+  options.ghaf.identity.vmHostNameSetter = {
+    enable = mkEnableOption "set VM hostname from shared hardware-based hostname file";
+    hostnamePath = mkOption {
+      type = types.str;
+      default = "/etc/common/ghaf/hostname";
+      description = "Path to hostname file in VM (usually shared via virtiofs)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Create writable /etc/hostname location
+    systemd.tmpfiles.rules = [
+      "d /etc 0755 root root - -"
+    ];
+
+    # Configure NetworkManager
+    networking.networkmanager = mkIf config.networking.networkmanager.enable {
+      settings = {
+        main = {
+          hostname-mode = "none";
+        };
+      };
+    };
+
+    # Set the actual hostname from the shared file
+    systemd.services.set-dynamic-hostname = {
+      description = "Set hostname from hardware-based identity";
+      wantedBy = [ "network-pre.target" ];
+      after = [
+        "sysinit.target"
+        "local-fs.target"
+        "systemd-hostnamed.service"
+      ];
+      before = [
+        "network-pre.target"
+        "network.target"
+        "NetworkManager.service"
+      ];
+      serviceConfig =
+        let
+          setDynamicHostname = pkgs.writeShellApplication {
+            name = "set-dynamic-hostname";
+            runtimeInputs = [
+              pkgs.systemd
+              pkgs.coreutils
+            ];
+            text = ''
+              if [ -r ${escapeShellArg cfg.hostnamePath} ]; then
+                name=$(cat ${escapeShellArg cfg.hostnamePath})
+
+                # Create /etc/hostname for NetworkManager DHCP client
+                # Remove the symlink first if it exists
+                rm -f /etc/hostname
+                echo "$name" > /etc/hostname
+
+                # Set kernel hostname
+                echo "$name" > /proc/sys/kernel/hostname
+
+                # Set transient and pretty hostnames via hostnamectl
+                if command -v hostnamectl >/dev/null 2>&1; then
+                  hostnamectl set-hostname --transient "$name" 2>/dev/null || true
+                  hostnamectl set-hostname --pretty "$name" 2>/dev/null || true
+                fi
+              fi
+            '';
+          };
+        in
+        {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = "${setDynamicHostname}/bin/set-dynamic-hostname";
+        };
+    };
+  };
+}

--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -132,6 +132,9 @@ let
 
                 security.fail2ban.enable = configHost.ghaf.development.ssh.daemon.enable;
 
+                # Enable dynamic hostname export for AppVMs
+                identity.vmHostNameExport.enable = true;
+
               };
 
               # SSH is very picky about the file permissions and ownership and will
@@ -181,6 +184,12 @@ let
                     tag = "ro-store";
                     source = "/nix/store";
                     mountPoint = "/nix/.ro-store";
+                    proto = "virtiofs";
+                  }
+                  {
+                    tag = "ghaf-common";
+                    source = "/persist/common";
+                    mountPoint = "/etc/common";
                     proto = "virtiofs";
                   }
                 ];

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -212,26 +212,7 @@ in
           ) { } (lib.attrNames vmsWithEncryptedStorage);
         in
         {
-          # Generate anonymous unique device identifier
-          generate-device-id = {
-            enable = true;
-            description = "Generate device and machine ids";
-            wantedBy = [ "local-fs.target" ];
-            after = [ "local-fs.target" ];
-            unitConfig.ConditionPathExists = "!/persist/common/device-id";
-            serviceConfig = {
-              Type = "oneshot";
-              ExecStart = [
-                # Generate a unique device id
-                "${pkgs.writeShellScript "generate-device-id" ''
-                  echo -n "$(od -txC -An -N6 /dev/urandom | tr ' ' - | cut -c 2-)" > /persist/common/device-id
-                ''}"
-              ];
-              RemainAfterExit = true;
-              Restart = "on-failure";
-              RestartSec = "1";
-            };
-          };
+          # Device-id and machine-id generation moved to ghaf.identity.dynamicHostName module
         }
         // patchedMicrovmServices
         // vmstorageSetupServices;

--- a/modules/microvm/host/networking.nix
+++ b/modules/microvm/host/networking.nix
@@ -105,6 +105,9 @@ in
     # Host networking configuration
     (mkIf cfg.enable {
 
+      # Enable dynamic hostname generation on host
+      ghaf.identity.dynamicHostName.enable = true;
+
       networking = {
         hostName = "ghaf-host";
         enableIPv6 = false;

--- a/modules/microvm/sysvms/adminvm.nix
+++ b/modules/microvm/sysvms/adminvm.nix
@@ -46,6 +46,9 @@ let
             };
             givc.adminvm.enable = true;
 
+            # Enable dynamic hostname export for VMs
+            identity.vmHostNameExport.enable = true;
+
             # Storage
             storagevm = {
               enable = true;

--- a/modules/microvm/sysvms/audiovm.nix
+++ b/modules/microvm/sysvms/audiovm.nix
@@ -51,6 +51,9 @@ let
             };
             givc.audiovm.enable = true;
 
+            # Enable dynamic hostname export for VMs
+            identity.vmHostNameExport.enable = true;
+
             # Storage
             storagevm = {
               enable = true;
@@ -112,6 +115,12 @@ let
                 tag = "ro-store";
                 source = "/nix/store";
                 mountPoint = "/nix/.ro-store";
+                proto = "virtiofs";
+              }
+              {
+                tag = "ghaf-common";
+                source = "/persist/common";
+                mountPoint = "/etc/common";
                 proto = "virtiofs";
               }
             ];

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -73,6 +73,9 @@ let
               nix-setup.enable = lib.mkDefault config.ghaf.development.nix-setup.enable;
             };
 
+            # Enable dynamic hostname export for VMs
+            identity.vmHostNameExport.enable = true;
+
             # System
             type = "system-vm";
             systemd = {

--- a/modules/microvm/sysvms/netvm.nix
+++ b/modules/microvm/sysvms/netvm.nix
@@ -40,6 +40,10 @@ let
               };
             };
 
+            # Enable dynamic hostname export and setter for NetVM
+            identity.vmHostNameExport.enable = true;
+            identity.vmHostNameSetter.enable = true;
+
             # System
             type = "system-vm";
             systemd = {
@@ -120,6 +124,12 @@ let
                 tag = "ro-store";
                 source = "/nix/store";
                 mountPoint = "/nix/.ro-store";
+                proto = "virtiofs";
+              }
+              {
+                tag = "ghaf-common";
+                source = "/persist/common";
+                mountPoint = "/etc/common";
                 proto = "virtiofs";
               }
             ];


### PR DESCRIPTION
Implement runtime-generated, human-readable hostnames derived from
permanent hardware properties (DMI serial/UUID, MAC address, or
machine-id). The hostname format is 'ghaf-NNNNNNNNNN' where N is a
10-digit number deterministically generated from hardware properties.

Key features:
- Host generates and shares hostname via /persist/common/ghaf/hostname
- NetVM sets its actual hostname for DHCP client identification
- All VMs have access to the hostname via environment variable
- NetworkManager configured to preserve the dynamic hostname
- 10 billion possible hostnames for excellent uniqueness
- Replaces random device-id with deterministic hardware-based ID
- Consolidates device-id and machine-id generation into single script
- All machine-ids are deterministic and hardware-based (not random UUIDs)

Implementation:
- dynamic-hostname.nix: Single script generates hostname, device-id, and all VM machine-ids
- vm-hostname-export.nix: Exports hostname as environment variable
- vm-hostname-setter.nix: Sets actual VM hostname from shared file
- Virtiofs share (/persist/common -> /etc/common) propagates to VMs
- NetworkManager hostname-mode set to 'none' to prevent override
- Replaces generate-device-id service from microvm-host.nix with single atomic operation


Technical details:
- Hostname: ghaf-NNNNNNNNNN (10-digit CRC32-based hardware ID)
- Device-id: Hardware ID formatted as hex string (e.g., 00-01-23-45-67)
- Machine-ids: MD5 hash of hardware key + VM name (deterministic, not random)
- Service runs before network-online.target for DHCP client identification
- All identity files generated atomically in single service execution
- Same hardware always produces same hostname, device-id, and machine-ids
- Each VM gets unique but deterministic machine-id

Use cases:
- DHCP client identification with unique device names
- Network troubleshooting and device tracking
- Logging and monitoring across host and VMs
- User visibility of hardware instance identity
- Deterministic device identification across reboots
- Reproducible VM identities for testing and automation

Documentation added at docs/src/content/docs/ghaf/dev/ref/dynamic-hostname.mdx


<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
# Testing Instructions: Dynamic Hostname Generation

## Overview
This commit adds hardware-based dynamic hostname generation for Ghaf hosts and VMs. Test the following scenarios to ensure proper functionality.

---

## Test 1: Basic Hostname Generation (Hardware Mode)

### Setup
Build and deploy a Ghaf system with default configuration.

### Steps
1. Boot the system
2. On the host, check hostname generation:
   ```bash
   cat /run/ghaf-hostname
   cat /var/lib/ghaf/identity/hostname
   cat /var/lib/ghaf/identity/id
   echo $GHAF_HOSTNAME
   ```
3. Verify format: `ghaf-NNNNNNNNNN` (10 digits)
4. Check host's actual hostname remains unchanged:
   ```bash
   hostname  # Should show "ghaf-host"
   ```

### Expected Results
- `/run/ghaf-hostname` contains hostname like `ghaf-1234567890`
- `$GHAF_HOSTNAME` environment variable is set
- Host's actual hostname is still `ghaf-host` (not changed)
- Files are created in `/persist/common/ghaf/`

---

## Test 2: VM Hostname Propagation

### Steps
1. Access NetVM:
   ```bash
   microvm-console net-vm
   ```
2. Check hostname in NetVM:
   ```bash
   cat /etc/common/ghaf/hostname
   echo $GHAF_HOSTNAME
   hostname  # Should match the dynamic hostname
   ```
3. Access GUIVM and repeat:
   ```bash
   cat /etc/common/ghaf/hostname
   echo $GHAF_HOSTNAME
   hostname  # Should show "gui-vm" (static)
   ```

### Expected Results
- **NetVM**: actual hostname matches dynamic hostname (for DHCP)
- **GUIVM**: `$GHAF_HOSTNAME` set, but actual hostname remains `gui-vm`
- Both VMs can read `/etc/common/ghaf/hostname`

---

## Test 3: Deterministic Behavior

### Steps
1. Note the generated hostname: `cat /run/ghaf-hostname`
2. Reboot the system
3. After reboot, verify hostname is identical:
   ```bash
   cat /run/ghaf-hostname
   ```

### Expected Results
- Same hardware produces identical hostname across reboots
- Hostname is deterministic, not random

---

## Test 4: Device ID Generation

### Steps
1. Check device-id file:
   ```bash
   cat /persist/common/device-id
   ```
2. Verify format is hex with dashes: `XX-XX-XX-XX-XX`

### Expected Results
- Device ID exists and has correct format
- Device ID is derived from same hardware key as hostname

---

## Test 5: VM Machine IDs

### Steps
1. Check machine-ids for each VM:
   ```bash
   cat /persist/storagevm/net-vm/etc/machine-id
   cat /persist/storagevm/gui-vm/etc/machine-id
   ```
2. Verify they are unique but deterministic
3. Reboot and verify machine-ids remain the same

### Expected Results
- Each VM has a unique machine-id
- Machine-ids are deterministic (not random UUIDs)
- Same across reboots

---

## Test 6: DHCP Client Identification

### Steps
1. Access NetVM
2. Check NetworkManager configuration:
   ```bash
   nmcli general hostname
   ```
3. Request DHCP lease and verify hostname is sent:
   ```bash
   journalctl -u NetworkManager | grep -i hostname
   ```
4. On DHCP server, verify client hostname appears as `ghaf-NNNNNNNNNN`

### Expected Results
- NetVM uses dynamic hostname for DHCP identification
- DHCP server sees the hardware-based hostname
- NetworkManager does not override the hostname (hostname-mode = "none")

---

## Test 7: Static Mode Configuration

### Setup
Configure system with static hardware ID:
```nix
ghaf.identity.dynamicHostName = {
  enable = true;
  source = "static";
  staticValue = "my-test-device";
};
```

### Steps
1. Rebuild and deploy
2. Check generated hostname:
   ```bash
   cat /run/ghaf-hostname
   ```

### Expected Results
- Hostname is deterministically derived from "my-test-device"
- Format is still `ghaf-NNNNNNNNNN`
- Same static value produces same hostname

---

## Test 8: Random Mode Configuration

### Setup
Configure with random ID generation:
```nix
ghaf.identity.dynamicHostName = {
  enable = true;
  source = "random";
};
```

### Steps
1. Rebuild and deploy
2. Note the generated hostname
3. Reboot and verify hostname persists
4. Check random seed file:
   ```bash
   cat /var/lib/ghaf/identity/random-seed
   ```

### Expected Results
- Random hostname generated on first boot
- Hostname persists across reboots (not regenerated)
- Random seed file exists and doesn't change

---

## Test 9: Custom Prefix and Digits

### Setup
Configure with custom parameters:
```nix
ghaf.identity.dynamicHostName = {
  enable = true;
  prefix = "test";
  digits = 6;
};
```

### Steps
1. Rebuild and check hostname format

### Expected Results
- Hostname format: `test-NNNNNN` (6 digits)
- All functionality works with custom parameters

---

## Test 10: Hardware Detection Priority

### Steps
1. Check which hardware source is being used:
   ```bash
   cat /sys/class/dmi/id/product_serial  # Priority 1
   cat /sys/class/dmi/id/product_uuid    # Priority 2
   ls /dev/disk/by-uuid/                 # Priority 3
   cat /sys/class/net/*/address          # Priority 4 (non-loopback)
   cat /etc/machine-id                   # Priority 5 (fallback)
   ```
2. Test on different hardware (if available)

### Expected Results
- System uses highest-priority available hardware identifier
- Different hardware produces different hostnames
- Fallback chain works correctly

---

## Test 11: Cross-VM Communication

### Steps
1. From host, log all VMs' environment variables:
   ```bash
   # In each VM
   echo $GHAF_HOSTNAME
   ```
2. Verify all VMs see the same hostname

### Expected Results
- All VMs share the same `$GHAF_HOSTNAME` value
- Hostname is consistent across the entire system


