### PR TITLE
jetpack-nixos: bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,16 +382,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1765275864,
-        "narHash": "sha256-NtJ5vWEjeYVPNkMWwCqDtDmCaWTujZBonGgX3l1M1dc=",
+        "lastModified": 1766005785,
+        "narHash": "sha256-2g1Qa1N/vgH0oi5eZgqP8Uf0Rn6TS/G8VyASZ6EQjXc=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "7fed21ac8c8908d584f8e8344408166703a6b4ad",
+        "rev": "e9983d75ac3b57c600bae9bd167268621dde133c",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
-        "ref": "xavier-merged",
+        "ref": "december-bump",
         "repo": "jetpack-nixos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -121,7 +121,7 @@
     # Nvidia Orin support for NixOS
     jetpack-nixos = {
       #url = "github:anduril/jetpack-nixos";
-      url = "github:tiiuae/jetpack-nixos/xavier-merged";
+      url = "github:tiiuae/jetpack-nixos/december-bump";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
* upstream kernel from 6.6.118 to 6.6.119
* bug fix: compile against 5.15
* basic jetpack-nixos sync

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
