### PR TITLE
cosmic: enable nm in login, replace nm-applet with cosmi's builtin

### DIFF
--- a/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
@@ -150,6 +150,7 @@ com.system76.CosmicPanel.Panel:
         "com.system76.CosmicAppletInputSources",
         "com.system76.CosmicAppletStatusArea",
         "com.system76.CosmicAppletTiling",
+        "com.system76.CosmicAppletNetwork",
         "com.system76.CosmicAppletAudio",
         "com.system76.CosmicAppletBattery",
         "com.system76.CosmicAppletPower",

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -198,6 +198,7 @@ in
           "com.system76.CosmicAppletInputSources"
           "com.system76.CosmicAppletStatusArea"
           "com.system76.CosmicAppletTiling"
+          "com.system76.CosmicAppletNetwork"
           "com.system76.CosmicAppletAudio"
           "com.system76.CosmicAppletBattery"
           "com.system76.CosmicAppletPower"
@@ -333,6 +334,7 @@ in
         partOf = [ "cosmic-session.target" ];
         wantedBy = [ "cosmic-session.target" ];
       };
+
       usb-passthrough-applet = {
         description = "USB Passthrough Applet";
         serviceConfig = {
@@ -344,21 +346,6 @@ in
           ];
           ExecStart = ''
             ${lib.getExe' pkgs.ghaf-usb-applet "usb_applet"}
-          '';
-        };
-        partOf = [ "cosmic-session.target" ];
-        wantedBy = [ "cosmic-session.target" ];
-      };
-
-      nm-applet = {
-        inherit (graphicsProfileCfg.networkManager.applet) enable;
-        description = "Network Manager Applet";
-        serviceConfig = {
-          Type = "simple";
-          Restart = "always";
-          RestartSec = "1";
-          ExecStart = ''
-            ${getExe' pkgs.networkmanagerapplet "nm-applet"} --indicator
           '';
         };
         partOf = [ "cosmic-session.target" ];

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -208,7 +208,6 @@ let
             systemPackages =
               (rmDesktopEntries [
                 pkgs.waypipe
-                pkgs.networkmanagerapplet
                 pkgs.gnome-calculator
                 pkgs.sticky-notes
               ])

--- a/overlays/custom-packages/cosmic/cosmic-greeter/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-greeter/default.nix
@@ -1,15 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-# Disable network manager in cosmic-greeter
-# Ref: https://github.com/pop-os/cosmic-greeter/blob/master/Cargo.toml
 { prev }:
 prev.cosmic-greeter.overrideAttrs (oldAttrs: {
-  cargoBuildNoDefaultFeatures = true;
-  cargoBuildFeatures = [
-    "logind"
-    # "networkmanager"
-    "upower"
-  ];
   patches = oldAttrs.patches ++ [
     ./0001-Replace-fallback-background-with-Ghaf-default.patch
   ];


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

1. Added back network manager functionality to cosmic-greeter (login and lock screen)
2. Removed nm-applet in favor of COSMIC's built-in Network applet

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Boot into Ghaf and verify login screen has a network icon
2. Verify lock screen also has a network icon
3. Evaluate the usability of COSMIC's built-in Network applet (top right)
