### PR TITLE
logging: start Alloy after dynamic hostname setter when enabled

### DIFF
--- a/modules/common/logging/client.nix
+++ b/modules/common/logging/client.nix
@@ -15,6 +15,7 @@ let
     ;
   cfg = config.ghaf.logging.client;
   inherit (config.ghaf.logging) listener;
+  dynHostEnabled = config.ghaf.identity.vmHostNameSetter.enable or false;
 in
 {
   options.ghaf.logging.client = {
@@ -125,7 +126,10 @@ in
     services.alloy.enable = true;
 
     systemd.services.alloy.serviceConfig = {
-      after = [ "systemd-journald.service" ];
+      after = [
+        "systemd-journald.service"
+      ]
+      ++ lib.optionals dynHostEnabled [ "set-dynamic-hostname.service" ];
       requires = [ "systemd-journald.service" ];
 
       # Once alloy.service in admin-vm stopped this service will

--- a/modules/common/logging/server.nix
+++ b/modules/common/logging/server.nix
@@ -16,6 +16,7 @@ let
     ;
   inherit (lib.strings) hasPrefix;
   cfg = config.ghaf.logging.server;
+  dynHostEnabled = config.ghaf.identity.vmHostNameSetter.enable or false;
 in
 {
   options.ghaf.logging.server = {
@@ -232,7 +233,10 @@ in
     services.alloy.enable = true;
 
     systemd.services.alloy.serviceConfig = {
-      after = [ "systemd-journald.service" ];
+      after = [
+        "systemd-journald.service"
+      ]
+      ++ lib.optionals dynHostEnabled [ "set-dynamic-hostname.service" ];
       requires = [ "systemd-journald.service" ];
 
       # If there is no internet connection , shutdown/reboot will take around 100sec


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This PR fixes an issue where net-vm logs were missing in Grafana, while logs from other VMs on the same device were still present (https://jira.tii.ae/browse/SSRCSP-7542).

In net-vm, the hostname is set dynamically and is later exposed by journald as `__journal__hostname`, which is used by `alloy.service` to label and ship logs. In some cases, `alloy.service` was starting before the dynamic hostname was set, leading to inconsistent or missing net-vm logs when filtering by machine/device identifier.

To avoid this race, `alloy.service` is now started after the dynamic hostname setter service, but only when that service is enabled. 

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7542
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Log into `net-vm` 
2. Generate any traceable log:
2.1. `[ghaf@ghaf-0013702975:~]$ logger "testing this PR" `
3. Search on Grafana for the log
3.1. Plese note that the `host` on Grafana should be set as the **dynamic hosname** (e.g., ghaf-0013702975)
3.2. You should be able to visualize all the logs from net-vm (using the dynamic hostname), including the new generated log:
<img width="510" height="266" alt="image" src="https://github.com/user-attachments/assets/43ebd8cb-e80e-47dc-b201-17cca94638bb" />
 
