### PR TITLE
feat(nvidia): enable givc and logging for nvidia targets

### DIFF
--- a/lib/builders/mkGhafConfiguration.nix
+++ b/lib/builders/mkGhafConfiguration.nix
@@ -109,17 +109,15 @@ let
       # 1. ghaf.profiles.{debug,release}.enable for host-side module activation
       # 2. ghaf.global-config to the corresponding profile for VM-side config propagation
       #
-      # Note: global-config uses mkDefault so that platform-specific profiles (like orin.nix)
-      # can override specific values. For example, orin.nix sets ghaf.givc.enable = false
-      # and this should propagate to VMs via ghaf.global-config.givc.enable.
+      # Note: global-config uses mkDefault so target modules can still override specific
+      # values when needed.
+
       variantModule = {
         ghaf.profiles = {
           debug.enable = variant == "debug";
           release.enable = variant == "release";
         };
         # Set global-config to match the variant's profile using mkDefault
-        # This allows profile modules to override specific global-config values
-        # Example: orin.nix can set ghaf.global-config.givc.enable = false
         ghaf.global-config = lib.mapAttrsRecursive (_: v: lib.mkDefault v) (
           lib.ghaf.profiles.${variant} or lib.ghaf.profiles.minimal
         );

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -52,6 +52,12 @@ rec {
             description = "Logging listener address";
           };
 
+          serverName = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = "Optional TLS server name for validating the admin-vm logging listener certificate";
+          };
+
           port = mkOption {
             type = types.port;
             default = 9999;

--- a/modules/common/global-config.nix
+++ b/modules/common/global-config.nix
@@ -47,6 +47,10 @@
       logging.listener.address = lib.mkIf (
         config.ghaf.global-config.logging.enable && config.ghaf.common.adminHost != null
       ) (lib.mkDefault config.ghaf.networking.hosts.admin-vm.ipv4);
+      # Auto-populate logging TLS server_name for producer-side certificate validation.
+      logging.listener.serverName = lib.mkIf (
+        config.ghaf.global-config.logging.enable && config.ghaf.common.adminHost != null
+      ) (lib.mkDefault "admin-vm");
     };
   };
 }

--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -178,6 +178,15 @@ in
       default = 9999;
     };
 
+    listener.serverName = mkOption {
+      description = ''
+        Optional TLS server name used by log producers when
+        verifying the admin-vm listener certificate.
+      '';
+      type = types.nullOr types.str;
+      default = null;
+    };
+
     journalRetention = {
       enable = mkOption {
         description = ''

--- a/modules/common/security/audit/default.nix
+++ b/modules/common/security/audit/default.nix
@@ -127,6 +127,19 @@ in
         before = lib.mkForce [ ];
       };
 
+      services.auditd-resume-after-boot = {
+        description = "Resume auditd after early boot space check settles";
+        after = [
+          "auditd.service"
+          "audit-rules-nixos.service"
+        ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.runtimeShell} -c '${pkgs.coreutils}/bin/sleep 5; ${pkgs.audit}/bin/auditctl --signal resume'";
+        };
+      };
+
       # Systemd oneshot service to immediate rotation, obeying num_logs.
       services.auditd-rotate = {
         description = "Time-based rotation of audit logs";
@@ -163,7 +176,7 @@ in
       space_left_action = SYSLOG
       admin_space_left = 5%
       admin_space_left_action = SINGLE
-      disk_full_action = ROTATE
+      disk_full_action = SUSPEND
       disk_error_action = SUSPEND
     '';
   };

--- a/modules/common/security/audit/default.nix
+++ b/modules/common/security/audit/default.nix
@@ -90,7 +90,11 @@ in
     security.audit = {
       enable = true;
       failureMode = if cfg.debug then "printk" else "panic";
-      backlogLimit = 8192;
+      # 8192 default fills during first-boot bursts (cert gen, spire restarts,
+      # microvm bring-up) and the kernel then blocks audit-triggering syscalls
+      # up to audit_backlog_wait_time (15s), stalling PAM login on slow boards
+      # (e.g. NX). 32k entries ~ 24MB kernel memory, 4x headroom.
+      backlogLimit = 32768;
       rules =
         cfg.commonRules
         ++ cfg.extraRules

--- a/modules/common/security/spire/agent.nix
+++ b/modules/common/security/spire/agent.nix
@@ -70,9 +70,12 @@ let
 
       echo "Checking SPIRE Server readiness at $SERVER_URL..."
 
-      until curl --fail --silent "$SERVER_URL" > /dev/null 2>&1; do
-        echo "SPIRE Server is not ready yet. Retrying in 3 seconds..."
-        sleep 3
+      # Short per-attempt timeouts: without them, curl defaults to ~30s on
+      # silently-dropped SYNs (rpfilter / netfilter not yet up on admin-vm),
+      # so a single hung TCP burns the whole 90s ExecStartPre budget.
+      until curl --fail --silent --connect-timeout 1 --max-time 2 "$SERVER_URL" > /dev/null 2>&1; do
+        echo "SPIRE Server is not ready yet. Retrying in 1 second..."
+        sleep 1
       done
 
       echo "SPIRE Server is ready! Starting SPIRE Agent..."
@@ -144,9 +147,14 @@ in
             "network-online.target"
             "local-fs.target"
           ];
