### PR TITLE
iso: do not copy the system closure only the disk

### DIFF
--- a/lib/builders/mkLaptopInstaller.nix
+++ b/lib/builders/mkLaptopInstaller.nix
@@ -30,8 +30,21 @@ let
                 "${toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
               ];
 
+              # Prevent the image from being included in the nix store
+              # by explicitly excluding store contents
+              isoImage.storeContents = [ ];
+
+              # Include the image file directly in the ISO filesystem (not in /nix/store)
+              # This copies the file without creating a runtime dependency
+              isoImage.contents = [
+                {
+                  source = "${imagePath}/disk1.raw.zst";
+                  target = "/ghaf-image/disk1.raw.zst";
+                }
+              ];
+
               environment.sessionVariables = {
-                IMG_PATH = imagePath;
+                IMG_PATH = "/iso/ghaf-image";
               };
 
               systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];


### PR DESCRIPTION
The iso was containing the disk image that is to be flashed to the target device along with the entire system closure. This is why the disk image of 6.4 GB (system76 darter pro) was causing an iso of 13GB to be created.

Now we ensure not to copy the closure just the disk image. There is still room for improvement, but that will come in a follow up PR.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
