### PR TITLE
systemd: restore user-runtime-dir service hardening

### DIFF
--- a/modules/common/systemd/hardened-configs/default.nix
+++ b/modules/common/systemd/hardened-configs/default.nix
@@ -37,7 +37,7 @@
     systemd-udevd.serviceConfig = import ./systemd-udevd.nix;
     systemd-udev-trigger.serviceConfig = import ./systemd-udev-trigger.nix;
     systemd-user-sessions.serviceConfig = import ./systemd-user-sessions.nix;
-    #"user-runtime-dir@".serviceConfig = import ./user-runtime-dir.nix;
+    "user-runtime-dir@".serviceConfig = import ./user-runtime-dir.nix;
     vsockproxy.serviceConfig = import ./vsockproxy.nix;
     wpa_supplicant.serviceConfig = import ./wpa_supplicant.nix;
     nw-packet-forwarder.serviceConfig = import ./nw-packet-forwarder.nix;

--- a/modules/common/systemd/hardened-configs/user-runtime-dir.nix
+++ b/modules/common/systemd/hardened-configs/user-runtime-dir.nix
@@ -136,13 +136,9 @@
   ################
 
   SystemCallFilter = [
-    # "~@clock"
     "~@cpu-emulation"
     "~@debug"
-    # "~@module"
-    # "~@mount"
     "~@obsolete"
-    "~@privileged"
     "~@raw-io"
     "~@reboot"
     "~@resources"


### PR DESCRIPTION
The user-runtime-dir@.service was failing due to blocked quotactl system call, which is now required by newer systemd versions.

Allow @privileged system call filter group to permit quotactl operations

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- The user-runtime-dir@.service was failing due to blocked quotactl system call, which is now required by newer systemd versions.
- Allow @privileged system call filter group to permit quotactl operations

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. After successful login check the status user-runtime-dir@<uid>.service, there should not be any error.
