### PR TITLE
refactor(homes): persist appvm homes by default

### DIFF
--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -91,16 +91,18 @@ let
                 storagevm = {
                   enable = true;
                   name = vmName;
-                  users.${config.ghaf.users.appUser.name}.directories = [
-                    ".config/"
-                    ".cache"
-                    ".local"
-                    "Downloads"
-                    "Music"
-                    "Pictures"
-                    "Documents"
-                    "Videos"
-                  ];
+                  directories =
+                    lib.optionals (!lib.hasAttr "${config.ghaf.users.appUser.name}" config.ghaf.storagevm.users)
+                      [
+                        # By default, persist appusers entire home directory unless overwritten by defining
+                        # either storagevm.users.<user>.directories and/or .files explicitly in an appvm.
+                        {
+                          directory = "/home/${config.ghaf.users.appUser.name}";
+                          user = "${config.ghaf.users.appUser.name}";
+                          group = "${config.ghaf.users.appUser.name}";
+                          mode = "0700";
+                        }
+                      ];
                   shared-folders.enable = sharedVmDirectory.enable && builtins.elem vmName sharedVmDirectory.vms;
                   encryption.enable = configHost.ghaf.virtualization.storagevm-encryption.enable;
                 };

--- a/modules/reference/appvms/flatpak.nix
+++ b/modules/reference/appvms/flatpak.nix
@@ -106,9 +106,6 @@ in
             "nosuid"
             "exec" # For Bubblewrap sandbox to execute the file
           ];
-          users.${config.ghaf.users.appUser.name}.directories = [
-            ".var" # For app data
-          ];
         };
 
         programs.dconf.enable = true;

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -22,6 +22,7 @@ in
         "business-vm"
         "comms-vm"
         "chrome-vm"
+        "flatpak-vm"
       ];
 
       virtualization.microvm.appvm = {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Persist appvms 'appuser' home by default.

If appusers' home directories or files are explicitly defined in an appvm instance via the storagevm options, this setting will be ineffective - only the defined files and directories are then persisted. This is generally useful as apps often create app-specific folders.

Also adds shared folder for flatpack-vm.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other: both work, in case of nixos-rebuild the old file structures are still present

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
