### PR TITLE
jetpack: fix cuda support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -383,16 +383,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1764210424,
-        "narHash": "sha256-v5+P67em4OVtnBhHdi0ldT5S64UzlnJMdD+FQ0QQxDA=",
+        "lastModified": 1764556344,
+        "narHash": "sha256-ow6zdXAHNcOuO9UGhQskvfzYsSbzdx5CcmQvWZH+qPQ=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "12fd024dff4938d1664030f06156b71ca2ea3725",
+        "rev": "2c419c95dbd0df00c1e55b3e07eb21a4c6d58b1a",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
-        "ref": "another-kernel-fix-rebased-again",
+        "ref": "cuda-fix",
         "repo": "jetpack-nixos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
     # Nvidia Orin support for NixOS
     jetpack-nixos = {
       #url = "github:anduril/jetpack-nixos";
-      url = "github:tiiuae/jetpack-nixos/another-kernel-fix-rebased-again";
+      url = "github:tiiuae/jetpack-nixos/cuda-fix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
Use the new paths that have been defined for 25.11 baseline.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
