### PR TITLE
Fix atomic user creation to prevent boot failure on interruption

### DIFF
--- a/modules/common/users/desktop.nix
+++ b/modules/common/users/desktop.nix
@@ -181,6 +181,25 @@ in
                   # Consider 'systemctl stop' as normal exit
                   trap 'exit 0' TERM
 
+                  # Clean up any partial state from previous interrupted runs
+                  # This ensures atomic behavior - either user is fully created or we start fresh
+                  if [ ! -f /var/lib/nixos/user.lock ]; then
+                    echo "Cleaning up any partial user creation state..."
+                    # Remove any partial homed user records
+                    if [ -d /var/lib/systemd/home ]; then
+                      for user_file in /var/lib/systemd/home/*.home; do
+                        [ -e "$user_file" ] || continue
+                        if [ -f "$user_file" ]; then
+                          username=$(basename "$user_file" .home)
+                          echo "Removing incomplete user: $username"
+                          homectl remove "$username" 2>/dev/null || true
+                        fi
+                      done
+                      # Clean up any remaining files
+                      rm -rf /var/lib/systemd/home/* 2>/dev/null || true
+                    fi
+                  fi
+
                   brightnessctl set 100%
 
                   SETUP_COMPLETE=false
@@ -310,6 +329,29 @@ in
                   install -m 000 /dev/null /var/lib/nixos/user.lock
                 '';
               };
+
+              cleanupScript = pkgs.writeShellApplication {
+                name = "cleanup-ghaf-user";
+                runtimeInputs = [
+                  pkgs.coreutils
+                  pkgs.systemd
+                ];
+                text = ''
+                  # Clean up partial state if lock file doesn't exist (interrupted setup)
+                  if [ ! -f /var/lib/nixos/user.lock ] && [ -d /var/lib/systemd/home ]; then
+                    echo "Cleaning up interrupted user setup..."
+                    for user_file in /var/lib/systemd/home/*.home; do
+                      [ -e "$user_file" ] || continue
+                      if [ -f "$user_file" ]; then
+                        username=$(basename "$user_file" .home)
+                        echo "Removing incomplete user: $username"
+                        homectl remove "$username" 2>/dev/null || true
+                      fi
+                    done
+                    rm -rf /var/lib/systemd/home/* 2>/dev/null || true
+                  fi
+                '';
+              };
             in
             {
               description = "First boot user setup";
@@ -327,6 +369,7 @@ in
                 TTYReset = true;
                 TTYVHangup = true;
                 ExecStart = "${userSetupScript}/bin/setup-ghaf-user";
+                ExecStopPost = "${cleanupScript}/bin/cleanup-ghaf-user";
                 Restart = "on-failure";
               };
             };


### PR DESCRIPTION
- Add cleanup of partial systemd-homed state at script start
- Add ExecStopPost cleanup handler for interrupted service
- Ensure user creation is atomic: either fully created or start fresh
- Fixes boot failure when setup-ghaf-user is interrupted (e.g., Ctrl-Alt-Del)

Previously, if the system was rebooted during user creation, partial state in /var/lib/systemd/home/* could prevent subsequent boots because the lock file wasn't created but user data was partially written.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
 
 If system is rebooted during 1st time boot when the user creation wizard is running, it should not lock up on next boot.
