### PR TITLE
login-manager: prevent greeter hang on empty password

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -34,7 +34,8 @@ path = [
   "overlays/custom-packages/cosmic/cosmic-applets/*.patch",
   "overlays/custom-packages/system76-scheduler/0001-fix-add-missing-loop-in-process-scheduler-refresh-ta.patch",
   "overlays/custom-packages/cosmic/cosmic-greeter/0001-Fix-softlock.patch",
-  "overlays/custom-packages/cosmic/cosmic-greeter/0002-fix-username-handle-empty-usernames.patch"
+  "overlays/custom-packages/cosmic/cosmic-greeter/0002-fix-username-handle-empty-usernames.patch",
+  "overlays/custom-packages/cosmic/cosmic-greeter/0003-greeter-avoid-auth-on-empty-password.patch"
 ]
 
 [[annotations]]

--- a/overlays/custom-packages/cosmic/cosmic-greeter/0003-greeter-avoid-auth-on-empty-password.patch
+++ b/overlays/custom-packages/cosmic/cosmic-greeter/0003-greeter-avoid-auth-on-empty-password.patch
@@ -1,0 +1,54 @@
+From 92b81c72be96bd0dc7667352a4c4a543e349662f Mon Sep 17 00:00:00 2001
+From: Everton de Matos <everton.dematos@tii.ae>
+Date: Tue, 20 Jan 2026 12:57:32 +0400
+Subject: [PATCH] cosmic-greeter: ignore empty password submissions
+
+Signed-off-by: Everton de Matos <everton.dematos@tii.ae>
+---
+ src/greeter.rs |  7 +++++++
+ src/locker.rs  | 11 +++++++++++
+ 2 files changed, 18 insertions(+)
+
+diff --git a/src/greeter.rs b/src/greeter.rs
+index d917e79..3125177 100644
+--- a/src/greeter.rs
++++ b/src/greeter.rs
+@@ -1475,6 +1475,13 @@ impl cosmic::Application for App {
+             }
+             Message::Auth(response) => {
+                 self.common.error_opt = None;
++
++                if matches!(response.as_deref(), None | Some("")) {
++                    self.authenticating = false;
++                    self.common.error_opt = Some(fl!("auth-error-credentials"));
++                    return Task::none();
++                }
++
+                 self.authenticating = true;
+                 self.send_request(Request::PostAuthMessageResponse { response });
+ 
+diff --git a/src/locker.rs b/src/locker.rs
+index 49b13fe..651fd49 100644
+--- a/src/locker.rs
++++ b/src/locker.rs
+@@ -1041,6 +1041,17 @@ impl cosmic::Application for App {
+             }
+             Message::Submit(value) => {
+                 self.common.error_opt = None;
++
++                if value.is_empty() {
++                    self.authenticating = false;
++                    if let Some(handle) = self.spinner_handle.take() {
++                        handle.abort();
++                    }
++                    self.spinner_rotation = 0.0;
++                    self.common.error_opt = Some(fl!("auth-error-credentials"));
++                    return Task::none();
++                }
++
+                 self.authenticating = true;
+                 match self.value_tx_opt.take() {
+                     Some(value_tx) => {
+-- 
+2.52.0
+

--- a/overlays/custom-packages/cosmic/cosmic-greeter/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-greeter/default.nix
@@ -6,5 +6,6 @@ prev.cosmic-greeter.overrideAttrs (oldAttrs: {
     ./0001-Replace-fallback-background-with-Ghaf-default.patch
     ./0001-Fix-softlock.patch
     ./0002-fix-username-handle-empty-usernames.patch
+    ./0003-greeter-avoid-auth-on-empty-password.patch
   ];
 })


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This PR fixes an issue (https://jira.tii.ae/browse/SSRCSP-7795) where pressing `Enter` on an empty password causes the COSMIC greeter to remain stuck at `"Authenticating..."`. 

The login manager now properly handles empty password submissions so the greeter returns an error and allows retry, instead of hanging.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7795
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Try to enter empty password for login - both for initial login or for lock screen.
2. An "Incorrect password" message should be displayed. 
