### PR TITLE
performance: add thermal limit adjustment option

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -666,24 +666,6 @@ in
           )
         ))
       ];
-
-      # Power management services
-      # TODO Evaluate these services
-      # powerManagement.powertop.enable = config.ghaf.profiles.debug.enable;
-      # services.thermald.enable = true;
-      # services.auto-cpufreq = {
-      #   enable = true;
-      #   settings = {
-      #     battery = {
-      #       governor = "powersave";
-      #       turbo = "never";
-      #     };
-      #     charger = {
-      #       governor = "performance";
-      #       turbo = "auto";
-      #     };
-      #   };
-      # };
     })
   ]);
 }

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -96,6 +96,7 @@ let
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
           profiles.graphics.idleManagement.enable = false;
+          services.performance.host.thermalLimitMode = "enabled";
         };
       }
     ]))
@@ -117,6 +118,7 @@ let
         ghaf = {
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
+          services.performance.host.thermalLimitMode = "enabled";
         };
       }
     ]))
@@ -292,6 +294,7 @@ let
         ghaf = {
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
+          services.performance.host.thermalLimitMode = "enabled";
         };
       }
     ]))


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

**Introduced new options to configure Intel CPUs' thermal behavior**
   - New options as part of `ghaf.services.performance.host`:
     - **thermalLimitMode** - enum used to control vendor-defined thermal limits
     - **thermalLimitTemp** - configure a custom thermal limit at which the system will start throttling
   - Thermal throttling seems to occur at 60-70C on many laptops by default.
     Disabling the thermal limit allows the CPU to boost up to the defined limit (90 C by default).
   - Thermal limits are managed by [Thermal Daemon](https://man.archlinux.org/man/extra/thermald/thermald.8.en) and apply only to Intel CPUs
   - Vendor thermal limits are now disabled by default when running on AC power to improve sustained performance under load.
   - May result in improved boot times, especially in scenarios where the system is thermally constrained (e.g., lab testing environments) :crossed_fingers: .

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
Reference values used below are for **X1 gen 11**, with an **[i7-1355U](https://www.intel.com/content/www/us/en/products/sku/232160/intel-core-i71355u-processor-12m-cache-up-to-5-00-ghz/specifications.html)**
1. Boot into Ghaf and open two remote terminals in `ghaf-host`
2. Make sure device is running on AC power and is in "balanced" power profile.
3. In term A, run `sudo s-tui`; In term B run `watch "systemctl status thermald --no-pager"`
4. In term B, confirm the service `thermald.service` is active
5. In term A, start the stress test (click or select and hit Enter on the `( ) Stress` mode)
6. Observe CPU core temps and frequencies during the test:
   - The CPU should comfortably boost to 80% of its all-core max frequency (on X1 this should be 3.8 GHz for P-cores, 2.6 GHz for E-cores)
   - CPU should not start throttling until ~95-100C. If cooling is sufficient, throttling should not occur at all.
7. Keep the stress test running and disconnect the AC power adapter
8. In term B, confirm the service `thermald.service` is inactive.
9. Observe CPU core temps and frequencies during the test:
   - Within ~15 seconds of `thermald.service` becoming inactive the CPU should start throttling in an attempt to keep CPU core temps under 70 C
   - After throttling, the all-core frequency for P-cores should settle around 2.6 GHz
10. (Optional) Switch power profiles (powersave -> balanced -> performance) and repeat the test with and without AC power and observe CPU behavior.