### PR TITLE
performance module

### DIFF
--- a/modules/common/services/default.nix
+++ b/modules/common/services/default.nix
@@ -12,12 +12,13 @@
     ./github.nix
     ./hwinfo
     ./killswitch.nix
-    ./timezone.nix
+    ./locale.nix
+    ./performance
     ./power.nix
     ./storewatcher.nix
+    ./timezone.nix
     ./wifi.nix
     ./xpadneo.nix
     ./yubikey.nix
-    ./locale.nix
   ];
 }

--- a/modules/common/services/performance/default.nix
+++ b/modules/common/services/performance/default.nix
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.ghaf.services.performance;
+  inherit (lib)
+    getExe
+    getExe'
+    literalExpression
+    mkIf
+    mkOption
+    types
+    ;
+
+  # General TuneD script generator
+  # Here we can add helper functions which can be used in the scripts
+  mkTunedScript =
+    {
+      name ? "tuned-script",
+      start ? "",
+      stop ? "",
+    }:
+    pkgs.writeShellApplication {
+      inherit name;
+      runtimeInputs = with pkgs; [
+        tuned
+        wirelesstools
+      ];
+      bashOptions = [ ];
+      text = ''
+        # shellcheck disable=SC1091
+        source ${pkgs.tuned}/lib/tuned/functions
+
+        # Set wireless power management
+        wifi_set_pm() {
+          # 'on' - enable power saving
+          # 'off' - disable power saving
+          pm=$1
+
+          # do not report errors on systems with no wireless
+          [ -e /proc/net/wireless ] || return 0
+
+          # apply the settings using iwconfig
+          ifaces=$(cat /proc/net/wireless | grep -v '|' | sed 's@^ *\([^:]*\):.*@\1@')
+
+          for iface in $ifaces; do
+            iwconfig "$iface" power "$pm"
+          done
+        }
+
+        # Set PCI device runtime power management
+        pci_device_runtime_pm() {
+          # 'on' - best performance
+          # 'auto' - best power saving
+
+          pm=$1
+          devices=$2
+
+          for device in $devices; do
+            (echo "$pm" > "/sys/bus/pci/devices/$device/power/control") &> /dev/null
+          done
+        }
+
+        start() {
+          ${if start == "" then "return 0" else start}
+        }
+
+        stop() {
+          ${if stop == "" then "return 0" else stop}
+        }
+
+        process "$@"
+      '';
+    };
+
+in
+{
+  imports = [
+    (import ./host.nix {
+      inherit
+        pkgs
+        config
+        lib
+        mkTunedScript
+        ;
+    })
+    (import ./guests.nix {
+      inherit
+        pkgs
+        config
+        lib
+        mkTunedScript
+        ;
+    })
+  ];
+
+  options.ghaf.services.performance = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable hardware-agnostic Ghaf performance and scheduler optimizations.
+
+        For more information, see `tuned-main.conf(5)`, `tuned-profiles.7`,
+        and system76-scheduler documentation.
+      '';
+      example = literalExpression ''
+        # In host
+        config.ghaf.services.performance = {
+          enable = true;
+          host.enable = true;
+        };
+
+        # In GUI VM
+        config.ghaf.services.performance = {
+          enable = true;
+          gui.enable = true;
+        };
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !config.hardware.system76.power-daemon.enable;
+        message = "`config.ghaf.performance` conflicts with `config.hardware.system76.power-daemon.enable`.";
+      }
+      {
+        assertion = cfg.vm.enable -> (!cfg.host.enable && !cfg.gui.enable);
+        message = "Enabling the generic VM performance profile ('ghaf.services.performance.vm.enable') requires the 'host' and 'vm' profiles to be disabled.";
+      }
+    ];
+    services.system76-scheduler = {
+      useStockConfig = false;
+    };
+    systemd.services = mkIf config.ghaf.profiles.debug.enable {
+      tuned = {
+        serviceConfig.ExecStart = [
+          ""
+          "${getExe pkgs.tuned} -P -l -D"
+        ];
+      };
+      tuned-ppd = {
+        serviceConfig.ExecStart = [
+          ""
+          "${getExe' pkgs.tuned "tuned-ppd"} -l -D"
+        ];
+      };
+    };
+  };
+}

