### PR TITLE
fix: acs override to separate iommu groups

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -36,7 +36,8 @@ path = [
   "overlays/custom-packages/system76-scheduler/0001-fix-add-missing-loop-in-process-scheduler-refresh-ta.patch",
   "overlays/custom-packages/cosmic/cosmic-greeter/0001-Fix-softlock.patch",
   "overlays/custom-packages/cosmic/cosmic-greeter/0002-fix-username-handle-empty-usernames.patch",
-  "modules/secureboot/keys/*"
+  "modules/secureboot/keys/*",
+  "modules/hardware/passthrough/pci-acs-override/0001-pci-add-pcie_acs_override-for-pci-passthrough.patch"
 ]
 
 [[annotations]]

--- a/modules/hardware/passthrough/default.nix
+++ b/modules/hardware/passthrough/default.nix
@@ -5,6 +5,7 @@
   imports = [
     ./evdev-rules.nix
     ./passthrough.nix
+    ./pci-acs-override/pci-acs-override.nix
     ./pci-ports.nix
     ./pci-rules.nix
     ./usb-quirks.nix

--- a/modules/hardware/passthrough/pci-acs-override/0001-pci-add-pcie_acs_override-for-pci-passthrough.patch
+++ b/modules/hardware/passthrough/pci-acs-override/0001-pci-add-pcie_acs_override-for-pci-passthrough.patch
@@ -1,0 +1,136 @@
+From 4f9ce06d51e1e4574e80f2a30809f0cec6abbc0d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enes=20=C3=96zt=C3=BCrk?= <enes.ozturk@unikie.com>
+Date: Fri, 16 Jan 2026 11:00:24 +0200
+Subject: [PATCH] pci: add pcie_acs_override for pci passthrough
+
+Add kernel boot parameter pcie_acs_override to override missing PCIe
+ACS (Access Control Services) support for IOMMU grouping. This enables
+PCI passthrough for devices that don't properly implement ACS.
+
+Usage: pcie_acs_override=id:vid:did[,id:vid:did...]
+Example: pcie_acs_override=id:8086:550a
+---
+ .../admin-guide/kernel-parameters.txt         |  6 ++
+ drivers/pci/quirks.c                          | 82 +++++++++++++++++++
+ 2 files changed, 88 insertions(+)
+
+diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
+index 184f2f96f..e3483d4ac 100644
+--- a/Documentation/admin-guide/kernel-parameters.txt
++++ b/Documentation/admin-guide/kernel-parameters.txt
+@@ -4309,6 +4309,12 @@
+ 		nomsi		[MSI] If the PCI_MSI kernel config parameter is
+ 				enabled, this kernel boot option can be used to
+ 				disable the use of MSI interrupts system-wide.
++		pcie_acs_override=
++				[PCIE] Override ACS for specific devices to isolate
++				them into separate IOMMU groups.
++				Format: id:vid:did[,id:vid:did...]
++				vid:did = vendor:device ID in hex
++				Example: pcie_acs_override=id:8086:550a
+ 		noioapicquirk	[APIC] Disable all boot interrupt quirks.
+ 				Safety option to keep boot IRQs enabled. This
+ 				should never be necessary.
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 70f484b81..c2b6792a4 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -3740,6 +3740,87 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
+ 	dev->dev_flags |= PCI_DEV_FLAGS_NO_BUS_RESET;
+ }
+ 
++#define NUM_ACS_IDS 16
++struct acs_on_id {
++	unsigned short vendor;
++	unsigned short device;
++};
++static struct acs_on_id acs_on_ids[NUM_ACS_IDS];
++static u8 max_acs_id;
++
++static __init int pcie_acs_override_setup(char *p)
++{
++	if (!p)
++		return -EINVAL;
++
++	while (*p) {
++		if (!strncmp(p, "id:", 3)) {
++			char opt[5];
++			int ret;
++			long val;
++
++			if (max_acs_id >= NUM_ACS_IDS - 1) {
++				pr_warn("pcie_acs_override: out of slots (%d)\n", NUM_ACS_IDS);
++				goto next;
++			}
++
++			p += 3;
++			snprintf(opt, 5, "%s", p);
++			ret = kstrtol(opt, 16, &val);
++			if (ret) {
++				pr_warn("pcie_acs_override: parse error %d\n", ret);
++				goto next;
++			}
++			acs_on_ids[max_acs_id].vendor = val;
++
++			p += strcspn(p, ":");
++			if (*p != ':') {
++				pr_warn("pcie_acs_override: invalid ID format\n");
++				goto next;
++			}
++
++			p++;
++			snprintf(opt, 5, "%s", p);
++			ret = kstrtol(opt, 16, &val);
++			if (ret) {
++				pr_warn("pcie_acs_override: parse error %d\n", ret);
++				goto next;
++			}
++			acs_on_ids[max_acs_id].device = val;
++			pr_info("pcie_acs_override: added %04x:%04x\n",
++				acs_on_ids[max_acs_id].vendor,
++				acs_on_ids[max_acs_id].device);
++			max_acs_id++;
++		}
++next:
++		p += strcspn(p, ",");
++		if (*p == ',')
++			p++;
++	}
++
++	if (max_acs_id)
++		pr_warn("pcie_acs_override: %d device(s) will be isolated\n", max_acs_id);
++
++	return 0;
++}
++early_param("pcie_acs_override", pcie_acs_override_setup);
++
++static int pcie_acs_overrides(struct pci_dev *dev, u16 acs_flags)
++{
++	int i;
++
++	for (i = 0; i < max_acs_id; i++) {
++		if (acs_on_ids[i].vendor == dev->vendor &&
++		    acs_on_ids[i].device == dev->device) {
++			pr_info("pcie_acs_override: %04x:%04x isolated\n",
++				dev->vendor, dev->device);
++			return 1;
++		}
++	}
++
++	return -ENOTTY;
++}
++
+ /*
+  * Some NVIDIA GPU devices do not work with bus reset, SBR needs to be
+  * prevented for those affected devices.
+@@ -5164,6 +5245,7 @@ static const struct pci_dev_acs_enabled {
+ 	{ PCI_VENDOR_ID_ZHAOXIN, PCI_ANY_ID, pci_quirk_zhaoxin_pcie_ports_acs },
+ 	/* Wangxun nics */
+ 	{ PCI_VENDOR_ID_WANGXUN, PCI_ANY_ID, pci_quirk_wangxun_nic_acs },
++	{ PCI_ANY_ID, PCI_ANY_ID, pcie_acs_overrides },
+ 	{ 0 }
+ };
+ 
+-- 
+2.47.2
+

