### PR TITLE
feat(jetson-orin): add generic LUKS flash flow

### DIFF
--- a/docs/src/content/docs/ghaf/dev/ref/build_and_run.mdx
+++ b/docs/src/content/docs/ghaf/dev/ref/build_and_run.mdx
@@ -90,6 +90,9 @@ This is the primary reference device for Ghaf on AArch64 architecture, built usi
    # For 32GB AGX version (cross-compiled):
    nix build .#nvidia-jetson-orin-agx-debug-from-x86_64-flash-script
 
+   # For 32GB AGX with LUKS rootfs encryption:
+   nix build .#nvidia-jetson-orin-agx-debug-luks-from-x86_64-flash-script
+
    # For 64GB AGX version (cross-compiled):
    nix build .#nvidia-jetson-orin-agx64-debug-from-x86_64-flash-script
    ```
@@ -106,6 +109,17 @@ This is the primary reference device for Ghaf on AArch64 architecture, built usi
    cd result
    sudo ./flash.sh
    ```
+
+   For `*-luks-*` targets:
+
+   ```sh
+   sudo ./result/bin/flash-ghaf-host
+   ```
+
+   No passphrase prompt — the root is encrypted at image build time. The device
+   unlocks with a device-unique OP-TEE key. The first boot rotates away from the
+   manufacturing passphrase and re-encrypts the root (~1 min/GB); later boots
+   unlock unattended.
 
 <Aside type="note">
   **Jetson boot time and clock sync**: Some Jetson boards may expose an RTC value that is not valid after a cold boot. Ghaf prevents invalid RTC data from rewinding host wall clock time during boot. When the RTC device appears, Ghaf can seed system time from RTC only when the RTC value is plausible: at or above the persisted `/var/lib/systemd/timesync/clock` anchor and not more than 180 days ahead. Native `systemd-timesyncd` then converges to network time when available.

--- a/docs/src/content/docs/ghaf/dev/ref/cross_compilation.mdx
+++ b/docs/src/content/docs/ghaf/dev/ref/cross_compilation.mdx
@@ -24,6 +24,7 @@ The NVIDIA Jetson family represents Ghaf's primary AArch64 platform with full cr
 ```sh
 # Debug variants
 nix build .#nvidia-jetson-orin-agx-debug-from-x86_64
+nix build .#nvidia-jetson-orin-agx-debug-luks-from-x86_64
 nix build .#nvidia-jetson-orin-agx-debug-nodemoapps-from-x86_64
 
 # Release variants
@@ -32,6 +33,7 @@ nix build .#nvidia-jetson-orin-agx-release-nodemoapps-from-x86_64
 
 # Flash script generation
 nix build .#nvidia-jetson-orin-agx-debug-from-x86_64-flash-script
+nix build .#nvidia-jetson-orin-agx-debug-luks-from-x86_64-flash-script
 ```
 
 #### Jetson AGX Orin (64GB)

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -29,6 +29,38 @@
 let
   cfg = config.ghaf.profiles.orin;
   hostGlobalConfig = config.ghaf.global-config;
+  ensureSystemProfile = pkgs.writeShellApplication {
+    name = "ghaf-ensure-system-profile";
+    runtimeInputs = with pkgs; [
+      coreutils
+      nix
+    ];
+    text = ''
+      profile=/nix/var/nix/profiles/system
+      registration=/nix-path-registration
+      current_system=$(readlink -f /run/current-system)
+      generation_link=/nix/var/nix/profiles/system-1-link
+
+      if [ -z "$current_system" ] || [ ! -e "$current_system" ]; then
+        echo "Current system closure is unavailable" >&2
+        exit 1
+      fi
+
+      if [ ! -f "$registration" ] && [ -L "$profile" ] && [ "$(readlink -f "$profile")" = "$current_system" ]; then
+        exit 0
+      fi
+
+      if [ -f "$registration" ]; then
+        nix-store --load-db < "$registration"
+        rm -f "$registration"
+        touch /etc/NIXOS
+      fi
+
+      mkdir -p /nix/var/nix/profiles
+      ln -sfn "$current_system" "$generation_link"
+      ln -sfn system-1-link "$profile"
+    '';
+  };
 in
 {
   _file = ./orin.nix;
@@ -238,6 +270,17 @@ in
     environment.sessionVariables = {
       GBM_BACKEND = "dri";
       __EGL_VENDOR_LIBRARY_FILENAMES = "/run/opengl-driver/share/glvnd/egl_vendor.d/50_mesa.json";
+    };
+
+    systemd.services.ghaf-ensure-system-profile = {
+      description = "Ensure persistent NixOS system profile exists";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "local-fs.target" ];
+      before = [ "nix-gc.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${ensureSystemProfile}/bin/ghaf-ensure-system-profile";
+      };
     };
 
     # Cosmic on orin

--- a/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
@@ -24,7 +24,11 @@
         agx.enableNetvmWlanPCIPassthrough = true;
         carrierBoard = "devkit";
         # AGX industrial devkit boots rootfs from eMMC.
-        flashScriptOverrides.rootfsDevice = "mmcblk0p1";
+        flashScriptOverrides = {
+          deviceDisk = "mmcblk0";
+          deviceDiskEspPartition = "mmcblk0p1";
+          deviceDiskRootfsPartition = "mmcblk0p2";
+        };
       };
 
       # Net VM hardware-specific modules - use hardware.definition for composition model

--- a/modules/reference/hardware/jetpack/agx/orin-agx.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx.nix
@@ -24,7 +24,11 @@
         agx.enableNetvmWlanPCIPassthrough = true;
         carrierBoard = "devkit";
         # AGX devkit boots rootfs from eMMC.
-        flashScriptOverrides.rootfsDevice = "mmcblk0p1";
+        flashScriptOverrides = {
+          deviceDisk = "mmcblk0";
+          deviceDiskEspPartition = "mmcblk0p1";
+          deviceDiskRootfsPartition = "mmcblk0p2";
+        };
       };
 
       # Net VM hardware-specific modules - use hardware.definition for composition model

--- a/modules/reference/hardware/jetpack/agx/orin-agx64.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx64.nix
@@ -24,7 +24,11 @@
         agx.enableNetvmWlanPCIPassthrough = true;
         carrierBoard = "devkit";
         # AGX64 devkit boots rootfs from eMMC.
-        flashScriptOverrides.rootfsDevice = "mmcblk0p1";
+        flashScriptOverrides = {
+          deviceDisk = "mmcblk0";
+          deviceDiskEspPartition = "mmcblk0p1";
+          deviceDiskRootfsPartition = "mmcblk0p2";
+        };
       };
 
       # Net VM hardware-specific modules - use hardware.definition for composition model

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -5,12 +5,27 @@
 {
   lib,
   config,
+  options,
   pkgs,
   ...
 }:
 let
   cfg = config.ghaf.hardware.nvidia.orin;
 
