### PR TITLE
audio: disable pipewire logs by default

### DIFF
--- a/modules/common/services/audio.nix
+++ b/modules/common/services/audio.nix
@@ -23,7 +23,7 @@ in
     enable = mkEnableOption "Enable audio service for audio VM";
     debug = mkOption {
       type = types.bool;
-      default = config.ghaf.profiles.debug.enable;
+      default = false;
       defaultText = "config.ghaf.profiles.debug.enable";
       description = "Enable debug logs for pipewire and wireplumber";
     };
@@ -97,7 +97,7 @@ in
 
     systemd.services =
       let
-        debugLevel = if cfg.debug then "3" else "1";
+        debugLevel = if cfg.debug then "3" else "0";
       in
       {
         pipewire = {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Minor change to disable verbose pipewire logs on audio-vm by default.
Should address an issue where alloy service would perform excessive IO ops on audio-vm. (pipewire logs are way too detailed to keep enabled)

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch` can be rebuilt but older logs will remain, so real effect won't be noticed until logs are purged
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
N/A