--- a/modules/hardware/passthrough/pci-acs-override/pci-acs-override.nix
+++ b/modules/hardware/passthrough/pci-acs-override/pci-acs-override.nix
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.ghaf.hardware.passthrough.pciAcsOverride;
+  hwDef = config.ghaf.hardware.definition;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    types
+    mkIf
+    ;
+
+  # Convert device IDs to kernel parameter format (id:VENDOR:DEVICE)
+  idOptions = map (id: "id:${id}") cfg.ids;
+
+  # Get all known PCI device IDs from all *.pciDevices in hardware definition
+  allPciDevices = hwDef.network.pciDevices ++ hwDef.gpu.pciDevices ++ hwDef.audio.pciDevices;
+  devicePciIds = map (dev: "${dev.vendorId}:${dev.productId}") (
+    builtins.filter (dev: dev.vendorId != null && dev.productId != null) allPciDevices
+  );
+
+  # Check which IDs are not in the hardware definition
+  unmatchedIds = builtins.filter (id: !(builtins.elem id devicePciIds)) cfg.ids;
+in
+{
+  options.ghaf.hardware.passthrough.pciAcsOverride = {
+    enable = mkEnableOption "PCIe ACS (Access Control Services) override support for VFIO device assignment";
+
+    ids = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "8086:550a"
+        "8086:7702"
+      ];
+      description = ''
+        List of specific PCI device IDs (vendor:device in hex) to override ACS.
+        This works for ALL PCI devices including non-PCIe devices.
+
+        Use this when you need to split IOMMU groups for specific devices
+        that are not PCIe (e.g., LPC/eSPI devices like Intel 00:1f.x).
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.ids != [ ];
+        message = "pciAcsOverride: 'ids' cannot be empty when enabled.";
+      }
+      {
+        assertion = unmatchedIds == [ ];
+        message = ''
+          pciAcsOverride: IDs must match devices in hardware definition (*.pciDevices).
+          Unmatched IDs: ${lib.concatStringsSep ", " unmatchedIds}
+          Device PCI IDs: ${lib.concatStringsSep ", " devicePciIds}
+        '';
+      }
+    ];
+
+    boot.kernelPatches = [
+      {
+        name = "pci-acs-override";
+        patch = ./0001-pci-add-pcie_acs_override-for-pci-passthrough.patch;
+      }
+    ];
+
+    boot.kernelParams = [
+      "pcie_acs_override=${lib.concatStringsSep "," idOptions}"
+    ];
+
+    warnings = [
+      ''
+        PCIe ACS Override is enabled. This overrides hardware isolation boundaries
+        and IOMMU group assignments. Only use this if you understand the security
+        implications for your specific hardware topology and use case.
+
+        Device IDs: ${lib.concatStringsSep ", " cfg.ids}
+      ''
+    ];
+  };
+}

