### PR TITLE
logging: add clock-jump recovery and tighten Alloy service ordering

### DIFF
--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -1,8 +1,73 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkIf mkOption types;
+  recCfg = config.ghaf.logging.recovery;
+
+  ghafClockJumpWatcher = pkgs.writeShellApplication {
+    name = "ghaf-clock-jump-watcher";
+    runtimeInputs = with pkgs; [
+      coreutils
+      gawk
+      systemd
+    ];
+    text = ''
+      threshold="${toString recCfg.thresholdSeconds}"
+      interval="${toString recCfg.intervalSeconds}"
+
+      last_real="$(date +%s)"
+      last_up="$(cut -d' ' -f1 /proc/uptime)"
+
+      while true; do
+        sleep "$interval"
+        real="$(date +%s)"
+        up="$(cut -d' ' -f1 /proc/uptime)"
+
+        drift="$(awk -v r1="$last_real" -v r2="$real" -v u1="$last_up" -v u2="$up" \
+          'BEGIN{print (r2-r1) - (u2-u1)}')"
+
+        abs="$(awk -v d="$drift" 'BEGIN{print (d<0)?-d:d}')"
+
+        if awk -v a="$abs" -v t="$threshold" 'BEGIN{exit !(a>=t)}'; then
+          systemctl start ghaf-journal-alloy-recover.service || true
+        fi
+
+        last_real="$real"
+        last_up="$up"
+      done
+    '';
+  };
+
+  ghafJournalAlloyRecover = pkgs.writeShellApplication {
+    name = "ghaf-journal-alloy-recover";
+    runtimeInputs = with pkgs; [
+      coreutils
+      systemd
+    ];
+    text = ''
+      stamp="/run/ghaf-journal-alloy-recover.stamp"
+      now="$(date +%s)"
+      cooldown="${toString recCfg.cooldownSeconds}"
+
+      if [ -e "$stamp" ]; then
+        last="$(cat "$stamp" 2>/dev/null || echo 0)"
+        if [ "$((now-last))" -lt "$cooldown" ]; then
+          exit 0
+        fi
+      fi
+      echo "$now" > "$stamp"
+
+      systemd-tmpfiles --create --prefix /var/log/journal
+      systemctl restart systemd-journald.service
+      systemctl restart alloy.service
+    '';
+  };
 in
 {
   # Creating logging configuration options needed across the host and vms
@@ -76,6 +141,61 @@ in
         '';
         type = types.str;
         default = "1day";
+      };
+    };
+
+    recovery = {
+      enable = mkOption {
+        description = "Recover journald/alloy after a realtime clock jump (e.g., manual clock change).";
+        type = types.bool;
+        default = false;
+      };
+
+      thresholdSeconds = mkOption {
+        description = "Only act on clock jumps >= this many seconds.";
+        type = types.int;
+        default = 30;
+      };
+
+      intervalSeconds = mkOption {
+        description = "Polling interval used by the clock-jump watcher.";
+        type = types.int;
+        default = 5;
+      };
+
+      cooldownSeconds = mkOption {
+        description = "Minimum time between recover executions.";
+        type = types.int;
+        default = 60;
+      };
+    };
+  };
+
+  config = mkIf (config.ghaf.logging.enable && recCfg.enable) {
+
+    # Watcher: detects realtime jumps by comparing realtime vs monotonic progression
+    systemd.services.ghaf-clock-jump-watcher = {
+      description = "Detect realtime clock jumps and trigger journald/alloy recovery";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        RestartSec = 2;
+        ExecStart = lib.getExe ghafClockJumpWatcher;
+      };
+    };
+
+    systemd.services.ghaf-journal-alloy-recover = {
+      description = "Recover journald/alloy after time jump";
+
+      unitConfig = {
+        StartLimitIntervalSec = "0";
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = lib.getExe ghafJournalAlloyRecover;
       };
     };
   };

--- a/modules/microvm/sysvms/adminvm.nix
+++ b/modules/microvm/sysvms/adminvm.nix
@@ -91,6 +91,7 @@ let
                   };
                 };
               };
+              recovery.enable = true;
             };
 
             security.fail2ban.enable = configHost.ghaf.development.ssh.daemon.enable;


### PR DESCRIPTION
## Description of Changes

This PR introduces a clock-jump recovery mechanism for Ghaf logging, designed to handle manual or abrupt realtime clock changes that may otherwise disrupt journald ordering and Alloy log shipping. This PR aims to resolve the bug described at https://jira.tii.ae/browse/SSRCSP-7772. Summary of modifications:

- Add `ghaf.logging.recovery` options and clock-jump watcher + recover oneshot services.
- Ensure `alloy.service` is ordered after/requires systemd-journald on client and server.
- Implementation is centralized in `modules/common/logging/common.nix` and reusable across all VMs.
- Enabled by default only for `admin-vm`, as it aggregates and forwards the system logs. Can be enabled for different VMs with different parameters (e.g., `thresholdSeconds`, `intervalSeconds`, etc.)
- Server pipeline: route journald through `loki.process`, drop entries older than 168h, and align WAL `max_segment_age`. Aligned WAL retention and log dropping policy (`older_than` = 168h). It is also aligned with the Grafana 7-day (168h) default policy.

#### Performance Evaluation

The `ghaf-clock-jump-watcher.service` was monitored in two 30-minute window situations: 
- (i) idle scenario, with no clock jumps to detect;
- (ii) when there were two clock jumps + recovery. 

The following Table summarizes the CPU and memory consumption results for both scenarios:

| Scenario | Avg CPU (%) | Max CPU (%) | Avg Memory (MiB) | Max Memory (MiB) |
|------|-------|-------|-------|-------|
| (i) | 0.027 | 0.2 | 3.37 | 5.44 |
| (ii) | 0.039 | 0.4 | 3.36 | 7.91 |

Graph for scenario (i):
<img width="640" height="480" alt="ghaf-clock-jump-watcher_metrics_20260113_110810" src="https://github.com/user-attachments/assets/cee4b616-15d4-4a6c-b6a0-141ddd25fb7e" />

Graph for scenario (ii):
<img width="640" height="480" alt="ghaf-clock-jump-watcher_metrics_20260113_114403" src="https://github.com/user-attachments/assets/50269840-2a39-46d4-bff3-d5ff86351d3c" />


### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7772
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
You can perform the exact same steps as described at https://jira.tii.ae/browse/SSRCSP-7772:
1. Boot ghaf on the laptop and connect to internet
2. Open terminal in gui-vm and check device-id: cat /persist/common/device-id
3. Check that there are admin-vm logs from the last minutes in grafana:https://ghaflogs.vedenemo.dev/explore e.g. {machine="00-f0-a4-58-bc", host="admin-vm"}
4. Disconnect from internet
5. Open terminal and ssh to admin-vm: ssh ghaf@admin-vm
6. Set wrong time to admin-vm: sudo date -s '01/11/23 11:00:00 UTC'
7. Verify time change: timedatectl -a
8. Connect laptop again to internet
9. In admin-vm: systemctl restart systemd-timesyncd.service
9.1. This step is not mandatory, as the system does it by default when back online
11. Verify time has been updated: timedatectl -a
12. Check if admin-vm logs are still forwarded to grafana