+  # verity-volume.nix owns fileSystems."/" (tmpfs overlay) when enabled, so the
+  # diskEncryption ext4 root override below must stand down to avoid a
+  # conflicting mkForce. Defensive `options ?` check so this evaluates even in
+  # module sets where the verity option is absent. An assertion below rejects
+  # the combination outright.
+  verityEnabled =
+    (options ? ghaf.partitioning.verity.enable) && config.ghaf.partitioning.verity.enable;
+  luksDiskKeyDescription = "luksDiskDeviceUniqueKey";
+  inherit (cfg.diskEncryption) luksUuid;
+
+  # ESP is referenced by its FAT label, which both media share. Fall back to the
+  # sd-image default when config.sdImage is absent (e.g. verity image builds),
+  # so this evaluates in module sets that do not use the sd-image format.
+  espLabel = config.sdImage.firmwarePartitionName or "FIRMWARE";
   rtcSeedAnchorPath = "/var/lib/systemd/timesync/clock";
   rtcSeedMaxAheadSeconds = 180 * 24 * 60 * 60;
   rtcSeedMinEpochSeconds = 1704067200; # 2024-01-01T00:00:00Z
@@ -228,6 +243,9 @@ let
         # Avoid interactive prompt in gen_ekb.py by providing UEFI auth key.
         printf '%s' "0x00000000000000000000000000000000" > auth.key
 
+        # Used for disk encryption.
+        printf '%s' "0x00000000000000000000000000000000" > sym2_t234.key
+
                 openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
                   -keyout ek-rsa-key.pem -out ek-rsa.pem \
                   -subj "/CN=Jetson Orin fTPM EK RSA/O=Ghaf" \
@@ -246,6 +264,7 @@ let
           -chip t234 \
           -oem_k1_key oem_k1.key \
           -in_auth_key auth.key \
+          -in_sym_key2 sym2_t234.key \
           -in_ftpm_rsa_ek_cert ek-rsa.der \
           -in_ftpm_ec_ek_cert ek-ecc.der \
           -out "$out/eks_t234.img"
@@ -257,6 +276,310 @@ let
     mkIf
     types
     ;
