### PR TITLE
Fix missing warning pop-up for flatpak browsers

### DIFF
--- a/modules/reference/appvms/flatpak.nix
+++ b/modules/reference/appvms/flatpak.nix
@@ -100,7 +100,7 @@ let
         else
           echo "No supported browser found on the system"
           # Assignment in order to avoid build warning
-          if ${lib.getExe pkgs.yad} --title="No App Store Browser Found" \
+          if XDG_SESSION_TYPE="wayland" WAYLAND_DISPLAY="wayland-1" DISPLAY=":0" ${lib.getExe pkgs.yad} --title="No Browser Found" \
               --image=dialog-warning \
               --width=500 \
               --text="<b>No browser installed through App Store was found in this VM.</b>\n\nFor optimal security and functionality, please install a browser:\n  • Firefox\n  • Chrome\n  • Brave\n  • Chromium\n\nInstall from the App Store and try again.\n\n<i>Alternatively, continue with the standard browser (may malfunction).</i>" \


### PR DESCRIPTION

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Fix missing warning pop-up when no browser is available, instead of failing silently and starting the default Chrome-VM browser.

### Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has run `make-checks` and it passes
- [X] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions
1. Install and run Spotify from App Store 
2. Press 'Log in' button on Spotify app
   **Expected:** 'No Browser Found' warning pop-up appears
3. Press 'Exit' button
3. Install a browser (Chrome, Firefox, Brave)
4. Press 'Try again', then 'Log in' in Spotify app
    **Expected:** the pop-up doesn't appear and the browser is started
5. Finish and verify Spotify log in procedure.

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [X] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
