### PR TITLE
microvm: use a store image and not share /nix/store

### DIFF
--- a/modules/microvm/common/microvm-store-mode.nix
+++ b/modules/microvm/common/microvm-store-mode.nix
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Global configuration for MicroVM /nix/store mode
+{
+  lib,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.ghaf.virtualization.microvm.storeOnDisk = mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      Global setting for all MicroVMs: use storeOnDisk (erofs compressed image)
+      instead of shared virtiofs /nix/store.
+
+      When true:  All VMs use storeOnDisk (compressed, less memory)
+      When false: All VMs use sharedStore (virtiofs, more memory)
+
+      Default is false (shared store for easier development experience).
+
+      This setting is read by MicroVMs via configHost.ghaf.virtualization.microvm.storeOnDisk
+      to configure their /nix/store access method.
+    '';
+  };
+}

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -11,6 +11,7 @@
       (import ./sysvms/guivm.nix { inherit inputs; })
       (import ./sysvms/audiovm.nix { inherit inputs; })
       (import ./sysvms/idsvm/idsvm.nix { inherit inputs; })
+      ./common/microvm-store-mode.nix
       ./modules.nix
     ];
 
@@ -20,6 +21,7 @@
 
     vm-modules.imports = [
       ./common/ghaf-audio.nix
+      ./common/microvm-store-mode.nix
       ./common/shared-directory.nix
       ./common/storagevm.nix
       ./common/vm-networking.nix

--- a/modules/partitioning/disko-debug-partition.nix
+++ b/modules/partitioning/disko-debug-partition.nix
@@ -52,7 +52,7 @@ in
         disk = {
           disk1 = {
             type = "disk";
-            imageSize = "60G";
+            imageSize = "80G";
             content = {
               type = "gpt";
               partitions = {
@@ -108,7 +108,7 @@ in
                       priority = 3;
                     };
                 root = {
-                  size = "40G";
+                  size = "60G";
                   content = {
                     type = "filesystem";
                     format = "ext4";

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -226,6 +226,35 @@ let
       }
     ]))
 
+    (laptop-configuration "system76-darp11-b-storeDisk" "debug" (withCommonModules [
+      self.nixosModules.hardware-system76-darp11-b
+      {
+        ghaf = {
+          reference.profiles.mvp-user-trial.enable = true;
+          partitioning.disko.enable = true;
+          profiles.graphics.idleManagement.enable = true;
+          profiles.graphics.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
+
+          # Enable storeOnDisk for all VMs
+          virtualization.microvm.storeOnDisk = true;
+
+          virtualization.microvm.guivm.extraModules = [
+            {
+              # We explicitly enable only those we need
+              hardware.system76 = {
+                power-daemon.enable = false;
+                kernel-modules.enable = true;
+                # Firmware daemon requires EFI mount point, not available in guivm
+                firmware-daemon.enable = false;
+              };
+            }
+          ];
+        };
+        # Add system76 and system76-io kernel modules to host
+        hardware.system76.kernel-modules.enable = true;
+      }
+    ]))
+
     (laptop-configuration "tower-5080" "debug" (withCommonModules [
       self.nixosModules.hardware-tower-5080
       {


### PR DESCRIPTION
move to using the storeOnDisk option.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
