### PR TITLE
fix: fix softlock on incorrect password

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -32,7 +32,8 @@ path = [
   "overlays/custom-packages/cosmic/cosmic-initial-setup/0001-Preselect-Ghaf-themes.patch",
   "overlays/custom-packages/cosmic/cosmic-greeter/0001-Replace-fallback-background-with-Ghaf-default.patch",
   "overlays/custom-packages/cosmic/cosmic-applets/*.patch",
-  "overlays/custom-packages/system76-scheduler/0001-fix-add-missing-loop-in-process-scheduler-refresh-ta.patch"
+  "overlays/custom-packages/system76-scheduler/0001-fix-add-missing-loop-in-process-scheduler-refresh-ta.patch",
+  "overlays/custom-packages/cosmic/cosmic-greeter/0001-Fix-softlock.patch"
 ]
 
 [[annotations]]

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -297,7 +297,7 @@ in
     services.displayManager.cosmic-greeter.enable = true;
 
     ghaf.graphics.login-manager.enable = true;
-    ghaf.graphics.login-manager.failLock.enable = true;
+    ghaf.graphics.login-manager.failLock.enable = false;
 
     ghaf.graphics.screen-recorder.enable = cfg.screenRecorder.enable;
 

--- a/modules/desktop/graphics/login-manager.nix
+++ b/modules/desktop/graphics/login-manager.nix
@@ -41,6 +41,7 @@ in
         default = 2;
       };
     };
