### PR TITLE
Fix audit rules service on Zathura VM

### DIFF
--- a/modules/reference/appvms/zathura.nix
+++ b/modules/reference/appvms/zathura.nix
@@ -45,7 +45,7 @@
           image = true;
         };
         # Let systemd use default ordering for audit-rules instead of early-boot
-        systemd.services.audit-rules = {
+        systemd.services.audit-rules-nixos = {
           unitConfig.DefaultDependencies = lib.mkForce true;
           before = lib.mkForce [ ];
         };


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Fixes the audit-rules-nixos.service @ Zathura VM.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7574

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Enable audit - `security.audit.enable = true`; - https://github.com/everton-dematos/ghaf/blob/pr_audit_zathura/modules/reference/profiles/mvp-user-trial.nix#L107
2. At Zathura VM, run the following: `systemctl status audit-rules-nixos.service`
3. The service should be enabled, active, with no errors.
