### PR TITLE
screenshot: add grim for promptless screenshots in testing

### DIFF
--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -267,6 +267,7 @@ in
           papirus-icon-theme-grey
           adwaita-icon-theme
           ghaf-wallpapers
+          grim # promptless screenshot for test automation
           (import ../launchers-pkg.nix { inherit pkgs config; })
         ]
         ++ [ (lib.hiPrio ghaf-cosmic-config) ];


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

The currently used `cosmic-screenshot` talks to the XDG Desktop Portal to capture the screen.
This works fine for normal user interaction, but can sometimes cause hangups in test automation due to the portal sometimes asking for permission to capture the screen.

We add `grim` here as a CLI alternative, which talks to the Wayland compositor directly to capture the screen.
To mimic `cosmic-screenshot` screenshot output as a normal logged in user, one can run:
```bash
grim "$XDG_PICTURES_DIR/Screenshot_$(date '+%Y-%m-%d_%H_%M_%S').png"
```

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7876

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
N/A