+    unixAuth = mkEnableOption "Unix authentication for greetd and greeters";
   };
 
   config = mkIf cfg.enable {
@@ -70,6 +71,7 @@ in
 
     security.pam.services = {
       cosmic-greeter = {
+        inherit (cfg) unixAuth;
         rules = {
           auth = {
             systemd_home.order = 11399; # Re-order to allow either password _or_ fingerprint on lockscreen
@@ -78,6 +80,7 @@ in
         };
       };
       greetd = {
+        inherit (cfg) unixAuth;
         fprintAuth = false; # User needs to enter password to decrypt home on login
         rules = {
           account.group_video = {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -41,8 +41,10 @@ in
         proxyAudio = false;
       };
 
+      graphics.login-manager.unixAuth = true;
+
       graphics.cosmic = {
-        # Crucial to for Orin devices to use the correct render device
+        # Crucial for Orin devices to use the correct render device
         # Also needs 'mesa' to be in hardware.graphics.extraPackages
         renderDevice = "/dev/dri/renderD129";
         # Keep only essential applets for Orin devices

--- a/overlays/custom-packages/cosmic/cosmic-greeter/0001-Fix-softlock.patch
+++ b/overlays/custom-packages/cosmic/cosmic-greeter/0001-Fix-softlock.patch
@@ -1,0 +1,106 @@
+From ecaade5d43a11803dd867915d17230b378e1ff05 Mon Sep 17 00:00:00 2001
+From: Kajus Naujokaitis <kajus.naujokaitis@unikie.com>
+Date: Fri, 12 Dec 2025 11:49:08 +0200
+Subject: [PATCH] fix: prevent softlock via auth_message_type error
+
+Signed-off-by: Kajus Naujokaitis <kajus.naujokaitis@unikie.com>
+---
+ src/common.rs      | 13 ++++++++++++-
+ src/greeter/ipc.rs |  7 ++++---
+ src/locker.rs      | 22 ++++++++++++++++++++--
+ 3 files changed, 36 insertions(+), 6 deletions(-)
+
+diff --git a/src/common.rs b/src/common.rs
+index 724d7ed..c2bb35f 100644
+--- a/src/common.rs
++++ b/src/common.rs
+@@ -296,8 +296,19 @@ impl<M: From<Message> + Send + 'static> Common<M> {
+                     .map(|(name, level)| (widget::icon::from_name(name).into(), level));
+             }
+             Message::Prompt(prompt, secret, value_opt) => {
++                let mut new_value_opt = value_opt;
++
++                let should_clear =
++                    self.prompt_opt
++                        .as_ref()
++                        .map(|(prev_prompt, _, _)| prev_prompt != &prompt)
++                        .unwrap_or(true);
++
++                if should_clear {
++                    new_value_opt = Some(String::new());
++                }
+                 let prompt_was_none = self.prompt_opt.is_none();
+-                self.prompt_opt = Some((prompt, secret, value_opt));
++                self.prompt_opt = Some((prompt, secret, new_value_opt));
+                 if prompt_was_none {
+                     if let Some(surface_id) = self.active_surface_id_opt {
+                         if let Some(text_input_id) = self
+diff --git a/src/greeter/ipc.rs b/src/greeter/ipc.rs
+index c6e070d..ff930af 100644
+--- a/src/greeter/ipc.rs
++++ b/src/greeter/ipc.rs
+@@ -101,9 +101,7 @@ pub fn subscription() -> Subscription<Message> {
+                                             )
+                                             .await;
+                                     }
+-                                    //TODO: treat error type differently?
+-                                    greetd_ipc::AuthMessageType::Info
+-                                    | greetd_ipc::AuthMessageType::Error => {
++                                    greetd_ipc::AuthMessageType::Info => {
+                                         _ = sender
+                                             .send(
+                                                 common::Message::Prompt(auth_message, false, None)
+@@ -111,6 +109,9 @@ pub fn subscription() -> Subscription<Message> {
+                                             )
+                                             .await;
+                                     }
++                                    greetd_ipc::AuthMessageType::Error => {
++                                        _ = sender.send(Message::Error(auth_message)).await;
++                                    }
+                                 },
+                                 greetd_ipc::Response::Error {
+                                     error_type,
+diff --git a/src/locker.rs b/src/locker.rs
+index 7c147c0..4fa6a28 100644
+--- a/src/locker.rs
++++ b/src/locker.rs
+@@ -202,6 +202,25 @@ impl Conversation {
+             pam_client::ErrorCode::CONV_ERR
+         })
+     }
++
++    fn error_message(&mut self, prompt_c: &CStr) -> Result<(), pam_client::ErrorCode> {
++        let prompt = prompt_c.to_str().map_err(|err| {
++            tracing::error!("failed to convert prompt to UTF-8: {:?}", err);
++            pam_client::ErrorCode::CONV_ERR
++        })?;
++
++        futures::executor::block_on(async {
++            self.msg_tx
++                .send(cosmic::Action::App(
++                    Message::Error(prompt.to_string()).into(),
++                ))
++                .await
++        })
++        .map_err(|err| {
++            tracing::error!("failed to send error message: {:?}", err);
++            pam_client::ErrorCode::CONV_ERR
++        })
++    }
+ }
+
+ impl pam_client::ConversationHandler for Conversation {
+@@ -223,9 +242,8 @@ impl pam_client::ConversationHandler for Conversation {
+         }
+     }
+     fn error_msg(&mut self, prompt_c: &CStr) {
+-        //TODO: treat error type differently?
+         tracing::info!("error_msg {:?}", prompt_c);
+-        match self.message(prompt_c) {
++        match self.error_message(prompt_c) {
+             Ok(()) => (),
+             Err(err) => {
+                 tracing::warn!("failed to send error_msg: {:?}", err);
+--
+2.51.2
+

--- a/overlays/custom-packages/cosmic/cosmic-greeter/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-greeter/default.nix
@@ -4,5 +4,6 @@
 prev.cosmic-greeter.overrideAttrs (oldAttrs: {
   patches = oldAttrs.patches ++ [
     ./0001-Replace-fallback-background-with-Ghaf-default.patch
+    ./0001-Fix-softlock.patch
   ];
 })


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
 

1. **Patched cosmic-greeter:**
   - Added proper handling of **auth_message** of type **error** for greetd ipc ([ref](https://man.archlinux.org/man/greetd-ipc.7.en))
     These messages will be treated as errors.
   - Added proper handling of PAM conversation error messages.
     These messages will be treated as errors.
   - The above changes should prevent the system from getting softlocked in the "Authenticating..." state (https://jira.tii.ae/browse/SSRCSP-7679)
   
2. **Login-manager changes:**
   - Disabled faillock PAM modules due to incompatibility with current login flow:
     During testing, I observed this scenario:
     - Input incorrect password - login is denied
     - Input incorrect password again - login is denied
     - Input _correct_ password - homed accepts it internally, but faillock prevents login anyway
   - Added **unixAuth** option to control `unixAuth` in greetd and greeter:
      - Disabled by default
      - Enabled for Orins

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7679

Upstream PR - https://github.com/pop-os/cosmic-greeter/pull/367

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
Verify https://jira.tii.ae/browse/SSRCSP-7679 is fixed (login and lockscreen should be tested separately)