### PR TITLE
cosmic-applets: hide some buttons

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -30,7 +30,8 @@ path = [
   "overlays/custom-packages/cosmic/cosmic-comp/0001-Add-security-context-indicator.patch",
   "overlays/custom-packages/cosmic/cosmic-comp/0001-Disable-VRR-by-default.patch",
   "overlays/custom-packages/cosmic/cosmic-initial-setup/0001-Preselect-Ghaf-themes.patch",
-  "overlays/custom-packages/cosmic/cosmic-greeter/0001-Replace-fallback-background-with-Ghaf-default.patch"
+  "overlays/custom-packages/cosmic/cosmic-greeter/0001-Replace-fallback-background-with-Ghaf-default.patch",
+  "overlays/custom-packages/cosmic/cosmic-applets/*.patch"
 ]
 
 [[annotations]]

--- a/overlays/custom-packages/cosmic/cosmic-applets/0001-audio-applet-hide-sound-settings-button.patch
+++ b/overlays/custom-packages/cosmic/cosmic-applets/0001-audio-applet-hide-sound-settings-button.patch
@@ -1,0 +1,28 @@
+From dd3426ef7515c557b48718a4c1d77427ac4a13b3 Mon Sep 17 00:00:00 2001
+From: Kajus Naujokaitis <kajusn@gmail.com>
+Date: Mon, 24 Nov 2025 12:47:17 +0200
+Subject: [PATCH] audio-applet: hide sound settings button
+
+Signed-off-by: Kajus Naujokaitis <kajusn@gmail.com>
+---
+ cosmic-applet-audio/src/lib.rs | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/cosmic-applet-audio/src/lib.rs b/cosmic-applet-audio/src/lib.rs
+index ab9374b..94b3562 100644
+--- a/cosmic-applet-audio/src/lib.rs
++++ b/cosmic-applet-audio/src/lib.rs
+@@ -955,9 +955,7 @@ impl cosmic::Application for Audio {
+                 )
+                 .text_size(14)
+                 .width(Length::Fill)
+-            ),
+-            padded_control(divider::horizontal::default()).padding([space_xxs, space_s]),
+-            menu_button(text::body(fl!("sound-settings"))).on_press(Message::OpenSettings)
++            )
+         ]
+         .align_x(Alignment::Start)
+         .padding([8, 0]);
+-- 
+2.51.2
+

--- a/overlays/custom-packages/cosmic/cosmic-applets/0001-bluetooth-applet-hide-bluetooth-settings-button.patch
+++ b/overlays/custom-packages/cosmic/cosmic-applets/0001-bluetooth-applet-hide-bluetooth-settings-button.patch
@@ -1,0 +1,27 @@
+From 4b7a57d5a64eed2eaf7d8c493f1567f4266b923d Mon Sep 17 00:00:00 2001
+From: Kajus Naujokaitis <kajusn@gmail.com>
+Date: Mon, 24 Nov 2025 12:50:07 +0200
+Subject: [PATCH] bluetooth-applet: hide bluetooth settings button
+
+Signed-off-by: Kajus Naujokaitis <kajusn@gmail.com>
+---
+ cosmic-applet-bluetooth/src/app.rs | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/cosmic-applet-bluetooth/src/app.rs b/cosmic-applet-bluetooth/src/app.rs
+index 386f4d4..3d10428 100644
+--- a/cosmic-applet-bluetooth/src/app.rs
++++ b/cosmic-applet-bluetooth/src/app.rs
+@@ -537,9 +537,6 @@ impl cosmic::Application for CosmicBluetoothApplet {
+         } else {
+             content = content.push(Column::with_children(list_column));
+         }
+-        content = content
+-            .push(padded_control(divider::horizontal::default()).padding([space_xxs, space_s]))
+-            .push(menu_button(text::body(fl!("settings"))).on_press(Message::OpenSettings));
+ 
+         self.core.applet.popup_container(content).into()
+     }
+-- 
+2.51.2
+

