### PR TITLE
bluetooth: rename adapter, dont enable on boot, adjust cfg

### DIFF
--- a/modules/common/services/bluetooth.nix
+++ b/modules/common/services/bluetooth.nix
@@ -26,12 +26,35 @@ in
       description = "Name of the bluetooth user";
     };
 
+    defaultName = mkOption {
+      type = types.str;
+      default = "Ghaf";
+      description = ''
+        Default Bluetooth adapter name.
+
+        If unset, BlueZ will attempt to fetch the hostname via hostnamed DBus service.
+        If hostnamed is disabled, BlueZ will fall back to "BlueZ [BlueZ version]".
+      '';
+    };
+
   };
   config = mkIf cfg.enable {
 
     # Enable bluetooth
     hardware.bluetooth = {
       enable = true;
+      # Save battery by disabling bluetooth on boot
+      powerOnBoot = false;
+      # https://github.com/bluez/bluez/blob/master/src/main.conf full list of options
+      settings = {
+        General = {
+          Name = lib.optionalAttrs (cfg.defaultName != null && cfg.defaultName != "") cfg.defaultName;
+          FastConnectable = "true";
+          JustWorksRepairing = "confirm";
+          Privacy = "device";
+          DiscoverableTimeout = "60"; # Default is 180 seconds
+        };
+      };
     };
 
     # Setup bluetooth user and group


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Set default bluetooth adapter name to "Ghaf"
   - When the adapter is enabled and discoverable, other devices will be able to identify our system as "Ghaf" instead of "BlueZ [BlueZ version]"
   - Normally, BlueZ queries `hostnamed` for the hostname and uses that for the adapter name, but we don't have hostnamed enabled in most VMs, therefore we statically define the adapter name here.
- Adjusted default BlueZ [config](https://github.com/bluez/bluez/blob/master/src/main.conf):
  - Enabled `FastConnectable`
  - Enabled `JustWorksRepairing`
  - Set Privacy to `device`
  - Reduced the `DiscoverableTimeout` from 180 to 60s

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify no regression in general bluetooth functionality:
   - Devices can still connect
   - Bluetooth audio works
2. Verify Ghaf's bluetooth adapter can be identified as "Ghaf":
   - Open Bluetooth settings -> Bluetooth Adapters
   - Verify the adapter name is set to "Ghaf"
