### PR TITLE
logging: prevent stalls on rotated journald entries

### DIFF
--- a/modules/common/logging/client.nix
+++ b/modules/common/logging/client.nix
@@ -102,6 +102,7 @@ in
         loki.source.journal "journal" {
           path          = "/var/log/journal"
           relabel_rules = discovery.relabel.journal.rules
+          max_age       = "168h"
           forward_to    = [loki.write.adminvm.receiver]
         }
 
@@ -131,6 +132,11 @@ in
       ]
       ++ lib.optionals dynHostEnabled [ "set-dynamic-hostname.service" ];
       requires = [ "systemd-journald.service" ];
+
+      SupplementaryGroups = [
+        "systemd-journal"
+        "adm"
+      ];
 
       # Once alloy.service in admin-vm stopped this service will
       # still keep on retrying to send logs batch, so we need to

--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -198,5 +198,12 @@ in
         ExecStart = lib.getExe ghafJournalAlloyRecover;
       };
     };
+
+    systemd.tmpfiles.rules = [
+      # Create persistent journal dir with the standard perms/group.
+      "d /var/log/journal 2755 root systemd-journal - -"
+      # Repair perms recursively if something messes them up.
+      "Z /var/log/journal 2755 root systemd-journal - -"
+    ];
   };
 }


### PR DESCRIPTION
## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

This PR addresses cases where log forwarding could stall after journald rotation, resulting in no logs being sent to Grafana.

- Fix journal access after rotation by enforcing persistent journal directory permissions via `systemd-tmpfiles` and adding required `SupplementaryGroups` (`systemd-journal`, `adm`) to the Alloy service - as peer `loki` documentation https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.journal/

- Limit replay of stale journald entries by setting `max_age = "168h"` on journal sources to avoid forwarding very old logs.

- Add batching and timeout tuning (`batch_size`, `max_backoff_period`, `remote_timeout`) to improve resilience when the remote Loki endpoint is slow or unavailable, helping prevent pipeline stalls.

- Introduce a short `older_than = "15m"` drop window for specific processing stages to keep ingestion moving under current remote Grafana/Loki constraints.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-7612
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify that logs are being sent to Grafana
2. This PR should solve the "20 to 30 minutes issue" where logs stopped going to Grafana after rotation - https://jira.tii.ae/browse/SSRCSP-7612 