+
+  resizepartitionsScript = pkgs.writeShellApplication {
+    name = "resize-partitions-cmds";
+    runtimeInputs = with pkgs; [
+      gptfdisk
+      parted
+      cryptsetup
+      util-linux
+      e2fsprogs
+      coreutils
+      systemd
+    ];
+    text = ''
+      RESIZE_MARKER=".ghaf-resize-done"
+      ESP_MOUNT="/mnt-esp"
+      ESP_DEVICE="/dev/disk/by-label/${espLabel}"
+
+      # Resolve the root partition by the pinned LUKS header UUID rather than a
+      # hardcoded device name or a partition-table PARTUUID (which differs between
+      # the USB sd-image (MBR) and the eMMC/NVMe flash (GPT)). blkid matches the
+      # crypto_LUKS container by its own UUID, identical on both media.
+      PART_DEV=""
+      for _ in $(seq 1 30); do
+        for d in $(blkid -o device -t UUID=${luksUuid} 2>/dev/null); do
+          ${lib.optionalString cfg.diskEncryption.enable ''
+            [ "$(blkid -o value -s TYPE "$d" 2>/dev/null)" = "crypto_LUKS" ] || continue
+          ''}
+          PART_DEV="$d"
+          break
+        done
+        if [ -n "$PART_DEV" ]; then break; fi
+        sleep 1
+      done
+
+      if [ -z "$PART_DEV" ]; then
+        echo "Root partition (LUKS UUID=${luksUuid}) not found, skipping resize."
+        exit 0
+      fi
+
+      # Derive disk and partition number from the resolved node, so mmcblk/nvme/sda all work.
+      real_dev=$(readlink -f "$PART_DEV")
+      base_dev=$(basename "$real_dev")
+      PART_NUM=$(cat "/sys/class/block/$base_dev/partition")
+      DISK="/dev/$(basename "$(readlink -f "/sys/class/block/$base_dev/..")")"
+
+      RESIZE_TARGET="$PART_DEV"
+      ${lib.optionalString cfg.diskEncryption.enable ''
+        MAPPER_NAME="${cfg.diskEncryption.mapperName}"
+        RESIZE_TARGET="/dev/mapper/$MAPPER_NAME"
+      ''}
+
+      mkdir -p "$ESP_MOUNT"
+      if [[ -b $ESP_DEVICE ]]; then
+        if mount "$ESP_DEVICE" "$ESP_MOUNT"; then
+          if [ -f "$ESP_MOUNT/$RESIZE_MARKER" ]; then
+            echo "Resize already performed, skipping."
+            umount "$ESP_MOUNT"
+            exit 0
+          fi
+          umount "$ESP_MOUNT"
+        else
+          echo "Failed to mount ESP $ESP_DEVICE, continuing without marker check."
+        fi
+      else
+        echo "ESP partition not found, continuing without marker check."
+      fi
+
+      for _ in {1..30}; do
+        [ -b "$RESIZE_TARGET" ] && break
+        sleep 1
+      done
+
+      if [ ! -b "$RESIZE_TARGET" ]; then
+        echo "Target device $RESIZE_TARGET not found, skipping."
+        exit 0
+      fi
+
+      echo "Fixing GPT..."
+      sgdisk -e "$DISK" || true
+
+      echo "Resizing partition $PART_NUM to 100%..."
+      # Use resizepart which works on busy partitions by using the BLKPG_RESIZE_PARTITION ioctl
+      parted -s "$DISK" resizepart "$PART_NUM" 100%
+
+      partprobe "$DISK" || true
+      udevadm settle || true
+
+      ${lib.optionalString cfg.diskEncryption.enable ''
+        echo "Resizing LUKS container $MAPPER_NAME..."
+        ${
+          # deviceUniqueKey and userPassphrase are mutually exclusive and exactly
+          # one is set (assertion below), so this if/else always resizes.
+          if cfg.diskEncryption.deviceUniqueKey.enable then
+            ''
+              cryptsetup resize --key-description ${luksDiskKeyDescription} "$MAPPER_NAME"
+            ''
+          else
+            ''
+              # Use systemd-ask-password to handle prompts in a non-interactive environment
+              PASSPHRASE=$(systemd-ask-password --timeout=60 "Enter passphrase for resizing LUKS container:")
+              if [ -n "$PASSPHRASE" ]; then
+                echo "$PASSPHRASE" | cryptsetup resize -v "$MAPPER_NAME" --key-file=-
+              else
+                echo "No passphrase entered, LUKS resize might have failed."
+              fi
+            ''
+        }
+        echo "LUKS status for $MAPPER_NAME after resize:"
+        cryptsetup status "$MAPPER_NAME"
+      ''}
+
+      echo "Resizing filesystem on $RESIZE_TARGET..."
+      # resize2fs may require a filesystem check before resizing
+      e2fsck -fy "$RESIZE_TARGET" || true
+      resize2fs "$RESIZE_TARGET"
+
+      # Persist completion on the ESP so later initrd boots can skip the
+      # service without mounting the root filesystem and racing fsck.
+      if [[ -b $ESP_DEVICE ]] && mount "$ESP_DEVICE" "$ESP_MOUNT"; then
+        touch "$ESP_MOUNT/$RESIZE_MARKER"
+        umount "$ESP_MOUNT"
+      else
+        echo "Failed to persist resize marker on ESP."
+      fi
+    '';
+  };
+
+  preDiskUniqueKeyScript = pkgs.writeShellApplication {
+    name = "pre-disk-unique-key";
+    runtimeInputs = with pkgs; [
+      cryptsetup
+      coreutils
+      gnused
+      keyutils
+      nvidia-jetpack.nvLuksSrv
+      gnugrep
+      util-linux
+    ];
+    text = ''
+      handle_error() {
+        if ! nvluks-srv-app -n; then
+          printf "Note: Attempt to stop the nvluks service failed (it may have already been stopped). Proceeding with device reboot.\n"
+        fi
+
+        printf "Encountered unexpected/unrecoverable error with disk encryption.\n"
+        printf "Rebooting in 10 seconds...\n"
+        sleep 10
+        reboot
+      }
+
+      wait_for_luks_device() {
+        luksDev=$1
+
+        for _ in {0..5}; do
+          if cryptsetup isLuks "$luksDev"; then
+            return 0
+          fi
+          sleep 1
+        done
+
+        printf "error: [%s] is not a luks device OR device is not ready\n" "$luksDev"
+        handle_error
+      }
+
+      sanitize_string() {
+        local dirty_str="$1"
+
+        echo "$dirty_str" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9'
+      }
+
+      read_luksDev_serial() {
+        local luksDev=$1
+        local luksSerial
+
+        luksSerial=$(sanitize_string "$(udevadm info --query=property --name="$luksDev" | sed -n 's/^ID_SERIAL=//p')")
+        if [[ -z "$luksSerial" ]]; then
+           printf "error: Failed to get luksDev serial\n"
+           handle_error
+        else
+          echo "$luksSerial"
+        fi
+      }
+
+      switch_to_use_device_unique_key() {
+        uniqueKeyDescription=$1
+        defaultKey=$2
+        luksDev=$3
+
+        printf "Switching to use device unique key. This might take a bit..\n"
+        if ! printf "%s" "$defaultKey" | cryptsetup luksAddKey --new-key-description "$uniqueKeyDescription" --key-file=- "$luksDev"; then
+          printf "error: Failed to set unique key\n"
+          handle_error
+        fi
+
+        if ! printf "%s" "$defaultKey" | cryptsetup luksRemoveKey --key-file=- "$luksDev"; then
+          printf "error: Failed to remove default key\n"
+          handle_error
+        fi
+
+        # luksAddKey/luksRemoveKey only swap keyslots; the volume key that
+        # actually encrypts the data is still the one the manufacturing
+        # passphrase protected. Reencrypt derives a fresh volume key from the
+        # device-unique key, so a leaked manufacturing passphrase grants nothing.
+        printf "Note: Re-encryption may take 1 minute for every 1 GB of data ...\n"
+        if ! cryptsetup reencrypt --key-description "$uniqueKeyDescription" "$luksDev"; then
+           printf "error: Re-encryption failed\n"
+           handle_error
+        fi
+      }
+
+      # Resolve the LUKS partition by its pinned header UUID and verify it is a
+      # crypto_LUKS payload, independent of mmcblk/nvme/sda enumeration and of the
+      # partition-table scheme (MBR on USB, GPT on eMMC/NVMe).
+      luksDev=""
+      for _ in $(seq 1 30); do
+        for d in $(blkid -o device -t UUID=${luksUuid} 2>/dev/null); do
+          [ "$(blkid -o value -s TYPE "$d" 2>/dev/null)" = "crypto_LUKS" ] || continue
+          luksDev="$d"
+          break
+        done
+        if [ -n "$luksDev" ]; then break; fi
+        sleep 1
+      done
+      if [[ -z "$luksDev" ]]; then
+        printf "error: LUKS root partition (UUID=%s) not found\n" "${luksUuid}"
+        handle_error
+      fi
+      defaultManufactureKey=${cfg.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase}
+      luksDiskKeyKeyringDescription=${luksDiskKeyDescription}
+
+      wait_for_luks_device "$luksDev"
+
+      luksDevSerial=$(read_luksDev_serial "$luksDev")
+
+      luksKeyKeyringID=$(printf "%s" "$(nvluks-srv-app -c "$luksDevSerial" -u | tr -d '\n')" | keyctl padd user "$luksDiskKeyKeyringDescription" @u)
+
+      # Lock/prevent any other queries to luks key
+      if ! nvluks-srv-app -n; then
+        printf "error: Unable to stop nvluks service\n";
+        handle_error
+      fi
+
+      # Granting write access, because otherwise key is not removable
+      if ! keyctl setperm "$luksKeyKeyringID"  0x3f070000; then
+        printf "error: Unable modify setperm\n"
+        handle_error
+      fi
+
+      if ! keyctl describe "$luksKeyKeyringID" > /dev/null 2>&1; then
+        printf "error: Unable to add luks key to keyring\n"
+        handle_error
+      fi
+
+
+      # First boot is determined by checking whether the LUKS keyring description exists.
+      # Do not use cryptsetup --test-passphrase for this check, because it succeeds
+      # if the device can be unlocked by any available mechanism, including tokens/keyring.
+      if ! cryptsetup luksDump "$luksDev" 2>/dev/null | grep -Fq ${luksDiskKeyDescription}; then
+        switch_to_use_device_unique_key "$luksDiskKeyKeyringDescription" "$defaultManufactureKey" "$luksDev"
+      fi
+
+      if ! cryptsetup token add --key-description "$luksDiskKeyKeyringDescription" "$luksDev" > /dev/null 2>&1; then
+        printf "error: Unable to add cryptrsetup token\n"
+        handle_error
+      fi
+    '';
+  };
+
+  postDiskUniqueKeyScript = pkgs.writeShellApplication {
+    name = "post-disk-unique-key";
+    runtimeInputs = with pkgs; [
+      coreutils
+      keyutils
+    ];
+    text = ''
+      if ! keyctl revoke "$(keyctl search @u user ${luksDiskKeyDescription})"; then
+        printf "warn: Unable to revoke a key from keyring\n"
+      fi
+    '';
+  };
+
+  # Shared by the deviceDisk, deviceDiskRootfsPartition and deviceDiskEspPartition
+  # options declared below.
+  deviceDiskDescription = ''
+    Rootfs disk and its ESP/rootfs partitions, as kernel device names. The
+    rootfs partition is passed to NVIDIA's flash.sh as the trailing argument
+    and is consumed by the partition layout in the .conf file referenced by
+    configFileName, deciding where the APP partition lands. Downstream callers
+    (e.g. disk-encryption modules) read these to know the rootfs location at
+    build time.
+
+    Orin NX booting from USB, for example:
+
+    ```nix
+    flashScriptOverrides.deviceDisk = "sda";
+    flashScriptOverrides.deviceDiskEspPartition = "sda1";
+    flashScriptOverrides.deviceDiskRootfsPartition = "sda2";
+    ```
+
+    No default: rootfs storage is not common to all carrier boards, so every
+    per-SoM module must set all three explicitly. An assertion in the config
+    block enforces non-empty values.
+  '';
+
 in
 {
   _file = ./jetson-orin.nix;
@@ -273,19 +596,20 @@ in
       default = "";
     };
 
