### PR TITLE
fix: switch darp11-b to S3 deep sleep and harden PCI suspend

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,15 +751,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1769806076,
-        "narHash": "sha256-i89OFmUj32fTi0xRa2Z8QywysIhIhY6sbpDHakiO43Y=",
-        "owner": "tiiuae",
+        "lastModified": 1771140376,
+        "narHash": "sha256-tYH0yVLL8/9/LmqAY130SAALlI7VqkcQzlXniKLbfwc=",
+        "owner": "brianmcgillion",
         "repo": "vhotplug",
-        "rev": "2fed6103e62fc5de1910cdb903f9016759926e09",
+        "rev": "5ab9cd560d027687975daeff7cef94d24d16feaf",
         "type": "github"
       },
       "original": {
-        "owner": "tiiuae",
+        "owner": "brianmcgillion",
+        "ref": "fix-device-recheck",
         "repo": "vhotplug",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -186,7 +186,7 @@
 
     # Hot-plugging USB devices into virtual machines
     vhotplug = {
-      url = "github:tiiuae/vhotplug";
+      url = "github:brianmcgillion/vhotplug/fix-device-recheck";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -153,8 +153,11 @@ let
           case "$action" in
             suspend)
               echo "Suspending PCI devices for $vm_name..."
-              vhotplugcli pci suspend --vm "$vm_name"
-
+              if ! vhotplugcli pci suspend --vm "$vm_name"; then
+                echo "Failed to detach PCI devices for $vm_name. Please check the logs."
+                echo "Fallback: restarting $vm_name to ensure clean state before suspend..."
+                systemctl restart microvm@"$vm_name".service
+              fi
               ;;
             resume)
               echo "Resuming PCI devices for $vm_name..."

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -276,7 +276,7 @@ let
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
-        services.power-manager.suspend.mode = "s2idle";
+        services.power-manager.suspend.mode = "deep";
         # Enable PCI ACS override to split IOMMU groups
         # Needed to separate Ethernet (8086:550a) from Audio devices
         hardware.passthrough.pciAcsOverride = {
@@ -310,7 +310,7 @@ let
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
-        services.power-manager.suspend.mode = "s2idle";
+        services.power-manager.suspend.mode = "deep";
         virtualization.microvm.storeOnDisk = true;
         hardware.passthrough.pciAcsOverride = {
           enable = true;
@@ -531,7 +531,7 @@ let
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
-        services.power-manager.suspend.mode = "s2idle";
+        services.power-manager.suspend.mode = "deep";
         hardware.passthrough.pciAcsOverride = {
           enable = true;
           ids = [ "8086:550a" ];
@@ -562,7 +562,7 @@ let
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
-        services.power-manager.suspend.mode = "s2idle";
+        services.power-manager.suspend.mode = "deep";
         virtualization.microvm.storeOnDisk = true;
         hardware.passthrough.pciAcsOverride = {
           enable = true;


### PR DESCRIPTION
S3 deep sleep fully powers down the PCIe bus, eliminating VFIO FLR config space corruption on the Intel BE200 WiFi after resume.

Also add error handling to the pci-suspend path in power.nix, mirroring the existing resume fallback (VM restart on failure).

Update vhotplug to include post-attach VID/DID verification.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
