### PR TITLE
killswitch: avoid re-blocking devices already in blocked state

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -278,11 +278,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764664374,
-        "narHash": "sha256-aWOUOUs7wrNHofYCiAGgIIII6c7w7CGOVue7Z3XzwDE=",
+        "lastModified": 1764769965,
+        "narHash": "sha256-5h60zeK3DeJzASBJIrc18dkR9m86pe69qJYWjM8Zezo=",
         "owner": "tiiuae",
         "repo": "ghafpkgs",
-        "rev": "387abd2e57c51008672fb00991320cbb7866409c",
+        "rev": "715921be871d5002b4962b439f9b2fcf803a162f",
         "type": "github"
       },
       "original": {

--- a/modules/common/services/killswitch.nix
+++ b/modules/common/services/killswitch.nix
@@ -288,11 +288,7 @@ let
           devices = audioPciDevices;
           blockedVar = "mic_blocked";
         }}
-        if [ "$mic_blocked" = "true" ]; then
-          echo "mic: blocked"
-        else
-          echo "mic: unblocked"
-        fi
+        [ "$mic_blocked" = true ] && echo "mic: blocked" || echo "mic: unblocked"
 
         # Check for Network status
         net_blocked="false"
@@ -300,11 +296,7 @@ let
           devices = netPciDevices;
           blockedVar = "net_blocked";
         }}
-        if [ "$net_blocked" = "true" ]; then
-          echo "net: blocked"
-        else
-          echo "net: unblocked"
-        fi
+        [ "$net_blocked" = true ] && echo "net: blocked" || echo "net: unblocked"
 
         # Disable the warning that appears when no USB devices
         # shellcheck disable=SC2034
@@ -316,11 +308,7 @@ let
           devices = camUsbDevices;
           blockedVar = "cam_blocked";
         }}
-        if [ "$cam_blocked" = "true" ]; then
-          echo "cam: blocked"
-        else
-          echo "cam: unblocked"
-        fi
+        [ "$cam_blocked" = true ] && echo "cam: blocked" || echo "cam: unblocked"
 
         # Check for bluetooth status
         bt_blocked="false"
@@ -328,11 +316,7 @@ let
           devices = btUsbDevices;
           blockedVar = "bt_blocked";
         }}
-        if [ "$bt_blocked" = "true" ]; then
-          echo "bluetooth: blocked"
-        else
-          echo "bluetooth: unblocked"
-        fi
+        [ "$bt_blocked" = true ] && echo "bluetooth: blocked" || echo "bluetooth: unblocked"
       }
 
       supportedDevices=(${builtins.concatStringsSep " " supportedDevices})


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Addresses a corner case where the "block --all" command is triggered and some devices are already blocked. To resolve this, I've added logic to detect the current device status and continue the loop if a device is already blocked. 


**Corner case as described below**

**This PR:**

```bash
[ghaf@gui-vm:~]$ ghaf-killswitch block  net
Blocking net device ...
INFO Successfully detached

[ghaf@gui-vm:~]$ ghaf-killswitch block --all
Blocking mic device ...
INFO Successfully detached
INFO Successfully detached
INFO Successfully detached
INFO Successfully detached
INFO Successfully detached
Skipping net - already blocked
Blocking device cam0 ...
INFO Successfully detached
Blocking device bt0 ...
INFO Successfully detached
```

**VS Mainline:**
```bash
[ghaf@gui-vm:~]$ ghaf-killswitch block  net
Blocking net device ...
INFO Successfully detached

[ghaf@gui-vm:~]$ ghaf-killswitch block --all
Blocking mic device ...
INFO Successfully detached
INFO Successfully detached
INFO Successfully detached
INFO Successfully detached
INFO Successfully detached
Blocking net device ...
ERROR Failed to detach PCI: Device 0000:2e:00.0 8086:272B (Intel Corporation Wi-Fi 7(802.11be) AX1775*/AX1790*/BE20*/BE401/BE1750* 2x2 (BE200 320MHz [Gale Peak])) is not attached to any VM
```


### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets
Will also include fixes from https://github.com/tiiuae/ghafpkgs/pull/154  (Merged)

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Detailed steps mentioned in `Description of Changes` section.
2.  Also fixes https://jira.tii.ae/browse/SSRCSP-7673