### PR TITLE
Agx industrial ethernet

### DIFF
--- a/modules/reference/hardware/jetpack/agx-industrial-ethernet-pci-passthrough-overlay.dts
+++ b/modules/reference/hardware/jetpack/agx-industrial-ethernet-pci-passthrough-overlay.dts
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+ * SPDX-License-Identifier: CC-BY-SA-4.0
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/reset/tegra234-reset.h>
+#include <dt-bindings/power/tegra234-powergate.h>
+#include <dt-bindings/memory/tegra234-mc.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+    overlay-name = "PCI ethernet passthrough";
+    compatible = "nvidia,p3701-0008";
+
+    fragment@0 {
+        target-path = "/bus@0";
+        __overlay__ {
+            pcie@14100000 {
+                iommus = <>;
+            };
+            pcie@14180000 {
+                iommus = <>;
+            };
+        };
+    };
+
+};

--- a/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
@@ -22,7 +22,7 @@
   };
 
   # To enable or disable wireless
-  networking.wireless.enable = true;
+  networking.wireless.enable = false;
 
   hardware = {
     # Device Tree
@@ -61,17 +61,11 @@
       # modules/reference/hardware/jetpack Please refer to that
       # section for hardware dependent netvm configuration.
 
-      # Wireless Configuration. Orin AGX has WiFi enabled where Orin NX does
-      # not.
+      # Wireless Configuration. Orin AGX has WiFi enabled where Orin NX and
+      # Orin AGX-industrial does not.
 
       # To enable or disable wireless
-      networking.wireless.enable = true;
-
-      # For WLAN firmwares
-      hardware = {
-        enableRedistributableFirmware = true;
-        wirelessRegulatoryDatabase = true;
-      };
+      networking.wireless.enable = false;
 
     }
     # Hardware info guest support


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Multiple PCI ethernet devices for passthrough, Two PCI bases. Removal of Wifi device for AGX-industrial.

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ X ] Improvement / Refactor

## Related Issues / Tickets



## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has run `make-checks` and it passes
- [X] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [X] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
1. No tests on ghaf side. There is no official agx-industrial development kit and can be tested on custom boards. 