-    flashScriptOverrides.rootfsDevice = mkOption {
-      description = ''
-        Rootfs device passed to NVIDIA's flash.sh as the trailing argument
-        (e.g. "mmcblk0p1" for eMMC/SD, "nvme0n1p1" for NVMe). This is
-        consumed by the partition layout in the .conf file referenced by
-        configFileName and decides where the APP partition lands. Downstream
-        callers (e.g. disk-encryption modules) can read this to know the
-        rootfs location at build time.
+    flashScriptOverrides.deviceDisk = mkOption {
+      description = deviceDiskDescription;
+      type = types.str;
+      default = "";
+    };
 
-        No default: rootfs storage is not common to all carrier boards, so
-        every per-SoM module must set this explicitly. An assertion in the
-        config block enforces a non-empty value.
-      '';
+    flashScriptOverrides.deviceDiskRootfsPartition = mkOption {
+      description = deviceDiskDescription;
+      type = types.str;
+      default = "";
+    };
+
+    flashScriptOverrides.deviceDiskEspPartition = mkOption {
+      description = deviceDiskDescription;
       type = types.str;
       default = "";
     };
@@ -328,18 +652,120 @@ in
       default = true;
     };
 
+    diskEncryption = {
+      enable = mkEnableOption "generic LUKS root filesystem encryption for eMMC APP partition";
+
+      deviceUniqueKey = {
+        enable = mkEnableOption ''
+          disk decryption using a unique hardware key fetched from the OP-TEE.
+
+          On the first boot, the key (initially encrypted with a manufacturer key)
+          is rotated and re-encrypted with a device-unique key. Note that this
+          initial setup makes the first boot significantly slower.
+
+          This method provides an unattended boot process and does not require
+          user input to unlock the drive'';
+
+        deviceManufacturerPassphrase = mkOption {
+          description = ''
+            The temporary passphrase used to decrypt the device disk at the first
+            boot. Once the key is rotated to a device-unique key, this passphrase
+            is no longer needed for subsequent unlocks.
+          '';
+          type = types.str;
+          default = "ghaf";
+        };
+      };
+
+      userPassphrase = {
+        enable = mkEnableOption ''
+          a semi-manual passphrase for disk encryption. During device boot, the
+          device will prompt the console for the user to input the password.
+
+          Note: This option is primarily intended for testing purposes'';
+
+        passphrase = mkOption {
+          description = "The manual passphrase used to encrypt the disk.";
+          type = types.str;
+          default = "ghaf";
+        };
+      };
+
+      mode = mkOption {
+        description = "Disk encryption mode for Jetson root filesystem";
+        type = types.enum [ "generic-luks-passphrase" ];
+        default = "generic-luks-passphrase";
+      };
+
+      mapperName = mkOption {
+        description = "Mapped device name used by initrd after LUKS unlock";
+        type = types.str;
+        default = "cryptroot";
+      };
+
+      luksUuid = mkOption {
+        description = ''
+          Pinned LUKS2 header UUID of the encrypted root. Set on the container at
+          image build time (`sdimage.nix`, `cryptsetup reencrypt --uuid`) and
+          referenced at runtime as `/dev/disk/by-uuid/<uuid>` by the crypttab
+          device, the `pre-disk-unique-key` udev rule and the resize scan.
+
+          The header UUID rather than a partition PARTUUID, because the same
+          container ships on two partition tables — the raw sd-image on USB
+          (MBR) and the NVIDIA flash on eMMC/NVMe (GPT) — which necessarily carry
+          different PARTUUIDs. The header lives inside the container, so it is
+          identical on both media and independent of the kernel device name
+          (mmcblk/nvme/sda). It also survives the first-boot device-unique-key
+          rekey, which is a keyslot operation, not a header rewrite.
+
+          Read-only: two drives holding a verbatim ghaf flash carry the same UUID,
+          so a runtime scan cannot tell them apart and picks the first match.
+          Disambiguating needs a per-install-unique UUID, left as follow-up.
+        '';
+        type = types.str;
+        readOnly = true;
+        default = "0ada0e5b-0e5b-4e5b-8e5b-0000000000a9";
+      };
+    };
   };
 
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.flashScriptOverrides.rootfsDevice != "";
+        assertion =
+          cfg.flashScriptOverrides.deviceDisk != ""
+          && cfg.flashScriptOverrides.deviceDiskRootfsPartition != ""
+          && cfg.flashScriptOverrides.deviceDiskEspPartition != "";
         message = ''
-          ghaf.hardware.nvidia.orin.flashScriptOverrides.rootfsDevice must be
-          set explicitly (e.g. "mmcblk0p1" for eMMC/SD, "nvme0n1p1" for NVMe).
+          ghaf.hardware.nvidia.orin.flashScriptOverrides.deviceDisk* must be
+          set explicitly (e.g. "mmcblk0" for eMMC/SD, "nvme0n1" for NVMe).
           The default is intentionally empty because rootfs storage varies per
           carrier board; the per-SoM module must declare it to avoid silently
           flashing to the wrong device.
