### PR TITLE
login: fix empty password softlock

### DIFF
--- a/modules/desktop/graphics/login-manager.nix
+++ b/modules/desktop/graphics/login-manager.nix
@@ -73,6 +73,7 @@ in
         rules = {
           auth = {
             systemd_home.order = 11399; # Re-order to allow either password _or_ fingerprint on lockscreen
+            unix.settings.use_first_pass = !config.ghaf.services.sssd.enable;
             fprintd.args = [ "maxtries=3" ];
           };
         };
@@ -82,6 +83,7 @@ in
         rules = {
           auth = {
             systemd_home.order = 11399; # Re-order to allow either password _or_ fingerprint on lockscreen
+            unix.settings.use_first_pass = !config.ghaf.services.sssd.enable;
             fprintd.args = [ "maxtries=3" ];
 
             # This should precede other auth rules e.g. pam_sss.so (pam module for SSSD)


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

What appears to happen (at least to my understanding) is that `pam_systemd_home` sends a `PAM_AUTHTOK_ERR`  to the next pam module in the stack.

when `pam_unix` is not present, it goes straight to `pam_deny` , and the chain is restarted properly
when `pam_unix` is present, it goes to pam_unix , which has the [flags](https://linux.die.net/man/8/pam_unix) `likeauth nullok try_first_pass` , and for some reason it hangs
if we add the `use_first_pass` flag to `pam_unix` , it tries the empty password and fails properly

The only concern is that if we add this `use_first_pass` by default, it might break authentication with `pam_sss` , if as Manuel suggested, it needs a password from a previous pam module

So the stack atm is like so, if I understand it correctly
```
pam_systemd_home
pam_unix
[pam_sss]
pam_deny
```
With this patch we force `use_first_pass`  for `pam_unix` , so it will [never prompt for a password](https://linux.die.net/man/8/pam_unix)


Thanks to Everton and Manuel for their help debugging :saluting_face: :rocket: 

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify empty password no longer causes a softlock on normal images
2. Verify AD functionality is not affected
3. (optional) Check behavior AD login behavior with an empty password