+          # givc-key-setup writes /etc/givc/{key,cert,ca-cert}.pem that
+          # LoadCredential below depends on. Without explicit After=, the
+          # agent races the cert generator and the early ExecStartPre
+          # restarts on CREDENTIALS failure before settling.
           after = [
             "network-online.target"
             "local-fs.target"
+            "givc-key-setup.service"
           ];
 
           unitConfig = {

--- a/modules/common/services/firmware.nix
+++ b/modules/common/services/firmware.nix
@@ -3,21 +3,25 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
   cfg = config.ghaf.services.firmware;
   inherit (lib) mkIf mkEnableOption;
-  isX86_64 = pkgs.stdenv.hostPlatform.isx86_64;
 in
 {
   _file = ./firmware.nix;
 
   options.ghaf.services.firmware = {
-    enable = mkEnableOption "PLaceholder for firmware handling";
+    enable = mkEnableOption "Placeholder for firmware handling";
   };
-  config = mkIf (cfg.enable && isX86_64) {
+  # Previously gated on isX86_64, which made this a no-op on the aarch64
+  # Jetson targets — net-vm then shipped without rtl_nic firmware, so the
+  # RTL8153 USB-ethernet dongle ran on unpatched ROM firmware and dropped
+  # packets intermittently on cold boot (flaky SSH in pre-merge HW tests).
+  # USB peripherals passed through to the VMs need their firmware on every
+  # arch.
+  config = mkIf cfg.enable {
     hardware = {
       enableAllFirmware = true;
     };

--- a/modules/givc/host.nix
+++ b/modules/givc/host.nix
@@ -15,6 +15,7 @@ let
     optionalString
     optionals
     ;
+  tlsStoragePath = "/persist/storagevm/givc";
 in
 {
   _file = ./host.nix;
@@ -80,7 +81,7 @@ in
         addr = v.ipv4;
       }) config.ghaf.networking.hosts;
       generatorHostName = config.networking.hostName;
-      storagePath = "/persist/storagevm/givc";
+      storagePath = tlsStoragePath;
     };
 
     ghaf.security.audit.extraRules = [

--- a/modules/microvm/host/networking.nix
+++ b/modules/microvm/host/networking.nix
@@ -103,6 +103,28 @@ in
             matchConfig.Name = "tap-*";
             networkConfig.Bridge = "${cfg.bridgeNicName}";
           };
+          # USB ethernet adapters are hot-plugged into VMs by vhotplug.
+          # The host must never configure them: if host networkd claims
+          # the link (assigns an address, manages carrier), then vhotplug
+          # detaches the device and networkd tears it down — the churn,
+          # compounded by the r8152-cfgselector reset and the QEMU xHCI
+          # re-enumeration on the VM side, leaves the VM uplink flaky on
+          # cold boot (intermittent SSH timeouts in pre-merge HW tests).
+          # Mark them Unmanaged unconditionally — unlike 99-disable-external
+          # this must apply even when enableExternalNetworking is set (e.g.
+          # the debug profile), since these NICs belong to a VM regardless.
+          "12-usb-ethernet-unmanaged" = {
+            matchConfig.Driver = [
+              "r8152"
+              "r8153_ecm"
+              "cdc_ether"
+              "cdc_ncm"
+              "asix"
+              "ax88179_178a"
+              "smsc95xx"
+            ];
+            linkConfig.Unmanaged = "yes";
+          };
           # Disable addititional, non-defined external interfaces
           "99-disable-external" = optionalAttrs (!cfg.enableExternalNetworking) {
             matchConfig.Name = [

--- a/modules/microvm/host/networking.nix
+++ b/modules/microvm/host/networking.nix
@@ -70,10 +70,21 @@ in
 
       # Setup host VM network bridge
       systemd.network = {
-        netdevs."10-${cfg.bridgeNicName}".netdevConfig = {
-          Kind = "bridge";
-          Name = "${cfg.bridgeNicName}";
-          MACAddress = hosts.${hostName}.mac;
+        netdevs."10-${cfg.bridgeNicName}" = {
+          netdevConfig = {
+            Kind = "bridge";
+            Name = "${cfg.bridgeNicName}";
+            MACAddress = hosts.${hostName}.mac;
+          };
+          # Disable STP to skip the 15s forward-delay during port learning.
+          # Without this, taps added to the bridge spend ~15s in
+          # blocking/listening state, which delays spire-agent's
+          # ExecStartPre health check past TimeoutStartSec on first boot.
+          # We have a static topology (tap-<vm>/virbr0), no loops possible.
+          bridgeConfig = {
+            STP = false;
+            ForwardDelaySec = 0;
+          };
         };
         networks = {
           "10-${cfg.bridgeNicName}" = {

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -206,6 +206,16 @@ in
       allowedUDPPorts = [ dnsPort ];
     };
 
+  # Disable mDNS publishing on net-vm. With two live interfaces (internal
+  # ethint0 + USB/Wi-Fi uplink), systemd-resolved hears its own announcements
+  # echo between them and enters an unbounded conflict-resolution loop. The
+  # dynamic hostname `ghaf-NNNNNNNNNN` matches resolved's `<base>-<int>`
+  # pattern, so conflict resolution strips the numeric tail and republishes as
+  # `ghaf-<rand>`, producing thousands of renames per hour. Net-vm never needs
+  # to be discoverable via mDNS, so turn publishing off on both sides.
+  systemd.network.networks."10-ethint0".networkConfig.MulticastDNS = false;
+  networking.networkmanager.connectionConfig."connection.mdns" = 0;
+
   systemd.tmpfiles.rules = [ "d /persist/sysupdate 0755 ghaf root -" ]; # Set permissions for mountpoint
   microvm = {
     # Optimize is disabled because when it is enabled, qemu is built without libusb

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -210,8 +210,13 @@ in
   microvm = {
     # Optimize is disabled because when it is enabled, qemu is built without libusb
     optimize.enable = false;
-    # Sensible defaults - can be overridden via vmConfig
-    vcpu = lib.mkDefault 2;
+    # 4 vCPUs is the minimum that keeps QEMU USB emulation (libusb
+    # redirection of the ethernet dongle) from starving when alloy, givc
+    # node + stunnel, and spire-agent are all active on Orin NX. At 2 vCPUs
+    # the xhci_hcd guest driver desyncs with the QEMU event ring under load
+    # ("Transfer event TRB DMA ptr not part of current TD" + NETDEV WATCHDOG
+    # TX timeouts). AGX is unaffected because it has more cores per slice.
+    vcpu = lib.mkDefault 4;
     # Memory default is set to 1GB as some WiFi drivers require at least that much memory to function properly. This can be overridden via vmConfig.
     mem = lib.mkDefault 1024;
     hypervisor = "qemu";

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -227,8 +227,12 @@ in
     # ("Transfer event TRB DMA ptr not part of current TD" + NETDEV WATCHDOG
     # TX timeouts). AGX is unaffected because it has more cores per slice.
     vcpu = lib.mkDefault 4;
-    # Memory default is set to 1GB as some WiFi drivers require at least that much memory to function properly. This can be overridden via vmConfig.
-    mem = lib.mkDefault 1024;
+    # 2GB headroom: alloy + stunnel + spire-agent + givc-agent + auditd
+    # pile up on net-vm with the givc/logging stack enabled, and the
+    # 1GB default OOMs during the first-boot burst on Orin NX. The kernel
+    # then evicts page cache backing the USB-eth driver and the dongle
+    # disconnects, killing sshd on the test-net IP.
+    mem = lib.mkDefault 2048;
     hypervisor = "qemu";
 
     shares = [

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -209,13 +209,6 @@ in
         nvidia-docker.daemon.enable = true;
       };
 
-      # Disable givc on Orin - GIVC requires TLS certificate infrastructure
-      # that isn't set up for Orin devices. This must be set in both:
-      # 1. ghaf.givc.enable (host-level option)
-      # 2. ghaf.global-config.givc.enable (propagates to VMs via specialArgs)
-      givc.enable = false;
-      global-config.givc.enable = false;
-
       host.networking = {
         enable = true;
       };

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -304,6 +304,13 @@ in
     hardware.nvidia-jetpack.kernel.version = "${cfg.kernelVersion}";
     nixpkgs.hostPlatform.system = "aarch64-linux";
 
+    ghaf.givc.enable = true;
+    ghaf.givc.debug = false;
+    ghaf.logging.enable = true;
+    ghaf.logging.listener.address = config.ghaf.networking.hosts.admin-vm.ipv4;
+
+    ghaf.global-config.givc.enable = true;
+    ghaf.global-config.logging.enable = true;
     ghaf.hardware = {
       aarch64.systemd-boot-dtb.enable = true;
       passthrough = {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -418,11 +418,9 @@ in
       after = [
         "local-fs.target"
         "systemd-modules-load.service"
-        "dev-tpmrm0.device"
         "tee-supplicant.service"
         "ghaf-load-ftpm-module.service"
       ];
-      requires = [ "dev-tpmrm0.device" ];
       unitConfig.ConditionPathExists = "/dev/tpmrm0";
       unitConfig.OnSuccess = [ "ghaf-export-ek-endorsement-bundle.service" ];
 

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Configuration for NVIDIA Jetson Orin AGX/NX
+#  Configuration for NVIDIA Jetson Orin AGX/NX
 #
 {
   lib,


### PR DESCRIPTION
Enable GIVC and logging for nvidia targets

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
