### PR TITLE
logging: add MaxFileSec for journald

### DIFF
--- a/modules/common/logging/client.nix
+++ b/modules/common/logging/client.nix
@@ -73,7 +73,8 @@ in
 
     # Local journal retention
     services.journald.extraConfig = mkIf config.ghaf.logging.journalRetention.enable ''
-      MaxRetentionSec=${toString (config.ghaf.logging.journalRetention.maxRetentionDays * 86400)}
+      MaxRetentionSec=${config.ghaf.logging.journalRetention.maxRetention}
+      MaxFileSec=${config.ghaf.logging.journalRetention.MaxFileSec}
       SystemMaxUse=${config.ghaf.logging.journalRetention.maxDiskUsage}
       SystemMaxFileSize=100M
       Storage=persistent

--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -48,13 +48,15 @@ in
         default = true;
       };
 
-      maxRetentionDays = mkOption {
+      maxRetention = mkOption {
         description = ''
-          Maximum number of days to retain journal logs locally.
+          Period of time to retain journal logs locally.
           After this period, old logs will be deleted automatically.
+          This setting takes time values which may be suffixed with the units:
+          'year', 'month', 'week', 'day', 'h' or ' m' to override the default time unit of seconds.
         '';
-        type = types.int;
-        default = 30;
+        type = types.str;
+        default = "30day";
       };
 
       maxDiskUsage = mkOption {
@@ -64,6 +66,16 @@ in
         '';
         type = types.str;
         default = "500M";
+      };
+
+      MaxFileSec = mkOption {
+        description = ''
+          The maximum time to store entries in a single journal file before rotating to the next one.
+          This setting takes time values which may be suffixed with the units:
+          'year', 'month', 'week', 'day', 'h' or ' m' to override the default time unit of seconds.
+        '';
+        type = types.str;
+        default = "1day";
       };
     };
   };

--- a/modules/common/logging/server.nix
+++ b/modules/common/logging/server.nix
@@ -120,7 +120,8 @@ in
 
     # Local journal retention for admin-vm's own logs
     services.journald.extraConfig = mkIf config.ghaf.logging.journalRetention.enable ''
-      MaxRetentionSec=${toString (config.ghaf.logging.journalRetention.maxRetentionDays * 86400)}
+      MaxRetentionSec=${config.ghaf.logging.journalRetention.maxRetention}
+      MaxFileSec=${config.ghaf.logging.journalRetention.MaxFileSec}
       SystemMaxUse=${config.ghaf.logging.journalRetention.maxDiskUsage}
       SystemMaxFileSize=100M
       Storage=persistent


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Add a `MaxFileSec` option to control how long entries stay in a single journal file before rotation.
  - This basically forces log rotation every _X_ time interval, enforcing the log retention.

- Replace `maxRetentionDays` (int, days) with `maxRetention` (string) to directly configure `MaxRetentionSec` using systemd time units (e.g., 5min, 30day).

- Add both options into `services.journald.extraConfig` for the logging client and admin-vm server.

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Change the `maxRetention` to **5m** (i.e., 5 minutes) - https://github.com/everton-dematos/ghaf/blob/pr_enforce_retention/modules/common/logging/common.nix#L59
2. Change the `MaxFileSec` to **15** (i.e., 15 seconds) - https://github.com/everton-dematos/ghaf/blob/pr_enforce_retention/modules/common/logging/common.nix#L78
3. Verify at any VM that the retention time (`maxRetention`) is being enforced:
4. Verify the configuration:
```
$ cat /etc/systemd/journald.conf 
[Journal]
Storage=persistent
RateLimitInterval=30s
RateLimitBurst=10000


Audit=keep
MaxRetentionSec=5m
MaxFileSec=15
SystemMaxUse=500M
SystemMaxFileSize=100M
Storage=persistent
```
5. Verify that the "First Entry" is updated after the `MaxRetentionSec` period:
```
$ journalctl --list-boots
IDX BOOT ID                          FIRST ENTRY                 LAST ENTRY                 
  0 2015010f212e41a1bae5a5a486749355 Fri 2025-11-14 10:09:36 UTC Fri 2025-11-14 10:14:28 UTC 
$ journalctl --list-boots
IDX BOOT ID                          FIRST ENTRY                 LAST ENTRY                 
  0 2015010f212e41a1bae5a5a486749355 Fri 2025-11-14 10:09:51 UTC Fri 2025-11-14 10:14:37 UTC
$ journalctl --list-boots
IDX BOOT ID                          FIRST ENTRY                 LAST ENTRY                 
  0 2015010f212e41a1bae5a5a486749355 Fri 2025-11-14 10:10:06 UTC Fri 2025-11-14 10:14:51 UTC
$ journalctl --list-boots
IDX BOOT ID                          FIRST ENTRY                 LAST ENTRY                 
  0 2015010f212e41a1bae5a5a486749355 Fri 2025-11-14 10:10:21 UTC Fri 2025-11-14 10:15:07 UTC
```
