### PR TITLE
Fix printf octal interpretation error in hostname generation

### DIFF
--- a/modules/common/identity/dynamic-hostname.nix
+++ b/modules/common/identity/dynamic-hostname.nix
@@ -115,7 +115,7 @@ let
 
       # Generate device-id from our hardware-derived ID (for backward compatibility)
       # Use the same ID but format as hex string with dashes like: 00-01-23-45-67
-      printf "%010x" "$id" | fold -w2 | paste -sd'-' | tr -d '\n' > "$shareDir/../device-id"
+      printf "%010x" "$((10#$id))" | fold -w2 | paste -sd'-' | tr -d '\n' > "$shareDir/../device-id"
 
       # Generate unique machine-ids for all VMs based on hardware ID
       # Each VM gets a deterministic ID derived from hardware + VM name


### PR DESCRIPTION
When the generated ID starts with 0 (e.g., 0990473387), printf '%x' interprets it as an octal number, causing 'invalid octal number' error since 09 is not valid in octal (only 0-7 digits allowed).

Force base-10 interpretation using $((10#id)) to prevent this corner case.


<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
