### PR TITLE
Refine deferred disk encryption and passphrase handling

### DIFF
--- a/modules/partitioning/btrfs-postboot.nix
+++ b/modules/partitioning/btrfs-postboot.nix
@@ -84,7 +84,7 @@ let
             if config.ghaf.profiles.debug.enable then
               ''
                 # Debug mode: use empty password
-                printf '\n' | cryptsetup resize -v crypted --key-file=- 2>&1 || {
+                printf 'ghaf' | cryptsetup resize -v crypted --key-file=- 2>&1 || {
                   echo "WARNING: LUKS resize failed, trying without key..."
                   cryptsetup resize -v crypted || true
                 }

--- a/modules/partitioning/deferred-disk-encryption.nix
+++ b/modules/partitioning/deferred-disk-encryption.nix
@@ -137,6 +137,10 @@ let
         sleep 2
       fi
 
+      # Ensure terminal is correctly configured for interaction
+      export TERM=linux
+      stty cols 256 2>/dev/null || true
+
       echo "+--------------------------------------------------------+"
       echo "|         First Boot - Disk Encryption Setup             |"
       echo "+--------------------------------------------------------+"


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
This commit introduces several refinements to the deferred disk encryption process, focusing on robustness, passphrase handling and control over LUKS slot management.

In debug image, the default passphrase for encryption has been standardized to "ghaf", addressing limitations with empty passphrases in `systemd-cryptenroll`.

**Fixed resize issue with `release-installer` when disk encryption is used.**

User can enroll with either TPM2 or FIDO2 and the Yubikey can be utilized for both disk encryption and user account management.


*Below table shows key enrolment difference:*
| PR | Mainline |
|----------|----|
| `[ghaf@ghaf-host:~]$ sudo systemd-cryptenroll /dev/nvme0n1p3`<br>`SLOT TYPE`<br>`0 password`<br>`1 tpm2`<br>`2 recovery` | `[ghaf@ghaf-host:~]$ sudo systemd-cryptenroll /dev/nvme0n1p3`<br>`SLOT TYPE`<br>`0 password` |


By default `tpm2` will be enabled.

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. PR functionality is available with installer only, when used with `-e` option.
      ```bash
         sudo ghaf-installer -e

2.  User can change to `fido2` by modifying `default = "fido2"` in [disk-encryption ](https://github.com/tiiuae/ghaf/blob/main/modules/common/security/disk-encryption.nix#L44) using that Yubikey can be used both to disk encryption and user account management.

3. When using `fido2`, user need to `confirm presence` by tapping on the Yubikey once encryption is complete, as illustrated below.
      <img width="1552" height="222" alt="image" src="https://github.com/user-attachments/assets/9e31442b-9e9d-4097-bc6a-5e07b08183c6" />
 
4. Test `tpm2` and `fido2` functionality with debug and release images when disk encryption is used. 

| Enrolment | Debug Image | Release Image |
|----------|-------------|---------------|
| fido2    |     Need to tap on Yubikey on every boot to unlock disk       |      Need to tap on Yubikey and enter encryption password       |
| tpm2     |   System will boot automatically without user interaction       | Need to enter TPM PIN  and encryption password  |

