### PR TITLE
jetpack-nixos: bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -383,16 +383,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1764556344,
-        "narHash": "sha256-ow6zdXAHNcOuO9UGhQskvfzYsSbzdx5CcmQvWZH+qPQ=",
+        "lastModified": 1765275864,
+        "narHash": "sha256-NtJ5vWEjeYVPNkMWwCqDtDmCaWTujZBonGgX3l1M1dc=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "2c419c95dbd0df00c1e55b3e07eb21a4c6d58b1a",
+        "rev": "7fed21ac8c8908d584f8e8344408166703a6b4ad",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
-        "ref": "cuda-fix",
+        "ref": "xavier-merged",
         "repo": "jetpack-nixos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
     # Nvidia Orin support for NixOS
     jetpack-nixos = {
       #url = "github:anduril/jetpack-nixos";
-      url = "github:tiiuae/jetpack-nixos/cuda-fix";
+      url = "github:tiiuae/jetpack-nixos/xavier-merged";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/modules/reference/hardware/jetpack/nx/orin-nx.nix
+++ b/modules/reference/hardware/jetpack/nx/orin-nx.nix
@@ -18,7 +18,7 @@
     kernelVersion = "upstream-6-6";
     somType = "nx";
     nx.enableNetvmEthernetPCIPassthrough = true;
-    carrierBoard = "xavierNXdevkit";
+    carrierBoard = "xavierNxDevkit";
   };
   hardware = {
     # Sake of clarity: Jetson 35.4 and IO BASE B carrier board
@@ -33,7 +33,7 @@
     nvidia-jetpack = {
       enable = true;
       som = "orin-nx";
-      carrierBoard = "xavierNXdevkit";
+      carrierBoard = "xavierNxDevkit";
       modesetting.enable = true;
       firmware.uefi = {
         logo = "${pkgs.ghaf-artwork}/1600px-Ghaf_logo.svg";


### PR DESCRIPTION
jetpack-nixos: bump
* upstream kernel from 6.6.75 to 6.6.118
* basic jetpack-nixos sync

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
