### PR TITLE
Fix USB input devices hot-plugging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764526226,
-        "narHash": "sha256-lmcEOKmrCMwMllZjNkDABFMib+x4BkecRwkoqjLrqIY=",
+        "lastModified": 1764681846,
+        "narHash": "sha256-jgURyMhQzuommxVORnZq5O7k1c462AMwm5kK2QnjbqI=",
         "owner": "tiiuae",
         "repo": "vhotplug",
-        "rev": "c5f2c95df83024a199cd4471ead51066ddcc5a09",
+        "rev": "af4ce4b40ee95db1564b70c4010d30784ade75ba",
         "type": "github"
       },
       "original": {

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -49,7 +49,7 @@ in
           business-vm.permittedDevices = [ "cam0" ];
         };
         usb = {
-          guivmRules = [
+          guivmRules = lib.mkOptionDefault [
             {
               description = "Fingerprint Readers for GUIVM";
               targetVm = "gui-vm";


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This fixes issues with hot-plugging input devices to the gui-vm after the recent refactoring. Additional rules for reference USB devices are now added using mkOptionDefault to preserve the default configuration. The vhotplug has also been updated to the latest version which includes a minor bug fix.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<https://jira.tii.ae/browse/SSRCSP-7675>

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

Connect a USB mouse or keyboard and make sure it works properly in the gui-vm.