### PR TITLE
audit: Centralize ordering and systemd service override

### DIFF
--- a/modules/reference/appvms/zathura.nix
+++ b/modules/reference/appvms/zathura.nix
@@ -44,11 +44,6 @@
           pdf = true;
           image = true;
         };
-        # Let systemd use default ordering for audit-rules instead of early-boot
-        systemd.services.audit-rules-nixos = {
-          unitConfig.DefaultDependencies = lib.mkForce true;
-          before = lib.mkForce [ ];
-        };
       }
     ];
   };


### PR DESCRIPTION
This PR addresses two separate issues:

1. The standard NixOS auditd module generates an `audit.rules` file that includes flags to set the backlog limit (`-b 8192`) and failure mode (`-f`). We are already defining those parameters inside `security.audit`. In some environments, `auditctl` lacks the permissions to set these kernel parameters at runtime, causing failures. The `-D` was kept to clear any pre-existing rules. In summary, the kernel parameters were defined redundantly.

2. Resetting the service dependencies makes it run later, like a normal service, resolving a race condition problem. Previously, it was added only to `zathura-vm` to solve this issue. However, we could see the same issue in `ghaf-host` when some specific audit rules were applied. That is why it was decided to centralize the ordering for all the VMs.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->
https://jira.tii.ae/browse/SSRCSP-7625

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Set `audit.enable` to `true`: https://github.com/everton-dematos/ghaf/blob/pr_audit_fixes/modules/reference/profiles/mvp-user-trial.nix#L112
2. Verify that `auditd` and `audit-rules-nixos` services are active/enabled (any VM - specially `ghaf-host`, `chrome-vm`, and `zathura-vm` that were presenting issues):
2.1 `systemctl status audit-rules-nixos.service`
2.2 `systemctl status auditd.service`
3. In case you want to test this specific issue: https://jira.tii.ae/browse/SSRCSP-7625. Then, please enable OSPP rules, by setting `enableOspp` to `true` - https://github.com/everton-dematos/ghaf/blob/pr_audit_fixes/modules/common/security/audit/default.nix#L52
