### PR TITLE
wireguard-gui: add Proton VPN config parsing support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -817,11 +817,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1767948499,
-        "narHash": "sha256-7KspDX1EZ9y9+OacMhRoZb8x+Ypn9HWUmhPV4UdueKs=",
+        "lastModified": 1769001222,
+        "narHash": "sha256-SV8V8cR91/o+y+p0N8cwv9WG9R5ahzAaDeIZa4Gk6RQ=",
         "owner": "tiiuae",
         "repo": "wireguard-gui",
-        "rev": "9921370533dea60cf9db593d6177ddf611ab0827",
+        "rev": "d2873e286d1b13069be0683da1dfd4f992e9d0cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Add support for parsing Proton VPN generated WireGuard config files:
- Extract `# Key for <user>` as interface name
- Extract first standalone comment after `[Peer]` as peer name (e.g., `NL-FREE#241`, `AT#133`)
- Log unknown comment keys as warnings
- Return errors for unknown attribute keys
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets
https://github.com/tiiuae/wireguard-gui/pull/129
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