+        '';
+      }
+      {
+        assertion =
+          if cfg.diskEncryption.enable then
+            (cfg.diskEncryption.deviceUniqueKey.enable != cfg.diskEncryption.userPassphrase.enable)
+          else
+            true;
+        message = ''
+          Disk encryption is enabled, but the unlock method is misconfigured.
+          You must enable exactly one of:
+          - 'diskEncryption.deviceUniqueKey.enable'
+          - 'diskEncryption.userPassphrase.enable'
+
+          Note: They are mutually exclusive and cannot both be false.
+        '';
+      }
+      {
+        assertion = !(cfg.diskEncryption.enable && verityEnabled);
+        message = ''
+          ghaf.hardware.nvidia.orin.diskEncryption.enable and
+          ghaf.partitioning.verity.enable are mutually exclusive root strategies:
+          verity owns fileSystems."/" as a tmpfs overlay, LUKS as an ext4 root on
+          /dev/mapper/${cfg.diskEncryption.mapperName}. Enable at most one.
         '';
       }
     ];
@@ -349,13 +775,13 @@ in
     hardware.nvidia-jetpack.firmware.eksFile = "${firmwareEkbImage}/eks_t234.img";
     hardware.nvidia-jetpack.kernel.version = "${cfg.kernelVersion}";
     # jetpack-nixos hardcodes the trailing rootfs device as mmcblk0p1; replay
-    # the same default here but route it through cfg.flashScriptOverrides.rootfsDevice
-    # so per-SoM modules (e.g. orin-nx → nvme0n1p1) only set the option, not
+    # the same default here but route it through cfg.flashScriptOverrides.deviceDiskRootfsPartition
+    # so per-SoM modules (e.g. orin-nx → nvme0n1p2) only set the option, not
     # the whole flashArgs list. mkOverride 75 beats jetpack-nixos's plain
     # assignment (prio 100) while leaving room for downstream mkForce (prio 50).
     hardware.nvidia-jetpack.flashScriptOverrides.flashArgs = lib.mkOverride 75 [
       config.hardware.nvidia-jetpack.flashScriptOverrides.configFileName
-      cfg.flashScriptOverrides.rootfsDevice
+      cfg.flashScriptOverrides.deviceDiskRootfsPartition
     ];
     nixpkgs.hostPlatform.system = "aarch64-linux";
 
@@ -366,6 +792,15 @@ in
 
     ghaf.global-config.givc.enable = true;
     ghaf.global-config.logging.enable = true;
+
+    environment.systemPackages = with pkgs; [
+      gptfdisk
+      parted
+      cryptsetup
+      util-linux
+      e2fsprogs
+    ];
+
     ghaf.hardware = {
       aarch64.systemd-boot-dtb.enable = true;
       passthrough = {
@@ -419,7 +854,199 @@ in
             HW_RANDOM_TPM = no;
           };
         }
+      ]
+      ++ lib.optionals (cfg.diskEncryption.enable && cfg.kernelVersion == "upstream-6-6") [
+        {
+          name = "dm-crypt-config";
+          patch = null;
+          # LUKS needs the device-mapper stack built in (not modular) so the
+          # initrd can open cryptroot. Force the DM entries to win over the
+          # modular defaults the jetpack/verity kernel config pulls in (=m),
+          # which otherwise collide on the -verity-*-luks combo targets.
+          structuredExtraConfig = with lib.kernel; {
+            BLK_DEV_DM = lib.mkForce yes;
+            DM_BUFIO = lib.mkForce yes;
+            DM_BIO_PRISON = lib.mkForce yes;
+            DM_CRYPT = lib.mkForce yes;
+            CRYPTO_USER_API = yes;
+            CRYPTO_USER_API_HASH = yes;
+            CRYPTO_USER_API_SKCIPHER = yes;
+            CRYPTO_XTS = yes;
+          };
+        }
       ];
+
+    };
+
+    boot.initrd = {
+      # Keep module selection aligned with the Orin JetPack baseline and avoid
+      # requesting dm-crypt as a loadable module for upstream-6-6.
+      availableKernelModules = [
+        "xhci-tegra"
+        "ucsi_ccg"
+        "typec_ucsi"
+        "typec"
+        "nvme"
+        "tegra_mce"
+        "phy-tegra-xusb"
+        "i2c-tegra"
+        "fusb301"
+        "phy_tegra194_p2u"
+        "pcie_tegra194"
+        "nvpps"
+        "nvethernet"
+      ]
+      ++ lib.optionals cfg.diskEncryption.enable [
+        "dm-crypt"
+        "dm-mod"
+      ];
+      kernelModules = [ ];
+      # algif_skcipher is not available with the upstream-6-6 kernel variant
+      # used by current Orin reference targets.
+      luks.cryptoModules = lib.mkIf cfg.diskEncryption.enable (
+        lib.mkForce [
+          "aes"
+          "aes_generic"
+          "cbc"
+          "xts"
+          "sha1"
+          "sha256"
+          "sha512"
+          "af_alg"
+        ]
+      );
+      luks.devices = lib.mkIf cfg.diskEncryption.enable {
+        ${cfg.diskEncryption.mapperName} = {
+          device = "/dev/disk/by-uuid/${luksUuid}";
+          allowDiscards = true;
+          keyFile = if cfg.diskEncryption.deviceUniqueKey.enable then "none" else null;
+        };
+      };
+
+      systemd.initrdBin = with pkgs; [
+        gnused
+        keyutils
+        nvidia-jetpack.nvLuksSrv
+        gnugrep
+      ];
+
+      systemd.storePaths =
+        with pkgs;
+        [
+          gptfdisk
+          parted
+          cryptsetup
+          util-linux
+          e2fsprogs
+          coreutils
+          systemd
+          resizepartitionsScript
+        ]
+        ++ lib.optionals cfg.diskEncryption.deviceUniqueKey.enable [
+          preDiskUniqueKeyScript
+          postDiskUniqueKeyScript
+        ];
+
+      services.udev.rules = lib.optionalString cfg.diskEncryption.deviceUniqueKey.enable ''
+        ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_UUID}=="${luksUuid}", TAG+="systemd", ENV{SYSTEMD_WANTS}+="pre-disk-unique-key.service"
+      '';
+
+      systemd.services = {
+        resize-partitions = {
+          description = "Resize partitions to fill the disk on first boot";
+          wantedBy = [ "initrd.target" ];
+          before = [
+            "systemd-fsck-root.service"
+            "sysroot.mount"
+            "initrd-root-fs.target"
+          ];
+          after = [
+            "initrd-root-device.target"
+            "cryptsetup.target"
+          ];
+          unitConfig = {
+            DefaultDependencies = false;
+          };
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${resizepartitionsScript}/bin/resize-partitions-cmds";
+            StandardInput = "tty";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+            KeyringMode = "shared";
+          };
+        };
+      }
+      // lib.optionalAttrs cfg.diskEncryption.deviceUniqueKey.enable {
+        load-diskkey-to-keyring = {
+          description = "Service for loading unique device key to kernel keyring";
+          before = [
+            "systemd-pre-disk-unique-key.service"
+          ];
+          unitConfig = {
+            DefaultDependencies = false;
+          };
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${preDiskUniqueKeyScript}/bin/pre-disk-unique-key";
+            StandardInput = "tty";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+          };
+        };
+
+        pre-disk-unique-key = {
+          description = "Service for device unique key disk encryption";
+          before = [
+            "systemd-cryptsetup@${cfg.diskEncryption.mapperName}.service"
+          ];
+          unitConfig = {
+            DefaultDependencies = false;
+          };
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${preDiskUniqueKeyScript}/bin/pre-disk-unique-key";
+            StandardInput = "tty";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+            KeyringMode = "shared";
+          };
+        };
+
+        post-disk-unique-key = {
+          description = "Cleanup service for device unique key disk encryption";
+          wantedBy = [ "initrd-switch-root.target" ];
+          after = [
+            "systemd-resize-partitions.service"
+          ];
+          unitConfig = {
+            DefaultDependencies = false;
+          };
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${postDiskUniqueKeyScript}/bin/post-disk-unique-key";
+            StandardInput = "tty";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+          };
+        };
+      };
+
+      supportedFilesystems = [
+        "ext4"
+        "vfat"
+      ];
+    };
+
+    fileSystems = mkIf (cfg.diskEncryption.enable && !verityEnabled) {
+      "/" = lib.mkForce {
+        device = "/dev/mapper/${cfg.diskEncryption.mapperName}";
+        fsType = "ext4";
+      };
     };
 
     services.udev.extraRules = ''

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -139,6 +139,10 @@ let
     runtimeInputs = [
       pkgs.pkgsBuildBuild.zstd
       pkgs.pkgsBuildBuild.gnused
+      pkgs.pkgsBuildBuild.cryptsetup
+      pkgs.pkgsBuildBuild.e2fsprogs
+      pkgs.pkgsBuildBuild.coreutils
+      pkgs.pkgsBuildBuild.util-linux
     ];
     text = ''
       echo "============================================================"