--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330.nix
@@ -35,7 +35,6 @@
 
   # Network devices for passthrough to netvm
   network = {
-    #TODO Add the Ethernet device
     pciDevices = [
       {
         # Network controller: Intel Corporation Wi-Fi 6E(802.11ax) AX210/AX1675* 2x2 [Typhoon Peak] (rev 1a)
@@ -47,11 +46,23 @@
         # Detected kernel driver: iwlwifi
         # Detected kernel modules: iwlwifi
       }
+      {
+        # Ethernet controller: Intel Corporation Ethernet Connection (13) I219-LM (rev 20)
+        name = "eth0";
+        path = "0000:00:1f.6";
+        vendorId = "8086";
+        productId = "15fb";
+        # Detected kernel driver: e1000e
+        # Detected kernel modules: e1000e
+      }
     ];
     kernelConfig = {
       # Kernel modules are indicative only, please investigate with lsmod/modinfo
       stage1.kernelModules = [ ];
-      stage2.kernelModules = [ "iwlwifi" ];
+      stage2.kernelModules = [
+        "iwlwifi"
+        "e1000e"
+      ];
       kernelParams = [ ];
     };
   };
@@ -79,7 +90,7 @@
 
   # Audio device for passthrough to audiovm
   audio = {
-    #TODO: Fix splitting the Ethernet from the Audio iommu
+
     pciDevices = [
       {
         # ISA bridge: Intel Corporation Tiger Lake-LP LPC Controller (rev 20)
@@ -109,15 +120,6 @@
         # Detected kernel modules: snd_hda_intel,snd_sof_pci_intel_tgl
       }
       {
-        # Ethernet controller: Intel Corporation Ethernet Connection (13) I219-LM (rev 20)
-        name = "snd0-3";
-        path = "0000:00:1f.6";
-        vendorId = "8086";
-        productId = "15fb";
-        # Detected kernel driver: e1000e
-        # Detected kernel modules: e1000e
-      }
-      {
         # SMBus: Intel Corporation Tiger Lake-LP SMBus Controller (rev 20)
         name = "snd0-4";
         path = "0000:00:1f.4";
@@ -131,7 +133,6 @@
       # Kernel modules are indicative only, please investigate with lsmod/modinfo
       stage1.kernelModules = [ ];
       stage2.kernelModules = [
-        "e1000e"
         "i2c_i801"
         "snd_hda_intel"
         "snd_sof_pci_intel_tgl"

--- a/modules/reference/hardware/system76/definitions/system76-darp11-b.nix
+++ b/modules/reference/hardware/system76/definitions/system76-darp11-b.nix
@@ -44,7 +44,23 @@
         # Detected kernel driver: iwlwifi
         # Detected kernel modules: iwlwifi
       }
+      {
+        # Ethernet controller: Intel Corporation Device 550a
+        # NOTE: This device is in the same IOMMU group as audio devices (0000:00:1f.x).
+        # PCI ACS override is enabled in the laptop configuration to split this group.
+        name = "eth0";
+        path = "0000:00:1f.6";
+        vendorId = "8086";
+        productId = "550a";
+        # Detected kernel driver: e1000e
+        # Detected kernel modules: e1000e
+      }
     ];
+    kernelConfig = {
+      stage2.kernelModules = [
+        "e1000e"
+      ];
+    };
   };
 
   # GPU devices for passthrough to guivm
@@ -111,20 +127,9 @@
         # Detected kernel driver: i801_smbus
         # Detected kernel modules: i2c_i801
       }