--- a/modules/common/services/performance/guests.nix
+++ b/modules/common/services/performance/guests.nix
@@ -1,0 +1,357 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  pkgs,
+  config,
+  lib,
+  mkTunedScript,
+  ...
+}:
+let
+  cfg = config.ghaf.services.performance;
+  inherit (lib)
+    concatMapStringsSep
+    getExe
+    getExe'
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    nameValuePair
+    optionalString
+    replaceString
+    types
+    ;
+
+  useGivc = config.ghaf.givc.enable;
+
+  givc-cli = "${getExe' pkgs.givc-cli "givc-cli"} ${
+    replaceString "/run" "/etc" config.ghaf.givc.cliArgs
+  }";
+
+  guiVmSchedulerAssignments = {
+    desktop-environment = {
+      nice = -9;
+      ioClass = "realtime";
+      ioPrio = 0;
+      matchers = [
+        "cosmic-comp"
+      ];
+    };
+    waypipe = {
+      nice = -12;
+      ioClass = "best-effort";
+      ioPrio = 1;
+      matchers = [
+        "waypipe"
+      ];
+    };
+    sound-server = {
+      nice = -15;
+      ioClass = "realtime";
+      ioPrio = 0;
+      matchers = [
+        "pipewire"
+        "pipewire-pulse"
+      ];
+    };
+    # Session services belonging to the user
+    session-services = {
+      nice = 12;
+      ioClass = "idle";
+      matchers = [
+        "include cgroup=\"/user.slice/*.service\" parent=\"systemd\""
+        "include cgroup=\"/user.slice/*.session.slice/*\" parent=\"systemd\""
+        "include cgroup=\"/user.slice/*app-dbus*\""
+      ];
+    };
+    # System services belonging to root
+    system-services = {
+      nice = 15;
+      ioClass = "idle";
+      matchers = [
+        "include cgroup=\"/system.slice/*\""
+      ];
+    };
+  };
+
+  mkBrightnessScript = level: ''
+    b=$(${getExe pkgs.brightnessctl} get)
+    m=$(${getExe pkgs.brightnessctl} max)
+    ((b*100/m>${toString level})) && ${getExe pkgs.brightnessctl} set ${toString level}%
+  '';
+
+  # For a general structure of the scripts, see:
+  # https://github.com/redhat-performance/tuned/blob/master/profiles/powersave/script.sh
+  guiProfileScripts = {
+    gui-powersave = mkTunedScript {
+      name = "gui-powersave";
+      start =
+        (mkBrightnessScript 40)
+        + optionalString useGivc ''
+          ${givc-cli} start service --vm "ghaf-host" host-powersave.service &
+          ${givc-cli} start service --vm "net-vm" net-powersave.service &
+        '';
+    };
+    gui-balanced = mkTunedScript {
+      name = "gui-balanced";
+      start =
+        (mkBrightnessScript 70)
+        + optionalString useGivc ''
+          ${givc-cli} start service --vm "ghaf-host" host-balanced.service &
+          ${givc-cli} start service --vm "net-vm" net-balanced.service &
+        '';
+    };
+    gui-performance = mkTunedScript {
+      name = "gui-performance";
+      start =
+        ''''
+        + optionalString useGivc ''
+          ${givc-cli} start service --vm "ghaf-host" host-performance.service &
+          ${givc-cli} start service --vm "net-vm" net-performance.service &
+        '';
+    };
+    gui-powersave-battery = mkTunedScript {
+      name = "gui-powersave-battery";
+      start =
+        (mkBrightnessScript 25)
+        + optionalString useGivc ''
+          ${givc-cli} start service --vm "ghaf-host" host-powersave-battery.service &
+          ${givc-cli} start service --vm "net-vm" net-powersave-battery.service &
+        '';
+    };
+    gui-balanced-battery = mkTunedScript {
+      name = "gui-balanced-battery";
+      start =
+        (mkBrightnessScript 50)
+        + optionalString useGivc ''
+          ${givc-cli} start service --vm "ghaf-host" host-balanced-battery.service &
+          ${givc-cli} start service --vm "net-vm" net-balanced-battery.service &
+        '';
+    };
+    gui-performance-battery = mkTunedScript {
+      name = "gui-performance-battery";
+      start =
+        (mkBrightnessScript 70)
+        + optionalString useGivc ''
+          ${givc-cli} start service --vm "ghaf-host" host-performance-battery.service &
+          ${givc-cli} start service --vm "net-vm" net-performance-battery.service &
+        '';
+    };
+  };
+  netProfileScripts = {
+    net-performance = mkTunedScript {
+      name = "net-performance";
+      start = ''
+        wifi_set_pm off
+      '';
+      stop = ''
+        wifi_set_pm on
+      '';
+    };
+  };
+
+  tunedProfiles = {
+    vm = {
+      main = {
+        summary = "Ghaf TuneD profile for Virtual Machines";
+        include = "virtual-guest";
+      };
+    };
+  };
+in
+{
+  options.ghaf.services.performance = {
+    gui = {
+      enable = mkEnableOption "Ghaf-specific scheduler and power optimizations for gui-vm.";
+      scheduler = {
+        enable = mkEnableOption "system76-scheduler on gui-vm for Ghaf-specific process scheduling." // {
+          default = true;
+        };
+      };
+      tuned = {
+        enable = mkEnableOption "TuneD service on the gui-vm for Ghaf-specific performance profiles." // {
+          default = true;
+        };
+        defaultProfile = mkOption {
+          type = types.str;
+          default = "gui-balanced";
+          description = "Default TuneD profile to use on gui-vm.";
+        };
+      };
+    };
+
+    net = {
+      enable = mkEnableOption "Ghaf-specific scheduler and power optimizations for net-vm.";
+      scheduler = {
+        # net-vm is running on one core, so scheduling is too heavy for it to be useful
+        enable = mkEnableOption "system76-scheduler on net-vm for Ghaf-specific process scheduling.";
+      };
+      tuned = {
+        enable = mkEnableOption "TuneD service on the net-vm for Ghaf-specific performance profiles." // {
+          default = true;
+        };
+        defaultProfile = mkOption {
+          type = types.str;
+          default = "net-balanced";
+          description = "Default TuneD profile to use on net-vm.";
+        };
+      };
+    };
+
+    vm = {
+      enable = mkEnableOption ''
+        Generalized Ghaf-specific power and performance optimizations for VMs.
+
+        This will enable the general virtual-guest tuned profile statically -
+        gui-vm power profile changes will not propagate to this VM and no custom scripts will be run.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.gui.enable {
+      services.system76-scheduler = {
+        inherit (cfg.gui.scheduler) enable;
+        settings = {
+          processScheduler = {
+            pipewireBoost.enable = true;
+          };
+        };
+        assignments = guiVmSchedulerAssignments;
+      };
+      services.tuned = {
+        inherit (cfg.gui.tuned) enable;
+        ppdSupport = true;
+        settings.profile_dirs = "/etc/tuned/profiles,${
+          concatMapStringsSep "," (script: "${script}") (lib.attrValues guiProfileScripts)
+        }";
+        ppdSettings = {
+          main.default = "balanced";
+          battery = {
+            power-saver = "gui-powersave-battery";
+            balanced = "gui-balanced-battery";
+            performance = "gui-performance-battery";
+          };
+          profiles = {
+            power-saver = "gui-powersave";
+            balanced = "gui-balanced";
+            performance = "gui-performance";
+          };
+        };
+        profiles = {
+          gui-powersave = tunedProfiles.vm // {
+            script.script = "${getExe guiProfileScripts.gui-powersave}";
+          };
+          gui-balanced = tunedProfiles.vm // {
+            script.script = "${getExe guiProfileScripts.gui-balanced}";
+          };
+          gui-performance = tunedProfiles.vm // {
+            script.script = "${getExe guiProfileScripts.gui-performance}";
+          };
+          gui-powersave-battery = tunedProfiles.vm // {
+            script.script = "${getExe guiProfileScripts.gui-powersave-battery}";
+          };
+          gui-balanced-battery = tunedProfiles.vm // {
+            script.script = "${getExe guiProfileScripts.gui-balanced-battery}";
+          };
+          gui-performance-battery = tunedProfiles.vm // {
+            script.script = "${getExe guiProfileScripts.gui-performance-battery}";
+          };
+        };
+      };
+      environment.etc."tuned/recommend.conf".text = ''
+        [${cfg.gui.tuned.defaultProfile}]
+      '';
+    })
+
+    (mkIf cfg.net.enable (
+      {
+        services.system76-scheduler = {
+          inherit (cfg.net.scheduler) enable;
+          settings = {
+            processScheduler = {
+              # Instead poll every 60s
+              useExecsnoop = false;
+            };
+          };
+        };
+        services.tuned = {
+          inherit (cfg.net.tuned) enable;
+          ppdSupport = true;
+          settings.sleep_interval = 60;
+          settings.profile_dirs = "/etc/tuned/profiles,${
+            concatMapStringsSep "," (script: "${script}") (lib.attrValues netProfileScripts)
+          }";
+          ppdSettings = {
+            main.default = "balanced";
+            battery = {
+              power-saver = "net-powersave-battery";
+              balanced = "net-balanced-battery";
+              performance = "net-performance-battery";
+            };
+            profiles = {
+              power-saver = "net-powersave";
+              balanced = "net-balanced";
+              performance = "net-performance";
+            };
+          };
+          profiles = {
+            net-powersave = tunedProfiles.vm;
+            net-balanced = tunedProfiles.vm;
+            net-performance = tunedProfiles.vm // {
+              script.script = "${getExe netProfileScripts.net-performance}";
+            };
+            net-powersave-battery = tunedProfiles.vm;
+            net-balanced-battery = tunedProfiles.vm;
+            net-performance-battery = tunedProfiles.vm // {
+              script.script = "${getExe netProfileScripts.net-performance}";
+            };
+          };
+        };
+        environment.etc."tuned/recommend.conf".text = ''
+          [${cfg.net.tuned.defaultProfile}]
+        '';
+      }
+      # Service units to set Ghaf PPD profiles on the net-vm when requested from GUI VM
+      # These must be whitelisted in modules/givc/netvm.nix
+      // {
+        systemd.services =
+          let
+            mkPpdService = profile: {
+              description = "Enable ${profile} Ghaf PPD profile on net-vm";
+              serviceConfig = {
+                Type = "oneshot";
+                ExecStart = ''
+                  -${getExe' pkgs.tuned "tuned-adm"} profile ${profile}
+                '';
+              };
+            };
+            netProfiles = [
+              "net-powersave"
+              "net-balanced"
+              "net-performance"
+              "net-powersave-battery"
+              "net-balanced-battery"
+              "net-performance-battery"
+            ];
+          in
+          lib.listToAttrs (map (profile: nameValuePair "${profile}" (mkPpdService profile)) netProfiles);
+      }
+    ))
+
+    (mkIf cfg.vm.enable {
+      services.tuned = {
+        inherit (cfg.vm) enable;
+        settings.sleep_interval = 60;
+        ppdSupport = true;
+        profiles = {
+          vm-balanced = tunedProfiles.vm;
+        };
+      };
+      environment.etc."tuned/recommend.conf".text = ''
+        [vm-balanced]
+      '';
+    })
+  ]);
+}

--- a/modules/common/services/performance/host.nix
+++ b/modules/common/services/performance/host.nix
@@ -1,0 +1,325 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  pkgs,
+  config,
+  lib,
+  mkTunedScript,
+  ...
+}:
+let
+  cfg = config.ghaf.services.performance;
+  inherit (lib)
+    hasAttrByPath
+    concatMapStringsSep
+    getExe
+    getExe'
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    nameValuePair
+    types
+    ;
+
+  hostSchedulerAssignments = {
+    system-vms = {
+      nice = -15;
+      ioClass = "realtime";
+      ioPrio = 0;
+      matchers = [
+        "include cgroup=\"/system.slice/system-sysvms.slice/*\""
+      ];
+    };
+    app-vms = {
+      nice = -10;
+      ioClass = "best-effort";
+      ioPrio = 2;
+      matchers = [
+        "include cgroup=\"/system.slice/system-appvms.slice/*\""
+      ];
+    };
+    # System services belonging to root
+    system-services = {
+      nice = 12;
+      ioClass = "idle";
+      matchers = [
+        "include cgroup=\"/system.slice/*\""
+      ];
+    };
+  };
+
+  hostProfileScripts =
+    let
+      # PCI devices we can adjust power management for
+      pciDevices =
+        if
+          (hasAttrByPath [
+            "hardware"
+          ] config.ghaf.common)
+        then
+          map (device: device.path) (
+            config.ghaf.common.hardware.gpus
+            ++ config.ghaf.common.hardware.audio
+            ++ config.ghaf.common.hardware.nics
+          )
+        else
+          [ ];
+    in
+    {
+      host-powersave = mkTunedScript {
+        name = "host-powersave";
+        start = ''
+          pci_device_runtime_pm auto "${lib.concatStringsSep " " pciDevices}"
+        '';
+      };
+      host-balanced = mkTunedScript {
+        name = "host-balanced";
+        start = ''
+          pci_device_runtime_pm auto "${lib.concatStringsSep " " pciDevices}"
+        '';
+      };
+      host-performance = mkTunedScript {
+        name = "host-performance";
+        start = ''
+          pci_device_runtime_pm on "${lib.concatStringsSep " " pciDevices}"
+        '';
+      };
+      host-powersave-battery = mkTunedScript {
+        name = "host-powersave-battery";
+        start = ''
+          pci_device_runtime_pm auto "${lib.concatStringsSep " " pciDevices}"
+        '';
+      };
+      host-balanced-battery = mkTunedScript {
+        name = "host-balanced-battery";
+        start = ''
+          pci_device_runtime_pm auto "${lib.concatStringsSep " " pciDevices}"
+        '';
+      };
+      host-performance-battery = mkTunedScript {
+        name = "host-performance-battery";
+        start = ''
+          pci_device_runtime_pm on "${lib.concatStringsSep " " pciDevices}"
+        '';
+      };
+    };
+
+  # Customized TuneD profiles based on TuneD's built-in profiles and system76-power
+  tunedProfiles = {
+    powersave = {
+      main.summary = "Ghaf TuneD profile for power saving and battery life";
+
+      cpu = {
+        governor = "powersave|conservative";
+        energy_perf_bias = "powersave|power";
+        energy_performance_preference = "balance_power";
+        min_perf_pct = "0";
+        max_perf_pct = "50";
+        boost = "0";
+        no_turbo = "1";
+        hwp_dynamic_boost = "0";
+      };
+
+      acpi.platform_profile = "low-power|quiet";
+
+      vm = {
+        dirty_background_bytes = "1%";
+        dirty_bytes = "5%";
+        transparent_hugepages = "madvise";
+      };
+
+      audio.timeout = "5";
+
+      scsi_host.alpm = "min_power";
+
+      sysctl = {
+        "vm.swappiness" = "30";
+        "vm.laptop_mode" = "5";
+        "vm.dirty_writeback_centisecs" = "1500";
+        "kernel.nmi_watchdog" = "0";
+      };
+    };
+
+    balanced = {
+      main.summary = "Ghaf TuneD profile for balanced performance and power savings";
+
+      cpu = {
+        governor = "powersave|ondemand|schedutil";
+        energy_perf_bias = "normal";
+        energy_performance_preference = "balance_performance";
+        min_perf_pct = "0";
+        max_perf_pct = "80";
+        boost = "1";
+        no_turbo = "0";
+        hwp_dynamic_boost = "1";
+      };
+
+      acpi.platform_profile = "balanced";
+
+      vm = {
+        dirty_background_bytes = "10%";
+        dirty_bytes = "20%";
+        transparent_hugepages = "madvise";
+      };
+
+      audio.timeout = "10";
+
+      scsi_host.alpm = "medium_power";
+
+      sysctl = {
+        "vm.swappiness" = "20";
+        "vm.dirty_writeback_centisecs" = "1500";
+        "kernel.sched_autogroup_enabled" = "1";
+        "vm.laptop_mode" = "2";
+      };
+    };
+
+    performance = {
+      main.summary = "Ghaf TuneD profile for maximum performance";
+
+      cpu = {
+        governor = "performance";
+        energy_perf_bias = "performance";
+        force_latency = "cstate.id_no_zero:3|70";
+        energy_performance_preference = "performance";
+        min_perf_pct = "0";
+        max_perf_pct = "100";
+        boost = "1";
+        no_turbo = "0";
+        hwp_dynamic_boost = "1";
+      };
+
+      acpi.platform_profile = "performance";
+
+      vm = {
+        dirty_bytes = "40%";
+        dirty_background_bytes = "10%";
+      };
+
+      disk.readahead = ">4096";
+
+      scsi_host.alpm = "max_performance";
+
+      sysctl = {
+        "vm.swappiness" = "10";
+        "net.core.somaxconn" = ">2048";
+        "vm.dirty_writeback_centisecs" = "1500";
+        "vm.laptop_mode" = "0";
+      };
+    };
+  };
+in
+{
+  options.ghaf.services.performance = {
+    host = {
+      enable = mkEnableOption "Ghaf-specific scheduler and power optimizations for the host.";
+      scheduler = {
+        enable = mkEnableOption "system76-scheduler on host for Ghaf-specific process scheduling." // {
+          default = true;
+        };
+      };
+      tuned = {
+        enable = mkEnableOption "TuneD service on the host for Ghaf-specific performance profiles." // {
+          default = true;
+        };
+        defaultProfile = mkOption {
+          type = types.str;
+          # Default to performance to improve boot time
+          default = "host-balanced";
+          description = "Default TuneD profile to use on the host.";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.host.enable (
+      {
+        services.system76-scheduler = {
+          inherit (cfg.host.scheduler) enable;
+          settings = {
+            cfsProfiles.enable = false;
+            processScheduler = {
+              pipewireBoost.enable = false;
+              foregroundBoost.enable = false;
+            };
+          };
+          assignments = hostSchedulerAssignments;
+        };
+        services.tuned = {
+          inherit (cfg.host.tuned) enable;
+
+          settings.profile_dirs = "/etc/tuned/profiles,${
+            concatMapStringsSep "," (script: "${script}") (lib.attrValues hostProfileScripts)
+          }";
+
+          settings.recommend_command = false;
+
+          ppdSettings = {
+            main.default = "balanced";
+            battery = {
+              power-saver = "host-powersave-battery";
+              balanced = "host-balanced-battery";
+              performance = "host-performance-battery";
+            };
+            profiles = {
+              power-saver = "host-powersave";
+              balanced = "host-balanced";
+              performance = "host-performance";
+            };
+          };
+
+          profiles = {
+            host-powersave = tunedProfiles.powersave // {
+              script.script = "${getExe hostProfileScripts.host-powersave}";
+            };
+            host-balanced = tunedProfiles.balanced // {
+              script.script = "${getExe hostProfileScripts.host-balanced}";
+            };
+            host-performance = tunedProfiles.performance // {
+              script.script = "${getExe hostProfileScripts.host-performance}";
+            };
+            host-powersave-battery = tunedProfiles.powersave // {
+              script.script = "${getExe hostProfileScripts.host-powersave-battery}";
+            };
+            host-balanced-battery = tunedProfiles.balanced // {
+              script.script = "${getExe hostProfileScripts.host-balanced-battery}";
+            };
+            host-performance-battery = tunedProfiles.performance // {
+              script.script = "${getExe hostProfileScripts.host-performance-battery}";
+            };
+          };
+        };
+        environment.etc."tuned/recommend.conf".text = ''
+          [${cfg.host.tuned.defaultProfile}]
+        '';
+      }
+      # Service units to set Ghaf PPD profiles on the host when requested from GUI VM
+      # These must be whitelisted in modules/givc/host.nix
+      // {
+        systemd.services =
+          let
+            mkPpdService = profile: {
+              description = "Enable ${profile} Ghaf PPD profile on host";
+              serviceConfig = {
+                Type = "oneshot";
+                ExecStart = ''
+                  -${getExe' pkgs.tuned "tuned-adm"} profile ${profile}
+                '';
+              };
+            };
+            hostProfiles = [
+              "host-powersave"
+              "host-balanced"
+              "host-performance"
+              "host-powersave-battery"
+              "host-balanced-battery"
+              "host-performance-battery"
+            ];
+          in
+          lib.listToAttrs (map (profile: nameValuePair "${profile}" (mkPpdService profile)) hostProfiles);
+      }
+    ))
+  ]);
+}

--- a/modules/givc/host.nix
+++ b/modules/givc/host.nix
@@ -11,6 +11,7 @@ let
     mkEnableOption
     mkIf
     optionalString
+    optionals
     ;
   inherit (config.networking) hostName;
   inherit (config.ghaf.networking) hosts;
@@ -35,6 +36,14 @@ in
         "reboot.target"
         "poweroff.target"
         "suspend.target"
+      ]
+      ++ optionals config.ghaf.services.performance.host.tuned.enable [
+        "host-powersave.service"
+        "host-balanced.service"
+        "host-performance.service"
+        "host-powersave-battery.service"
+        "host-balanced-battery.service"
+        "host-performance-battery.service"
       ];
       adminVm = optionalString (adminHost != null) "microvm@${adminHost}.service";
       systemVms = map (vmName: "microvm@${vmName}.service") config.ghaf.common.systemHosts;

--- a/modules/givc/netvm.nix
+++ b/modules/givc/netvm.nix
@@ -38,6 +38,14 @@ in
       ++ optionals config.ghaf.services.power-manager.vm.enable [
         "suspend.target"
         "systemd-suspend.service"
+      ]
+      ++ optionals config.ghaf.services.performance.net.tuned.enable [
+        "net-powersave.service"
+        "net-balanced.service"
+        "net-performance.service"
+        "net-powersave-battery.service"
+        "net-balanced-battery.service"
+        "net-performance-battery.service"
       ];
       hwidService = true;
       tls.enable = config.ghaf.givc.enableTls;

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -102,6 +102,10 @@ in
             host.enable = true;
             gui.enable = config.ghaf.profiles.graphics.enable;
           };
+          performance = {
+            host.enable = true;
+            gui.enable = config.ghaf.profiles.graphics.enable;
+          };
           kill-switch.enable = true;
           create-fake-battery.enable = true;
         };

--- a/modules/microvm/modules.nix
+++ b/modules/microvm/modules.nix
@@ -129,6 +129,13 @@ let
         inherit (configHost.ghaf.services.power-manager) enable;
       };
     };
+
+    # Performance module
+    performance = {
+      config.ghaf.services.performance = {
+        inherit (configHost.ghaf.services.performance) enable;
+      };
+    };
   };
 
   # User account settings
@@ -212,6 +219,7 @@ in
           serviceModules.wifi
           serviceModules.audit
           serviceModules.power
+          serviceModules.performance
           referenceServiceModule
         ];
       # Audiovm modules
@@ -232,6 +240,7 @@ in
           serviceModules.bluetooth
           serviceModules.xpadneo
           serviceModules.power
+          serviceModules.performance
           managedUserAccounts
         ];
       # Guivm modules
@@ -254,6 +263,7 @@ in
           serviceModules.audit
           serviceModules.brightness
           serviceModules.power
+          serviceModules.performance
           referenceServiceModule
         ];
 

--- a/modules/microvm/sysvms/audiovm.nix
+++ b/modules/microvm/sysvms/audiovm.nix
@@ -80,6 +80,9 @@ let
                   "bluetooth.service"
                 ];
               };
+              performance.vm = {
+                enable = true;
+              };
             };
             logging.client.enable = configHost.ghaf.logging.enable;
 

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -146,6 +146,10 @@ let
                 gui.enable = true;
               };
 
+              performance = {
+                gui.enable = true;
+              };
+
               github = {
                 enable = true;
                 token = "xxxxxxxxxxxxxxxxxxxx"; # Will be updated when the user login

--- a/modules/microvm/sysvms/netvm.nix
+++ b/modules/microvm/sysvms/netvm.nix
@@ -86,6 +86,10 @@ let
                   "wpa_supplicant.service"
                 ];
               };
+
+              performance = {
+                net.enable = true;
+              };
             };
             logging.client.enable = config.ghaf.logging.enable;
 

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -111,6 +111,9 @@ in
       # Enable power management
       services.power-manager.enable = true;
 
+      # Enable performance optimizations
+      services.performance.enable = true;
+
       # Enable kill switch
       services.kill-switch.enable = true;
     };

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -194,7 +194,7 @@ let
             {
               # We explicitly enable only those we need
               hardware.system76 = {
-                power-daemon.enable = true;
+                power-daemon.enable = false;
                 kernel-modules.enable = true;
                 # Firmware daemon requires EFI mount point, not available in guivm
                 firmware-daemon.enable = false;
@@ -203,7 +203,7 @@ let
           ];
         };
         # Add system76 and system76-io kernel modules to host
-        hardware.system76.enableAll = true;
+        hardware.system76.kernel-modules.enable = true;
       }
     ]))
 
@@ -328,7 +328,23 @@ let
         ghaf = {
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
+          profiles.graphics.idleManagement.enable = true;
+          profiles.graphics.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
+
+          virtualization.microvm.guivm.extraModules = [
+            {
+              # We explicitly enable only those we need
+              hardware.system76 = {
+                power-daemon.enable = false;
+                kernel-modules.enable = true;
+                # Firmware daemon requires EFI mount point, not available in guivm
+                firmware-daemon.enable = false;
+              };
+            }
+          ];
         };
+        # Add system76 and system76-io kernel modules to host
+        hardware.system76.kernel-modules.enable = true;
       }
     ]))
     # keep-sorted end


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Introduced a new **performance module** inspired by [System76 Scheduler](https://github.com/pop-os/system76-scheduler/tree/master) and [TuneD](https://github.com/redhat-performance/tuned/tree/master).  
This module replaces both **power-profiles-daemon** and **system76-power**, providing greater flexibility and allowing the definition of **custom power profiles** for both AC and battery modes in Ghaf.

With the addition of the module, Ghaf-specific power profiles are introduced as well, and are enabled by default for the host, based on the selected power profile (e.g. selecting **powersave** enables the **ghaf-powersave** profile).
Gui, net and audio VMs all use the upstream `virtual-guest` profile, which can be found [here](https://github.com/redhat-performance/tuned/blob/master/profiles/virtual-guest/tuned.conf).

---

### Key Features

- **TuneD’s power-profiles-daemon API** - allows changing power profiles on **any** device via gui-vm
- Enables **custom Ghaf-specific, hardware-agnostic power and scheduler optimizations**
- Automatically detects **AC/battery** usage and adjusts profiles dynamically
- Propagates **power profile changes from gui-vm to host**
- Allows the use of custom scripts during power profile activation

---

### Current configuration

#### gui-vm, net-vm, other possible guests

```ini
{
  power-saver = "virtual-guest";
  balanced = "virtual-guest";
  performance = "virtual-guest";
};
```
- Generally VMs use `virtual-guest` default TuneD profile, with some extra functionality provided by scripts:
  - gui-vm scripts include propagating profile changes to other VMs and host, as well as reducing backlight brightness
  - net-vm scripts adjust Wi-Fi power management - disable in perf mode, re-enable for all other modes

#### host
```ini
{
  power-saver = "ghaf-powersave";
  balanced = "ghaf-balanced";
  performance = "ghaf-performance";
};
```
- `ghaf-*` profiles are a mixture of the default profiles from **system76-power** and TuneD's `virtual-host` profile
- PCI device power management is disabled in performance mode, enabled on powersave

**Note**: Battery and AC profiles are the same except for backlight adjustment - on battery, backlight adjustment is more aggressive.

---

### Behavior

- Users can now change the device's power profile at runtime by using COSMIC's battery applet (top panel, right side)
- Changing the power profile automatically propagates the change to the host as well
- 6 distinct profiles available - powersave, balanced, performance, and their respective "-battery" profiles
- "Battery" profiles are activated automatically if the device is running on battery power only

#### Real world performance
Thanks to @milva-unikie and @leivos-unikie, we now have a clear visualization of the impact of this change.
The table below shows two power-measurement graphs collected on a Lenovo X1 Gen 11.

| Before  | After |
| ------------- | ------------- |
|  ![Before](https://github.com/user-attachments/assets/b0347947-ccb7-4804-92b4-88d651061f9a) | ![After](https://github.com/user-attachments/assets/7fb9f9d8-46a9-4b64-944f-885e875364b0)  |
| Mainline power measurements with the system left idle in its default state. | Power measurements for this PR, taken in two-minute intervals for each power mode (**performance** -> **balanced** -> **powersave**), then repeated once. Backlight brightness is fixed at 100% throughout the test. |
| Power consumption stays around 14–15 W, dropping to ~12 W when the backlight eventually dims. The system suspends at around the 15-minute mark. | Power consumption is approximately 19–20 W in **performance** mode, 14–15 W in **balanced** mode, and 9–10 W in **powersave** mode. This represents a worst-case scenario since the backlight is locked at full brightness; in normal use, **balanced** and **powersave** modes should see an additional ~2 W reduction. |

---

### Supported Targets

- host (enabled by default)
- gui-vm (enabled by default)
- net-vm (enabled by default)

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
General:
1. Boot into Ghaf
2. Verify the default power profile is **Balanced**
3. Change the power profile (battery applet, top right)
4. Verify the power profile changes in gui-vm, net-vm, and host, to their respective profiles, by running this command in each: `tuned-adm active`

Performance (Optional, perf tests can be done after merge):
1. Boot into Ghaf and test the general responsiveness and performance (boot time, app load time, etc) using the different performance profiles
2. Verify no degradation in performance using the **balanced** profile, comment on the "feeling" of using **powersave** and **performance** profiles

Battery life:
1. Boot into Ghaf
2. Login and wait 2-3 minutes for the system to settle and set backlight brightness to 100%
3. Wait for system to settle 1-2 mins, unplug the charger, and observe the estimated remaining battery time in the battery applet (top right)
4. Repeat step 3 for **performance** and **powersave** profiles and verify battery time increases or decreases as the profiles change **performance** -> **balanced** -> **powersave**
