### PR TITLE
Pass NHLT table in intel-laptop target only when present on the host

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -731,11 +731,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765898502,
-        "narHash": "sha256-/f3IU8jGYJ80uw4c++YiadYBM7w9cvfckqFn1Uv/iA0=",
+        "lastModified": 1766483112,
+        "narHash": "sha256-6IWw7umkaLhzrw3FOy+56kQy2u74eGd3ZABZMM8rsE8=",
         "owner": "tiiuae",
         "repo": "vhotplug",
-        "rev": "0fb08e12a26fdbfb50fa273646e0e9441d2cdf9d",
+        "rev": "ac9a5ee0cd646f14b47763d702f3cf8cfb3bcbd0",
         "type": "github"
       },
       "original": {

--- a/modules/hardware/passthrough/pci-rules.nix
+++ b/modules/hardware/passthrough/pci-rules.nix
@@ -99,10 +99,25 @@ let
         ];
       }
     ];
+
+  # ACPI NHLT table passthrough is required for the microphone array on some devices
+  audiovmAcpiRules = [
+    {
+      description = "NHLT ACPI Table for AudioVM";
+      targetVm = "audio-vm";
+      allow = [
+        {
+          acpiTable = "/sys/firmware/acpi/tables/NHLT";
+          setUser = "microvm";
+        }
+      ];
+    }
+  ];
+
   busPrefix = config.ghaf.hardware.passthrough.pciPorts.pcieBusPrefix;
   hwDetectModule = vm: [
     {
-      microvm.extraArgsScript = "${lib.getExe' pkgs.vhotplug "vhotplugcli"} pci vmmargs --vm ${vm} --qemu-bus-prefix ${busPrefix}";
+      microvm.extraArgsScript = "${lib.getExe' pkgs.vhotplug "vhotplugcli"} vmm args --vm ${vm} --qemu-bus-prefix ${busPrefix}";
     }
   ];
 
@@ -159,6 +174,8 @@ in
       optionals config.ghaf.virtualization.microvm.guivm.enable cfg.guivmRules
       ++ optionals config.ghaf.virtualization.microvm.netvm.enable cfg.netvmRules
       ++ optionals config.ghaf.virtualization.microvm.audiovm.enable cfg.audiovmRules;
+
+    ghaf.hardware.passthrough.vhotplug.acpiRules = optionals cfg.autoDetectAudio audiovmAcpiRules;
 
     ghaf.virtualization.microvm.guivm.extraModules = optionals cfg.autoDetectGpu (
       hwDetectModule "gui-vm"

--- a/modules/hardware/passthrough/vhotplug.nix
+++ b/modules/hardware/passthrough/vhotplug.nix
@@ -50,6 +50,14 @@ in
       '';
     };
 
+    acpiRules = mkOption {
+      type = types.listOf types.attrs;
+      default = [ ];
+      description = ''
+        List of ACPI hot plugging rules.
+      '';
+    };
+
     vms = mkOption {
       type = types.listOf types.attrs;
       default = defaultVms;
@@ -144,6 +152,7 @@ in
       usbPassthrough = cfg.prependUsbRules ++ cfg.usbRules ++ cfg.postpendUsbRules;
       pciPassthrough = cfg.pciRules;
       evdevPassthrough = cfg.evdevRules;
+      acpiPassthrough = cfg.acpiRules;
 
       inherit (cfg) vms;
 

--- a/modules/reference/hardware/intel-laptop/intel-laptop.nix
+++ b/modules/reference/hardware/intel-laptop/intel-laptop.nix
@@ -59,6 +59,11 @@
 
   # Audio device for passthrough to audiovm detected dynamically in vhotplug
   audio = {
+    # This is used to pass the NHLT ACPI table from the host to audio-vm (/sys/firmware/acpi/tables/NHLT)
+    # It is required to enable the Lenovo X1 microphone array profile
+    # The NHLT table may not exist on other systems so it is disabled here and managed dynamically by vhotplug
+    acpiPath = null;
+
     kernelConfig = {
       stage1.kernelModules = [ ];
       stage2.kernelModules = [


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This disables static passthrough of the NHLT table in the intel-laptop target and creates a rule for vhotplug so that it's passed only when it exists on the host. It allows the intel-laptop target to work both on devices that have the table and on those that don't, like System 76.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

Run the intel-laptop image on System 76 and make sure audio-vm is running and audio is working. On the current main, it fails to start because qemu is unable to read the NHLT table.

