### PR TITLE
carrierBoard name fix

### DIFF
--- a/modules/reference/hardware/jetpack/nx/orin-nx.nix
+++ b/modules/reference/hardware/jetpack/nx/orin-nx.nix
@@ -18,7 +18,7 @@
     kernelVersion = "upstream-6-6";
     somType = "nx";
     nx.enableNetvmEthernetPCIPassthrough = true;
-    carrierBoard = "xavierNxDevkit";
+    carrierBoard = "xavierNxdevkit";
   };
   hardware = {
     # Sake of clarity: Jetson 35.4 and IO BASE B carrier board
@@ -33,7 +33,7 @@
     nvidia-jetpack = {
       enable = true;
       som = "orin-nx";
-      carrierBoard = "xavierNxDevkit";
+      carrierBoard = "xavierNxdevkit";
       modesetting.enable = true;
       firmware.uefi = {
         logo = "${pkgs.ghaf-artwork}/1600px-Ghaf_logo.svg";


### PR DESCRIPTION
Some jetpack version conflict caused this. Not needed.



<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

The carrierBoard name in orin-nx definition files was wrong. (xavierNxDevkit). It is replaced with xavierNxdevkit.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has run `make-checks` and it passes
- [X] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. No tests needed as it has no direct effect on ghaf. In ghaf we are only checking if it is not devkit.
