### PR TITLE
fix(flatpak): Add Slack URL scheme support for OAuth flow

### DIFF
--- a/modules/reference/appvms/flatpak.nix
+++ b/modules/reference/appvms/flatpak.nix
@@ -118,6 +118,31 @@ let
 
     '';
   };
+  # XDG item for slack://
+  xdgSlackFlatpakItem = pkgs.makeDesktopItem {
+    name = "ghaf-slack-xdg-flatpak";
+    desktopName = "Ghaf Slack Opener";
+    exec = "${slackScript}/bin/xdgflatpakslack %u";
+    mimeTypes = [
+      "x-scheme-handler/slack"
+    ];
+    noDisplay = true;
+  };
+  slackScript = pkgs.writeShellApplication {
+    name = "xdgflatpakslack";
+    text = ''
+      url="$*"
+      [[ -z "$url" ]] && { echo "xdgflatpakslack: No URL provided" >&2; exit 1; }
+
+      app="com.slack.Slack"
+
+      ${lib.getExe pkgs.flatpak} info --system "$app" &>/dev/null || {
+        echo "xdgflatpakslack: Slack not installed" >&2
+        exit 1
+      }
+
+      exec ${lib.getExe pkgs.flatpak} run "$app" "$url"    '';
+  };
 
 in
 {
@@ -153,6 +178,7 @@ in
 
         environment.systemPackages = [
           xdgUrlFlatpakItem
+          xdgSlackFlatpakItem
         ];
 
         security.polkit = {
@@ -190,6 +216,7 @@ in
               "text/html" = lib.mkForce "ghaf-url-xdg-flatpak.desktop";
               "x-scheme-handler/http" = lib.mkForce "ghaf-url-xdg-flatpak.desktop";
               "x-scheme-handler/https" = lib.mkForce "ghaf-url-xdg-flatpak.desktop";
+              "x-scheme-handler/slack" = lib.mkForce "ghaf-slack-xdg-flatpak.desktop";
             };
           };
         };


### PR DESCRIPTION
- Implement slack:// URL handling within the Flatpak VM
- Ensure Slack launches correctly with authorization links

Slack OAuth login now works end-to-end, allowing authorization links to properly open inside the Flatpak sandbox instead of failing or looping.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [X] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has run `make-checks` and it passes
- [X] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

### Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [X] Dell Latitude `x86_64`
- [X] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Open *Applications → App Store* in the Flatpak VM.
2. Install Slack and at least one web browser (e.g., Chrome/Firefox/Brave/Chromium).
3. Launch Slack.
4. Sign in using the "Sign in with browser" flow.
5. Verify that:
   - The browser opens the Slack authorization page.
   - Slack completes the sign-in process and reaches the workspace.
6. Sign out and sign back in again to confirm the OAuth redirect works reliably.
