### PR TITLE
Create a new target lenovo-x1-carbon-gen11-uki

### DIFF
--- a/modules/reference/hardware/flake-module.nix
+++ b/modules/reference/hardware/flake-module.nix
@@ -77,6 +77,14 @@
       }
     ];
 
+    hardware-lenovo-x1-efi-uki.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      {
+        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen11.nix;
+      }
+      ./lenovo-x1/uki.nix
+    ];
+
     hardware-lenovo-x1-carbon-gen11.imports = [
       inputs.self.nixosModules.hardware-x86_64-workstation
       {

--- a/modules/reference/hardware/lenovo-x1/uki.nix
+++ b/modules/reference/hardware/lenovo-x1/uki.nix
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkIf mkEnableOption;
+
+  cfg = config.ghaf.hardware.lenovo-x1-efi-uki;
+
+  # Kernel command line from config (no system.build.toplevel here to avoid recursion)
+  kernelCmdline = lib.concatStringsSep " " config.boot.kernelParams;
+
+  ghafX1Uki =
+    pkgs.runCommand "ghaf-x1-uki"
+      {
+        nativeBuildInputs = [ pkgs.systemdUkify ];
+      }
+      ''
+            set -e
+            echo "Building UKI for Lenovo X1 with config-based cmdline…"
+
+            mkdir -p "$out/EFI/BOOT"
+
+            # Provide an os-release file so ukify doesn't try /usr/lib/os-release
+            cat > os-release <<'EOF'
+        NAME="Ghaf"
+        ID=ghaf
+        PRETTY_NAME="Ghaf (Lenovo X1 UKI)"
+        VERSION_ID="debug"
+        EOF
+
+            "${pkgs.systemdUkify}/bin/ukify" build \
+              --linux  "${config.system.build.kernel}/${config.system.boot.loader.kernelFile}" \
+              --initrd "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}" \
+              --cmdline ${lib.escapeShellArg kernelCmdline} \
+              --os-release=@os-release \
+              --output "$out/EFI/BOOT/BOOTX64.EFI"
+
+      '';
+in
+{
+  options.ghaf.hardware.lenovo-x1-efi-uki.enable = mkEnableOption "custom UKI for Lenovo X1";
+
+  config = mkIf cfg.enable {
+    system.build.ghafX1Uki = ghafX1Uki;
+
+    boot.loader.systemd-boot.extraFiles = {
+      "EFI/BOOT/BOOTX64.EFI" = "${ghafX1Uki}/EFI/BOOT/BOOTX64.EFI";
+    };
+  };
+}

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -159,6 +159,17 @@ let
       }
     ]))
 
+    (laptop-configuration "lenovo-x1-carbon-gen11-uki" "debug" (withCommonModules [
+      self.nixosModules.hardware-lenovo-x1-efi-uki
+      {
+        ghaf = {
+          hardware.lenovo-x1-efi-uki.enable = true;
+          reference.profiles.mvp-user-trial.enable = true;
+          partitioning.disko.enable = true;
+        };
+      }
+    ]))
+
     (laptop-configuration "lenovo-x1-carbon-gen12" "debug" (withCommonModules [
       self.nixosModules.hardware-lenovo-x1-carbon-gen12
       {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Create a new target lenovo-x1-carbon-gen11-uki with a UKI-enabled EFI partition. 

At the moment, we generate the UKI in CI, which technically violates SLSA principles because it modifies the image after the build step. Although UEFI signing is also a form of post-build modification, introducing this new target ensures that signing becomes the only such change, thereby minimizing CI-side modifications and improving alignment with SLSA requirements.

We are introducing this as a separate target for testing purposes. If this approach proves successful, we may later update the existing x86_64 targets to produce UKI images directly.

### Type of Change
- [ X] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

https://jira.tii.ae/browse/SSRCSP-7187

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ X] Clear summary in PR description
- [ X] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ X] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
This PR introduces a new target that makes significant changes to the EFI partition and may therefore impact the boot process. After a successful boot, the system is expected to behave identically to the existing lenovo-x1-carbon-gen11-debug target. For this reason, testing should focus primarily on validating the boot flow and early startup behaviour.

To build the new target, run:

nix build .#lenovo-x1-carbon-gen11-uki-debug

Test procedure

- Deploy the resulting image to the Lenovo X1 SSD.
- Boot the system and closely observe the boot process.
- The system should behave the same as lenovo-x1-carbon-gen11-debug after startup, although boot management details may differ due to EFI changes.

Alternative testing

Basic boot validation tests may be performed instead of manual testing. 