### PR TITLE
idle: use cosmic-idle, allow runtime idle config adjustment

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -282,10 +282,10 @@ in
 
     allowSuspend = mkOption {
       type = types.bool;
-      default = config.ghaf.profiles.graphics.allowSuspend;
-      defaultText = "config.ghaf.profiles.graphics.allowSuspend";
+      default = true;
       description = ''
-        Whether to allow the system to suspend. This is enabled if the option config.ghaf.profiles.graphics.allowSuspend is set.
+        Whether to enable system suspension.
+
         If disabled, the system will not respond to suspend requests, and all VMs with a power management profile enabled are
         prohibited to perform any suspend action.
       '';

--- a/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
+++ b/modules/desktop/graphics/cosmic/config/cosmic-config.yaml
@@ -335,9 +335,11 @@ com.system76.CosmicSettings.Shortcuts:
         /// Opens the application library
         AppLibrary: "cosmic-app-library",
         /// Decreases screen brightness
-        BrightnessDown: "",
+        BrightnessDown: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon DecreaseDisplayBrightness",
         /// Increases screen brightness
-        BrightnessUp: "",
+        BrightnessUp: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon IncreaseDisplayBrightness",
+        /// Toggles display mode
+        DisplayToggle: "cosmic-osd display",
         /// Switch between input sources
         InputSourceSwitch: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon InputSourceSwitch",
         /// Opens the home folder in a system default file browser
@@ -366,6 +368,10 @@ com.system76.CosmicSettings.Shortcuts:
         PowerOff: "cosmic-osd shutdown",
         /// Takes a screenshot
         Screenshot: "cosmic-screenshot",
+        /// Suspend the system
+        Suspend: "systemctl suspend",
+        /// Toggles the screen reader
+        ScreenReader: "busctl --user call com.system76.CosmicSettingsDaemon /com/system76/CosmicSettingsDaemon com.system76.CosmicSettingsDaemon ScreenReader",
         /// Opens the system default terminal
         Terminal: "cosmic-term",
         /// Toggles touchpad on/off

--- a/modules/microvm/modules.nix
+++ b/modules/microvm/modules.nix
@@ -73,15 +73,6 @@ let
       };
     };
 
-    # Graphics profiles module
-    graphics = {
-      config.ghaf.profiles.graphics = {
-        inherit (configHost.ghaf.profiles.graphics) allowSuspend;
-        idleManagement = {
-          inherit (configHost.ghaf.profiles.graphics.idleManagement) enable;
-        };
-      };
-    };
     # Bluetooth module
     bluetooth = optionalAttrs cfg.audiovm.audio { config.ghaf.services.bluetooth.enable = true; };
 
@@ -255,7 +246,6 @@ in
           kernelConfigs.guivm
           firmwareModule
           qemuModules.guivm
-          serviceModules.graphics
           serviceModules.fprint
           serviceModules.yubikey
           serviceModules.audit

--- a/modules/profiles/graphics.nix
+++ b/modules/profiles/graphics.nix
@@ -25,19 +25,17 @@ in
         type = types.bool;
         default = true;
         description = ''
-          Enable or disable system idle management using swayidle.
+          Whether to enable idle management.
 
-          When enabled, this will handle automatic screen dimming, locking, and suspending.
+          When enabled, the system will automatically manage screen blanking and suspension
+          based on user inactivity.
+
+          Disabling this option is the same as setting all idle timeouts to '0'.
+
+          If 'config.ghaf.services.power-manager.allowSuspend' is false, suspension will not occur
+          regardless of this setting.
         '';
       };
-    };
-    allowSuspend = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Allow the system to suspend. When enabled, the system will suspend via either the suspend icon,
-        lid close, or button press.
-      '';
     };
     autoLogin = {
       enable = mkOption {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -26,9 +26,6 @@ in
     ghaf = {
       profiles.graphics = {
         enable = true;
-        idleManagement.enable = false;
-        # Disable suspend by default, not working as intended
-        allowSuspend = false;
         # Explicitly enable auto-login for Orins
         autoLogin = {
           enable = true;
@@ -39,6 +36,9 @@ in
         bluetooth.applet.enable = false;
         networkManager.applet.enable = false;
       };
+
+      # Disable suspend by default, not working as intended
+      services.power-manager.allowSuspend = false;
 
       graphics.cosmic = {
         # Crucial for Orin devices to use the correct render device

--- a/overlays/custom-packages/cosmic/cosmic-settings/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-settings/default.nix
@@ -15,7 +15,7 @@
     "page-display"
     "page-input"
     "page-region"
-    # "page-power"
+    "page-power"
     "page-sound"
     # "page-users"
     "page-legacy-applications"

--- a/packages/ghaf-powercontrol/package.nix
+++ b/packages/ghaf-powercontrol/package.nix
@@ -121,7 +121,7 @@ writeShellApplication {
         ;;
       suspend)
       ${
-        if ghafConfig.profiles.graphics.allowSuspend then
+        if ghafConfig.services.power-manager.allowSuspend then
           ''
             systemctl suspend
           ''

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -56,8 +56,7 @@ let
         ghaf = {
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
-          profiles.graphics.idleManagement.enable = false;
-          profiles.graphics.allowSuspend = false;
+          services.power-manager.allowSuspend = false;
         };
       }
     ]))
@@ -206,8 +205,7 @@ let
         ghaf = {
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
-          profiles.graphics.idleManagement.enable = true;
-          profiles.graphics.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
+          services.power-manager.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
 
           virtualization.microvm.guivm.extraModules = [
             {
@@ -233,7 +231,7 @@ let
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
           profiles.graphics.idleManagement.enable = true;
-          profiles.graphics.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
+          services.power-manager.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
 
           # Enable storeOnDisk for all VMs
           virtualization.microvm.storeOnDisk = true;
@@ -396,7 +394,7 @@ let
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
           profiles.graphics.idleManagement.enable = true;
-          profiles.graphics.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
+          services.power-manager.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
 
           virtualization.microvm.guivm.extraModules = [
             {


### PR DESCRIPTION
## Description of Changes

1. **Idle config changes:**
   - Removed swayidle
   - Re-enabled COSMIC Settings 'Power & battery' page
      - This page should now be fully functional
      - Allows runtime adjustment of system idle behavior
   - Adjusted idle nix config in graphics profile to only allow enabling/disabling
     Up for debate:
       Disabling only sets the timeouts to 0 by default, but they can still be overridden by the user at runtime.
       Is it worth keeping the enable/disable option?
2. **Adjusted suspend configuration:**
   - Moved `allowSuspend` option to `power-manager` namespace, for easier maintainability and clarity
   - Adjusted some targets, where suspend should be disabled, accordingly.
3. **Other: Adjusted brightness shortcut to use COSMIC settings dbus**

## Removed functionality:

- Swayidle
- Idle notifications, informing the user of incoming session lock/suspension. Replaced by cosmic-idle's fade-to-black

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify idle timeouts work as expected according to these timers:
   - 5 mins - screen off and session locked
   - 15 mins - suspend on AC (if suspend is enabled)
   - 15 mins - suspend on battery (if suspend is enabled)
2. Verify idle timeouts can be interrupted by user activity
3. Adjust idle timeouts in the COSMIC Settings -> Power & battery page, verify adjustments take effect
4. (Optional) adjust power profiles via COSMIC Settings -> Power & battery. Adjustments should take effect immediately, same as with the battery applet.
5. Verify suspension is still disabled on s76 darp11