@@ -147,6 +151,7 @@ let
       echo "Version: ${config.ghaf.version}"
       echo "SoM: ${config.hardware.nvidia-jetpack.som}"
       echo "Carrier board: ${config.hardware.nvidia-jetpack.carrierBoard}"
+      echo "Disk encryption: ${lib.boolToString cfg.diskEncryption.enable}"
       echo "============================================================"
       echo ""
       WORKDIR=$PWD
@@ -246,15 +251,18 @@ let
            bs=512 iseek="$ESP_OFFSET" count="$ESP_SIZE" status=progress
 
         echo "Extracting root partition..."
+        ROOT_IMAGE_PATH="$WORKDIR/bootloader/root.img"
         dd if=<(pzstd -d "$img" -c) \
-           of="$WORKDIR/bootloader/root.img" \
+           of="$ROOT_IMAGE_PATH" \
            bs=512 iseek="$ROOT_OFFSET" count="$ROOT_SIZE" status=progress
 
-        echo ""
-        echo "Patching flash.xml with image paths..."
+        echo "Patching flash.xml with image paths and sizes..."
+        ROOT_IMAGE_SIZE_BYTES=$(stat -c %s "$ROOT_IMAGE_PATH")
         sed -i \
           -e "s#bootloader/esp.img#$WORKDIR/bootloader/esp.img#" \
-          -e "s#root.img#$WORKDIR/bootloader/root.img#" \
+          -e "s#root.img#$ROOT_IMAGE_PATH#" \
+          -e "s#ESP_SIZE#$((ESP_SIZE * 512))#" \
+          -e "s#ROOT_SIZE#$ROOT_IMAGE_SIZE_BYTES#" \
           flash.xml
       ''}
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -18,6 +18,27 @@
   lib,
   ...
 }:
+let
+  # The flash-time LUKS conversion needs more headroom than the stock sd-image
+  # builder leaves after its final resize2fs pass.
+  rootfsExtraSlackMiB = 64;
+
+  # Pin the LUKS2 header UUID so the runtime references (crypttab/udev/resize in
+  # jetson-orin.nix) resolve the root by /dev/disk/by-uuid/<uuid> on both the USB
+  # sd-image (MBR) and the eMMC/NVMe flash (GPT).
+  inherit (config.ghaf.hardware.nvidia.orin.diskEncryption) luksUuid;
+
+  cryptsetup =
+    (pkgs.callPackage "${toString pkgs.path}/pkgs/by-name/cr/cryptsetup/package.nix" { }).overrideAttrs
+      (oldAttrs: {
+        # /run/cryptsetup (the upstream default) is not writable inside the
+        # image build, and /build only exists on sandboxed-to-/build builders.
+        # /tmp is writable in every nix build environment.
+        configureFlags = oldAttrs.configureFlags ++ [
+          "--with-luks2-lock-path=/tmp/cryptsetup"
+        ];
+      });
+in
 {
   imports = [ (modulesPath + "/installer/sd-card/sd-image.nix") ];
 
@@ -51,6 +72,13 @@
     in
     {
       firmwareSize = 256;
+
+      # The stock expand-root-partition.service resolves the root device via
+      # `lsblk -npo PKNAME /`, which is empty for a /dev/mapper/cryptroot root
+      # and makes sfdisk fail ("no disk device specified"). The initrd
+      # resize-partitions service already grows the LUKS partition + filesystem,
+      # so disable the redundant stock expand when encryption is enabled.
+      expandOnBoot = !config.ghaf.hardware.nvidia.orin.diskEncryption.enable;
       populateFirmwareCommands = ''
         mkdir -pv firmware
         ${mkESPContent} \
@@ -59,6 +87,77 @@
           --device-tree ${fdtPath}
       '';
       populateRootCommands = "";
+
+      preBuildCommands = ''
+        ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
+          printf "\nGeneric LUKS rootfs encryption is enabled.\n"
+
+          ROOT_IMAGE=$root_fs
+
+          if [ ! -w "$ROOT_IMAGE" ]; then
+            chmod 755 $ROOT_IMAGE
+          fi
+
+          e2fsck -fy "$ROOT_IMAGE"
+
+          # Reserve space for LUKS
+          current_blocks=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block count:[[:space:]]*//p')
+          block_size=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block size:[[:space:]]*//p')
+          extra_blocks=$(( ${toString rootfsExtraSlackMiB} * 1024 * 1024 / block_size ))
+          resize2fs "$ROOT_IMAGE" "$((current_blocks + extra_blocks))"
+
+          LUKS_REDUCTION_BYTES=$((16 * 1024 * 1024))
+          LUKS_DATA_OFFSET_BYTES=$((8 * 1024 * 1024))
+          # Host-side verification of root.enc.img shows the mapped device ends up
+          # four additional LUKS data offsets smaller than the final image file.
+          # Account for that before reencrypting so the ext4 filesystem fits the
+          # post-conversion payload exactly.
+          LUKS_PAYLOAD_SLACK_BYTES=$((4 * LUKS_DATA_OFFSET_BYTES))
+
+          GHAF_LUKS_PASSPHRASE_FILE=$(mktemp ".luks-passphrase.XXXXXX")
+          chmod 600 "$GHAF_LUKS_PASSPHRASE_FILE"
+          printf '%s' "${
+            if config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.enable then
+              config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase
+            else
+              config.ghaf.hardware.nvidia.orin.diskEncryption.userPassphrase.passphrase
+          }" > "$GHAF_LUKS_PASSPHRASE_FILE"
+
+          echo "Shrinking plaintext root filesystem before LUKS conversion ..."
+          e2fsck -fy "$ROOT_IMAGE"
+          BLOCK_SIZE=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block size:[[:space:]]*//p')
+          TARGET_PAYLOAD_BYTES=$(( $(stat -c %s "$ROOT_IMAGE") - LUKS_REDUCTION_BYTES - LUKS_DATA_OFFSET_BYTES - LUKS_PAYLOAD_SLACK_BYTES ))
+          TARGET_BLOCKS=$(( TARGET_PAYLOAD_BYTES / BLOCK_SIZE ))
+          resize2fs "$ROOT_IMAGE" "$TARGET_BLOCKS"
+          # Keep the plaintext file one LUKS data offset larger than the
+          # ext4 payload so reencrypt does not collapse the final image size
+          # together with the resized filesystem.
+          truncate -s "$(( TARGET_PAYLOAD_BYTES + LUKS_DATA_OFFSET_BYTES ))" "$ROOT_IMAGE"
+
+          echo "Encrypting extracted root image with LUKS2 ..."
+          # cryptsetup is built with --with-luks2-lock-path=/tmp/cryptsetup;
+          # newer releases refuse to take the reencryption lock if that
+          # directory does not already exist.
+          mkdir -p /tmp/cryptsetup
+          ${cryptsetup}/bin/cryptsetup reencrypt \
+            --encrypt \
+            --type luks2 \
+            --batch-mode \
+            --uuid "${luksUuid}" \
+            --reduce-device-size "$LUKS_REDUCTION_BYTES" \
+            --key-file "$GHAF_LUKS_PASSPHRASE_FILE" \
+            "$ROOT_IMAGE"
+
+          # Re-materialize the final APP image as a fully allocated raw file.
+          # The flash pipeline should see a dense payload, not a sparse file
+          # with holes introduced by truncate during the sizing step above.
+          ROOT_IMAGE_DENSE_PATH="root.enc.dense.img"
+          cp --sparse=never "$ROOT_IMAGE" "$ROOT_IMAGE_DENSE_PATH"
+          mv "$ROOT_IMAGE_DENSE_PATH" "$ROOT_IMAGE"
+
+          rm -f "$GHAF_LUKS_PASSPHRASE_FILE"
+        ''}
+      '';
       postBuildCommands = ''
         fdisk_output=$(fdisk -l "$img")
 

--- a/modules/reference/hardware/jetpack/nx/orin-nx.nix
+++ b/modules/reference/hardware/jetpack/nx/orin-nx.nix
@@ -26,9 +26,13 @@
         somType = "nx";
         nx.enableNetvmEthernetPCIPassthrough = true;
         carrierBoard = "xavierNxDevkit";
-        # Orin NX p3768 devkit boots rootfs from NVMe (no eMMC on this SoM);
-        # configFileName below wires up the matching .conf + flash XML.
-        flashScriptOverrides.rootfsDevice = "nvme0n1p1";
+        # Orin NX p3768 devkit boots rootfs from NVMe and USB (no eMMC on this SoM);
+        # Default is set to USB
+        flashScriptOverrides = {
+          deviceDisk = "sda";
+          deviceDiskEspPartition = "sda1";
+          deviceDiskRootfsPartition = "sda2";
+        };
       };
 
       # Net VM hardware-specific modules - use hardware.definition for composition model
@@ -91,9 +95,9 @@
       # The "-nvme" config sources p3768-0000-p3767-0000-a0.conf and uses
       # flash_t234_qspi_nvme.xml, which probes NVMe instead.
       flashScriptOverrides.configFileName = "jetson-orin-nano-devkit-nvme";
-      # The trailing rootfs device passed to flash.sh is now driven by
-      # ghaf.hardware.nvidia.orin.flashScriptOverrides.rootfsDevice (set
-      # to "nvme0n1p1" above); jetson-orin.nix applies that to flashArgs.
+      # The trailing rootfs device passed to flash.sh is driven by
+      # ghaf.hardware.nvidia.orin.flashScriptOverrides.deviceDiskRootfsPartition;
+      # jetson-orin.nix applies that to flashArgs.
       modesetting.enable = true;
       firmware.uefi = {
         logo = "${pkgs.ghaf-artwork}/1600px-Ghaf_logo.svg";

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -259,28 +259,68 @@ let
       package = lazyPackage name hostConfiguration.config.system.build.ghafImage;
     };
 
+  generate-luks =
+    tgt:
+    tgt
+    // rec {
+      name = tgt.name + "-luks";
+      hostConfiguration = tgt.hostConfiguration.extendModules {
+        modules = [
+          {
+            ghaf.hardware.nvidia.orin.diskEncryption.enable = true;
+            ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.enable = true;
+          }
+        ];
+      };
+      package = hostConfiguration.config.system.build.ghafImage;
+    };
+
+  # LUKS and dm-verity are mutually exclusive root strategies (see the assertion
+  # in jetson-orin.nix), so the verity targets get no -luks variant.
+  luksable-target-configs = builtins.filter (t: !isVerityTarget t) target-configs;
+
   # Add nodemoapps targets
-  targets = target-configs ++ (map generate-nodemoapps target-configs);
+  targets =
+    target-configs
+    ++ (map generate-nodemoapps target-configs)
+    ++ (map generate-luks luksable-target-configs)
+    ++ (map (t: generate-luks (generate-nodemoapps t)) luksable-target-configs);
   crossTargets = map generate-cross-from-x86_64 targets;