-      # TODO: Fix splitting the Ethernet from the Audio iommu
-      {
-        # Ethernet controller: Intel Corporation Device 550a
-        name = "snd0-4";
-        path = "0000:00:1f.6";
-        vendorId = "8086";
-        productId = "550a";
-        # Detected kernel driver: e1000e
-        # Detected kernel modules: e1000e
-      }
     ];
     kernelConfig = {
       stage2.kernelModules = [
-        "e1000e"
         "i2c_i801"
         "snd_hda_intel"
         "snd_sof_pci_intel_mtl"

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -80,6 +80,12 @@ let
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
 
+          # Enable PCI ACS override to split IOMMU groups
+          # Needed to separate Ethernet (8086:15fb) from Audio devices
+          hardware.passthrough.pciAcsOverride = {
+            enable = true;
+            ids = [ "8086:15fb" ]; # Ethernet controller at 00:1f.6
+          };
           virtualization.microvm.guivm.extraModules = [
             {
               microvm.mem = lib.mkForce 6144;
@@ -209,6 +215,13 @@ let
           partitioning.disko.enable = true;
           services.power-manager.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
 
+          # Enable PCI ACS override to split IOMMU groups
+          # Needed to separate Ethernet (8086:550a) from Audio devices
+          hardware.passthrough.pciAcsOverride = {
+            enable = true;
+            ids = [ "8086:550a" ]; # Ethernet controller at 00:1f.6
+          };
+
           virtualization.microvm.guivm.extraModules = [
             {
               # We explicitly enable only those we need
@@ -237,6 +250,13 @@ let
 
           # Enable storeOnDisk for all VMs
           virtualization.microvm.storeOnDisk = true;
+
+          # Enable PCI ACS override to split IOMMU groups
+          # Needed to separate Ethernet (8086:550a) from Audio devices
+          hardware.passthrough.pciAcsOverride = {
+            enable = true;
+            ids = [ "8086:550a" ]; # Ethernet controller at 00:1f.6
+          };
 
           virtualization.microvm.guivm.extraModules = [
             {
@@ -295,7 +315,12 @@ let
         ghaf = {
           reference.profiles.mvp-user-trial.enable = true;
           partitioning.disko.enable = true;
-
+          # Enable PCI ACS override to split IOMMU groups
+          # Needed to separate Ethernet (8086:15fb) from Audio devices
+          hardware.passthrough.pciAcsOverride = {
+            enable = true;
+            ids = [ "8086:15fb" ]; # Ethernet controller at 00:1f.6
+          };
           virtualization.microvm.guivm.extraModules = [
             {
               microvm.mem = lib.mkForce 6144;
@@ -398,6 +423,13 @@ let
           profiles.graphics.idleManagement.enable = true;
           services.power-manager.allowSuspend = false; # Suspension is broken (SSRCSP-7016)
 
+          # Enable PCI ACS override to split IOMMU groups
+          # Needed to separate Ethernet (8086:550a) from Audio devices
+          hardware.passthrough.pciAcsOverride = {
+            enable = true;
+            ids = [ "8086:550a" ]; # Ethernet controller at 00:1f.6
+          };
+
           virtualization.microvm.guivm.extraModules = [
             {
               # We explicitly enable only those we need
@@ -426,6 +458,13 @@ let
 
           # Enable storeOnDisk for all VMs
           virtualization.microvm.storeOnDisk = true;
+
+          # Enable PCI ACS override to split IOMMU groups
+          # Needed to separate Ethernet (8086:550a) from Audio devices
+          hardware.passthrough.pciAcsOverride = {
+            enable = true;
+            ids = [ "8086:550a" ]; # Ethernet controller at 00:1f.6
+          };
 
           virtualization.microvm.guivm.extraModules = [
             {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
On System76 darp11-b and Dell 7330, the Ethernet controller (00:1f.6) is in the same IOMMU group as audio devices (00:1f.0, 00:1f.3, 00:1f.4, 00:1f.5). This prevents passing the Ethernet to netvm while audio goes to audiovm, since VFIO requires entire IOMMU groups. Adding a kernel patch (pcie_acs_override) that overrides ACS capabilities for specific PCI devices by vendor:device ID. This allows devices to be isolated into separate IOMMU groups.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets
SSRCSP-7725
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [x] Dell Latitude 7330 `x86_64` 
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. All the VMs must be up and running.
2. `audio-vm` must only have the `ethint0` Ethernet interface (no other Ethernet interfaces present).
3. `net-vm` must have an `eth0` network interface and  `eth0` has an IP address after connected to the network.
4. Connect to internet through built-in ethernet port (Do not connect wifi)
