### PR TITLE
cosmic: add pre-defined layouts and layout config

### DIFF
--- a/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
@@ -85,6 +85,12 @@ com.system76.CosmicPanel:
         "Dock",
     ]
 
+com.system76.CosmicPanel-bottom-panel:
+  entries: |
+    [
+        "Panel",
+    ]
+
 com.system76.CosmicPanel.Dock:
   anchor: Bottom
   anchor_gap: true
@@ -156,6 +162,46 @@ com.system76.CosmicPanel.Panel:
         "com.system76.CosmicAppletPower",
     ]))
   size: XS
+  spacing: 2
+
+com.system76.CosmicPanel.Panel-bottom-panel:
+  anchor: Bottom
+  anchor_gap: false
+  autohide: None
+  autohover_delay_ms: Some(500)
+  background: ThemeDefault
+  border_radius: 0
+  exclusive_zone: false
+  expand_to_edges: true
+  keyboard_interactivity: OnDemand
+  layer: Top
+  margin: 0
+  name: "Panel"
+  opacity: 0.75
+  output: All
+  padding: 0
+  plugins_center: Some([])
+  plugins_wings: |
+    Some(([
+        "com.system76.CosmicPanelLauncherButton",
+        "com.system76.CosmicPanelWorkspacesButton",
+        "com.system76.CosmicPanelAppButton",
+        "com.system76.CosmicAppList",
+        "com.system76.CosmicAppletMinimize",
+    ], [
+        "com.system76.CosmicAppletInputSources",
+        "com.system76.CosmicAppletStatusArea",
+        "com.system76.CosmicAppletA11y",
+        "com.system76.CosmicAppletTiling",
+        "com.system76.CosmicAppletAudio",
+        "com.system76.CosmicAppletBluetooth",
+        "com.system76.CosmicAppletNetwork",
+        "com.system76.CosmicAppletBattery",
+        "com.system76.CosmicAppletNotifications",
+        "com.system76.CosmicAppletTime",
+        "com.system76.CosmicAppletPower",
+    ]))
+  size: M
   spacing: 2
 
 com.system76.CosmicSettings.Shortcuts:

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -24,7 +24,7 @@ let
 
   ghaf-cosmic-config = import ./config/cosmic-config.nix {
     inherit lib pkgs;
-    inherit (cfg) panelApplets;
+    inherit (cfg) topPanelApplets bottomPanelApplets;
     secctx = cfg.securityContext;
     extraShortcuts = lib.optionals cfg.screenRecorder.enable [
       {
@@ -165,7 +165,7 @@ in
       description = "Security context settings";
     };
 
-    panelApplets = mkOption {
+    topPanelApplets = mkOption {
       type = types.submodule {
         options = {
           left = lib.mkOption {
@@ -205,7 +205,60 @@ in
           "com.system76.CosmicAppletPower"
         ];
       };
-      description = "Cosmic panel applets configuration";
+      description = ''
+        Cosmic top panel applets configuration.
+
+        Used only when the top and bottom panel layout is selected.
+      '';
+    };
+
+    bottomPanelApplets = mkOption {
+      type = types.submodule {
+        options = {
+          left = lib.mkOption {
+            description = "List of applets to show on the left side of the panel.";
+            type = types.listOf types.str;
+            default = [ ];
+          };
+          center = lib.mkOption {
+            description = "List of applets to show in the center of the panel.";
+            type = types.listOf types.str;
+            default = [ ];
+          };
+          right = lib.mkOption {
+            description = "List of applets to show on the right side of the panel.";
+            type = types.listOf types.str;
+            default = [ ];
+          };
+        };
+      };
+      default = {
+        left = [
+          "com.system76.CosmicPanelAppButton"
+          "com.system76.CosmicPanelWorkspacesButton"
+          "com.system76.CosmicAppList"
+          "com.system76.CosmicAppletMinimize"
+        ];
+        # Keep center empty when using bottom-only panel
+        center = [ ];
+        right = [
+          "com.system76.CosmicAppletInputSources"
+          "com.system76.CosmicAppletStatusArea"
+          "ae.tii.CosmicAppletKillSwitch"
+          "com.system76.CosmicAppletTiling"
+          "com.system76.CosmicAppletNetwork"
+          "com.system76.CosmicAppletAudio"
+          "com.system76.CosmicAppletBattery"
+          "com.system76.CosmicAppletNotifications"
+          "com.system76.CosmicAppletTime"
+          "com.system76.CosmicAppletPower"
+        ];
+      };
+      description = ''
+        Cosmic top panel applets configuration.
+
+        Used only when the bottom-only panel layout is selected.
+      '';
     };
 
     renderDevice = mkOption {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -46,7 +46,13 @@ in
         # Also needs 'mesa' to be in hardware.graphics.extraPackages
         renderDevice = "/dev/dri/renderD129";
         # Keep only essential applets for Orin devices
-        panelApplets.right = [
+        topPanelApplets.right = [
+          "com.system76.CosmicAppletInputSources"
+          "com.system76.CosmicAppletStatusArea"
+          "com.system76.CosmicAppletTiling"
+          "com.system76.CosmicAppletPower"
+        ];
+        bottomPanelApplets.right = [
           "com.system76.CosmicAppletInputSources"
           "com.system76.CosmicAppletStatusArea"
           "com.system76.CosmicAppletTiling"

--- a/overlays/custom-packages/cosmic/cosmic-initial-setup/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-initial-setup/default.nix
@@ -5,9 +5,10 @@ prev.cosmic-initial-setup.overrideAttrs (oldAttrs: {
   patches = oldAttrs.patches ++ [
     ./0001-Preselect-Ghaf-themes.patch
   ];
-  # Don't install default cosmic themes
+  # Don't install default cosmic themes and layouts
   postPatch = oldAttrs.postPatch or "" + ''
     substituteInPlace justfile \
-      --replace-fail "find res/themes" "# find res/themes"
+      --replace-fail "find res/themes" "# find res/themes" \
+      --replace-fail "'share' / 'cosmic-layouts'" "'share' / 'cosmic-layouts-unused'"
   '';
 })


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Added "Top Panel and Bottom Dock" and "Bottom Panel" layouts:
- these layouts can be selected in the initial setup dialog
- layout configuration options added to `modules/desktop/graphics/cosmic/default.nix`

Fixes an issue where selecting one of the two layouts in the initial setup would reset Ghaf cosmic config, particularly applets in the panel.

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Install a fresh image or simply remove gui-vm's `~/.config`
2. In Ghaf, run `cosmic-initial-setup` manually or by booting a fresh image
3. Proceed to the "Layout configuration" page
4. In the layouts page, select either of the two layouts - changes should apply properly, ghaf-specific applets (killswitch, bluetooth, etc.) should remain accessible in both layouts.

Note: "Bottom Panel" layout feedback welcome - we can freely adjust the size, applets, and positions.