-  secureTarget =
+  flashTarget =
     t: qspiOnly:
     let
       innerName = t.hostConfiguration.config.hardware.nvidia-jetpack.name;
       noSB =
         (t.hostConfiguration.extendModules {
           modules = [
-            {
-              ghaf.hardware.nvidia.orin.flashScriptOverrides.onlyQSPI = qspiOnly;
-            }
+            (
+              {
+                ghaf.hardware.nvidia.orin.flashScriptOverrides.onlyQSPI = qspiOnly;
+              }
+              // lib.optionalAttrs (lib.strings.hasInfix "nx" t.name && !qspiOnly) {
+                # NX boots from USB or NVMe; the flash script targets NVMe.
+                ghaf.hardware.nvidia.orin.flashScriptOverrides.deviceDisk = lib.mkForce "nvme0n1";
+                ghaf.hardware.nvidia.orin.flashScriptOverrides.deviceDiskEspPartition = lib.mkForce "nvme0n1p1";
+                ghaf.hardware.nvidia.orin.flashScriptOverrides.deviceDiskRootfsPartition = lib.mkForce "nvme0n1p2";
+              }
+            )
           ];
         }).pkgs.nvidia-jetpack.flashScript;
       withSB =
         (t.hostConfiguration.extendModules {
           modules = [
-            {
-              ghaf.hardware.nvidia.orin.secureboot.enable = lib.mkForce true;
-              ghaf.hardware.nvidia.orin.flashScriptOverrides.onlyQSPI = qspiOnly;
-            }
+            (
+              {
+                ghaf.hardware.nvidia.orin.secureboot.enable = lib.mkForce true;
+                ghaf.hardware.nvidia.orin.flashScriptOverrides.onlyQSPI = qspiOnly;
+              }
+              // lib.optionalAttrs (lib.strings.hasInfix "nx" t.name && !qspiOnly) {
+                # NX boots from USB or NVMe; the flash script targets NVMe.
+                ghaf.hardware.nvidia.orin.flashScriptOverrides.deviceDisk = lib.mkForce "nvme0n1";
+                ghaf.hardware.nvidia.orin.flashScriptOverrides.deviceDiskEspPartition = lib.mkForce "nvme0n1p1";
+                ghaf.hardware.nvidia.orin.flashScriptOverrides.deviceDiskRootfsPartition = lib.mkForce "nvme0n1p2";
+              }
+            )
           ];
         }).pkgs.nvidia-jetpack.flashScript;
     in
@@ -346,7 +386,7 @@ in
             t:
             #Note: secureTarget does not toggle between secureboot on/off!!
             lib.nameValuePair "${t.name}-flash-script" (
-              lazyPackage "${t.name}-flash-script" (secureTarget t false)
+              lazyPackage "${t.name}-flash-script" (flashTarget t false)
             )
           ) crossTargets
         )
@@ -354,7 +394,7 @@ in
           map (
             t:
             #Note: secureTarget does not toggle between secureboot on/off!!
-            lib.nameValuePair "${t.name}-flash-qspi" (lazyPackage "${t.name}-flash-qspi" (secureTarget t true))
+            lib.nameValuePair "${t.name}-flash-qspi" (lazyPackage "${t.name}-flash-qspi" (flashTarget t true))
           ) crossTargets
         )
         # OTA update artifacts for verity targets


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Opt-in LUKS root filesystem encryption for Jetson Orin (`ghaf.hardware.nvidia.orin.diskEncryption.*`), with initrd unlock via `/dev/mapper/cryptroot`.

The root is encrypted at **image build time** (`sdimage.nix`, `cryptsetup reencrypt --encrypt`), so flashing is unattended and writes an already-encrypted APP partition. `*-luks-*` targets unlock with a device-unique key from OP-TEE: the first boot rotates away from the manufacturing passphrase and re-encrypts the volume key, and later boots unlock without user input. `userPassphrase` is available as a testing-only alternative.

Supporting changes:

- The encrypted container ships on two partition tables — the raw sd-image on USB (MBR) and the NVIDIA flash on eMMC/NVMe (GPT) — which necessarily carry different PARTUUIDs. The root is therefore identified by the pinned LUKS2 **header** UUID (`diskEncryption.luksUuid`, `readOnly`), identical on both media and independent of `mmcblk`/`nvme`/`sda` enumeration. The ESP is identified by its FAT label.
- New `flashScriptOverrides.deviceDisk` / `deviceDiskRootfsPartition` / `deviceDiskEspPartition`, replacing the single hardcoded `rootfsDevice`. No defaults — rootfs storage varies per carrier board, and an assertion requires all three. This lets Orin NX flash to NVMe while still supporting USB boot.
- LUKS and dm-verity are mutually exclusive root strategies (verity owns `fileSystems."/"` as a tmpfs overlay). An assertion rejects the combination, and the verity targets no longer generate `-luks` variants.
- LUKS targets stay on `upstream-6-6` and add the kernel config (`BLK_DEV_DM`, `DM_CRYPT`, related dm/crypto symbols) needed for device-mapper at boot.
- Docs updated for the LUKS build and flash flow.

Hardware-verified on an Orin AGX devkit (eMMC) and Orin NX (NVMe): the board resolves `/dev/disk/by-uuid/<uuid>`, LUKS unlocks to `/dev/mapper/cryptroot`, the first-boot resize grows the encrypted filesystem, and the system boots to `ghaf-host login:`.

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [x] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!--
The red `build` and `Analyze` checks are unrelated to this branch — see
https://github.com/tiiuae/ghaf/pull/2032. Fixed by that PR, not this one.
-->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

Four configurations are worth covering: AGX/eMMC and NX/USB with the device-unique key, a non-LUKS target as a regression check, and `userPassphrase` via a manual override. Full matrix with per-case commands and expected output is in [this comment](https://github.com/tiiuae/ghaf/pull/1742#issuecomment-4927222231).

The short version, for `nvidia-jetson-orin-agx-debug-luks`:

1. Build the image and flash script:
   ```sh
   nix build .#nvidia-jetson-orin-agx-debug-luks-from-x86_64
   nix build .#nvidia-jetson-orin-agx-debug-luks-from-x86_64-flash-script
   ```
2. Put the board in recovery mode and flash. No passphrase prompt:
   ```sh
   sudo ./result/bin/flash-ghaf-host
   ```
3. Watch the first boot on the serial console. It rotates to the device-unique key and re-encrypts the root (~1 min/GB on a 32GB AGX), then reaches `ghaf-host login:` without ever prompting.
4. Verify the encrypted root:
   ```sh
   findmnt /                                    # /dev/mapper/cryptroot
   sudo blkid /dev/mmcblk0p2                    # TYPE="crypto_LUKS"
   sudo cryptsetup luksDump /dev/mmcblk0p2      # luksDiskDeviceUniqueKey token
   df -h /                                      # grown to fill the disk
   ```
   The manufacturing passphrase must no longer unlock the disk:
   ```sh
   echo ghaf | sudo cryptsetup open --test-passphrase /dev/mmcblk0p2   # must fail
   ```
5. Reboot. It must be fast — no re-encryption, no prompt — and the resize skips via a marker on the ESP:
   ```sh
   sudo journalctl -b -u resize-partitions      # "Resize already performed, skipping."
   ```
