### PR TITLE
Improve PCI device auto-detection and enable it in the demo-tower target for network devices

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -731,11 +731,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765765134,
-        "narHash": "sha256-CDJLlQ00VJ3dXJE0znEwXvuWdCEeKJ5JMVat3CnT/rU=",
+        "lastModified": 1765898502,
+        "narHash": "sha256-/f3IU8jGYJ80uw4c++YiadYBM7w9cvfckqFn1Uv/iA0=",
         "owner": "tiiuae",
         "repo": "vhotplug",
-        "rev": "c036e2341b58a4e967b8fea83319891f526a6ec3",
+        "rev": "0fb08e12a26fdbfb50fa273646e0e9441d2cdf9d",
         "type": "github"
       },
       "original": {

--- a/modules/hardware/passthrough/vhotplug.nix
+++ b/modules/hardware/passthrough/vhotplug.nix
@@ -153,6 +153,7 @@ in
           inherit (cfg.api) port;
           inherit (cfg.api) transports;
           inherit (cfg.api) allowedCids;
+          unixSocketUser = "microvm";
         };
         modprobe = lib.getExe' pkgs.kmod "modprobe";
         modinfo = lib.getExe' pkgs.kmod "modinfo";
@@ -164,6 +165,7 @@ in
       description = "vhotplug";
       wantedBy = [ "multi-user.target" ];
       after = [ "local-fs.target" ];
+      before = [ "microvm@.service" ];
       serviceConfig = {
         Type = "simple";
         Restart = "always";

--- a/modules/reference/hardware/flake-module.nix
+++ b/modules/reference/hardware/flake-module.nix
@@ -49,7 +49,9 @@
       inputs.self.nixosModules.hardware-x86_64-workstation
       {
         ghaf.hardware.definition = import ./intel-laptop/intel-laptop.nix;
-        ghaf.hardware.passthrough.pci.autoDetectPci = true;
+        ghaf.hardware.passthrough.pci.autoDetectGpu = true;
+        ghaf.hardware.passthrough.pci.autoDetectNet = true;
+        ghaf.hardware.passthrough.pci.autoDetectAudio = true;
       }
     ];
 
@@ -113,6 +115,7 @@
         ghaf.virtualization.microvm.guivm.extraModules = [
           (import ./tower-5080/extra-config.nix)
         ];
+        ghaf.hardware.passthrough.pci.autoDetectNet = true;
       }
     ];
 

--- a/modules/reference/hardware/intel-laptop/intel-laptop.nix
+++ b/modules/reference/hardware/intel-laptop/intel-laptop.nix
@@ -9,13 +9,21 @@
 
   # Host configuration
   host = {
-    kernelConfig.kernelParams = [
-      "intel_iommu=on,sm_on"
-      "iommu=pt"
-      "acpi_backlight=vendor"
-      "acpi_osi=linux"
-      "module_blacklist=i915,xe,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,bluetooth,btusb,snd_pcm,mei_me,xesnd_hda_intel,snd_sof_pci_intel_lnl,spi_intel_pci,i801_smbus"
-    ];
+    kernelConfig = {
+      kernelParams = [
+        "intel_iommu=on,sm_on"
+        "iommu=pt"
+        "acpi_backlight=vendor"
+        "acpi_osi=linux"
+        "module_blacklist=i915,xe,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,bluetooth,btusb,snd_pcm,mei_me,xesnd_hda_intel,snd_sof_pci_intel_lnl,spi_intel_pci,i801_smbus"
+      ];
+
+      # The vfio-pci module must be explicitly enabled on the host
+      # On other targets, microvm loads it when static PCI devices are present
+      stage2.kernelModules = [
+        "vfio_pci"
+      ];
+    };
 
     # Assign the vfio-pci driver for all device types eligible for passthrough
     # vfio-pci.ids format is vendor:device[:subvendor[:subdevice[:class[:class_mask]]]]
@@ -37,14 +45,8 @@
     }
   ];
 
-  # GPU devices generally don't handle hotplugging well
-  # However, Intel integrated GPU usually has PCI address 0000:00:02.0, so we can keep it statically defined here
+  # GPU devices for passthrough to guivm detected dynamically in vhotplug
   gpu = {
-    pciDevices = [
-      {
-        path = "0000:00:02.0";
-      }
-    ];
     kernelConfig = {
       stage1.kernelModules = [
         "i915"

--- a/modules/reference/hardware/tower-5080/tower-5080.nix
+++ b/modules/reference/hardware/tower-5080/tower-5080.nix
@@ -20,6 +20,13 @@
       "acpi_osi=linux"
       "module_blacklist=nouveau,snd,snd_hda_intel,igc,iwlwifi,bluetooth"
     ];
+
+    # Assign the vfio-pci driver for all device types eligible for passthrough
+    # vfio-pci.ids format is vendor:device[:subvendor[:subdevice[:class[:class_mask]]]]
+    # 0xffffffff = PCI_ANY_ID
+    extraVfioPciIds = [
+      "ffffffff:ffffffff:ffffffff:ffffffff:020000:ff0000" # Network Controllers
+    ];
   };
 
   # Input devices


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Removed hardcoded GPU from the intel-laptop target and enabled cold-plugging of PCI devices by generating QEMU arguments in vhotplug and passing them to QEMU via microvm.extraArgsScript.
- Enabled network PCI device auto-detection in the demo-tower target.
- Updated vhotplug to a version with a fixed killswitch bug.

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
- The Ghaf killswitch persistently issue should now be fixed.
- No new changes to intel-laptop target but it should still now boot correctly on all laptops supported by Ghaf without a GPU being hardcoded in the code.
- The new demo tower with a different ethernet adapter should have it passed through to the NetVM using PCI auto-detection in vhotplug. This will only work if there are no other devices in the same IOMMU group.

