### PR TITLE
modules/partitioning: remove xcp workaround

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,15 +108,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1762276996,
-        "narHash": "sha256-TtcPgPmp2f0FAnc+DMEw4ardEgv1SGNR3/WFGH0N19M=",
+        "lastModified": 1764242537,
+        "narHash": "sha256-zeh+ECjLWV3xzPlu5GvkfzZBk6i4f9WYESwd1dL3l6w=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "af087d076d3860760b3323f6b583f4d828c1ac17",
+        "rev": "c4876bb08f42fcfe0b4b7ca5868b7e9c73f6a6b2",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "xcp",
         "repo": "disko",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,9 @@
 
     # For building and creating disk images and installers
     disko = {
-      url = "github:nix-community/disko";
+      # We currently test if this runs more stable in our CI
+      # https://github.com/nix-community/disko/pull/1166
+      url = "github:nix-community/disko/xcp";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/modules/partitioning/disko-debug-partition.nix
+++ b/modules/partitioning/disko-debug-partition.nix
@@ -43,20 +43,6 @@ in
     system.build.ghafImage = config.system.build.diskoImages;
     disko = {
       imageBuilder = {
-        # Use cp instead of xcp because xcp fails with "Permission denied" on virtiofs
-        # when trying to preserve attributes/ownership.
-        pkgs = pkgs.extend (
-          final: _prev: {
-            xcp = final.writeShellApplication {
-              name = "xcp";
-              runtimeInputs = [ _prev.xcp ];
-              text = ''
-                 # Limit parallelism to avoid hitting file descriptor limits
-                exec ${_prev.xcp}/bin/xcp --workers 2 "$@"
-              '';
-            };
-          }
-        );
         extraPostVM = lib.mkIf (cfg.imageBuilder.compression == "zstd") ''
           ${pkgs.zstd}/bin/zstd --compress $out/*raw
           rm $out/*raw


### PR DESCRIPTION
Disko now uses parallel cp instead of xcp, which hopefully will the errors we see with virtiofs. Upstream disko pr: https://github.com/nix-community/disko/pull/1166

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