--- a/overlays/custom-packages/cosmic/cosmic-applets/0001-network-applet-hide-airplane-mode-toggle.patch
+++ b/overlays/custom-packages/cosmic/cosmic-applets/0001-network-applet-hide-airplane-mode-toggle.patch
@@ -1,0 +1,38 @@
+From dbae1dc00b337dc4353472646fdf07a77823cfae Mon Sep 17 00:00:00 2001
+From: Kajus Naujokaitis <kajusn@gmail.com>
+Date: Mon, 24 Nov 2025 12:48:06 +0200
+Subject: [PATCH] network-applet: hide airplane mode toggle
+
+Signed-off-by: Kajus Naujokaitis <kajusn@gmail.com>
+---
+ cosmic-applet-network/src/app.rs | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/cosmic-applet-network/src/app.rs b/cosmic-applet-network/src/app.rs
+index b28b6ff..421f21e 100644
+--- a/cosmic-applet-network/src/app.rs
++++ b/cosmic-applet-network/src/app.rs
+@@ -892,20 +892,6 @@ impl cosmic::Application for CosmicNetworkApplet {
+                 Element::from(
+                     column![
+                         vpn_ethernet_col,
+-                        padded_control(
+-                            anim!(
+-                                //toggler
+-                                AIRPLANE_MODE,
+-                                &self.timeline,
+-                                fl!("airplane-mode"),
+-                                self.nm_state.airplane_mode,
+-                                |_chain, enable| { Message::ToggleAirplaneMode(enable) },
+-                            )
+-                            .text_size(14)
+-                            .width(Length::Fill)
+-                        ),
+-                        padded_control(divider::horizontal::default())
+-                            .padding([space_xxs, space_s]),
+                     ]
+                     .align_x(Alignment::Center)
+                 ),
+-- 
+2.51.2
+

--- a/overlays/custom-packages/cosmic/cosmic-applets/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-applets/default.nix
@@ -1,9 +1,18 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-# Add DBUS proxy socket for audio, network, and Bluetooth applets
+# Add DBUS proxy socket for audio and Bluetooth applets
+# audio-applet: patch to hide sound settings button
+# bluetooth-applet: patch to hide bluetooth settings button
+# network-applet: patch to hide airplane mode toggle
 # Ref: https://github.com/pop-os/cosmic-applets
 { prev }:
 prev.cosmic-applets.overrideAttrs (oldAttrs: {
+  patches = oldAttrs.patches ++ [
+    # audio and bluetooth patches should be removed when dbus-proxy allows
+    ./0001-audio-applet-hide-sound-settings-button.patch
+    ./0001-bluetooth-applet-hide-bluetooth-settings-button.patch
+    ./0001-network-applet-hide-airplane-mode-toggle.patch
+  ];
   postInstall = oldAttrs.postInstall or "" + ''
     sed -i 's|^Exec=.*|Exec=env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/dbusproxy_snd.sock cosmic-applet-audio|' $out/share/applications/com.system76.CosmicAppletAudio.desktop
     sed -i 's|^Exec=.*|Exec=env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/dbusproxy_snd.sock cosmic-applet-bluetooth|' $out/share/applications/com.system76.CosmicAppletBluetooth.desktop


### PR DESCRIPTION
1. **audio-applet**: added a patch to hide "Sound settings..." button
   - Needed to avoid opening cosmic-settings with audio-vm's system DBUS address
2. **bluetooth-applet**: added a patch to hide "Bluetooth settings..." button
   - Needed to avoid opening cosmic-settings with audio-vm's system DBUS address
3. **network-applet**: added a patch to hide "Airplane Mode" toggle

For 1. and 2. - these patches should be removed as soon as dbus-proxy supports audio and bluetooth

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify COSMIC Audio applet does no longer does not have the "Sound settings..." button at the bottom
2. Verify COSMIC Network applet does not have the "Airplane Mode" toggle at the top
