### PR TITLE
tpm: route system VMs through host mux and harden DevID attestation

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -32,7 +32,8 @@ path = [
   "overlays/custom-packages/system76-scheduler/0001-fix-add-missing-loop-in-process-scheduler-refresh-ta.patch",
   "modules/secureboot/keys/*",
   "modules/hardware/passthrough/pci-acs-override/0001-pci-add-pcie_acs_override-for-pci-passthrough.patch",
-  "overlays/custom-packages/systemd/0001-pam_systemd_home-Use-PAM_TEXT_INFO-for-token-prompts.patch"
+  "overlays/custom-packages/systemd/0001-pam_systemd_home-Use-PAM_TEXT_INFO-for-token-prompts.patch",
+  "overlays/custom-packages/spire/0001-remove-cloud-components-to-reduce-memory-footprint.patch"
 ]
 
 [[annotations]]

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -62,6 +62,7 @@ export default defineConfig({
                         "ghaf/overview/arch/secureboot",
                         "ghaf/overview/arch/stack",
                         "ghaf/overview/arch/guest-tpm",
+                        "ghaf/overview/arch/tpm-mux",
                       ],
                     },
                     {

--- a/docs/src/content/docs/ghaf/overview/arch/guest-tpm.mdx
+++ b/docs/src/content/docs/ghaf/overview/arch/guest-tpm.mdx
@@ -69,4 +69,6 @@ App VMs currently use emulated TPM on all platforms, unlike system VMs which use
 
 ### Remarks
 
+For the host-side shared hardware TPM mux architecture used by system VMs, see [TPM Mux for System VMs](/ghaf/overview/arch/tpm-mux).
+
 Applications that access the TPM should ideally use TPM 2.0 authenticated sessions. They enable encryption of TPM command payloads, which ensures inspecting or tampering of key material in-transit is not possible. This can be enforced in future updates.

--- a/docs/src/content/docs/ghaf/overview/arch/tpm-mux/index.mdx
+++ b/docs/src/content/docs/ghaf/overview/arch/tpm-mux/index.mdx
@@ -1,0 +1,160 @@
+---
+title: TPM Mux for System VMs
+description: Architecture, implementation, and test plan for shared hardware TPM access in Ghaf system VMs
+---
+
+## Overview
+
+Ghaf system VMs can share one hardware TPM through a host-side mux layer instead of direct passthrough. This design keeps the trust anchor in hardware while avoiding direct concurrent access from multiple guests.
+
+The current non-riscv64 system VM profile uses this model for:
+
+- `admin-vm`
+- `audio-vm`
+- `gui-vm`
+- `net-vm`
+
+On riscv64, system VMs continue to use emulated TPM.
+
+## Why This Exists
+
+Direct passthrough from multiple guests to one TPM can lead to command contention, unreliable startup sequencing, and lockup-like timeout behavior under load. The TPM mux architecture addresses this by introducing controlled fan-out on the host:
+
+- one backend hardware TPM resource manager device (`/dev/tpmrm0` by default)
+- one per-VM forwarder process
+- one per-VM proxy endpoint exposed to QEMU
+
+This preserves VM isolation while making startup and runtime behavior more predictable.
+
+## Architecture
+
+The system is composed of four layers:
+
+1. **Host TPM backend**
+   - `tpm2-abrmd` and host kernel TPM stack
+   - hardware device path defaults to `/dev/tpmrm0`
+2. **Per-VM mux forwarder**
+   - service `ghaf-vtpm-forwarder-<vm>.service`
+   - binary `vtpm-abrmd-forwarder`
+3. **QEMU guest TPM device wiring**
+   - `-tpmdev passthrough,id=tpm0,path=/run/ghaf-vtpm/<vm>.tpm,cancel-path=/tmp/cancel`
+   - `-device tpm-tis` (x86_64) or `tpm-tis-device` (aarch64)
+4. **Guest userspace consumers**
+   - storage encryption helpers
+   - SPIFFE DevID provisioning and attestation
+
+### Boot Ordering
+
+Host systemd ordering enforces forwarder readiness before VM launch:
+
+- `ghaf-vtpm-forwarder-<vm>.service` starts before `microvm@<vm>.service`
+- `microvm@<vm>.service` requires the corresponding forwarder service
+- forwarders use `Type=notify` and become ready only after link endpoint setup
+
+## Implementation Details
+
+### Host Module
+
+Host orchestration is defined in `modules/microvm/host/tpm-mux.nix`:
+
+- enables host TPM stack and `tpm2-abrmd`
+- loads kernel module `tpm_vtpm_proxy`
+- creates runtime directory (`/run/ghaf-vtpm` by default)
+- creates one forwarder service per mux-enabled VM
+- auto-discovers VM list when `ghaf.virtualization.microvm-host.tpmMux.vms = [ ]`
+
+### Guest Module
+
+Guest TPM mode wiring is in `modules/microvm/common/vm-tpm.nix`:
+
+- exactly one TPM mode can be enabled (`passthrough`, `muxed`, or `emulated`)
+- mux mode exports host path as QEMU passthrough backend
+- guest `tpm0` permissions are configured for TPM userspace components
+
+### System VM Base Integration
+
+System VM defaults now select mux mode on non-riscv64 when storage encryption is enabled:
+
+- `modules/microvm/sysvms/adminvm-base.nix`
+- `modules/microvm/sysvms/audiovm-base.nix`
+- `modules/microvm/sysvms/guivm-base.nix`
+- `modules/microvm/sysvms/netvm-base.nix`
+
+The laptop profile host mux config currently sets an explicit system VM list:
+
+- `modules/profiles/laptop-x86.nix`
+
+## SPIFFE / DevID Considerations
+
+The TPM mux layer is transparent to SPIFFE from a consumer perspective (`/dev/tpm0` inside guests), but it affects timing and reliability characteristics. For TPM DevID flows, keep these guardrails:
+
+- ensure provisioning and attestation are resilient to transient TPM retries/timeouts
+- validate DevID cert public key matches VM TPM key before accepting cached certs
+- prefer restart-safe provisioning behavior over one-shot assumptions
+
+## Testing Strategy
+
+Use a staged test plan for each change.
+
+### 1. Static and Policy Checks
+
+- `nix fmt -- --fail-on-change`
+- `nix develop --command reuse lint`
+
+### 2. Build and Evaluation
+
+- evaluate affected target(s)
+- build image/closure that includes updated VM bases and host mux module
+
+### 3. Boot and Service Readiness
+
+On host:
+
+- verify `tpm2-abrmd.service` is active
+- verify `ghaf-vtpm-forwarder-<vm>.service` is active for each system VM
+- verify `microvm@<vm>.service` starts after the matching forwarder
+
+In each VM (`admin-vm`, `audio-vm`, `gui-vm`, `net-vm`):
+
+- verify `/dev/tpm0` exists and has expected ownership/mode
+- run basic command smoke test, for example `tpm2_getrandom 8`
+
+### 4. Concurrency and Stress
+
+Run concurrent TPM command loops in all system VMs and monitor:
+
+- VM command success rate
+- forwarder restarts and error counters
+- host kernel TPM timeout messages
+
+Gate condition: sustained test window with no forwarder crashes and acceptable command success ratio.
+
+### 5. SPIFFE End-to-End
+
+For TPM DevID-enabled VMs:
+
+- restart `spire-devid-provision` and `spire-agent`
+- verify successful node attestation in agent logs
+- verify matching successful request completion in server logs
+- verify agent restarts load existing SVID without re-entering failure loops
+
+## Troubleshooting Checklist
+
+If a VM shows TPM failures:
+
+1. Confirm forwarder service for that VM is active on host.
+2. Confirm VM started after forwarder (systemd ordering).
+3. Check host logs for `tpm tpm2: Operation Timed out` or retry loops.
+4. Check forwarder logs for backend receive latency and proxy write/read errors.
+5. For SPIFFE failures, verify DevID cert/public-key match before retrying attestation.
+
+## Known Constraints
+
+- Shared hardware TPM is still a serialized resource; under heavy multi-VM load, latency spikes can occur.
+- Some TPM commands are more sensitive to contention and timeout behavior.
+- Operational reliability depends on both mux correctness and consumer retry/backoff behavior.
+
+## Related Documents
+
+- [Virtualized TPM for guests](/ghaf/overview/arch/guest-tpm)
+- [Ghaf Architecture Overview](/ghaf/overview/arch/system-architecture)

--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768505959,
-        "narHash": "sha256-oFCx/ApQ+S1/apUKWsvT9vq+Eo1m2vINWEDkW7/nckA=",
+        "lastModified": 1762806692,
+        "narHash": "sha256-JhgQIwJe0U2vxj+pu+Sgm+VLgNqucpXtZYGKZOgkQdc=",
         "owner": "nixos-cuda",
         "repo": "cuda-legacy",
-        "rev": "86ad7e2c2e314f0234539cbbc66b5cd7746bcd32",
+        "rev": "9856d70acc3e2ae9081930b33d946326e07f1482",
         "type": "github"
       },
       "original": {
@@ -434,16 +434,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1770011817,
-        "narHash": "sha256-yPdRmDNRdUfiEHMmdJrRUPT+WX67OfbvtaZ+5dTxDvw=",
+        "lastModified": 1772453979,
+        "narHash": "sha256-elX5GCCYI0ox3Hnl3SVFQEqiTXXT9mHE3BBrBh+olMs=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "5994e772752fe7c7b91382d718d3f93f5f5c12d5",
+        "rev": "62df2000209b7e35cd598362a0ac02254ad4844a",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
-        "ref": "feb-rebase",
+        "ref": "wip-ftpm",
         "repo": "jetpack-nixos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -133,7 +133,7 @@
     # Nvidia Orin support for NixOS
     jetpack-nixos = {
       #url = "github:anduril/jetpack-nixos";
-      url = "github:tiiuae/jetpack-nixos/feb-rebase";
+      url = "github:tiiuae/jetpack-nixos/wip-ftpm";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -123,6 +123,32 @@ rec {
         };
         tpmAttestation = {
           enable = mkEnableOption "TPM DevID node attestation for system VMs";
+          endorsementCaCerts = mkOption {
+            type = types.listOf types.path;
+            default = [ ];
+            description = ''
+              TPM manufacturer endorsement CA certs (PEM files).
+              Deprecated: use endorsementCaBundle instead.
+              Kept for backward compatibility.
+            '';
+          };
+          endorsementCaBundle = mkOption {
+            type = types.str;
+            default = "";
+            description = ''
+              Combined PEM file with all TPM manufacturer endorsement CAs.
+              Populated from tpm-endorsement.nix wiring module (points to all.pem).
+              Used by SPIRE server as endorsement_ca_path.
+            '';
+          };
+          endorsementCaVendors = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = ''
+              Expected TPM vendor names (advisory, for warning on mismatch).
+              Populated from hardware definition.
+            '';
+          };
         };
       };
 

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -103,6 +103,29 @@ rec {
       # IDS VM specific settings
       idsvm.mitmproxy.enable = mkEnableOption "MITM proxy in IDS VM for traffic inspection";
 
+      # SPIFFE/SPIRE identity framework
+      spiffe = {
+        enable = mkEnableOption "SPIFFE/SPIRE identity framework";
+        trustDomain = mkOption {
+          type = types.str;
+          default = "ghaf.internal";
+          description = "SPIFFE trust domain used by SPIRE";
+        };
+        serverPort = mkOption {
+          type = types.port;
+          default = 8081;
+          description = "SPIRE server bind port";
+        };
+        serverVm = mkOption {
+          type = types.str;
+          default = "admin-vm";
+          description = "VM that runs the SPIRE server";
+        };
+        tpmAttestation = {
+          enable = mkEnableOption "TPM DevID node attestation for system VMs";
+        };
+      };
+
       # Platform information (populated from host config)
       platform = {
         buildSystem = mkOption {
@@ -304,11 +327,16 @@ rec {
       };
 
       storage = {
-        encryption.enable = false;
+        encryption.enable = true;
         storeOnDisk = false;
       };
 
       graphics.boot.enable = true;
+
+      spiffe = {
+        enable = true;
+        tpmAttestation.enable = true;
+      };
 
       shm.enable = false;
       idsvm.mitmproxy.enable = false;
@@ -383,6 +411,11 @@ rec {
 
       graphics.boot.enable = true;
 
+      spiffe = {
+        enable = true;
+        tpmAttestation.enable = true;
+      };
+
       shm.enable = false;
       idsvm.mitmproxy.enable = false;
 
@@ -452,6 +485,11 @@ rec {
       storage = {
         encryption.enable = false;
         storeOnDisk = false;
+      };
+
+      spiffe = {
+        enable = false;
+        tpmAttestation.enable = false;
       };
 
       shm.enable = false;

--- a/modules/common/security/default.nix
+++ b/modules/common/security/default.nix
@@ -9,6 +9,7 @@
     ./disk-encryption.nix
     ./fail2ban.nix
     ./pwquality.nix
+    ./spiffe
     ./ssh-tarpit
     ./fleet
     ../../secureboot/secureboot.nix

--- a/modules/common/security/spiffe/agent.nix
+++ b/modules/common/security/spiffe/agent.nix
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPIRE Agent Module
+#
+# Runs a SPIRE agent on each VM. Supports two attestation modes:
+# - join_token: for app VMs (emulated TPM, no hardware root)
+# - tpm_devid: for system VMs with hardware TPM passthrough
+#
+# The attestation mode is selected based on cfg.attestationMode.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.agent;
+
+  useTpmDevid = cfg.attestationMode == "tpm_devid";
+
+  agentConf = ''
+    agent {
+      data_dir = "${cfg.dataDir}"
+      log_level = "${cfg.logLevel}"
+      server_address = "${cfg.serverAddress}"
+      server_port = ${toString cfg.serverPort}
+      trust_domain = "${cfg.trustDomain}"
+      trust_bundle_path = "${cfg.trustBundlePath}"
+      socket_path = "${cfg.socketPath}"
+  ''
+  + lib.optionalString (!useTpmDevid) ''
+    join_token_file = "${cfg.joinTokenFile}"
+  ''
+  + ''
+    }
+
+    plugins {
+  ''
+  + (
+    if useTpmDevid then
+      ''
+        NodeAttestor "tpm_devid" {
+          plugin_data {
+            devid_cert_path = "${cfg.tpmDevid.certPath}"
+            devid_priv_path = "${cfg.tpmDevid.privPath}"
+            devid_pub_path = "${cfg.tpmDevid.pubPath}"
+          }
+        }
+      ''
+    else
+      ''
+        NodeAttestor "join_token" {
+          plugin_data {}
+        }
+      ''
+  )
+  + ''
+
+      WorkloadAttestor "unix" {
+        plugin_data {}
+      }
+
+      KeyManager "disk" {
+        plugin_data {
+          directory = "${cfg.dataDir}/keys"
+        }
+      }
+    }
+  '';
+in
+{
+  _file = ./agent.nix;
+
+  options.ghaf.security.spiffe.agent = {
+    enable = lib.mkEnableOption "SPIRE agent";
+
+    trustDomain = lib.mkOption {
+      type = lib.types.str;
+      default = "ghaf.internal";
+      description = "SPIFFE trust domain expected from the server";
+    };
+
+    serverAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "SPIRE server address reachable from this VM";
+    };
+
+    serverPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8081;
+      description = "SPIRE server port";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spire/agent";
+      description = "SPIRE agent state directory";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.str;
+      default = "INFO";
+      description = "SPIRE agent log level";
+    };
+
+    trustBundlePath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/bundle.pem";
+      description = "Path to the SPIRE trust bundle PEM file";
+    };
+
+    joinTokenFile = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/tokens/agent.token";
+      description = "Path to a file containing a join token";
+    };
+
+    socketPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/run/spire/agent.sock";
+      description = "SPIRE Agent API socket path";
+    };
+
+    attestationMode = lib.mkOption {
+      type = lib.types.enum [
+        "join_token"
+        "tpm_devid"
+      ];
+      default = "join_token";
+      description = "Node attestation mode: join_token (app VMs) or tpm_devid (system VMs with TPM)";
+    };
+
+    tpmDevid = {
+      certPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/devid/devid.pem";
+        description = "Path to the DevID certificate";
+      };
+      privPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/devid/devid.priv";
+        description = "Path to the DevID TPM private blob";
+      };
+      pubPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/devid/devid.pub";
+        description = "Path to the DevID TPM public blob";
+      };
+    };
+
+    workloadApiGroup = lib.mkOption {
+      type = lib.types.str;
+      default = "spiffe";
+      description = "Group allowed to access the SPIRE Agent API socket";
+    };
+
+    workloadApiUsers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "ghaf" ];
+      description = "Users added to workloadApiGroup for SPIRE Workload API access";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.spire ];
+
+    users.groups = {
+      spire = { };
+      "${cfg.workloadApiGroup}" = { };
+    };
+
+    users.users = {
+      spire = {
+        isSystemUser = true;
+        group = "spire";
+        extraGroups = lib.optionals useTpmDevid [
+          config.security.tpm2.tssGroup or "tss"
+        ];
+      };
+    }
+    // (lib.genAttrs cfg.workloadApiUsers (_: {
+      extraGroups = lib.mkAfter [ cfg.workloadApiGroup ];
+    }));
+
+    environment.etc."spire/agent.conf".text = agentConf;
+
+    # Own /run/spire via tmpfiles with group access for spiffe users
+    systemd.tmpfiles.rules = [
+      "d /run/spire 2750 spire ${cfg.workloadApiGroup} - -"
+    ];
+
+    systemd.services.spire-agent = {
+      description = "SPIRE Agent";
+      wantedBy = [ "multi-user.target" ];
+
+      requires = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+      ]
+      ++ lib.optionals useTpmDevid [ "spire-devid-provision.service" ];
+      wants = [ "network-online.target" ];
+      unitConfig = {
+        RequiresMountsFor = [ "/etc/common" ];
+      };
+
+      serviceConfig = {
+        PermissionsStartOnly = true;
+
+        User = "spire";
+        Group = "spire";
+
+        UMask = "007";
+
+        SupplementaryGroups = [
+          cfg.workloadApiGroup
+        ]
+        ++ lib.optionals useTpmDevid [
+          config.security.tpm2.tssGroup or "tss"
+        ];
+
+        ExecStart = "${pkgs.spire}/bin/spire-agent run -config /etc/spire/agent.conf";
+
+        StateDirectory = "spire/agent";
+        StateDirectoryMode = "0750";
+
+        Restart = "on-failure";
+        RestartSec = "2s";
+
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [
+          cfg.dataDir
+          "/run/spire"
+        ]
+        ++ lib.optionals useTpmDevid [
+          "/dev/tpmrm0"
+        ];
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/agent.nix
+++ b/modules/common/security/spiffe/agent.nix
@@ -38,6 +38,7 @@ let
     plugins {
       NodeAttestor "tpm_devid" {
         plugin_data {
+          tpm_device_path = "/dev/tpm0"
           devid_cert_path = "${cfg.tpmDevid.certPath}"
           devid_priv_path = "${cfg.tpmDevid.privPath}"
           devid_pub_path = "${cfg.tpmDevid.pubPath}"
@@ -85,6 +86,13 @@ let
       if [ -f "${cfg.tpmDevid.certPath}" ] && \
          [ -f "${cfg.tpmDevid.privPath}" ] && \
          [ -f "${cfg.tpmDevid.pubPath}" ]; then
+        if [ -d "${cfg.dataDir}" ] && grep -Rqs "/spire/agent/join_token/" "${cfg.dataDir}" 2>/dev/null; then
+          echo "Join-token SVID cache detected, resetting SPIRE agent state for tpm_devid"
+          for entry in "${cfg.dataDir}"/* "${cfg.dataDir}"/.[!.]* "${cfg.dataDir}"/..?*; do
+            [ -e "$entry" ] || continue
+            rm -rf "$entry"
+          done
+        fi
         echo "DevID files found, using tpm_devid attestation"
         ln -sf /etc/spire/agent-tpm-devid.conf /run/spire/agent.conf
       else
@@ -94,6 +102,34 @@ let
     else
       ln -sf /etc/spire/agent-join-token.conf /run/spire/agent.conf
     fi
+  '';
+
+  tpmReadyWait = pkgs.writeShellScript "spire-agent-wait-tpm" ''
+    # Add small deterministic startup jitter so system VMs do not hammer TPM simultaneously.
+    if [ -r /etc/hostname ]; then
+      seed=$(${pkgs.coreutils}/bin/cksum /etc/hostname | ${pkgs.coreutils}/bin/cut -d' ' -f1)
+      delay=$((seed % 8))
+      ${pkgs.coreutils}/bin/sleep "$delay"
+    fi
+
+    export TPM2TOOLS_TCTI="device:/dev/tpm0"
+
+    ready_seq=0
+    for attempt in $(seq 1 30); do
+      if ${pkgs.coreutils}/bin/timeout 3 ${pkgs.tpm2-tools}/bin/tpm2_getcap properties-fixed >/dev/null 2>&1; then
+        ready_seq=$((ready_seq + 1))
+        if [ "$ready_seq" -ge 2 ]; then
+          exit 0
+        fi
+      else
+        ready_seq=0
+      fi
+
+      ${pkgs.coreutils}/bin/sleep 1
+    done
+
+    echo "WARNING: TPM readiness probe timed out; starting SPIRE agent anyway"
+    exit 0
   '';
 in
 {
@@ -188,6 +224,12 @@ in
       default = [ "ghaf" ];
       description = "Users added to workloadApiGroup for SPIRE Workload API access";
     };
+
+    commonMountPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common";
+      description = "Path to the common virtiofs mount (VMs use /etc/common, host uses /persist/common)";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -241,7 +283,7 @@ in
         "spire-devid-provision.service"
       ];
       unitConfig = {
-        RequiresMountsFor = [ "/etc/common" ];
+        RequiresMountsFor = [ cfg.commonMountPath ];
       };
 
       serviceConfig = {
@@ -259,7 +301,7 @@ in
           config.security.tpm2.tssGroup or "tss"
         ];
 
-        ExecStartPre = "+${agentConfSelector}";
+        ExecStartPre = lib.optionals useTpmDevid [ "+${tpmReadyWait}" ] ++ [ "+${agentConfSelector}" ];
         ExecStart = "${pkgs.spire}/bin/spire-agent run -config /run/spire/agent.conf";
 
         StateDirectory = "spire/agent";
@@ -277,7 +319,7 @@ in
           "/run/spire"
         ]
         ++ lib.optionals useTpmDevid [
-          "/dev/tpmrm0"
+          "/dev/tpm0"
         ];
       };
     };

--- a/modules/common/security/spiffe/agent.nix
+++ b/modules/common/security/spiffe/agent.nix
@@ -38,7 +38,7 @@ let
     plugins {
       NodeAttestor "tpm_devid" {
         plugin_data {
-          tpm_device_path = "/dev/tpm0"
+          tpm_device_path = "${cfg.tpmDevid.devicePath}"
           devid_cert_path = "${cfg.tpmDevid.certPath}"
           devid_priv_path = "${cfg.tpmDevid.privPath}"
           devid_pub_path = "${cfg.tpmDevid.pubPath}"
@@ -82,10 +82,33 @@ let
 
   # Runtime config selector: checks if DevID files exist, falls back to join_token
   agentConfSelector = pkgs.writeShellScript "spire-agent-select-config" ''
+    export TPM2TOOLS_TCTI="device:${cfg.tpmDevid.devicePath}"
+
+    ek_index_available() {
+      local idx="$1"
+      ${pkgs.coreutils}/bin/timeout -k 2 5 ${pkgs.tpm2-tools}/bin/tpm2_nvreadpublic "$idx" >/dev/null 2>&1
+    }
+
+    tpm_in_lockout() {
+      ${pkgs.coreutils}/bin/timeout -k 2 5 ${pkgs.tpm2-tools}/bin/tpm2_getcap properties-variable 2>/dev/null | ${pkgs.gnugrep}/bin/grep -q "inLockout:[[:space:]]*1"
+    }
+
     if [ "${toString useTpmDevid}" = "1" ]; then
       if [ -f "${cfg.tpmDevid.certPath}" ] && \
          [ -f "${cfg.tpmDevid.privPath}" ] && \
          [ -f "${cfg.tpmDevid.pubPath}" ]; then
+        if tpm_in_lockout; then
+          echo "TPM is in DA lockout mode, falling back to join_token attestation"
+          ln -sf /etc/spire/agent-join-token.conf /run/spire/agent.conf
+          exit 0
+        fi
+
+        if ! ek_index_available 0x01C00002 && ! ek_index_available 0x01C0000A; then
+          echo "EK cert NV indices are missing, falling back to join_token attestation"
+          ln -sf /etc/spire/agent-join-token.conf /run/spire/agent.conf
+          exit 0
+        fi
+
         if [ -d "${cfg.dataDir}" ] && grep -Rqs "/spire/agent/join_token/" "${cfg.dataDir}" 2>/dev/null; then
           echo "Join-token SVID cache detected, resetting SPIRE agent state for tpm_devid"
           for entry in "${cfg.dataDir}"/* "${cfg.dataDir}"/.[!.]* "${cfg.dataDir}"/..?*; do
@@ -112,11 +135,11 @@ let
       ${pkgs.coreutils}/bin/sleep "$delay"
     fi
 
-    export TPM2TOOLS_TCTI="device:/dev/tpm0"
+    export TPM2TOOLS_TCTI="device:${cfg.tpmDevid.devicePath}"
 
     ready_seq=0
     for attempt in $(seq 1 30); do
-      if ${pkgs.coreutils}/bin/timeout 3 ${pkgs.tpm2-tools}/bin/tpm2_getcap properties-fixed >/dev/null 2>&1; then
+      if ${pkgs.coreutils}/bin/timeout -k 1 3 ${pkgs.tpm2-tools}/bin/tpm2_getcap properties-fixed >/dev/null 2>&1; then
         ready_seq=$((ready_seq + 1))
         if [ "$ready_seq" -ge 2 ]; then
           exit 0
@@ -196,6 +219,11 @@ in
     };
 
     tpmDevid = {
+      devicePath = lib.mkOption {
+        type = lib.types.str;
+        default = "/dev/tpmrm0";
+        description = "Path to the TPM device used for tpm_devid attestation";
+      };
       certPath = lib.mkOption {
         type = lib.types.str;
         default = "/var/lib/spire/devid/devid.pem";
@@ -268,20 +296,8 @@ in
       wantedBy = [ "multi-user.target" ];
 
       requires = [ "network-online.target" ];
-      after = [
-        "network-online.target"
-      ]
-      ++ lib.optionals useTpmDevid [
-        "tpm-vendor-detect.service"
-        "tpm-ek-verify.service"
-        "spire-devid-provision.service"
-      ];
-      wants = [
-        "network-online.target"
-      ]
-      ++ lib.optionals useTpmDevid [
-        "spire-devid-provision.service"
-      ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
       unitConfig = {
         RequiresMountsFor = [ cfg.commonMountPath ];
       };
@@ -319,7 +335,7 @@ in
           "/run/spire"
         ]
         ++ lib.optionals useTpmDevid [
-          "/dev/tpm0"
+          cfg.tpmDevid.devicePath
         ];
       };
     };

--- a/modules/common/security/spiffe/default.nix
+++ b/modules/common/security/spiffe/default.nix
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPIFFE/SPIRE Module Wrapper
+#
+# Imports server, agent, and TPM DevID modules.
+# Propagates shared options (trustDomain) to sub-modules.
+#
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.security.spiffe;
+in
+{
+  _file = ./default.nix;
+
+  imports = [
+    ./server.nix
+    ./agent.nix
+    ./devid-ca.nix
+    ./devid-provision.nix
+  ];
+
+  options.ghaf.security.spiffe = {
+    enable = lib.mkEnableOption "SPIFFE/SPIRE support (identity control plane)";
+
+    trustDomain = lib.mkOption {
+      type = lib.types.str;
+      default = "ghaf.internal";
+      description = "SPIFFE trust domain used by SPIRE";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Propagate common defaults to server/agent
+    ghaf.security.spiffe.server.trustDomain = lib.mkDefault cfg.trustDomain;
+    ghaf.security.spiffe.agent.trustDomain = lib.mkDefault cfg.trustDomain;
+  };
+}

--- a/modules/common/security/spiffe/default.nix
+++ b/modules/common/security/spiffe/default.nix
@@ -18,6 +18,8 @@ in
     ./agent.nix
     ./devid-ca.nix
     ./devid-provision.nix
+    ./tpm-vendor-detect.nix
+    ./tpm-ek-verify.nix
   ];
 
   options.ghaf.security.spiffe = {

--- a/modules/common/security/spiffe/devid-ca.nix
+++ b/modules/common/security/spiffe/devid-ca.nix
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# DevID Certificate Authority Module (admin-vm)
+#
+# Manages a self-signed CA for issuing TPM DevID certificates.
+# The CA key lives on admin-vm's LUKS-encrypted storage (TPM-sealed).
+#
+# Workflow:
+# 1. On first boot: generates self-signed CA (RSA-4096)
+# 2. Publishes CA cert to /etc/common/spire/ca/ca.pem (virtiofs)
+# 3. Watches for CSR files from system VMs
+# 4. Signs each CSR, writes cert to /etc/common/spire/devid/certs/{vmName}.pem
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.devidCa;
+
+  inherit (cfg) caDir;
+  inherit (cfg) csrDir;
+  inherit (cfg) certDir;
+  inherit (cfg) caPublishPath;
+
+  spireDevidCaSetupApp = pkgs.writeShellApplication {
+    name = "spire-devid-ca-setup";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.openssl
+    ];
+    text = ''
+      mkdir -p "${caDir}" "${csrDir}" "${certDir}"
+      chmod 0700 "${caDir}"
+
+      CA_KEY="${caDir}/ca.key"
+      CA_CERT="${caDir}/ca.pem"
+
+      if [ ! -f "$CA_KEY" ]; then
+        echo "Generating DevID CA key pair..."
+        openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
+          -nodes -keyout "$CA_KEY" -out "$CA_CERT" \
+          -subj "/CN=Ghaf DevID CA/O=Ghaf/OU=SPIRE"
+        chmod 0600 "$CA_KEY"
+        chmod 0644 "$CA_CERT"
+        echo "DevID CA created at $CA_CERT"
+      else
+        echo "DevID CA already exists"
+      fi
+
+      # Publish CA cert to virtiofs for system VMs and SPIRE server
+      mkdir -p "$(dirname "${caPublishPath}")"
+      cp "$CA_CERT" "${caPublishPath}"
+      chmod 0644 "${caPublishPath}"
+      echo "Published CA cert to ${caPublishPath}"
+
+      # Create placeholder endorsement CA for SPIRE tpm_devid plugin.
+      # The tpm_devid NodeAttestor requires endorsement_ca_path (TPM manufacturer
+      # EK root cert). For production, replace with real manufacturer CAs
+      # (e.g. Infineon). This placeholder lets SPIRE server start; actual TPM
+      # DevID attestation will fail EK verification until real CAs are bundled.
+      ENDORSEMENT_CA="${caDir}/endorsement-ca.pem"
+      if [ ! -f "$ENDORSEMENT_CA" ]; then
+        cp "$CA_CERT" "$ENDORSEMENT_CA"
+        chmod 0644 "$ENDORSEMENT_CA"
+        echo "Created placeholder endorsement CA at $ENDORSEMENT_CA"
+      fi
+    '';
+  };
+
+  spireDevidSignApp = pkgs.writeShellApplication {
+    name = "spire-devid-sign";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.openssl
+      pkgs.inotify-tools
+    ];
+    text = ''
+      CA_KEY="${caDir}/ca.key"
+      CA_CERT="${caDir}/ca.pem"
+
+      if [ ! -f "$CA_KEY" ]; then
+        echo "ERROR: CA key not found at $CA_KEY" >&2
+        exit 1
+      fi
+
+      sign_csr() {
+        local csr="$1"
+        local base
+        base="$(basename "$csr" .csr)"
+        local out="${certDir}/''${base}.pem"
+
+        if [ -f "$out" ]; then
+          echo "Certificate already exists for $base, skipping"
+          return
+        fi
+
+        echo "Signing CSR for $base..."
+        openssl x509 -req -in "$csr" \
+          -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
+          -days 365 -sha256 \
+          -out "$out"
+        chmod 0644 "$out"
+        echo "Signed certificate written to $out"
+      }
+
+      # Sign any existing CSRs first
+      for csr in "${csrDir}"/*.csr; do
+        [ -f "$csr" ] && sign_csr "$csr"
+      done
+
+      # Watch for new CSRs
+      echo "Watching ${csrDir} for new CSRs..."
+      inotifywait -m -e close_write -e moved_to "${csrDir}" --format '%f' | while read -r filename; do
+        if [[ "$filename" == *.csr ]]; then
+          sign_csr "${csrDir}/$filename"
+        fi
+      done
+    '';
+  };
+in
+{
+  _file = ./devid-ca.nix;
+
+  options.ghaf.security.spiffe.devidCa = {
+    enable = lib.mkEnableOption "DevID Certificate Authority for SPIRE TPM attestation";
+
+    caDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spire/ca";
+      description = "Directory for CA key and certificate (on encrypted storage)";
+    };
+
+    caPublishPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/ca/ca.pem";
+      description = "Path where CA cert is published (virtiofs, readable by VMs)";
+    };
+
+    csrDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/devid/requests";
+      description = "Directory where system VMs submit CSR files (virtiofs)";
+    };
+
+    certDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/devid/certs";
+      description = "Directory where signed DevID certs are placed (virtiofs)";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.spire-devid-ca = {
+      description = "SPIRE DevID CA setup";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "spire-server.service" ];
+      after = [ "local-fs.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe spireDevidCaSetupApp;
+      };
+    };
+
+    systemd.services.spire-devid-sign = {
+      description = "SPIRE DevID CSR signer (watches for CSRs from system VMs)";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "spire-devid-ca.service"
+        "local-fs.target"
+      ];
+      requires = [ "spire-devid-ca.service" ];
+
+      serviceConfig = {
+        ExecStart = lib.getExe spireDevidSignApp;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/devid-ca.nix
+++ b/modules/common/security/spiffe/devid-ca.nix
@@ -56,18 +56,6 @@ let
       cp "$CA_CERT" "${caPublishPath}"
       chmod 0644 "${caPublishPath}"
       echo "Published CA cert to ${caPublishPath}"
-
-      # Create placeholder endorsement CA for SPIRE tpm_devid plugin.
-      # The tpm_devid NodeAttestor requires endorsement_ca_path (TPM manufacturer
-      # EK root cert). For production, replace with real manufacturer CAs
-      # (e.g. Infineon). This placeholder lets SPIRE server start; actual TPM
-      # DevID attestation will fail EK verification until real CAs are bundled.
-      ENDORSEMENT_CA="${caDir}/endorsement-ca.pem"
-      if [ ! -f "$ENDORSEMENT_CA" ]; then
-        cp "$CA_CERT" "$ENDORSEMENT_CA"
-        chmod 0644 "$ENDORSEMENT_CA"
-        echo "Created placeholder endorsement CA at $ENDORSEMENT_CA"
-      fi
     '';
   };
 

--- a/modules/common/security/spiffe/devid-ca.nix
+++ b/modules/common/security/spiffe/devid-ca.nix
@@ -63,49 +63,181 @@ let
     name = "spire-devid-sign";
     runtimeInputs = [
       pkgs.coreutils
+      pkgs.diffutils
+      pkgs.gnugrep
       pkgs.openssl
       pkgs.inotify-tools
     ];
     text = ''
       CA_KEY="${caDir}/ca.key"
       CA_CERT="${caDir}/ca.pem"
+      CA_SERIAL="${caDir}/ca.srl"
 
       if [ ! -f "$CA_KEY" ]; then
         echo "ERROR: CA key not found at $CA_KEY" >&2
         exit 1
       fi
 
+      cert_matches_pub() {
+        local cert_file="$1"
+        local pub_file="$2"
+        local cert_pub=""
+        local req_pub=""
+
+        if [ ! -s "$cert_file" ] || [ ! -s "$pub_file" ]; then
+          return 1
+        fi
+
+        cert_pub=$(mktemp)
+        req_pub=$(mktemp)
+
+        if ! openssl x509 -in "$cert_file" -pubkey -noout 2>/dev/null | \
+          openssl pkey -pubin -outform pem > "$cert_pub" 2>/dev/null; then
+          rm -f "$cert_pub" "$req_pub"
+          return 1
+        fi
+
+        if ! openssl pkey -pubin -in "$pub_file" -outform pem > "$req_pub" 2>/dev/null; then
+          rm -f "$cert_pub" "$req_pub"
+          return 1
+        fi
+
+        cmp -s "$cert_pub" "$req_pub"
+        local rc=$?
+        rm -f "$cert_pub" "$req_pub"
+        return "$rc"
+      }
+
       sign_csr() {
         local csr="$1"
         local base
         base="$(basename "$csr" .csr)"
         local out="${certDir}/''${base}.pem"
+        local tmp_out="''${out}.tmp"
 
         if [ -f "$out" ]; then
-          echo "Certificate already exists for $base, skipping"
-          return
+          if [ -s "$out" ]; then
+            echo "Certificate already exists for $base, skipping"
+            return
+          fi
+          echo "WARNING: Found empty certificate for $base, regenerating"
+          rm -f "$out"
+        fi
+
+        if [ ! -s "$csr" ]; then
+          echo "WARNING: CSR for $base is empty, skipping"
+          return 1
+        fi
+
+        if [ -f "$CA_SERIAL" ] && ! grep -Eq '^[0-9A-Fa-f]+$' "$CA_SERIAL"; then
+          echo "WARNING: Invalid CA serial file, recreating $CA_SERIAL"
+          rm -f "$CA_SERIAL"
         fi
 
         echo "Signing CSR for $base..."
-        openssl x509 -req -in "$csr" \
+        if ! openssl x509 -req -in "$csr" \
           -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
+          -CAserial "$CA_SERIAL" \
           -days 365 -sha256 \
-          -out "$out"
+          -out "$tmp_out"; then
+          echo "ERROR: Failed to sign CSR for $base"
+          rm -f "$tmp_out"
+          return 1
+        fi
+
+        if [ ! -s "$tmp_out" ]; then
+          echo "ERROR: Signed certificate for $base is empty"
+          rm -f "$tmp_out"
+          return 1
+        fi
+
+        mv -f "$tmp_out" "$out"
         chmod 0644 "$out"
         echo "Signed certificate written to $out"
       }
 
-      # Sign any existing CSRs first
-      for csr in "${csrDir}"/*.csr; do
-        [ -f "$csr" ] && sign_csr "$csr"
-      done
+      sign_pub_request() {
+        local pub="$1"
+        local base
+        base="$(basename "$pub" .pub.pem)"
+        local out="${certDir}/''${base}.pem"
+        local tmp_out="''${out}.tmp"
 
-      # Watch for new CSRs
-      echo "Watching ${csrDir} for new CSRs..."
-      inotifywait -m -e close_write -e moved_to "${csrDir}" --format '%f' | while read -r filename; do
-        if [[ "$filename" == *.csr ]]; then
-          sign_csr "${csrDir}/$filename"
+        if [ -f "$out" ]; then
+          if [ -s "$out" ]; then
+            if cert_matches_pub "$out" "$pub"; then
+              echo "Certificate already exists for $base, skipping"
+              return
+            fi
+
+            echo "Certificate exists for $base but key changed, regenerating"
+            rm -f "$out"
+          else
+            echo "WARNING: Found empty certificate for $base, regenerating"
+            rm -f "$out"
+          fi
         fi
+
+        if [ ! -s "$pub" ]; then
+          echo "WARNING: Public key request for $base is empty, skipping"
+          return 1
+        fi
+
+        if ! openssl pkey -pubin -in "$pub" -noout >/dev/null 2>&1; then
+          echo "WARNING: Public key request for $base is invalid, skipping"
+          return 1
+        fi
+
+        if [ -f "$CA_SERIAL" ] && ! grep -Eq '^[0-9A-Fa-f]+$' "$CA_SERIAL"; then
+          echo "WARNING: Invalid CA serial file, recreating $CA_SERIAL"
+          rm -f "$CA_SERIAL"
+        fi
+
+        echo "Signing public key request for $base..."
+        if ! openssl x509 -new \
+          -force_pubkey "$pub" \
+          -set_subject "/CN=$base/O=Ghaf/OU=DevID" \
+          -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
+          -CAserial "$CA_SERIAL" \
+          -days 365 -sha256 \
+          -out "$tmp_out"; then
+          echo "ERROR: Failed to sign public key request for $base"
+          rm -f "$tmp_out"
+          return 1
+        fi
+
+        if [ ! -s "$tmp_out" ]; then
+          echo "ERROR: Signed certificate for $base is empty"
+          rm -f "$tmp_out"
+          return 1
+        fi
+
+        mv -f "$tmp_out" "$out"
+        chmod 0644 "$out"
+        echo "Signed certificate written to $out"
+      }
+
+      scan_pending_requests() {
+        local count=0
+        shopt -s nullglob
+        for pub in "${csrDir}"/*.pub.pem; do
+          count=$((count + 1))
+          sign_pub_request "$pub" || true
+        done
+        for csr in "${csrDir}"/*.csr; do
+          count=$((count + 1))
+          sign_csr "$csr" || true
+        done
+        shopt -u nullglob
+        echo "Request scan complete: found $count request(s)"
+      }
+
+      # Startup sweep + resilient inotify/poll loop.
+      # Polling fallback handles virtiofs/inotify event loss.
+      while true; do
+        scan_pending_requests
+        echo "Watching ${csrDir} for new requests (5s window)..."
+        inotifywait -q -t 5 -e close_write -e moved_to "${csrDir}" >/dev/null 2>&1 || true
       done
     '';
   };

--- a/modules/common/security/spiffe/devid-provision.nix
+++ b/modules/common/security/spiffe/devid-provision.nix
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# DevID Key Provisioning Module (system VMs with hardware TPM)
+#
+# On each system VM with TPM passthrough, this service:
+# 1. Creates an ephemeral TPM primary key
+# 2. Creates RSA-2048 signing key under it
+# 3. Saves key blobs to encrypted storage
+# 4. Generates a CSR
+# 5. Submits CSR to admin-vm via virtiofs
+# 6. Waits for signed certificate
+#
+# Key blobs are transient (no persistent TPM handles needed).
+# The SPIRE agent loads key blobs on demand.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.devidProvision;
+
+  spireDevidProvisionApp = pkgs.writeShellApplication {
+    name = "spire-devid-provision";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.tpm2-tools
+      pkgs.openssl
+    ];
+    text = ''
+      VM_NAME="${cfg.vmName}"
+      DEVID_DIR="${cfg.devidDir}"
+      CSR_DIR="${cfg.csrDir}"
+      CERT_DIR="${cfg.certDir}"
+
+      mkdir -p "$DEVID_DIR"
+      chmod 0700 "$DEVID_DIR"
+
+      PRIV_BLOB="$DEVID_DIR/devid.priv"
+      PUB_BLOB="$DEVID_DIR/devid.pub"
+      CERT_FILE="$DEVID_DIR/devid.pem"
+
+      # Check if key blobs already exist
+      if [ -f "$PRIV_BLOB" ] && [ -f "$PUB_BLOB" ]; then
+        echo "DevID key blobs already exist for $VM_NAME"
+
+        # Still need to ensure we have a cert
+        if [ -f "$CERT_FILE" ]; then
+          echo "DevID cert already exists, skipping provisioning"
+          exit 0
+        fi
+
+        echo "Key blobs exist but no cert yet, waiting for cert..."
+      else
+        echo "Generating DevID key for $VM_NAME..."
+
+        # Create ephemeral primary key
+        tpm2_createprimary -C owner -c "$DEVID_DIR/primary.ctx" -Q
+
+        # Create RSA-2048 signing key under the primary
+        tpm2_create -C "$DEVID_DIR/primary.ctx" -G rsa2048:rsassa:sha256 \
+          -u "$PUB_BLOB" -r "$PRIV_BLOB" -Q
+
+        # Load the key to get a context for CSR generation
+        tpm2_load -C "$DEVID_DIR/primary.ctx" \
+          -u "$PUB_BLOB" -r "$PRIV_BLOB" \
+          -c "$DEVID_DIR/devid.ctx" -Q
+
+        # Extract the public key in PEM format for CSR generation
+        tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f pem -o "$DEVID_DIR/devid-pub.pem" -Q
+
+        # Generate CSR using openssl with the extracted public key
+        # Note: We create a CSR with just the public key; the TPM holds the private key
+        openssl req -new -key "$DEVID_DIR/devid-pub.pem" \
+          -subj "/CN=$VM_NAME/O=Ghaf/OU=DevID" \
+          -out "$DEVID_DIR/$VM_NAME.csr" 2>/dev/null || {
+          # If openssl refuses (needs private key for signing), create a self-signed
+          # placeholder CSR using tpm2-tools + openssl collaboration
+          echo "Generating CSR via TPM-backed key..."
+          # Create a minimal CSR data structure and sign with TPM
+          openssl req -new -newkey rsa:2048 -nodes \
+            -keyout /dev/null -subj "/CN=$VM_NAME/O=Ghaf/OU=DevID" \
+            -out "$DEVID_DIR/$VM_NAME.csr" 2>/dev/null || true
+        }
+
+        # Clean up transient context files
+        rm -f "$DEVID_DIR/primary.ctx" "$DEVID_DIR/devid.ctx"
+
+        chmod 0600 "$PRIV_BLOB" "$PUB_BLOB"
+        echo "DevID key blobs created"
+
+        # Submit CSR to admin-vm via virtiofs
+        if [ -f "$DEVID_DIR/$VM_NAME.csr" ]; then
+          mkdir -p "$CSR_DIR"
+          cp "$DEVID_DIR/$VM_NAME.csr" "$CSR_DIR/$VM_NAME.csr"
+          echo "CSR submitted to $CSR_DIR/$VM_NAME.csr"
+        fi
+      fi
+
+      # Wait for signed cert from admin-vm
+      echo "Waiting for signed DevID certificate..."
+      for i in $(seq 1 120); do
+        if [ -f "$CERT_DIR/$VM_NAME.pem" ]; then
+          cp "$CERT_DIR/$VM_NAME.pem" "$CERT_FILE"
+          chmod 0644 "$CERT_FILE"
+          echo "DevID certificate received and stored at $CERT_FILE"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting for cert... ($i/120)"
+        fi
+        sleep 2
+      done
+
+      echo "WARNING: Timed out waiting for DevID certificate"
+      exit 1
+    '';
+  };
+in
+{
+  _file = ./devid-provision.nix;
+
+  options.ghaf.security.spiffe.devidProvision = {
+    enable = lib.mkEnableOption "DevID key provisioning for SPIRE TPM attestation";
+
+    vmName = lib.mkOption {
+      type = lib.types.str;
+      description = "Name of this VM (used in CSR CN and file paths)";
+    };
+
+    devidDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spire/devid";
+      description = "Directory for DevID key blobs and cert (on encrypted storage)";
+    };
+
+    csrDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/devid/requests";
+      description = "Directory where CSR is submitted (virtiofs, admin-vm readable)";
+    };
+
+    certDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/devid/certs";
+      description = "Directory where signed certs are placed by admin-vm (virtiofs)";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.spire-devid-provision = {
+      description = "SPIRE DevID key provisioning (TPM)";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "spire-agent.service" ];
+      after = [ "local-fs.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe spireDevidProvisionApp;
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/devid-provision.nix
+++ b/modules/common/security/spiffe/devid-provision.nix
@@ -120,6 +120,10 @@ let
         return 1
       }
 
+      tpm_in_lockout() {
+        timeout 5 tpm2_getcap properties-variable 2>/dev/null | grep -q "inLockout:[[:space:]]*1"
+      }
+
       load_existing_devid_key() {
         cleanup_contexts
 
@@ -194,6 +198,12 @@ let
 
       # Check if key blobs already exist
       if [ -f "$PRIV_BLOB" ] && [ -f "$PUB_BLOB" ]; then
+        if tpm_in_lockout; then
+          echo "WARNING: TPM in DA lockout mode, falling back to join_token attestation"
+          echo "tpm-lockout" > /run/tpm/devid-status 2>/dev/null || true
+          exit 0
+        fi
+
         PUB_HEAD=$(od -An -tx1 -N2 "$PUB_BLOB" 2>/dev/null | tr -d ' \n')
         if [ "$PUB_HEAD" != "0001" ] && [ "$PUB_HEAD" != "0023" ]; then
           echo "WARNING: Existing DevID public blob is not TPMT_PUBLIC, regenerating key blobs"
@@ -344,32 +354,25 @@ let
         echo "DevID key blobs created"
       fi
 
-      # Wait for signed cert from admin-vm
-      echo "Waiting for signed DevID certificate..."
-      for i in $(seq 1 120); do
-        if [ -s "$SHARED_CERT_FILE" ] && openssl x509 -in "$SHARED_CERT_FILE" -noout >/dev/null 2>&1; then
-          if [ -f "$PUB_PEM" ] && ! cert_matches_pub "$SHARED_CERT_FILE" "$PUB_PEM"; then
-            echo "WARNING: Signed cert for $VM_NAME does not match TPM key, waiting for refresh"
-            sleep 2
-            continue
-          fi
-
-          cp "$SHARED_CERT_FILE" "$CERT_FILE"
-          chown root:spire "$CERT_FILE"
-          chmod 0644 "$CERT_FILE"
-          echo "DevID certificate received and stored at $CERT_FILE"
+      # Non-blocking cert pickup: if admin-vm has already signed it, store it now.
+      # Otherwise exit cleanly and let SPIRE selector fall back to join_token until
+      # cert material is available.
+      if [ -s "$SHARED_CERT_FILE" ] && openssl x509 -in "$SHARED_CERT_FILE" -noout >/dev/null 2>&1; then
+        if [ -f "$PUB_PEM" ] && ! cert_matches_pub "$SHARED_CERT_FILE" "$PUB_PEM"; then
+          echo "WARNING: Signed cert for $VM_NAME does not match TPM key"
+          echo "cert-mismatch" > /run/tpm/devid-status 2>/dev/null || true
           exit 0
-        elif [ -f "$SHARED_CERT_FILE" ]; then
-          echo "WARNING: Signed cert for $VM_NAME is empty/invalid, waiting for refresh"
         fi
-        if [ $((i % 10)) -eq 0 ]; then
-          echo "Still waiting for cert... ($i/120)"
-        fi
-        sleep 2
-      done
 
-      echo "WARNING: Timed out waiting for DevID certificate"
-      exit 1
+        cp "$SHARED_CERT_FILE" "$CERT_FILE"
+        chown root:spire "$CERT_FILE"
+        chmod 0644 "$CERT_FILE"
+        echo "DevID certificate received and stored at $CERT_FILE"
+      else
+        echo "DevID cert not ready yet; continuing with join_token fallback"
+        echo "cert-pending" > /run/tpm/devid-status 2>/dev/null || true
+      fi
+      exit 0
     '';
   };
 in
@@ -407,7 +410,6 @@ in
     systemd.services.spire-devid-provision = {
       description = "SPIRE DevID key provisioning (TPM)";
       wantedBy = [ "multi-user.target" ];
-      before = [ "spire-agent.service" ];
       wants = [ "storagevm-enroll.service" ];
       after = [
         "local-fs.target"
@@ -417,6 +419,9 @@ in
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        TimeoutStartSec = "45s";
+        TimeoutStopSec = "2s";
+        KillMode = "control-group";
         ExecStart = lib.getExe spireDevidProvisionApp;
       };
     };

--- a/modules/common/security/spiffe/devid-provision.nix
+++ b/modules/common/security/spiffe/devid-provision.nix
@@ -27,6 +27,7 @@ let
     name = "spire-devid-provision";
     runtimeInputs = [
       pkgs.coreutils
+      pkgs.diffutils
       pkgs.tpm2-tools
       pkgs.openssl
     ];
@@ -35,6 +36,10 @@ let
       DEVID_DIR="${cfg.devidDir}"
       CSR_DIR="${cfg.csrDir}"
       CERT_DIR="${cfg.certDir}"
+      mkdir -p /run/tpm
+
+      # Provision through TPM resource manager device.
+      export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
 
       mkdir -p "$DEVID_DIR"
       chmod 0750 "$DEVID_DIR"
@@ -42,82 +47,320 @@ let
 
       PRIV_BLOB="$DEVID_DIR/devid.priv"
       PUB_BLOB="$DEVID_DIR/devid.pub"
+      PUB_PEM="$DEVID_DIR/devid-pub.pem"
       CERT_FILE="$DEVID_DIR/devid.pem"
+      SHARED_CERT_FILE="$CERT_DIR/$VM_NAME.pem"
+      TSS_PUB_BLOB="$DEVID_DIR/devid.tss.pub"
+      PUB_REQ_FILE="$CSR_DIR/$VM_NAME.pub.pem"
+
+      cleanup_contexts() {
+        if [ -f "$DEVID_DIR/devid.ctx" ]; then
+          timeout 5 tpm2_flushcontext "$DEVID_DIR/devid.ctx" -Q >/dev/null 2>&1 || true
+        fi
+        if [ -f "$DEVID_DIR/primary.ctx" ]; then
+          timeout 5 tpm2_flushcontext "$DEVID_DIR/primary.ctx" -Q >/dev/null 2>&1 || true
+        fi
+        rm -f "$DEVID_DIR/primary.ctx" "$DEVID_DIR/devid.ctx" "$TSS_PUB_BLOB"
+      }
+
+      clear_devid_material() {
+        cleanup_contexts
+        rm -f "$PRIV_BLOB" "$PUB_BLOB" "$PUB_PEM" "$CERT_FILE" "$TSS_PUB_BLOB"
+      }
+
+      normalize_private_blob() {
+        if [ ! -f "$PRIV_BLOB" ]; then
+          return
+        fi
+
+        local priv_size priv_prefix_hex priv_prefix
+        priv_size=$(wc -c < "$PRIV_BLOB")
+        priv_prefix_hex=$(od -An -tx1 -N2 "$PRIV_BLOB" 2>/dev/null | tr -d ' \n')
+
+        if [[ "$priv_prefix_hex" =~ ^[0-9a-fA-F]{4}$ ]] && [ "$priv_size" -gt 2 ]; then
+          priv_prefix=$((16#$priv_prefix_hex))
+        else
+          priv_prefix=""
+        fi
+
+        if [ -n "$priv_prefix" ] && [ $((priv_prefix + 2)) -eq "$priv_size" ]; then
+          echo "Converting DevID private blob from TPM2B_PRIVATE to TPM2_PRIVATE"
+          if ! dd if="$PRIV_BLOB" of="$PRIV_BLOB.raw" bs=1 skip=2 status=none 2>/dev/null; then
+            echo "Failed to normalize DevID private blob"
+            echo "Falling back to join_token attestation"
+            echo "normalize-private-failed" > /run/tpm/devid-status 2>/dev/null || true
+            rm -f "$PRIV_BLOB.raw"
+            exit 0
+          fi
+          mv -f "$PRIV_BLOB.raw" "$PRIV_BLOB"
+        fi
+      }
+
+      create_srk_primary() {
+        # Match SPIRE/go-tpm SRKTemplateHighRSA as closely as possible.
+        # Fallback keeps compatibility with older tpm2-tools variants.
+        if timeout 15 tpm2_createprimary -C owner \
+          -G rsa2048:null:aes128cfb \
+          -a "fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|decrypt|noda" \
+          -c "$DEVID_DIR/primary.ctx" -Q 2>/dev/null; then
+          return 0
+        fi
+
+        timeout 15 tpm2_createprimary -C owner -c "$DEVID_DIR/primary.ctx" -Q 2>/dev/null
+      }
+
+      wait_for_tpm_ready() {
+        for attempt in $(seq 1 30); do
+          if timeout 5 tpm2_getcap properties-fixed >/dev/null 2>&1; then
+            return 0
+          fi
+          echo "Waiting for TPM readiness... ($attempt/30)"
+          sleep 2
+        done
+        return 1
+      }
+
+      load_existing_devid_key() {
+        cleanup_contexts
+
+        if ! create_srk_primary; then
+          return 1
+        fi
+
+        if ! timeout 15 tpm2_load \
+          -C "$DEVID_DIR/primary.ctx" \
+          -u "$PUB_BLOB" \
+          -r "$PRIV_BLOB" \
+          -c "$DEVID_DIR/devid.ctx" -Q 2>/dev/null; then
+          cleanup_contexts
+          return 1
+        fi
+
+        return 0
+      }
+
+      rebuild_missing_public_artifacts() {
+        if [ -s "$PUB_PEM" ]; then
+          return 0
+        fi
+
+        echo "WARNING: DevID public PEM missing, rebuilding from key blobs"
+        if ! load_existing_devid_key; then
+          echo "WARNING: Failed to load existing DevID key blobs"
+          return 1
+        fi
+
+        if ! tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f pem -o "$PUB_PEM" -Q 2>/dev/null; then
+          cleanup_contexts
+          echo "WARNING: Failed to rebuild DevID public PEM"
+          return 1
+        fi
+
+        chown root:spire "$PUB_PEM"
+        chmod 0640 "$PUB_PEM"
+        cleanup_contexts
+        return 0
+      }
+
+      cert_matches_pub() {
+        local cert_file="$1"
+        local pub_file="$2"
+        local cert_pub=""
+        local req_pub=""
+
+        if [ ! -s "$cert_file" ] || [ ! -s "$pub_file" ]; then
+          return 1
+        fi
+
+        cert_pub=$(mktemp)
+        req_pub=$(mktemp)
+
+        if ! openssl x509 -in "$cert_file" -pubkey -noout 2>/dev/null | \
+          openssl pkey -pubin -outform pem > "$cert_pub" 2>/dev/null; then
+          rm -f "$cert_pub" "$req_pub"
+          return 1
+        fi
+
+        if ! openssl pkey -pubin -in "$pub_file" -outform pem > "$req_pub" 2>/dev/null; then
+          rm -f "$cert_pub" "$req_pub"
+          return 1
+        fi
+
+        cmp -s "$cert_pub" "$req_pub"
+        local rc=$?
+        rm -f "$cert_pub" "$req_pub"
+        return "$rc"
+      }
 
       # Check if key blobs already exist
       if [ -f "$PRIV_BLOB" ] && [ -f "$PUB_BLOB" ]; then
+        PUB_HEAD=$(od -An -tx1 -N2 "$PUB_BLOB" 2>/dev/null | tr -d ' \n')
+        if [ "$PUB_HEAD" != "0001" ] && [ "$PUB_HEAD" != "0023" ]; then
+          echo "WARNING: Existing DevID public blob is not TPMT_PUBLIC, regenerating key blobs"
+          rm -f "$PRIV_BLOB" "$PUB_BLOB" "$PUB_PEM" "$CERT_FILE" "$TSS_PUB_BLOB"
+        fi
+      fi
+
+      if [ -f "$PRIV_BLOB" ] && [ -f "$PUB_BLOB" ]; then
+        normalize_private_blob
         echo "DevID key blobs already exist for $VM_NAME"
 
-        # Still need to ensure we have a cert
-        if [ -f "$CERT_FILE" ]; then
-          echo "DevID cert already exists, skipping provisioning"
+        if ! rebuild_missing_public_artifacts; then
+          clear_devid_material
+          echo "Falling back to join_token attestation"
+          echo "recover-public-failed" > /run/tpm/devid-status 2>/dev/null || true
           exit 0
+        fi
+
+        if [ -f "$PUB_PEM" ]; then
+          local_cert_ok=0
+          shared_cert_ok=0
+
+          if [ -s "$CERT_FILE" ] && openssl x509 -in "$CERT_FILE" -noout >/dev/null 2>&1; then
+            if cert_matches_pub "$CERT_FILE" "$PUB_PEM"; then
+              local_cert_ok=1
+            else
+              echo "WARNING: Local DevID cert does not match TPM key, refreshing"
+              rm -f "$CERT_FILE"
+            fi
+          elif [ -f "$CERT_FILE" ]; then
+            echo "WARNING: Existing DevID cert is empty/invalid, regenerating"
+            rm -f "$CERT_FILE"
+          fi
+
+          if [ -s "$SHARED_CERT_FILE" ] && openssl x509 -in "$SHARED_CERT_FILE" -noout >/dev/null 2>&1; then
+            if cert_matches_pub "$SHARED_CERT_FILE" "$PUB_PEM"; then
+              shared_cert_ok=1
+            else
+              echo "WARNING: Shared DevID cert does not match TPM key, requesting re-sign"
+            fi
+          elif [ -f "$SHARED_CERT_FILE" ]; then
+            echo "WARNING: Shared DevID cert is empty/invalid, requesting refresh"
+            rm -f "$SHARED_CERT_FILE"
+          fi
+
+          if [ "$local_cert_ok" -eq 1 ] && [ "$shared_cert_ok" -eq 1 ]; then
+            echo "DevID cert already exists and matches TPM key, skipping provisioning"
+            exit 0
+          fi
+
+          mkdir -p "$CSR_DIR"
+          cp "$PUB_PEM" "$PUB_REQ_FILE"
+          echo "Published DevID public key request to $PUB_REQ_FILE"
+        else
+          echo "WARNING: Missing $PUB_PEM for cert verification/re-signing request"
         fi
 
         echo "Key blobs exist but no cert yet, waiting for cert..."
       else
         echo "Generating DevID key for $VM_NAME..."
 
-        # Try to create primary key — hierarchies may be disabled when TPM is shared
-        if ! tpm2_createprimary -C owner -c "$DEVID_DIR/primary.ctx" -Q 2>/dev/null && \
-           ! tpm2_createprimary -C endorsement -c "$DEVID_DIR/primary.ctx" -Q 2>/dev/null; then
-          echo "WARNING: Cannot create TPM primary key — all hierarchies disabled"
-          echo "This is expected when TPM is shared across VMs with LUKS encryption"
+        if ! wait_for_tpm_ready; then
+          echo "TPM not ready after 60s"
           echo "Falling back to join_token attestation"
-          echo "no-hierarchy" > /run/tpm/devid-status 2>/dev/null || true
+          echo "no-tpm-ready" > /run/tpm/devid-status 2>/dev/null || true
           exit 0
         fi
 
-        # Create RSA-2048 signing key under the primary
-        tpm2_create -C "$DEVID_DIR/primary.ctx" -G rsa2048:rsassa:sha256 \
-          -u "$PUB_BLOB" -r "$PRIV_BLOB" -Q
+        PRIMARY_READY=0
+        for attempt in 1 2 3; do
+          if create_srk_primary; then
+            PRIMARY_READY=1
+            break
+          fi
+          cleanup_contexts
+          echo "Retrying primary creation... ($attempt/3)"
+          sleep 2
+        done
+        if [ "$PRIMARY_READY" -eq 0 ]; then
+          echo "Unable to create SRK primary"
+          echo "Falling back to join_token attestation"
+          echo "createprimary-failed" > /run/tpm/devid-status 2>/dev/null || true
+          exit 0
+        fi
 
-        # Load the key to get a context for CSR generation
-        tpm2_load -C "$DEVID_DIR/primary.ctx" \
-          -u "$PUB_BLOB" -r "$PRIV_BLOB" \
-          -c "$DEVID_DIR/devid.ctx" -Q
+        KEY_CREATED=0
+        if tpm2_create -C "$DEVID_DIR/primary.ctx" -G rsa2048:rsassa-sha256 \
+          -u "$TSS_PUB_BLOB" -r "$PRIV_BLOB" -c "$DEVID_DIR/devid.ctx" -Q 2>/dev/null; then
+          KEY_CREATED=1
+          echo "DevID key created with -G rsa2048:rsassa-sha256"
+        elif tpm2_create -C "$DEVID_DIR/primary.ctx" -G rsa2048:rsassa \
+          -u "$TSS_PUB_BLOB" -r "$PRIV_BLOB" -c "$DEVID_DIR/devid.ctx" -Q 2>/dev/null; then
+          KEY_CREATED=1
+          echo "DevID key created with -G rsa2048:rsassa"
+        fi
+        if [ "$KEY_CREATED" -ne 1 ]; then
+          echo "Failed to create DevID key with supported tpm2_create syntaxes"
+          echo "Falling back to join_token attestation"
+          echo "keygen-failed" > /run/tpm/devid-status 2>/dev/null || true
+          clear_devid_material
+          exit 0
+        fi
 
-        # Extract the public key in PEM format for CSR generation
-        tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f pem -o "$DEVID_DIR/devid-pub.pem" -Q
+        READPUB_OK=0
+        for _ in 1 2 3; do
+          if tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f tpmt -o "$PUB_BLOB" -Q 2>/dev/null; then
+            READPUB_OK=1
+            break
+          fi
+          sleep 1
+        done
+        if [ "$READPUB_OK" -ne 1 ]; then
+          echo "Failed to export DevID TPMT_PUBLIC blob"
+          echo "Falling back to join_token attestation"
+          echo "readpublic-tpmt-failed" > /run/tpm/devid-status 2>/dev/null || true
+          clear_devid_material
+          exit 0
+        fi
 
-        # Generate CSR using openssl with the extracted public key
-        # Note: We create a CSR with just the public key; the TPM holds the private key
-        openssl req -new -key "$DEVID_DIR/devid-pub.pem" \
-          -subj "/CN=$VM_NAME/O=Ghaf/OU=DevID" \
-          -out "$DEVID_DIR/$VM_NAME.csr" 2>/dev/null || {
-          # If openssl refuses (needs private key for signing), create a self-signed
-          # placeholder CSR using tpm2-tools + openssl collaboration
-          echo "Generating CSR via TPM-backed key..."
-          # Create a minimal CSR data structure and sign with TPM
-          openssl req -new -newkey rsa:2048 -nodes \
-            -keyout /dev/null -subj "/CN=$VM_NAME/O=Ghaf/OU=DevID" \
-            -out "$DEVID_DIR/$VM_NAME.csr" 2>/dev/null || true
-        }
+        normalize_private_blob
+
+        READPUB_PEM_OK=0
+        for _ in 1 2 3; do
+          if tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f pem -o "$PUB_PEM" -Q 2>/dev/null; then
+            READPUB_PEM_OK=1
+            break
+          fi
+          sleep 1
+        done
+        if [ "$READPUB_PEM_OK" -ne 1 ]; then
+          echo "Failed to export DevID public key"
+          echo "Falling back to join_token attestation"
+          echo "readpublic-failed" > /run/tpm/devid-status 2>/dev/null || true
+          clear_devid_material
+          exit 0
+        fi
+
+        mkdir -p "$CSR_DIR"
+        cp "$PUB_PEM" "$PUB_REQ_FILE"
+        echo "Published DevID public key request to $PUB_REQ_FILE"
 
         # Clean up transient context files
-        rm -f "$DEVID_DIR/primary.ctx" "$DEVID_DIR/devid.ctx"
+        cleanup_contexts
 
         chown root:spire "$PRIV_BLOB" "$PUB_BLOB"
         chmod 0640 "$PRIV_BLOB" "$PUB_BLOB"
+        echo "ready" > /run/tpm/devid-status 2>/dev/null || true
         echo "DevID key blobs created"
-
-        # Submit CSR to admin-vm via virtiofs
-        if [ -f "$DEVID_DIR/$VM_NAME.csr" ]; then
-          mkdir -p "$CSR_DIR"
-          cp "$DEVID_DIR/$VM_NAME.csr" "$CSR_DIR/$VM_NAME.csr"
-          echo "CSR submitted to $CSR_DIR/$VM_NAME.csr"
-        fi
       fi
 
       # Wait for signed cert from admin-vm
       echo "Waiting for signed DevID certificate..."
       for i in $(seq 1 120); do
-        if [ -f "$CERT_DIR/$VM_NAME.pem" ]; then
-          cp "$CERT_DIR/$VM_NAME.pem" "$CERT_FILE"
+        if [ -s "$SHARED_CERT_FILE" ] && openssl x509 -in "$SHARED_CERT_FILE" -noout >/dev/null 2>&1; then
+          if [ -f "$PUB_PEM" ] && ! cert_matches_pub "$SHARED_CERT_FILE" "$PUB_PEM"; then
+            echo "WARNING: Signed cert for $VM_NAME does not match TPM key, waiting for refresh"
+            sleep 2
+            continue
+          fi
+
+          cp "$SHARED_CERT_FILE" "$CERT_FILE"
           chown root:spire "$CERT_FILE"
           chmod 0644 "$CERT_FILE"
           echo "DevID certificate received and stored at $CERT_FILE"
           exit 0
+        elif [ -f "$SHARED_CERT_FILE" ]; then
+          echo "WARNING: Signed cert for $VM_NAME is empty/invalid, waiting for refresh"
         fi
         if [ $((i % 10)) -eq 0 ]; then
           echo "Still waiting for cert... ($i/120)"
@@ -165,7 +408,11 @@ in
       description = "SPIRE DevID key provisioning (TPM)";
       wantedBy = [ "multi-user.target" ];
       before = [ "spire-agent.service" ];
-      after = [ "local-fs.target" ];
+      wants = [ "storagevm-enroll.service" ];
+      after = [
+        "local-fs.target"
+        "storagevm-enroll.service"
+      ];
 
       serviceConfig = {
         Type = "oneshot";

--- a/modules/common/security/spiffe/server.nix
+++ b/modules/common/security/spiffe/server.nix
@@ -1,0 +1,459 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPIRE Server Module
+#
+# Runs the SPIRE server (identity authority) on admin-vm.
+# Supports dual attestation: join_token for app VMs + tpm_devid for system VMs.
+# Server address is derived from hostConfig (not hardcoded).
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.server;
+
+  tpmAttestationEnabled = cfg.tpmAttestation.enable;
+
+  # Generate server.conf HCL
+  serverConf = ''
+    server {
+      bind_address = "${cfg.bindAddress}"
+      bind_port = ${toString cfg.bindPort}
+      trust_domain = "${cfg.trustDomain}"
+      data_dir = "${cfg.dataDir}"
+      log_level = "${cfg.logLevel}"
+      socket_path = "${cfg.socketPath}"
+    }
+    plugins {
+      DataStore "sql" {
+        plugin_data {
+          database_type = "sqlite3"
+          connection_string = "${cfg.dataDir}/datastore.sqlite3"
+        }
+      }
+      KeyManager "disk" {
+        plugin_data {
+          keys_path = "${cfg.dataDir}/keys.json"
+        }
+      }
+      NodeAttestor "join_token" {
+        plugin_data {}
+      }
+  ''
+  + lib.optionalString tpmAttestationEnabled ''
+    NodeAttestor "tpm_devid" {
+      plugin_data {
+        devid_ca_path = "${cfg.tpmAttestation.devidCaPath}"
+        endorsement_ca_path = "${cfg.tpmAttestation.endorsementCaPath}"
+      }
+    }
+  ''
+  + ''
+    }
+  '';
+
+  spireGenerateJoinTokensApp = pkgs.writeShellApplication {
+    name = "spire-generate-join-tokens";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gawk
+      pkgs.spire
+    ];
+    text = ''
+      mkdir -p "${cfg.tokenDir}"
+      chmod 755 "${cfg.tokenDir}"
+
+      # Wait until the server is up
+      for i in $(seq 1 60); do
+        if spire-server healthcheck -socketPath ${cfg.socketPath} >/dev/null 2>&1; then
+          echo "SPIRE server is ready"
+          break
+        fi
+        echo "Waiting for SPIRE server... ($i/60)"
+        sleep 1
+      done
+
+      for vm in ${lib.concatStringsSep " " cfg.spireAgentVMs}; do
+        f="${cfg.tokenDir}/''${vm}.token"
+
+        # Check if agent is already registered
+        if spire-server agent list -socketPath ${cfg.socketPath} 2>/dev/null | grep -q "spiffe://${cfg.trustDomain}/agent/''${vm}"; then
+          echo "Agent $vm already registered, skipping token generation"
+          continue
+        fi
+
+        echo "Generating new token for $vm"
+        token="$(spire-server token generate \
+          -socketPath ${cfg.socketPath} \
+          | awk '/^Token:/ {print $2}')"
+
+        printf '%s\n' "$token" > "$f"
+        chmod 0644 "$f"
+        echo "Token written to $f"
+      done
+    '';
+  };
+
+  spirePublishBundleApp = pkgs.writeShellApplication {
+    name = "spire-publish-bundle";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.spire
+    ];
+    text = ''
+      out="${cfg.bundleOutPath}"
+      mkdir -p "$(dirname "$out")"
+
+      # Wait until the server API socket exists and the server is ready
+      for _ in $(seq 1 60); do
+        if [ -S "${cfg.socketPath}" ] && spire-server healthcheck -socketPath "${cfg.socketPath}" >/dev/null 2>&1; then
+          break
+        fi
+        sleep 1
+      done
+
+      if [ ! -S "${cfg.socketPath}" ]; then
+        echo "ERROR: SPIRE server socket not found at ${cfg.socketPath}" >&2
+        exit 1
+      fi
+
+      tmp="$(mktemp)"
+      spire-server bundle show -socketPath "${cfg.socketPath}" > "$tmp"
+      if [ ! -s "$tmp" ]; then
+        echo "ERROR: bundle export produced empty output" >&2
+        exit 1
+      fi
+
+      install -m 0644 -o root -g root "$tmp" "$out"
+      rm -f "$tmp"
+      echo "Wrote $out"
+    '';
+  };
+
+  spireCreateWorkloadEntriesApp = pkgs.writeShellApplication {
+    name = "spire-create-workload-entries";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gawk
+      pkgs.gnugrep
+      pkgs.spire
+    ];
+    text = ''
+      SOCKET="${cfg.socketPath}"
+      TRUST_DOMAIN="${cfg.trustDomain}"
+      EXPECTED_AGENTS=${toString (builtins.length cfg.spireAgentVMs)}
+
+      echo "=== SPIRE Workload Entry Creator ==="
+      echo "Expected agents: $EXPECTED_AGENTS"
+
+      # Wait for server
+      for _ in $(seq 1 60); do
+        if spire-server healthcheck -socketPath "$SOCKET" >/dev/null 2>&1; then
+          echo "Server ready"
+          break
+        fi
+        sleep 1
+      done
+
+      # Wait for ALL expected agents (up to 3 minutes)
+      echo "Waiting for all $EXPECTED_AGENTS agents to register..."
+      AGENT_COUNT=0
+      for i in $(seq 1 90); do
+        AGENT_COUNT=$(spire-server agent list -socketPath "$SOCKET" 2>/dev/null | grep "SPIFFE ID" | wc -l)
+        if [ "$AGENT_COUNT" -ge "$EXPECTED_AGENTS" ]; then
+          echo "All agents registered: $AGENT_COUNT/$EXPECTED_AGENTS"
+          break
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Waiting... $AGENT_COUNT/$EXPECTED_AGENTS agents [$i/90]"
+        fi
+        sleep 2
+      done
+
+      if [ "$AGENT_COUNT" -lt "$EXPECTED_AGENTS" ]; then
+        echo "WARNING: Only $AGENT_COUNT/$EXPECTED_AGENTS agents registered after timeout"
+        echo "Continuing with available agents..."
+      fi
+
+      # Get ALL agent IDs
+      AGENT_IDS=$(spire-server agent list -socketPath "$SOCKET" 2>/dev/null \
+        | grep "SPIFFE ID" \
+        | awk -F': ' '{print $2}' \
+        | tr -d ' ')
+
+      if [ -z "$AGENT_IDS" ]; then
+        echo "ERROR: No agents found"
+        exit 1
+      fi
+
+      AGENT_COUNT=$(echo "$AGENT_IDS" | wc -l)
+      echo ""
+      echo "Creating entries for $AGENT_COUNT agents..."
+
+      # Workload names
+      WORKLOADS=( ${lib.concatMapStringsSep " " (e: lib.escapeShellArg e.name) cfg.workloadEntries} )
+
+      # Create entries for EACH agent
+      CREATED=0
+      SKIPPED=0
+
+      for PARENT_ID in $AGENT_IDS; do
+        echo ""
+        echo "--- Agent: $PARENT_ID ---"
+
+        for WORKLOAD in "''${WORKLOADS[@]}"; do
+          SPIFFE_ID="spiffe://$TRUST_DOMAIN/workload/$WORKLOAD"
+
+          # Check if entry exists for this agent+workload combo
+          EXISTS=$(spire-server entry show -socketPath "$SOCKET" 2>/dev/null | grep -A1 "$SPIFFE_ID" | grep "$PARENT_ID" | wc -l)
+
+          if [ "$EXISTS" -gt 0 ]; then
+            echo "  [skip] $WORKLOAD"
+            SKIPPED=$((SKIPPED + 1))
+          else
+            echo "  [create] $WORKLOAD"
+            spire-server entry create \
+              -socketPath "$SOCKET" \
+              -parentID "$PARENT_ID" \
+              -spiffeID "$SPIFFE_ID" \
+              -selector unix:user:ghaf >/dev/null 2>&1 || echo "  [FAILED] $WORKLOAD"
+            CREATED=$((CREATED + 1))
+          fi
+        done
+      done
+
+      echo "Done: created=$CREATED skipped=$SKIPPED"
+    '';
+  };
+in
+{
+  _file = ./server.nix;
+
+  options.ghaf.security.spiffe.server = {
+    enable = lib.mkEnableOption "SPIRE server";
+
+    trustDomain = lib.mkOption {
+      type = lib.types.str;
+      default = "ghaf.internal";
+      description = "SPIFFE trust domain served by SPIRE server";
+    };
+
+    bindAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "SPIRE server bind address";
+    };
+
+    bindPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8081;
+      description = "SPIRE server bind port";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spire/server";
+      description = "SPIRE server state directory";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.str;
+      default = "INFO";
+      description = "SPIRE server log level";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Open firewall for SPIRE server bind port";
+    };
+
+    spireAgentVMs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "List of VM names that will run spire-agent";
+    };
+
+    tokenDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/tokens";
+      description = "Directory where join tokens are stored (virtiofs)";
+    };
+
+    bundleOutPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/bundle.pem";
+      description = "Path where the SPIRE trust bundle is published (virtiofs)";
+    };
+
+    generateJoinTokens = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Generate join tokens for listed VMs";
+    };
+
+    publishBundle = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Publish the SPIRE trust bundle to bundleOutPath";
+    };
+
+    socketPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/tmp/spire-server/private/api.sock";
+      description = "Unix socket for spire-server";
+    };
+
+    createWorkloadEntries = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Auto-create workload entries";
+    };
+
+    workloadEntries = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            name = lib.mkOption {
+              type = lib.types.str;
+              description = "Workload name";
+            };
+            selectors = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ "unix:user:ghaf" ];
+              description = "Workload selectors";
+            };
+          };
+        }
+      );
+      default = [ ];
+      description = "Workload entries to register";
+    };
+
+    tpmAttestation = {
+      enable = lib.mkEnableOption "TPM DevID attestation on SPIRE server";
+
+      devidCaPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/ca/ca.pem";
+        description = "Path to the DevID CA certificate";
+      };
+
+      endorsementCaPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/ca/endorsement-ca.pem";
+        description = ''
+          Path to TPM manufacturer endorsement key CA certificate(s).
+          Used to verify TPM genuineness during DevID attestation.
+          For production, bundle real manufacturer root CAs (e.g. Infineon).
+          The DevID CA setup creates a placeholder here on first boot.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.spire ];
+
+    users.groups.spire = { };
+    users.users.spire = {
+      isSystemUser = true;
+      group = "spire";
+    };
+
+    environment.etc."spire/server.conf".text = serverConf;
+
+    systemd.tmpfiles.rules = [
+      "d /tmp/spire-server 0755 root root - -"
+      "d /tmp/spire-server/private 0755 spire spire - -"
+    ]
+    ++ lib.optionals cfg.generateJoinTokens [
+      "d ${cfg.tokenDir} 0755 root root - -"
+    ];
+
+    systemd.services.spire-server = {
+      description = "SPIRE Server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = "spire";
+        Group = "spire";
+
+        ExecStart = "${pkgs.spire}/bin/spire-server run -config /etc/spire/server.conf";
+
+        StateDirectory = "spire/server";
+        StateDirectoryMode = "0750";
+
+        Restart = "on-failure";
+        RestartSec = "2s";
+
+        NoNewPrivileges = true;
+        PrivateTmp = false;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [
+          cfg.dataDir
+          "/tmp/spire-server"
+        ];
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.bindPort ];
+
+    systemd.services.spire-generate-join-tokens = lib.mkIf cfg.generateJoinTokens {
+      description = "Generate SPIRE join tokens for Ghaf VMs";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "spire-server.service"
+        "network-online.target"
+      ];
+      wants = [
+        "spire-server.service"
+        "network-online.target"
+      ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "root";
+        ExecStart = lib.getExe spireGenerateJoinTokensApp;
+      };
+    };
+
+    systemd.services.spire-publish-bundle = lib.mkIf cfg.publishBundle {
+      description = "Publish SPIRE trust bundle";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "spire-server.service" ];
+      wants = [ "spire-server.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+        ExecStart = lib.getExe spirePublishBundleApp;
+      };
+    };
+
+    systemd.services.spire-create-workload-entries = lib.mkIf cfg.createWorkloadEntries {
+      description = "Create SPIRE workload entries";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "spire-server.service"
+        "spire-generate-join-tokens.service"
+      ];
+      wants = [ "spire-server.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "root";
+        ExecStart = lib.getExe spireCreateWorkloadEntriesApp;
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/server.nix
+++ b/modules/common/security/spiffe/server.nix
@@ -395,8 +395,17 @@ in
     systemd.services.spire-server = {
       description = "SPIRE Server";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+      ]
+      ++ lib.optionals config.ghaf.storagevm.encryption.enable [
+        "storagevm-enroll.service"
+      ];
       wants = [ "network-online.target" ];
+      unitConfig = {
+        # Ensure dataDir bind mount from encrypted storage is ready
+        RequiresMountsFor = [ cfg.dataDir ];
+      };
 
       serviceConfig = {
         User = "spire";

--- a/modules/common/security/spiffe/server.nix
+++ b/modules/common/security/spiffe/server.nix
@@ -403,8 +403,10 @@ in
       ];
       wants = [ "network-online.target" ];
       unitConfig = {
-        # Ensure dataDir bind mount from encrypted storage is ready
-        RequiresMountsFor = [ cfg.dataDir ];
+        # SPIRE server must always start even if optional encrypted guestStorage
+        # mount plumbing is unavailable on some platforms/boot races.
+        # Require only the shared common mount that carries SPIRE bundle/CA data.
+        RequiresMountsFor = [ "/etc/common" ];
       };
 
       serviceConfig = {

--- a/modules/common/security/spiffe/server.nix
+++ b/modules/common/security/spiffe/server.nix
@@ -26,6 +26,7 @@ let
       bind_port = ${toString cfg.bindPort}
       trust_domain = "${cfg.trustDomain}"
       data_dir = "${cfg.dataDir}"
+      ca_ttl = "${cfg.caTtl}"
       log_level = "${cfg.logLevel}"
       socket_path = "${cfg.socketPath}"
     }
@@ -261,6 +262,12 @@ in
       description = "SPIRE server state directory";
     };
 
+    caTtl = lib.mkOption {
+      type = lib.types.str;
+      default = "168h";
+      description = "SPIRE server CA certificate TTL";
+    };
+
     logLevel = lib.mkOption {
       type = lib.types.str;
       default = "INFO";
@@ -301,6 +308,12 @@ in
       type = lib.types.bool;
       default = false;
       description = "Publish the SPIRE trust bundle to bundleOutPath";
+    };
+
+    bundleRefreshInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "30m";
+      description = "Interval for republishing the SPIRE trust bundle";
     };
 
     socketPath = lib.mkOption {
@@ -464,6 +477,18 @@ in
         Type = "oneshot";
         User = "root";
         ExecStart = lib.getExe spirePublishBundleApp;
+      };
+    };
+
+    systemd.timers.spire-publish-bundle = lib.mkIf cfg.publishBundle {
+      description = "Periodically publish SPIRE trust bundle";
+      wantedBy = [ "timers.target" ];
+
+      timerConfig = {
+        OnBootSec = "5m";
+        OnUnitActiveSec = cfg.bundleRefreshInterval;
+        Persistent = true;
+        Unit = "spire-publish-bundle.service";
       };
     };
 

--- a/modules/common/security/spiffe/tpm-ek-verify.nix
+++ b/modules/common/security/spiffe/tpm-ek-verify.nix
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TPM EK Certificate Verification Module
+#
+# Runs at boot on system VMs with hardware TPM to read the Endorsement Key
+# certificate from TPM NV RAM and verify its chain against the combined
+# endorsement CA bundle (all.pem).
+#
+# This is informational/defense-in-depth — the SPIRE server also validates
+# the endorsement chain during tpm_devid attestation. This service writes
+# status files to /run/tpm/ for operators/monitoring.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.tpmEkVerify;
+
+  tpmEkVerifyApp = pkgs.writeShellApplication {
+    name = "tpm-ek-verify";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.tpm2-tools
+      pkgs.openssl
+    ];
+    text = ''
+      EK_NV_RSA="0x01C00002"
+      EK_NV_ECC="0x01C0000A"
+      BUNDLE_PATH="${cfg.endorsementCaBundle}"
+
+      mkdir -p /run/tpm
+
+      # Try to read RSA EK cert first, fall back to ECC
+      EK_TYPE=""
+      if tpm2_nvread "$EK_NV_RSA" -o /run/tpm/ek-cert.der 2>/dev/null; then
+        EK_TYPE="RSA"
+      elif tpm2_nvread "$EK_NV_ECC" -o /run/tpm/ek-cert.der 2>/dev/null; then
+        EK_TYPE="ECC"
+      else
+        echo "WARNING: No EK cert found in TPM NV RAM"
+        echo "no-ek-cert" > /run/tpm/ek-status
+        exit 0
+      fi
+
+      echo "$EK_TYPE" > /run/tpm/ek-type
+
+      # Convert DER to PEM
+      if ! openssl x509 -inform DER -in /run/tpm/ek-cert.der -out /run/tpm/ek-cert.pem 2>/dev/null; then
+        echo "WARNING: Could not convert EK cert from DER to PEM"
+        echo "conversion-failed" > /run/tpm/ek-status
+        exit 0
+      fi
+
+      # Validate chain against all known endorsement CAs
+      if openssl verify -partial_chain -CAfile "$BUNDLE_PATH" /run/tpm/ek-cert.pem >/dev/null 2>&1; then
+        echo "verified" > /run/tpm/ek-status
+        ISSUER=$(openssl x509 -in /run/tpm/ek-cert.pem -noout -issuer 2>/dev/null)
+        echo "EK cert ($EK_TYPE) verified: $ISSUER"
+      else
+        echo "chain-invalid" > /run/tpm/ek-status
+        echo "WARNING: EK cert chain validation failed — TPM may not be genuine"
+        echo "This is advisory only — SPIRE server will also validate"
+      fi
+    '';
+  };
+in
+{
+  _file = ./tpm-ek-verify.nix;
+
+  options.ghaf.security.spiffe.tpmEkVerify = {
+    enable = lib.mkEnableOption "TPM EK certificate verification at boot";
+
+    endorsementCaBundle = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Path to combined endorsement CA bundle (all.pem)";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.tpm-ek-verify = {
+      description = "Verify TPM EK certificate chain at boot";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "local-fs.target"
+        "tpm-vendor-detect.service"
+      ];
+      before = [ "spire-devid-provision.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe tpmEkVerifyApp;
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/tpm-ek-verify.nix
+++ b/modules/common/security/spiffe/tpm-ek-verify.nix
@@ -28,6 +28,10 @@ let
       pkgs.openssl
     ];
     text = ''
+      set -euo pipefail
+
+      export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
+
       EK_NV_RSA="0x01C00002"
       EK_NV_ECC="0x01C0000A"
       BUNDLE_PATH="${cfg.endorsementCaBundle}"
@@ -36,9 +40,9 @@ let
 
       # Try to read RSA EK cert first, fall back to ECC
       EK_TYPE=""
-      if tpm2_nvread "$EK_NV_RSA" -o /run/tpm/ek-cert.der 2>/dev/null; then
+      if timeout -k 2s 8s tpm2_nvread "$EK_NV_RSA" -o /run/tpm/ek-cert.der 2>/dev/null; then
         EK_TYPE="RSA"
-      elif tpm2_nvread "$EK_NV_ECC" -o /run/tpm/ek-cert.der 2>/dev/null; then
+      elif timeout -k 2s 8s tpm2_nvread "$EK_NV_ECC" -o /run/tpm/ek-cert.der 2>/dev/null; then
         EK_TYPE="ECC"
       else
         echo "WARNING: No EK cert found in TPM NV RAM"
@@ -87,13 +91,14 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [
         "local-fs.target"
-        "tpm-vendor-detect.service"
       ];
-      before = [ "spire-devid-provision.service" ];
 
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        TimeoutStartSec = "20s";
+        TimeoutStopSec = "2s";
+        KillMode = "control-group";
         ExecStart = lib.getExe tpmEkVerifyApp;
       };
     };

--- a/modules/common/security/spiffe/tpm-vendor-detect.nix
+++ b/modules/common/security/spiffe/tpm-vendor-detect.nix
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TPM Vendor Detection Module
+#
+# Runs at boot on system VMs with hardware TPM to detect the actual
+# TPM manufacturer. Writes vendor info to /run/tpm/ for downstream
+# services (tpm-ek-verify, monitoring).
+#
+# If expectedVendors is set and the detected vendor doesn't match,
+# a warning is logged (but the service still succeeds — advisory only).
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.tpmVendorDetect;
+
+  tpmVendorDetectApp = pkgs.writeShellApplication {
+    name = "tpm-vendor-detect";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gawk
+      pkgs.gnused
+      pkgs.tpm2-tools
+    ];
+    text = ''
+      mkdir -p /run/tpm
+
+      # Read TPM manufacturer code
+      VENDOR_HEX=$(tpm2_getcap properties-fixed 2>/dev/null \
+        | grep TPM2_PT_MANUFACTURER -A1 | grep 'raw:' | awk '{print $2}') || true
+
+      if [ -z "$VENDOR_HEX" ]; then
+        echo "WARNING: Could not read TPM manufacturer property"
+        echo "unknown" > /run/tpm/vendor
+        echo "" > /run/tpm/vendor-code
+        exit 0
+      fi
+
+      # Convert hex to ASCII string (e.g., 0x49465800 -> "IFX")
+      # Strip 0x prefix, convert byte pairs to decimal, then to chars via awk
+      VENDOR_CODE=$(echo "$VENDOR_HEX" | sed 's/^0x//' | fold -w2 \
+        | awk '{val=strtonum("0x"$1); if(val>0) printf "%c",val}')
+
+      # Map vendor codes to TrustedTpm.cab names
+      case "$VENDOR_CODE" in
+        INTC) VENDOR_NAME="Intel" ;;
+        IFX*)  VENDOR_NAME="Infineon" ;;
+        AMD*)  VENDOR_NAME="AMD" ;;
+        STM*)  VENDOR_NAME="STMicro" ;;
+        NTC*)  VENDOR_NAME="Nuvoton" ;;
+        QCOM) VENDOR_NAME="QC" ;;
+        MSFT) VENDOR_NAME="Microsoft" ;;
+        ATML) VENDOR_NAME="Atmel" ;;
+        NTZ*)  VENDOR_NAME="NationZ" ;;
+        *)    VENDOR_NAME="Unknown" ;;
+      esac
+
+      echo "$VENDOR_NAME" > /run/tpm/vendor
+      echo "$VENDOR_CODE" > /run/tpm/vendor-code
+      echo "TPM vendor: $VENDOR_NAME ($VENDOR_CODE)"
+
+      # Advisory check against expected vendors
+      EXPECTED_VENDORS="${lib.concatStringsSep " " cfg.expectedVendors}"
+      if [ -n "$EXPECTED_VENDORS" ]; then
+        MATCH=0
+        for v in $EXPECTED_VENDORS; do
+          if [ "$v" = "$VENDOR_NAME" ]; then
+            MATCH=1
+            break
+          fi
+        done
+        if [ "$MATCH" -eq 0 ]; then
+          echo "WARNING: Detected TPM vendor '$VENDOR_NAME' not in expected list: $EXPECTED_VENDORS"
+          echo "This is advisory only — attestation will still proceed"
+        fi
+      fi
+    '';
+  };
+in
+{
+  _file = ./tpm-vendor-detect.nix;
+
+  options.ghaf.security.spiffe.tpmVendorDetect = {
+    enable = lib.mkEnableOption "TPM vendor detection at boot";
+
+    expectedVendors = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Expected vendor names (advisory, for warning on mismatch).
+        Examples: "Intel", "Infineon", "AMD".
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.tpm-vendor-detect = {
+      description = "Detect TPM manufacturer at boot";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "local-fs.target" ];
+      before = [
+        "tpm-ek-verify.service"
+        "spire-devid-provision.service"
+      ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe tpmVendorDetectApp;
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/tpm-vendor-detect.nix
+++ b/modules/common/security/spiffe/tpm-vendor-detect.nix
@@ -28,10 +28,14 @@ let
       pkgs.tpm2-tools
     ];
     text = ''
+      set -euo pipefail
+
+      export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
+
       mkdir -p /run/tpm
 
       # Read TPM manufacturer code
-      VENDOR_HEX=$(tpm2_getcap properties-fixed 2>/dev/null \
+      VENDOR_HEX=$(timeout -k 2s 8s tpm2_getcap properties-fixed 2>/dev/null \
         | grep TPM2_PT_MANUFACTURER -A1 | grep 'raw:' | awk '{print $2}') || true
 
       if [ -z "$VENDOR_HEX" ]; then
@@ -103,14 +107,13 @@ in
       description = "Detect TPM manufacturer at boot";
       wantedBy = [ "multi-user.target" ];
       after = [ "local-fs.target" ];
-      before = [
-        "tpm-ek-verify.service"
-        "spire-devid-provision.service"
-      ];
 
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        TimeoutStartSec = "20s";
+        TimeoutStopSec = "2s";
+        KillMode = "control-group";
         ExecStart = lib.getExe tpmVendorDetectApp;
       };
     };

--- a/modules/hardware/common/default.nix
+++ b/modules/hardware/common/default.nix
@@ -7,5 +7,6 @@
     ./input.nix
     ./kernel.nix
     ./qemu.nix
+    ./tpm-endorsement.nix
   ];
 }

--- a/modules/hardware/common/tpm-endorsement.nix
+++ b/modules/hardware/common/tpm-endorsement.nix
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TPM Endorsement CA Wiring Module
+#
+# Resolves vendor names from hardware definition to cert paths from the
+# tpm-endorsement-certs package and propagates them to globalConfig.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  hwDef = config.ghaf.hardware.definition.tpm;
+  # Per-vendor certs (kept for backward compat)
+  vendorCerts = map (v: "${pkgs.tpm-endorsement-certs}/vendors/${v}.pem") hwDef.endorsementCaVendors;
+  allCerts = vendorCerts ++ hwDef.endorsementCaCerts;
+  # Combined bundle with ALL vendor CAs — used by SPIRE server
+  allCertsBundle = "${pkgs.tpm-endorsement-certs}/all.pem";
+in
+{
+  _file = ./tpm-endorsement.nix;
+
+  config = {
+    # Always set the combined bundle (accepts any genuine TPM)
+    ghaf.global-config.spiffe.tpmAttestation.endorsementCaBundle = lib.mkDefault allCertsBundle;
+
+    # Propagate vendor names as advisory (for runtime mismatch warnings)
+    ghaf.global-config.spiffe.tpmAttestation.endorsementCaVendors =
+      lib.mkDefault hwDef.endorsementCaVendors;
+
+    # Keep per-vendor certs for backward compat
+    ghaf.global-config.spiffe.tpmAttestation.endorsementCaCerts = lib.mkIf (allCerts != [ ]) (
+      lib.mkDefault allCerts
+    );
+  };
+}

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -415,6 +415,31 @@ in
         };
       };
 
+      tpm = {
+        endorsementCaVendors = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          description = ''
+            TPM manufacturer vendor names (matching TrustedTpm.cab folder names).
+            Examples: "Intel", "Infineon", "AMD", "STMicro", "Nuvoton".
+            Multiple vendors supported for targets that ship with different TPMs
+            depending on SKU or production batch.
+          '';
+          example = [
+            "Intel"
+            "Infineon"
+          ];
+        };
+        endorsementCaCerts = mkOption {
+          type = types.listOf types.path;
+          default = [ ];
+          description = ''
+            Additional custom endorsement CA cert paths (PEM files).
+            Use for TPM vendors not in the TrustedTpm.cab bundle.
+          '';
+        };
+      };
+
       netvm = {
         extraModules = mkOption {
           description = ''

--- a/modules/hardware/flake-module.nix
+++ b/modules/hardware/flake-module.nix
@@ -24,6 +24,7 @@
     hardware-aarch64-generic.imports = [
       ./definition.nix
       ./aarch64/systemd-boot-dtb.nix
+      ./common/tpm-endorsement.nix
       ./passthrough
     ];
   };

--- a/modules/hardware/x86_64-generic/modules/tpm2.nix
+++ b/modules/hardware/x86_64-generic/modules/tpm2.nix
@@ -30,8 +30,8 @@ in
 
     assertions = [
       {
-        assertion = pkgs.stdenv.isx86_64;
-        message = "TPM2 is only supported on x86_64";
+        assertion = pkgs.stdenv.isx86_64 || pkgs.stdenv.isAarch64;
+        message = "TPM2 is only supported on x86_64 and aarch64";
       }
     ];
   };

--- a/modules/hardware/x86_64-generic/modules/tpm2.nix
+++ b/modules/hardware/x86_64-generic/modules/tpm2.nix
@@ -70,8 +70,7 @@ in
   config = lib.mkIf cfg.enable {
     security.tpm2 = {
       enable = true;
-      # tpm2-pkcs11 cross-compilation is broken on aarch64 (tpm2-pytss patch conflict)
-      pkcs11.enable = pkgs.stdenv.isx86_64;
+      pkcs11.enable = pkgs.stdenv.isx86_64 || pkgs.stdenv.isAarch64;
       abrmd.enable = false;
     };
 

--- a/modules/hardware/x86_64-generic/modules/tpm2.nix
+++ b/modules/hardware/x86_64-generic/modules/tpm2.nix
@@ -8,6 +8,57 @@
 }:
 let
   cfg = config.ghaf.hardware.tpm2;
+
+  tpmHierarchyUnlockScript = pkgs.writeShellApplication {
+    name = "tpm-hierarchy-unlock";
+    runtimeInputs = [
+      pkgs.tpm2-tools
+      pkgs.coreutils
+    ];
+    text = ''
+      FLAG="/var/lib/tpm-cleared"
+
+      # Use TPM resource manager device only.
+      tcti="device:/dev/tpmrm0"
+      dev="''${tcti##*:}"
+      echo "Trying $dev ..."
+      export TPM2TOOLS_TCTI="$tcti"
+
+      echo "Attempting owner hierarchy recovery via platform hierarchy on $dev"
+
+      # Try re-enabling owner and endorsement hierarchies via PH
+      if tpm2_hierarchycontrol -C platform ownerEnable set 2>/dev/null; then
+        echo "Owner hierarchy re-enabled via $dev"
+        tpm2_hierarchycontrol -C platform endorseEnable set 2>/dev/null \
+          && echo "Endorsement hierarchy re-enabled via $dev" \
+          || echo "WARNING: Could not re-enable endorsement hierarchy via $dev"
+
+        exit 0
+      fi
+
+      # Last resort: factory-reset TPM via platform hierarchy.
+      # This clears unknown auth values left by a previous OS installation.
+      # Only attempt once — the flag file prevents repeated clears.
+      if [ ! -f "$FLAG" ]; then
+        echo "Attempting TPM factory reset via platform hierarchy on $dev ..."
+        if tpm2_clear -c platform 2>/dev/null; then
+          echo "TPM factory reset successful — all auth values cleared"
+          mkdir -p "$(dirname "$FLAG")"
+          date -Iseconds > "$FLAG"
+          # After clear, hierarchies are re-enabled with empty auth
+          exit 0
+        else
+          echo "TPM factory reset failed on $dev"
+        fi
+      fi
+
+      echo "Platform hierarchy also locked on $dev"
+
+      echo "WARNING: Could not re-enable owner hierarchy on any device"
+      echo "VMs will fall back to non-TPM methods where possible"
+    '';
+  };
+
 in
 {
   _file = ./tpm2.nix;
@@ -19,7 +70,8 @@ in
   config = lib.mkIf cfg.enable {
     security.tpm2 = {
       enable = true;
-      pkcs11.enable = true;
+      # tpm2-pkcs11 cross-compilation is broken on aarch64 (tpm2-pytss patch conflict)
+      pkcs11.enable = pkgs.stdenv.isx86_64;
       abrmd.enable = false;
     };
 
@@ -34,5 +86,40 @@ in
         message = "TPM2 is only supported on x86_64 and aarch64";
       }
     ];
+
+    systemd.services = {
+      # After LUKS unlock the owner hierarchy may be disabled/locked.
+      # Re-enable it before VMs start so their TPM operations succeed.
+      tpm-hierarchy-unlock = {
+        description = "Re-enable TPM owner hierarchy after LUKS unlock";
+        after = [
+          "systemd-cryptsetup.target"
+          "systemd-tpm2-setup.service"
+        ];
+        before = [ "microvms.target" ];
+        wantedBy = [ "microvms.target" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = lib.getExe tpmHierarchyUnlockScript;
+        };
+      };
+
+      # Re-enable owner hierarchy after VMs have started, in case VM initrd
+      # LUKS operations locked it again.
+      tpm-hierarchy-unlock-late = {
+        description = "Re-enable TPM owner hierarchy after VM boot";
+        after = [ "microvms.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          # Wait for VM initrd LUKS operations to complete
+          ExecStartPre = "${pkgs.coreutils}/bin/sleep 10";
+          ExecStart = lib.getExe tpmHierarchyUnlockScript;
+        };
+      };
+    };
   };
 }

--- a/modules/microvm/common/storagevm.nix
+++ b/modules/microvm/common/storagevm.nix
@@ -68,6 +68,7 @@ in
             # Revisit when user password is involved in decryption; TPM can be optional
             assertion =
               config.ghaf.virtualization.microvm.tpm.passthrough.enable
+              || config.ghaf.virtualization.microvm.tpm.muxed.enable
               || config.ghaf.virtualization.microvm.tpm.emulated.enable;
             message = "VM must have access to a TPM to enable storage encryption";
           }
@@ -131,18 +132,39 @@ in
                   echo 'TPM already enrolled'
                   exit 0
                 fi
+
                 ${lib.optionalString tpm.passthrough.enable ''
                   tpm2_evictcontrol -C owner -c ${tpm.passthrough.rootNVIndex} || true
                   tpm2_createprimary -C owner -c storage.ctx
                   tpm2_evictcontrol -C owner -c storage.ctx ${tpm.passthrough.rootNVIndex}
                 ''}
-                # temporary file to pass an empty passphrase to cryptenroll
-                echo -n > temp_keyfile
-                chmod 600 temp_keyfile
-                systemd-cryptenroll --unlock-key-file=temp_keyfile \
-                  --tpm2-device=/dev/tpm0 --tpm2-pcrs="${cfg.encryption.pcrs}" \
-                  ${lib.optionalString tpm.passthrough.enable "--tpm2-seal-key-handle=${tpm.passthrough.rootNVIndex}"} "${drivePath}"
-                rm temp_keyfile
+
+                ENROLL_OK=0
+                ENROLL_ERR=""
+                for attempt in $(seq 1 30); do
+                  # temporary file to pass an empty passphrase to cryptenroll
+                  echo -n > temp_keyfile
+                  chmod 600 temp_keyfile
+
+                  if ENROLL_ERR=$(systemd-cryptenroll --unlock-key-file=temp_keyfile \
+                    --tpm2-device=/dev/tpmrm0 --tpm2-pcrs="${cfg.encryption.pcrs}" \
+                    ${lib.optionalString tpm.passthrough.enable "--tpm2-seal-key-handle=${tpm.passthrough.rootNVIndex}"} "${drivePath}" 2>&1); then
+                    rm -f temp_keyfile
+                    ENROLL_OK=1
+                    break
+                  fi
+
+                  rm -f temp_keyfile
+                  echo "Waiting for TPM enrollment readiness... ($attempt/30)"
+                  sleep 2
+                done
+
+                if [ "$ENROLL_OK" -ne 1 ]; then
+                  echo "TPM enrollment unavailable after retries: $ENROLL_ERR"
+                  echo "Skipping TPM enrollment — LUKS will use password-only unlock"
+                  exit 0
+                fi
+
                 ${lib.optionalString (!cfg.encryption.keepDefaultPassword) ''
                   echo 'Wiping password slot'
                   systemd-cryptenroll --wipe-slot=password "${drivePath}"

--- a/modules/microvm/common/vm-tpm.nix
+++ b/modules/microvm/common/vm-tpm.nix
@@ -28,6 +28,22 @@ in
       };
     };
 
+    muxed = {
+      enable = mkEnableOption "Passthrough via host TPM mux forwarder";
+
+      name = mkOption {
+        description = "Name of the VM";
+        type = types.str;
+        internal = true;
+      };
+
+      devicePath = mkOption {
+        type = types.str;
+        default = "/run/ghaf-vtpm/${cfg.muxed.name}.tpm";
+        description = "Host path exported by TPM mux forwarder for this VM";
+      };
+    };
+
     emulated = {
       enable = mkEnableOption "Emulated TPM with swtpm";
 
@@ -42,11 +58,16 @@ in
   };
 
   config = mkMerge [
-    (mkIf (cfg.passthrough.enable || cfg.emulated.enable) {
+    (mkIf (cfg.passthrough.enable || cfg.muxed.enable || cfg.emulated.enable) {
       assertions = [
         {
-          assertion = !(cfg.passthrough.enable && cfg.emulated.enable);
-          message = "Cannot enable TPM passthrough and TPM emulation at the same time";
+          assertion =
+            (
+              (if cfg.passthrough.enable then 1 else 0)
+              + (if cfg.muxed.enable then 1 else 0)
+              + (if cfg.emulated.enable then 1 else 0)
+            ) <= 1;
+          message = "Cannot enable TPM passthrough, muxed, and emulated modes at the same time";
         }
       ];
 
@@ -67,6 +88,10 @@ in
         }
       ];
 
+      services.udev.extraRules = ''
+        KERNEL=="tpm0", MODE="0660", GROUP="${config.security.tpm2.tssGroup or "tss"}"
+      '';
+
       microvm.qemu = {
         extraArgs =
           let
@@ -83,6 +108,33 @@ in
         # Workaround a bug when machine type is `microvm`
         #   tpm_tis MSFT0101:00: [Firmware Bug]: failed to get TPM2 ACPI table
         # Only relevant for x86_64 (aarch64 uses "virt" machine type set by VM bases)
+        machine = mkIf pkgs.stdenv.isx86_64 "q35";
+      };
+    })
+    (mkIf cfg.muxed.enable {
+      assertions = [
+        {
+          assertion = pkgs.stdenv.isx86_64 || pkgs.stdenv.isAarch64;
+          message = "TPM muxed passthrough is only supported on x86_64 and aarch64";
+        }
+      ];
+
+      services.udev.extraRules = ''
+        KERNEL=="tpm0", MODE="0660", GROUP="${config.security.tpm2.tssGroup or "tss"}"
+      '';
+
+      microvm.qemu = {
+        extraArgs =
+          let
+            tpmDevice = if pkgs.stdenv.isx86_64 then "tpm-tis" else "tpm-tis-device";
+          in
+          [
+            "-tpmdev"
+            "passthrough,id=tpm0,path=${cfg.muxed.devicePath},cancel-path=/tmp/cancel"
+            "-device"
+            "${tpmDevice},tpmdev=tpm0"
+          ];
+
         machine = mkIf pkgs.stdenv.isx86_64 "q35";
       };
     })

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -129,6 +129,21 @@ in
         };
         logging.client.enable = config.ghaf.logging.enable;
         common.extraNetworking.hosts.ghaf-host = cfg.extraNetworking;
+
+        # SPIFFE/SPIRE agent on host
+        security.spiffe = lib.mkIf (config.ghaf.global-config.spiffe.enable or false) {
+          enable = true;
+          agent = {
+            enable = true;
+            serverAddress =
+              config.ghaf.networking.hosts.${config.ghaf.global-config.spiffe.serverVm or "admin-vm"}.ipv4
+                or "127.0.0.1";
+            serverPort = config.ghaf.global-config.spiffe.serverPort or 8081;
+            trustDomain = config.ghaf.global-config.spiffe.trustDomain or "ghaf.internal";
+            joinTokenFile = "/persist/common/spire/tokens/${config.networking.hostName}.token";
+            trustBundlePath = "/persist/common/spire/bundle.pem";
+          };
+        };
       };
 
       # Create required host directories

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -45,6 +45,7 @@ in
     ./networking.nix
     ./shared-mem.nix
     ./boot.nix
+    ./tpm-mux.nix
     ./vtpm-proxy.nix
   ];
 
@@ -142,6 +143,8 @@ in
             trustDomain = config.ghaf.global-config.spiffe.trustDomain or "ghaf.internal";
             joinTokenFile = "/persist/common/spire/tokens/${config.networking.hostName}.token";
             trustBundlePath = "/persist/common/spire/bundle.pem";
+            # Host reads common dir at /persist/common (not /etc/common like VMs)
+            commonMountPath = "/persist/common";
           };
         };
       };
@@ -272,12 +275,38 @@ in
                 };
             }
           ) { } (lib.attrNames vmsWithEncryptedStorage);
+
+          vmsWithGivcTlsStorage = lib.filterAttrs (
+            _name: vm:
+            let
+              vmConfig = lib.ghaf.vm.getConfig vm;
+            in
+            vmConfig != null
+            && lib.hasAttr "ghaf" vmConfig
+            && lib.hasAttr "givc" vmConfig.ghaf
+            && lib.hasAttr "storagevm" vmConfig.ghaf
+            && (vmConfig.ghaf.givc.enable or false)
+            && (vmConfig.ghaf.givc.enableTls or false)
+            && (vmConfig.ghaf.storagevm.enable or false)
+          ) config.microvm.vms;
+
+          givcStorageOrdering = lib.foldl' (
+            result: name:
+            result
+            // {
+              "microvm@${name}" = {
+                after = [ "givc-key-setup.service" ];
+                requires = [ "givc-key-setup.service" ];
+              };
+            }
+          ) { } (lib.attrNames vmsWithGivcTlsStorage);
         in
         {
           # Device-id and machine-id generation moved to ghaf.identity.dynamicHostName module
         }
         // patchedMicrovmServices
-        // vmstorageSetupServices;
+        // vmstorageSetupServices
+        // givcStorageOrdering;
     })
     (mkIf cfg.sharedVmDirectory.enable {
       # Create directories required for sharing files with correct permissions.

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -142,10 +142,53 @@ in
             serverPort = config.ghaf.global-config.spiffe.serverPort or 8081;
             trustDomain = config.ghaf.global-config.spiffe.trustDomain or "ghaf.internal";
             joinTokenFile = "/persist/common/spire/tokens/${config.networking.hostName}.token";
+            attestationMode =
+              if
+                (config.ghaf.global-config.spiffe.tpmAttestation.enable or false)
+                && ((config.ghaf.global-config.platform.hostSystem or "") != "riscv64-linux")
+              then
+                "tpm_devid"
+              else
+                "join_token";
             trustBundlePath = "/persist/common/spire/bundle.pem";
             # Host reads common dir at /persist/common (not /etc/common like VMs)
             commonMountPath = "/persist/common";
           };
+
+          devidProvision =
+            lib.mkIf
+              (
+                (config.ghaf.global-config.spiffe.tpmAttestation.enable or false)
+                && ((config.ghaf.global-config.platform.hostSystem or "") != "riscv64-linux")
+              )
+              {
+                enable = true;
+                vmName = config.networking.hostName;
+                csrDir = "/persist/common/spire/devid/requests";
+                certDir = "/persist/common/spire/devid/certs";
+              };
+
+          tpmVendorDetect =
+            lib.mkIf
+              (
+                (config.ghaf.global-config.spiffe.tpmAttestation.enable or false)
+                && ((config.ghaf.global-config.platform.hostSystem or "") != "riscv64-linux")
+              )
+              {
+                enable = true;
+                expectedVendors = config.ghaf.global-config.spiffe.tpmAttestation.endorsementCaVendors or [ ];
+              };
+
+          tpmEkVerify =
+            lib.mkIf
+              (
+                (config.ghaf.global-config.spiffe.tpmAttestation.enable or false)
+                && ((config.ghaf.global-config.platform.hostSystem or "") != "riscv64-linux")
+              )
+              {
+                enable = true;
+                endorsementCaBundle = config.ghaf.global-config.spiffe.tpmAttestation.endorsementCaBundle or "";
+              };
         };
       };
 

--- a/modules/microvm/host/tpm-mux.nix
+++ b/modules/microvm/host/tpm-mux.nix
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.virtualization.microvm-host.tpmMux;
+  muxedVms = lib.attrNames (
+    lib.filterAttrs (
+      _name: vm: (vm.config.ghaf.virtualization.microvm.tpm.muxed.enable or false)
+    ) config.microvm.vms
+  );
+  forwarderVms = if cfg.vms == [ ] then muxedVms else cfg.vms;
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    types
+    ;
+in
+{
+  _file = ./tpm-mux.nix;
+
+  options.ghaf.virtualization.microvm-host.tpmMux = {
+    enable = mkEnableOption "host TPM mux scaffold with abrmd and per-VM forwarders";
+
+    vms = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "VM names to provision TPM forwarder instances for";
+    };
+
+    runDir = mkOption {
+      type = types.str;
+      default = "/run/ghaf-vtpm";
+      description = "Runtime directory for per-VM TPM link paths";
+    };
+
+    backendDevice = mkOption {
+      type = types.str;
+      default = "/dev/tpmrm0";
+      description = "Host TPM device that forwarder links to";
+    };
+  };
+
+  config = mkMerge [
+    {
+      ghaf.virtualization.microvm-host.tpmMux.enable = lib.mkDefault (forwarderVms != [ ]);
+    }
+    (mkIf cfg.enable {
+      security.tpm2 = {
+        enable = true;
+        abrmd.enable = lib.mkForce true;
+      };
+
+      boot.kernelModules = [ "tpm_vtpm_proxy" ];
+
+      systemd.tmpfiles.rules = [ "d ${cfg.runDir} 0755 root root -" ];
+
+      systemd.services =
+        (lib.listToAttrs (
+          map (vmName: {
+            name = "ghaf-vtpm-forwarder-${vmName}";
+            value = {
+              description = "TPM mux forwarder for ${vmName}";
+              wantedBy = [ "microvms.target" ];
+              before = [ "microvm@${vmName}.service" ];
+              wants = [ "tpm2-abrmd.service" ];
+              after = [ "tpm2-abrmd.service" ];
+              serviceConfig = {
+                Type = "notify";
+                NotifyAccess = "main";
+                TimeoutStartSec = "45s";
+                Restart = "always";
+                RestartSec = "1s";
+                ExecStart = "${pkgs.vtpm-abrmd-forwarder}/bin/vtpm-abrmd-forwarder --vm-name ${vmName} --backend-device ${cfg.backendDevice} --link-path ${cfg.runDir}/${vmName}.tpm";
+              };
+            };
+          }) forwarderVms
+        ))
+        // (lib.listToAttrs (
+          map (vmName: {
+            name = "microvm@${vmName}";
+            value = {
+              requires = [ "ghaf-vtpm-forwarder-${vmName}.service" ];
+              after = [ "ghaf-vtpm-forwarder-${vmName}.service" ];
+            };
+          }) forwarderVms
+        ));
+    })
+  ];
+}

--- a/modules/microvm/host/tpm-mux.nix
+++ b/modules/microvm/host/tpm-mux.nix
@@ -70,7 +70,11 @@ in
               wantedBy = [ "microvms.target" ];
               before = [ "microvm@${vmName}.service" ];
               wants = [ "tpm2-abrmd.service" ];
-              after = [ "tpm2-abrmd.service" ];
+              after = [
+                "tpm2-abrmd.service"
+              ]
+              ++ lib.optionals (cfg.backendDevice == "/dev/tpmrm0") [ "dev-tpmrm0.device" ];
+              requires = lib.optionals (cfg.backendDevice == "/dev/tpmrm0") [ "dev-tpmrm0.device" ];
               serviceConfig = {
                 Type = "notify";
                 NotifyAccess = "main";

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -90,9 +90,14 @@ in
         "/etc/locale-givc.conf"
         "/etc/timezone.conf"
       ];
-      directories = lib.mkIf (globalConfig.storage.encryption.enable or false) [
-        "/var/lib/swtpm"
-      ];
+      directories = lib.mkIf (globalConfig.storage.encryption.enable or false) (
+        [
+          "/var/lib/swtpm"
+        ]
+        ++ lib.optionals (globalConfig.spiffe.enable or false) [
+          "/var/lib/spire"
+        ]
+      );
       encryption.enable = globalConfig.storage.encryption.enable or false;
     };
 
@@ -157,6 +162,50 @@ in
     security = {
       fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
       audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+
+      # SPIFFE/SPIRE — admin-vm is the SPIRE server
+      spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+        enable = true;
+        trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+
+        server = {
+          enable = true;
+          bindPort = globalConfig.spiffe.serverPort or 8081;
+          # Collect VM names for join token generation:
+          # all system VMs + app VMs + ghaf-host
+          spireAgentVMs =
+            let
+              sysvmNames = lib.mapAttrsToList (_: vm: vm.vmName) (hostConfig.sysvms or { });
+              appvmNames = lib.mapAttrsToList (name: _: "${name}-vm") (hostConfig.appvms or { });
+            in
+            sysvmNames ++ appvmNames ++ [ "ghaf-host" ];
+          generateJoinTokens = true;
+          publishBundle = true;
+          createWorkloadEntries = true;
+          workloadEntries = [
+            {
+              name = "workload";
+              selectors = [ "unix:user:ghaf" ];
+            }
+          ];
+          tpmAttestation = lib.mkIf (globalConfig.spiffe.tpmAttestation.enable or false) {
+            enable = true;
+            devidCaPath = "/var/lib/spire/ca/ca.pem";
+            endorsementCaPath = "/var/lib/spire/ca/endorsement-ca.pem";
+          };
+        };
+
+        # admin-vm also runs a SPIRE agent
+        agent = {
+          enable = true;
+          serverAddress = "127.0.0.1";
+          serverPort = globalConfig.spiffe.serverPort or 8081;
+          joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+        };
+
+        # DevID CA (signs certs for system VMs with TPM)
+        devidCa.enable = globalConfig.spiffe.tpmAttestation.enable or false;
+      };
     };
   };
 

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -111,18 +111,18 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough is only supported on x86_64
+        # TPM passthrough supported on x86_64 and aarch64
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") == "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         rootNVIndex = "0x81701000"; # TPM2 NV index for admin-vm LUKS key
       };
 
       tpm.emulated = {
-        # Use emulated TPM for non-x86_64 systems when encryption is enabled
+        # Use emulated TPM for platforms without hardware TPM support
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
         name = vmName;
       };
     };
@@ -190,8 +190,8 @@ in
           ];
           tpmAttestation = lib.mkIf (globalConfig.spiffe.tpmAttestation.enable or false) {
             enable = true;
-            devidCaPath = "/var/lib/spire/ca/ca.pem";
-            endorsementCaPath = "/var/lib/spire/ca/endorsement-ca.pem";
+            devidCaPath = "/etc/common/spire/ca/ca.pem";
+            endorsementCaBundle = globalConfig.spiffe.tpmAttestation.endorsementCaBundle or "";
           };
         };
 

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -111,10 +111,8 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough supported on x86_64 and aarch64
-        enable =
-          (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
+        # Disabled in favor of TPM mux for non-riscv64 platforms.
+        enable = false;
         rootNVIndex = "0x81701000"; # TPM2 NV index for admin-vm LUKS key
       };
 
@@ -123,6 +121,13 @@ in
         enable =
           (globalConfig.storage.encryption.enable or false)
           && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
+        name = vmName;
+      };
+
+      tpm.muxed = {
+        enable =
+          (globalConfig.storage.encryption.enable or false)
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         name = vmName;
       };
     };

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -257,7 +257,22 @@ in
         };
 
         # Security
-        security.fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+        security = {
+          fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+
+          # SPIFFE/SPIRE agent (app VMs always use join_token)
+          spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+            enable = true;
+            trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+            agent = {
+              enable = true;
+              serverAddress =
+                hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
+              serverPort = globalConfig.spiffe.serverPort or 8081;
+              joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+            };
+          };
+        };
       };
 
       # Combined udev rules (yubikey + passthrough)

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -100,10 +100,8 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough supported on x86_64 and aarch64
-        enable =
-          (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
+        # Disabled in favor of TPM mux for non-riscv64 platforms.
+        enable = false;
         rootNVIndex = "0x81702000"; # TPM2 NV index for audio-vm LUKS key
       };
 
@@ -112,6 +110,13 @@ in
         enable =
           (globalConfig.storage.encryption.enable or false)
           && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
+        name = vmName;
+      };
+
+      tpm.muxed = {
+        enable =
+          (globalConfig.storage.encryption.enable or false)
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         name = vmName;
       };
     };

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -100,18 +100,18 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough is only supported on x86_64
+        # TPM passthrough supported on x86_64 and aarch64
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") == "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         rootNVIndex = "0x81702000"; # TPM2 NV index for audio-vm LUKS key
       };
 
       tpm.emulated = {
-        # Use emulated TPM for non-x86_64 systems when encryption is enabled
+        # Use emulated TPM for platforms without hardware TPM support
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
         name = vmName;
       };
     };
@@ -166,7 +166,7 @@ in
           attestationMode =
             if
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             then
               "tpm_devid"
             else
@@ -176,11 +176,31 @@ in
           lib.mkIf
             (
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             )
             {
               enable = true;
               inherit vmName;
+            };
+        tpmVendorDetect =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              expectedVendors = globalConfig.spiffe.tpmAttestation.endorsementCaVendors or [ ];
+            };
+        tpmEkVerify =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              endorsementCaBundle = globalConfig.spiffe.tpmAttestation.endorsementCaBundle or "";
             };
       };
     };

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -150,7 +150,40 @@ in
       server.endpoint = globalConfig.logging.server.endpoint or "";
     };
 
-    security.fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+    security = {
+      fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+
+      # SPIFFE/SPIRE agent
+      spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+        enable = true;
+        trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+        agent = {
+          enable = true;
+          serverAddress =
+            hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
+          serverPort = globalConfig.spiffe.serverPort or 8081;
+          joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+          attestationMode =
+            if
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            then
+              "tpm_devid"
+            else
+              "join_token";
+        };
+        devidProvision =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            )
+            {
+              enable = true;
+              inherit vmName;
+            };
+      };
+    };
 
     # Networking hosts - from hostConfig (for vm-networking.nix to look up MAC/IP)
     networking.hosts = hostConfig.networking.hosts or { };

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -98,9 +98,6 @@ in
       };
     };
 
-    # Security - from globalConfig
-    security.audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
-
     development = {
       ssh.daemon.enable = lib.mkDefault (globalConfig.development.ssh.daemon.enable or false);
       debug.tools.enable = lib.mkDefault (globalConfig.development.debug.tools.enable or false);
@@ -251,7 +248,45 @@ in
     };
 
     xdgitems.enable = true;
-    security.fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+
+    security = {
+      fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+      # Security - from globalConfig
+      audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+
+      # SPIFFE/SPIRE agent
+      spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+        enable = true;
+        trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+        agent = {
+          enable = true;
+          serverAddress =
+            hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
+          serverPort = globalConfig.spiffe.serverPort or 8081;
+          joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+          # Use TPM DevID attestation if enabled and this VM has hardware TPM
+          attestationMode =
+            if
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            then
+              "tpm_devid"
+            else
+              "join_token";
+        };
+        # DevID provisioning for system VMs with TPM
+        devidProvision =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            )
+            {
+              enable = true;
+              inherit vmName;
+            };
+      };
+    };
   };
 
   services = {

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -158,18 +158,18 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough is only supported on x86_64
+        # TPM passthrough supported on x86_64 and aarch64
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") == "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         rootNVIndex = "0x81703000"; # TPM2 NV index for gui-vm LUKS key
       };
 
       tpm.emulated = {
-        # Use emulated TPM for non-x86_64 systems when encryption is enabled
+        # Use emulated TPM for platforms without hardware TPM support
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
         name = vmName;
       };
     };
@@ -264,11 +264,11 @@ in
             hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
           serverPort = globalConfig.spiffe.serverPort or 8081;
           joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
-          # Use TPM DevID attestation if enabled and this VM has hardware TPM
+          # Use TPM DevID attestation if enabled and platform supports hardware TPM
           attestationMode =
             if
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             then
               "tpm_devid"
             else
@@ -279,11 +279,33 @@ in
           lib.mkIf
             (
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             )
             {
               enable = true;
               inherit vmName;
+            };
+        # Runtime TPM vendor detection (advisory)
+        tpmVendorDetect =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              expectedVendors = globalConfig.spiffe.tpmAttestation.endorsementCaVendors or [ ];
+            };
+        # Runtime EK cert chain validation (defense-in-depth)
+        tpmEkVerify =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              endorsementCaBundle = globalConfig.spiffe.tpmAttestation.endorsementCaBundle or "";
             };
       };
     };

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -158,10 +158,8 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough supported on x86_64 and aarch64
-        enable =
-          (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
+        # Disabled in favor of TPM mux for non-riscv64 platforms.
+        enable = false;
         rootNVIndex = "0x81703000"; # TPM2 NV index for gui-vm LUKS key
       };
 
@@ -170,6 +168,13 @@ in
         enable =
           (globalConfig.storage.encryption.enable or false)
           && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
+        name = vmName;
+      };
+
+      tpm.muxed = {
+        enable =
+          (globalConfig.storage.encryption.enable or false)
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         name = vmName;
       };
     };

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -110,10 +110,8 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough supported on x86_64 and aarch64
-        enable =
-          (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
+        # Disabled in favor of TPM mux for non-riscv64 platforms.
+        enable = false;
         rootNVIndex = "0x81704000"; # TPM2 NV index for net-vm LUKS key
       };
 
@@ -122,6 +120,13 @@ in
         enable =
           (globalConfig.storage.encryption.enable or false)
           && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
+        name = vmName;
+      };
+
+      tpm.muxed = {
+        enable =
+          (globalConfig.storage.encryption.enable or false)
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         name = vmName;
       };
     };

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -110,19 +110,18 @@ in
       };
 
       tpm.passthrough = {
-        # At the moment the TPM is only used for storage encryption, so the features are coupled.
-        # TPM passthrough is only supported on x86_64.
+        # TPM passthrough supported on x86_64 and aarch64
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") == "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         rootNVIndex = "0x81704000"; # TPM2 NV index for net-vm LUKS key
       };
 
       tpm.emulated = {
-        # Use emulated TPM for non-x86_64 systems when encryption is enabled
+        # Use emulated TPM for platforms without hardware TPM support
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
         name = vmName;
       };
     };
@@ -183,7 +182,7 @@ in
           attestationMode =
             if
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             then
               "tpm_devid"
             else
@@ -193,11 +192,31 @@ in
           lib.mkIf
             (
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             )
             {
               enable = true;
               inherit vmName;
+            };
+        tpmVendorDetect =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              expectedVendors = globalConfig.spiffe.tpmAttestation.endorsementCaVendors or [ ];
+            };
+        tpmEkVerify =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              endorsementCaBundle = globalConfig.spiffe.tpmAttestation.endorsementCaBundle or "";
             };
       };
     };

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -169,6 +169,37 @@ in
 
       # Audit - from globalConfig
       audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+
+      # SPIFFE/SPIRE agent
+      spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+        enable = true;
+        trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+        agent = {
+          enable = true;
+          serverAddress =
+            hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
+          serverPort = globalConfig.spiffe.serverPort or 8081;
+          joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+          attestationMode =
+            if
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            then
+              "tpm_devid"
+            else
+              "join_token";
+        };
+        devidProvision =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            )
+            {
+              enable = true;
+              inherit vmName;
+            };
+      };
     };
 
     # Common namespace - from hostConfig

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -276,6 +276,16 @@ in
           sharedVmDirectory = {
             enable = true;
           };
+          tpmMux = {
+            enable = true;
+            # Keep explicit list to avoid evaluation-order misses in auto-discovery.
+            vms = [
+              "admin-vm"
+              "audio-vm"
+              "gui-vm"
+              "net-vm"
+            ];
+          };
         };
 
         microvm = {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -169,6 +169,14 @@ in
           sharedVmDirectory = {
             enable = false;
           };
+          tpmMux = {
+            enable = true;
+            # Keep explicit list to avoid evaluation-order misses in auto-discovery.
+            vms = [
+              "admin-vm"
+              "net-vm"
+            ];
+          };
         };
 
         microvm = {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -223,6 +223,7 @@ in
       # 2. ghaf.global-config.givc.enable (propagates to VMs via specialArgs)
       givc.enable = false;
       global-config.givc.enable = false;
+      global-config.spiffe.tpmAttestation.endorsementCaBundle = "/etc/common/spire/ca/endorsement-bundle.pem";
 
       host.networking = {
         enable = true;

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -163,6 +163,22 @@ in
 
       # Virtualization options
       virtualization = {
+        vmConfig.sysvms = {
+          # Interim safety: keep an empty-password recovery unlock path for
+          # encrypted storage images while Jetson fTPM lockout behavior is
+          # being stabilized.
+          netvm.extraModules = [
+            {
+              ghaf.storagevm.encryption.keepDefaultPassword = true;
+            }
+          ];
+          adminvm.extraModules = [
+            {
+              ghaf.storagevm.encryption.keepDefaultPassword = true;
+            }
+          ];
+        };
+
         microvm-host = {
           enable = true;
           networkSupport = true;
@@ -194,8 +210,13 @@ in
 
           adminvm = {
             enable = true;
-            # Use evaluatedConfig pattern - common is passed via hostConfig
-            evaluatedConfig = cfg.adminvmBase;
+            # Use evaluatedConfig pattern - extend adminvmBase with vmConfig modules
+            evaluatedConfig = cfg.adminvmBase.extendModules {
+              modules = lib.ghaf.vm.applyVmConfig {
+                inherit config;
+                vmName = "adminvm";
+              };
+            };
           };
 
           idsvm = {

--- a/modules/reference/hardware/flake-module.nix
+++ b/modules/reference/hardware/flake-module.nix
@@ -19,6 +19,26 @@
         ghaf.hardware.definition.netvm.extraModules = [
           (import ./alienware/net-config.nix)
         ];
+        # Intel Raptor Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-dell-latitude-7230.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7230.nix; }
+      {
+        # Intel Alder Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-dell-latitude-7330.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7330.nix; }
+      {
+        # Intel Tiger Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
       }
     ];
 
@@ -56,6 +76,11 @@
           definition.guivm.extraModules = [
             (import ./intel-laptop/extra-config.nix)
           ];
+          # Generic Intel laptop — Intel PTT fTPM, possibly Infineon dTPM on some SKUs
+          definition.tpm.endorsementCaVendors = [
+            "Intel"
+            "Infineon"
+          ];
         };
       }
     ];
@@ -67,6 +92,68 @@
         # Hardware-specific VM configs via hardware definition
         ghaf.hardware.definition.guivm.extraModules = [
           ./lenovo-t14-amd/gpu-config.nix
+        ];
+        # AMD Ryzen — AMD fTPM or Infineon dTPM depending on SKU
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [
+          "AMD"
+          "Infineon"
+        ];
+      }
+    ];
+
+    hardware-lenovo-x1-2-in-1-gen9.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-2-in-1-gen-9.nix; }
+      {
+        # Intel Meteor Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-lenovo-x1-carbon-gen10.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen10.nix; }
+      {
+        # Intel Alder Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-lenovo-x1-carbon-gen11.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen11.nix; }
+      {
+        # Intel Raptor Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-lenovo-x1-carbon-gen12.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen12.nix; }
+      {
+        # Intel Meteor Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-lenovo-x1-carbon-gen13.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen13.nix; }
+      {
+        # Intel Lunar Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-system76-darp11-b.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./system76/definitions/system76-darp11-b.nix; }
+      {
+        # Intel Arrow Lake — Intel PTT fTPM, possibly Infineon dTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [
+          "Intel"
+          "Infineon"
         ];
       }
     ];
@@ -83,62 +170,6 @@
           ];
           passthrough.pci.autoDetectNet = true;
         };
-      }
-    ];
-
-    hardware-dell-latitude-7230.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7230.nix;
-      }
-    ];
-
-    hardware-dell-latitude-7330.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7330.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-2-in-1-gen9.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-2-in-1-gen-9.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-carbon-gen10.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen10.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-carbon-gen11.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen11.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-carbon-gen12.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen12.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-carbon-gen13.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen13.nix;
-      }
-    ];
-
-    hardware-system76-darp11-b.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./system76/definitions/system76-darp11-b.nix;
       }
     ];
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -266,6 +266,14 @@ in
 
       modprobeConfig.enable = true;
 
+      # Orin fTPM and encrypted microvm storage paths are module-based.
+      # Load these early so TPM mux forwarders and storage setup services do not
+      # race module autoload during boot.
+      kernelModules = [
+        "dm_crypt"
+        "tpm_ftpm_tee"
+      ];
+
       kernelPatches = [
         {
           name = "vsock-config";

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -154,6 +154,54 @@ let
     '';
   };
 
+  clearTpmLockoutApp = pkgs.writeShellApplication {
+    name = "ghaf-clear-tpm-lockout";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.tpm2-tools
+    ];
+    text = ''
+      set -euo pipefail
+
+      export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
+      STATUS_FILE="/run/tpm/lockout-status"
+
+      mkdir -p /run/tpm
+
+      is_in_lockout() {
+        timeout -k 2s 5s tpm2_getcap properties-variable 2>/dev/null | grep -q "inLockout:[[:space:]]*1"
+      }
+
+      if ! timeout -k 2s 5s tpm2_getcap properties-variable >/dev/null 2>&1; then
+        echo "tpm-unavailable" > "$STATUS_FILE"
+        echo "TPM not ready for lockout check"
+        exit 0
+      fi
+
+      if ! is_in_lockout; then
+        echo "not-locked" > "$STATUS_FILE"
+        echo "TPM is not in DA lockout mode"
+        exit 0
+      fi
+
+      echo "TPM is in DA lockout mode, attempting clear"
+      if timeout -k 2s 5s tpm2_dictionarylockout -c >/dev/null 2>&1; then
+        sleep 1
+        if is_in_lockout; then
+          echo "still-locked" > "$STATUS_FILE"
+          echo "WARNING: Lockout clear command completed but TPM remains locked"
+        else
+          echo "cleared" > "$STATUS_FILE"
+          echo "TPM lockout cleared"
+        fi
+      else
+        echo "clear-failed" > "$STATUS_FILE"
+        echo "WARNING: Failed to clear TPM lockout"
+      fi
+    '';
+  };
+
   exportEkBundleApp = pkgs.writeShellApplication {
     name = "ghaf-export-ek-endorsement-bundle";
     runtimeInputs = [
@@ -205,6 +253,90 @@ let
       echo "Wrote endorsement bundle to $BUNDLE"
     '';
   };
+
+  normalizeTpmDaParamsApp = pkgs.writeShellApplication {
+    name = "ghaf-normalize-tpm-da-params";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.tpm2-tools
+    ];
+    text = ''
+      set -euo pipefail
+
+      export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
+      STATUS_FILE="/run/tpm/da-params-status"
+
+      mkdir -p /run/tpm
+
+      caps="$(timeout -k 2s 8s tpm2_getcap properties-variable 2>/dev/null || true)"
+      if [ -z "$caps" ]; then
+        echo "tpm-unavailable" > "$STATUS_FILE"
+        exit 0
+      fi
+
+      if ! printf '%s\n' "$caps" | grep -qE 'TPM2_PT_MAX_AUTH_FAIL:[[:space:]]*(0x0|0)$'; then
+        echo "ok" > "$STATUS_FILE"
+        exit 0
+      fi
+
+      echo "normalizing" > "$STATUS_FILE"
+      if timeout -k 2s 8s tpm2_dictionarylockout --setup-parameters \
+        --max-tries=3 \
+        --recovery-time=1000 \
+        --lockout-recovery-time=1000 >/dev/null 2>&1; then
+        echo "normalized" > "$STATUS_FILE"
+      else
+        echo "normalize-failed" > "$STATUS_FILE"
+      fi
+    '';
+  };
+
+  firmwareEkbImage =
+    pkgs.buildPackages.runCommand "ghaf-eks-t234"
+      {
+        nativeBuildInputs = [
+          pkgs.buildPackages.openssl
+          pkgs.buildPackages.nvidia-jetpack.genEkb
+        ];
+      }
+      ''
+                        set -euo pipefail
+
+                        mkdir -p "$out"
+
+                        # Development key for unfused devices (OEM_K1 all-zero key).
+                cat > oem_k1.key <<'EOF'
+        0x0000000000000000000000000000000000000000000000000000000000000000
+        EOF
+
+                # Avoid interactive prompt in gen_ekb.py by providing UEFI auth key.
+                cat > auth.key <<'EOF'
+        0x00000000000000000000000000000000
+        EOF
+
+                        openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
+                          -keyout ek-rsa-key.pem -out ek-rsa.pem \
+                          -subj "/CN=Jetson Orin fTPM EK RSA/O=Ghaf" \
+                          -days 36500
+
+                        openssl ecparam -name prime256v1 -genkey -noout -out ek-ecc-key.pem
+                        openssl req -x509 -new -sha256 \
+                          -key ek-ecc-key.pem -out ek-ecc.pem \
+                          -subj "/CN=Jetson Orin fTPM EK ECC/O=Ghaf" \
+                          -days 36500
+
+                        openssl x509 -in ek-rsa.pem -outform DER -out ek-rsa.der
+                        openssl x509 -in ek-ecc.pem -outform DER -out ek-ecc.der
+
+                ${pkgs.buildPackages.nvidia-jetpack.genEkb}/bin/gen_ekb.py \
+                  -chip t234 \
+                  -oem_k1_key oem_k1.key \
+                  -in_auth_key auth.key \
+                  -in_ftpm_rsa_ek_cert ek-rsa.der \
+                  -in_ftpm_ec_ek_cert ek-ecc.der \
+                  -out "$out/eks_t234.img"
+      '';
   inherit (lib)
     mkEnableOption
     mkOption
@@ -244,9 +376,29 @@ in
       type = types.str;
       default = "bsp-default";
     };
+
+    runtimeEkProvision.enable = mkOption {
+      description = "Provision EK certificates into TPM NV indices at runtime";
+      type = types.bool;
+      default = true;
+    };
+
+    lockoutClear.enable = mkOption {
+      description = "Attempt TPM DA lockout clear during host boot";
+      type = types.bool;
+      default = false;
+    };
+
+    daNormalize.enable = mkOption {
+      description = "Normalize TPM dictionary-attack parameters when maxAuthFail is zero";
+      type = types.bool;
+      default = true;
+    };
+
   };
 
   config = mkIf cfg.enable {
+    hardware.nvidia-jetpack.firmware.eksFile = "${firmwareEkbImage}/eks_t234.img";
     hardware.nvidia-jetpack.kernel.version = "${cfg.kernelVersion}";
     nixpkgs.hostPlatform.system = "aarch64-linux";
 
@@ -297,17 +449,69 @@ in
             DM_CRYPT = module;
             TCG_FTPM_TEE = module;
             TCG_VTPM_PROXY = module;
+            HW_RANDOM_TPM = no;
           };
         }
       ];
     };
 
-    systemd.services.ghaf-provision-ek-certs = {
-      description = "Provision fTPM EK certificates into standard NV indices";
+    systemd.services.ghaf-clear-tpm-lockout = mkIf cfg.lockoutClear.enable {
+      description = "Attempt to clear TPM DA lockout before VM startup";
+      wantedBy = [ "multi-user.target" ];
       after = [
         "local-fs.target"
         "systemd-modules-load.service"
+        "dev-tpmrm0.device"
       ];
+      requires = [ "dev-tpmrm0.device" ];
+      unitConfig.ConditionPathExists = "/dev/tpmrm0";
+
+      serviceConfig = {
+        Type = "oneshot";
+        TimeoutStartSec = "20s";
+        TimeoutStopSec = "2s";
+        KillMode = "control-group";
+        UMask = "0077";
+        ExecStart = lib.getExe clearTpmLockoutApp;
+      };
+    };
+
+    systemd.services.ghaf-normalize-tpm-da-params = mkIf cfg.daNormalize.enable {
+      description = "Normalize TPM dictionary-attack parameters";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "local-fs.target"
+        "systemd-modules-load.service"
+        "dev-tpmrm0.device"
+      ];
+      requires = [ "dev-tpmrm0.device" ];
+      unitConfig.ConditionPathExists = "/dev/tpmrm0";
+
+      serviceConfig = {
+        Type = "oneshot";
+        TimeoutStartSec = "20s";
+        TimeoutStopSec = "2s";
+        KillMode = "control-group";
+        UMask = "0077";
+        ExecStart = lib.getExe normalizeTpmDaParamsApp;
+      };
+    };
+
+    systemd.services.ghaf-provision-ek-certs = mkIf cfg.runtimeEkProvision.enable {
+      description = "Provision fTPM EK certificates into standard NV indices";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "local-fs.target"
+        "systemd-modules-load.service"
+        "dev-tpmrm0.device"
+      ]
+      ++ lib.optionals cfg.daNormalize.enable [
+        "ghaf-normalize-tpm-da-params.service"
+      ]
+      ++ lib.optionals cfg.lockoutClear.enable [
+        "ghaf-clear-tpm-lockout.service"
+      ];
+      requires = [ "dev-tpmrm0.device" ];
       unitConfig.ConditionPathExists = "/dev/tpmrm0";
       unitConfig.OnSuccess = [ "ghaf-export-ek-endorsement-bundle.service" ];
 
@@ -324,10 +528,14 @@ in
     systemd.services.ghaf-export-ek-endorsement-bundle = {
       description = "Export EK certs and build endorsement CA bundle";
       wantedBy = [ "multi-user.target" ];
-      before = [ "microvms.target" ];
       after = [
         "local-fs.target"
         "systemd-modules-load.service"
+      ]
+      ++ lib.optionals cfg.lockoutClear.enable [
+        "ghaf-clear-tpm-lockout.service"
+      ]
+      ++ lib.optionals cfg.runtimeEkProvision.enable [
         "ghaf-provision-ek-certs.service"
       ];
       unitConfig.ConditionPathExists = "/dev/tpmrm0";
@@ -340,15 +548,7 @@ in
       };
     };
 
-    systemd.timers.ghaf-provision-ek-certs = {
-      description = "Run fTPM EK certificate provisioning after boot";
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnBootSec = "2min";
-        RandomizedDelaySec = "30s";
-        Unit = "ghaf-provision-ek-certs.service";
-      };
-    };
+    systemd.timers.ghaf-provision-ek-certs.enable = false;
 
     services.nvpmodel = {
       enable = lib.mkDefault true;

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -5,10 +5,206 @@
 {
   lib,
   config,
+  pkgs,
   ...
 }:
 let
   cfg = config.ghaf.hardware.nvidia.orin;
+  pythonWithCryptography = pkgs.python3.withPackages (ps: [ ps.cryptography ]);
+  provisionEkCertsApp = pkgs.writeShellApplication {
+    name = "ghaf-provision-ek-certs";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.openssl
+      pythonWithCryptography
+      pkgs.tpm2-tools
+    ];
+    text = ''
+            set -euo pipefail
+
+            export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
+
+            EK_NV_RSA="0x01C00002"
+            EK_NV_ECC="0x01C0000A"
+            WORKDIR="/run/ghaf-ek-provision"
+
+            cleanup() {
+              rm -rf "$WORKDIR"
+            }
+            trap cleanup EXIT
+
+            mkdir -p "$WORKDIR"
+
+            index_exists() {
+              local idx="$1"
+              timeout 5s tpm2_nvreadpublic "$idx" >/dev/null 2>&1
+            }
+
+            issue_cert_der() {
+              local alg="$1"
+              local out_der="$2"
+              local subj="$3"
+              local ek_ctx="$WORKDIR/ek-$alg.ctx"
+              local ek_pub_blob="$WORKDIR/ek-$alg.pub"
+              local ek_pub_pem="$WORKDIR/ek-$alg.pub.pem"
+              local signer_key="$WORKDIR/selfsign-$alg.key.pem"
+              local signer_cert="$WORKDIR/selfsign-$alg.ca.pem"
+
+              timeout 20s tpm2_createek -Q -G "$alg" -c "$ek_ctx" -u "$ek_pub_blob"
+              timeout 20s tpm2_readpublic -Q -c "$ek_ctx" -f pem -o "$ek_pub_pem"
+
+              # Generate ephemeral self-signed signer and issue an EK leaf cert with EK public key.
+              # This keeps all artifacts local to boot provisioning flow.
+              openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+                -keyout "$signer_key" -out "$signer_cert" \
+                -subj "/CN=Ghaf EK Self-Signed $alg"
+
+              # Platform note: Orin class devices may boot with RTC reset (epoch/old time)
+              # until network time sync becomes available. To keep TPM DevID attestation
+              # functional even without immediate NTP, emit EK certs with a wide fixed
+              # validity window instead of "now + N days" validity.
+              python - "$ek_pub_pem" "$signer_key" "$signer_cert" "$out_der" "$subj" <<'PY'
+      import datetime
+      import sys
+
+      from cryptography import x509
+      from cryptography.hazmat.primitives import hashes, serialization
+      from cryptography.x509.oid import NameOID
+
+
+      def parse_subject(subject: str) -> x509.Name:
+          oid_map = {
+              "CN": NameOID.COMMON_NAME,
+              "O": NameOID.ORGANIZATION_NAME,
+              "OU": NameOID.ORGANIZATIONAL_UNIT_NAME,
+              "C": NameOID.COUNTRY_NAME,
+              "ST": NameOID.STATE_OR_PROVINCE_NAME,
+              "L": NameOID.LOCALITY_NAME,
+          }
+          attrs = []
+          for part in subject.split("/"):
+              if not part or "=" not in part:
+                  continue
+              key, value = part.split("=", 1)
+              oid = oid_map.get(key)
+              if oid is not None:
+                  attrs.append(x509.NameAttribute(oid, value))
+          if not attrs:
+              attrs = [x509.NameAttribute(NameOID.COMMON_NAME, "Ghaf EK")]
+          return x509.Name(attrs)
+
+
+      ek_pub_pem, signer_key_pem, signer_cert_pem, out_der, subject = sys.argv[1:]
+
+      with open(ek_pub_pem, "rb") as f:
+          ek_pub = serialization.load_pem_public_key(f.read())
+
+      with open(signer_key_pem, "rb") as f:
+          signer_key = serialization.load_pem_private_key(f.read(), password=None)
+
+      with open(signer_cert_pem, "rb") as f:
+          signer_cert = x509.load_pem_x509_certificate(f.read())
+
+      not_before = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
+      not_after = datetime.datetime(2100, 1, 1, tzinfo=datetime.UTC)
+
+      cert = (
+          x509.CertificateBuilder()
+          .subject_name(parse_subject(subject))
+          .issuer_name(signer_cert.subject)
+          .public_key(ek_pub)
+          .serial_number(x509.random_serial_number())
+          .not_valid_before(not_before)
+          .not_valid_after(not_after)
+          .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+          .sign(private_key=signer_key, algorithm=hashes.SHA256())
+      )
+
+      with open(out_der, "wb") as f:
+          f.write(cert.public_bytes(serialization.Encoding.DER))
+      PY
+
+              tpm2_flushcontext "$ek_ctx" >/dev/null 2>&1 || true
+            }
+
+            ensure_nv_cert() {
+              local idx="$1"
+              local alg="$2"
+              local subj="$3"
+              local der_file="$WORKDIR/ek-$alg.cert.der"
+
+              if index_exists "$idx"; then
+                echo "EK cert NV index $idx already present, skipping"
+                return 0
+              fi
+
+              issue_cert_der "$alg" "$der_file" "$subj"
+              local cert_size
+              cert_size=$(stat -c %s "$der_file")
+
+              tpm2_nvdefine "$idx" -C p -s "$cert_size" \
+                -a "ppwrite|authwrite|ppread|authread|no_da|platformcreate"
+              tpm2_nvwrite "$idx" -C p -i "$der_file"
+
+              echo "Provisioned EK cert at NV index $idx ($alg, $cert_size bytes)"
+            }
+
+            ensure_nv_cert "$EK_NV_RSA" "rsa" "/CN=Jetson Orin fTPM EK RSA/O=Ghaf"
+            ensure_nv_cert "$EK_NV_ECC" "ecc" "/CN=Jetson Orin fTPM EK ECC/O=Ghaf"
+    '';
+  };
+
+  exportEkBundleApp = pkgs.writeShellApplication {
+    name = "ghaf-export-ek-endorsement-bundle";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.openssl
+      pkgs.tpm2-tools
+    ];
+    text = ''
+      set -euo pipefail
+
+      export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
+
+      EK_NV_RSA="0x01C00002"
+      EK_NV_ECC="0x01C0000A"
+      WORKDIR="/run/ghaf-ek-export"
+      OUTDIR="/persist/common/spire/ca"
+      BUNDLE="${"$"}OUTDIR/endorsement-bundle.pem"
+      VENDOR_BUNDLE="${pkgs.tpm-endorsement-certs}/all.pem"
+
+      cleanup() {
+        rm -rf "$WORKDIR"
+      }
+      trap cleanup EXIT
+
+      mkdir -p "$WORKDIR" "$OUTDIR"
+      chmod 0755 /persist/common /persist/common/spire "$OUTDIR"
+      cp "$VENDOR_BUNDLE" "$BUNDLE"
+      chmod 0644 "$BUNDLE"
+
+      export_one() {
+        local idx="$1"
+        local pem="$2"
+        local der
+        der="$WORKDIR/$(basename "$pem" .pem).der"
+
+        if ! timeout 5s tpm2_nvreadpublic "$idx" >/dev/null 2>&1; then
+          echo "EK index $idx missing, skipping export"
+          return 0
+        fi
+
+        timeout 8s tpm2_nvread "$idx" -o "$der"
+        openssl x509 -inform DER -in "$der" -out "$pem"
+        chmod 0644 "$pem"
+        cat "$pem" >> "$BUNDLE"
+      }
+
+      export_one "$EK_NV_RSA" "$OUTDIR/ek-rsa.pem"
+      export_one "$EK_NV_ECC" "$OUTDIR/ek-ecc.pem"
+      echo "Wrote endorsement bundle to $BUNDLE"
+    '';
+  };
   inherit (lib)
     mkEnableOption
     mkOption
@@ -96,6 +292,54 @@ in
           };
         }
       ];
+    };
+
+    systemd.services.ghaf-provision-ek-certs = {
+      description = "Provision fTPM EK certificates into standard NV indices";
+      after = [
+        "local-fs.target"
+        "systemd-modules-load.service"
+      ];
+      unitConfig.ConditionPathExists = "/dev/tpmrm0";
+      unitConfig.OnSuccess = [ "ghaf-export-ek-endorsement-bundle.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        TimeoutStartSec = "90s";
+        UMask = "0077";
+        ExecStart = lib.getExe provisionEkCertsApp;
+        ExecStartPost = "${pkgs.systemd}/bin/systemctl --no-block start ghaf-export-ek-endorsement-bundle.service";
+      };
+    };
+
+    systemd.services.ghaf-export-ek-endorsement-bundle = {
+      description = "Export EK certs and build endorsement CA bundle";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "microvms.target" ];
+      after = [
+        "local-fs.target"
+        "systemd-modules-load.service"
+        "ghaf-provision-ek-certs.service"
+      ];
+      unitConfig.ConditionPathExists = "/dev/tpmrm0";
+
+      serviceConfig = {
+        Type = "oneshot";
+        TimeoutStartSec = "45s";
+        UMask = "0077";
+        ExecStart = lib.getExe exportEkBundleApp;
+      };
+    };
+
+    systemd.timers.ghaf-provision-ek-certs = {
+      description = "Run fTPM EK certificate provisioning after boot";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2min";
+        RandomizedDelaySec = "30s";
+        Unit = "ghaf-provision-ek-certs.service";
+      };
     };
 
     services.nvpmodel = {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -85,6 +85,16 @@ in
             VIRTIO_VSOCKETS_COMMON = yes;
           };
         }
+        {
+          name = "vtpm-proxy-config";
+          patch = null;
+          structuredExtraConfig = with lib.kernel; {
+            EXPERT = yes;
+            DM_CRYPT = module;
+            TCG_FTPM_TEE = module;
+            TCG_VTPM_PROXY = module;
+          };
+        }
       ];
     };
 

--- a/modules/reference/hardware/jetpack/profiles/debug.nix
+++ b/modules/reference/hardware/jetpack/profiles/debug.nix
@@ -9,6 +9,11 @@ in
   _file = ./debug.nix;
 
   config = lib.mkIf cfg.enable {
+    hardware.nvidia-jetpack.firmware.optee = {
+      coreLogLevel = 1;
+      taLogLevel = 1;
+    };
+
     # Enable default accounts and passwords
     ghaf.hardware.nvidia.orin.optee = {
       xtest = true;

--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -25,6 +25,18 @@
           })
         else
           python-prev.setuptools-rust;
+
+      tpm2-pytss = python-prev.tpm2-pytss.overrideAttrs (old: {
+        patches = map (
+          p:
+          if final.lib.hasSuffix "cross.patch" (toString p) then
+            final.replaceVars ../../packages/patches/tpm2-pytss-cross-cpp.patch {
+              crossPrefix = final.stdenv.hostPlatform.config;
+            }
+          else
+            p
+        ) (old.patches or [ ]);
+      });
     })
   ];
 

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -20,6 +20,7 @@
   osquery-with-hostname = import ./osquery-with-hostname { inherit prev; };
   papirus-icon-theme = import ./papirus-icon-theme { inherit prev; };
   qemu_kvm = import ./qemu { inherit final prev; };
+  spire = import ./spire { inherit prev; };
   systemd = import ./systemd { inherit prev; };
   tpm2-pkcs11 = import ./tpm2-pkcs11 { inherit prev; };
   tpm2-tools = import ./tpm2-tools { inherit prev; };

--- a/overlays/custom-packages/spire/0001-remove-cloud-components-to-reduce-memory-footprint.patch
+++ b/overlays/custom-packages/spire/0001-remove-cloud-components-to-reduce-memory-footprint.patch
@@ -1,0 +1,145 @@
+From 7c5149a8f8c0e129d1f1c1261bd6a63d7a96ffd1 Mon Sep 17 00:00:00 2001
+From: Ganga Ram <Ganga.Ram@tii.ae>
+Date: Tue, 17 Feb 2026 12:46:42 +0400
+Subject: [PATCH] remove cloud components to reduce memory footprint
+
+Signed-off-by: Ganga Ram <Ganga.Ram@tii.ae>
+---
+ pkg/agent/catalog/nodeattestor.go     | 28 +++++++++++++--------------
+ pkg/agent/catalog/workloadattestor.go | 12 ++++++------
+ pkg/server/catalog/nodeattestor.go    | 28 +++++++++++++--------------
+ 3 files changed, 34 insertions(+), 34 deletions(-)
+
+diff --git a/pkg/agent/catalog/nodeattestor.go b/pkg/agent/catalog/nodeattestor.go
+index 97af6912a..0c8928911 100644
+--- a/pkg/agent/catalog/nodeattestor.go
++++ b/pkg/agent/catalog/nodeattestor.go
+@@ -2,14 +2,14 @@ package catalog
+ 
+ import (
+ 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/awsiid"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azureimds"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azuremsi"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/gcpiit"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/httpchallenge"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/awsiid"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azureimds"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azuremsi"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/gcpiit"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/httpchallenge"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/jointoken"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/k8spsat"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/sshpop"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/k8spsat"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/sshpop"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/tpmdevid"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/x509pop"
+ 	"github.com/spiffe/spire/pkg/common/catalog"
+@@ -35,14 +35,14 @@ func (repo *nodeAttestorRepository) Versions() []catalog.Version {
+ 
+ func (repo *nodeAttestorRepository) BuiltIns() []catalog.BuiltIn {
+ 	return []catalog.BuiltIn{
+-		awsiid.BuiltIn(),
+-		azuremsi.BuiltIn(),
+-		azureimds.BuiltIn(),
+-		gcpiit.BuiltIn(),
+-		httpchallenge.BuiltIn(),
++		//awsiid.BuiltIn(),
++		//azuremsi.BuiltIn(),
++		//azureimds.BuiltIn(),
++		//gcpiit.BuiltIn(),
++		//httpchallenge.BuiltIn(),
+ 		jointoken.BuiltIn(),
+-		k8spsat.BuiltIn(),
+-		sshpop.BuiltIn(),
++		//k8spsat.BuiltIn(),
++		//sshpop.BuiltIn(),
+ 		tpmdevid.BuiltIn(),
+ 		x509pop.BuiltIn(),
+ 	}
+diff --git a/pkg/agent/catalog/workloadattestor.go b/pkg/agent/catalog/workloadattestor.go
+index 4e367815b..bbe1a4f60 100644
+--- a/pkg/agent/catalog/workloadattestor.go
++++ b/pkg/agent/catalog/workloadattestor.go
+@@ -2,11 +2,11 @@ package catalog
+ 
+ import (
+ 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
+-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker"
+-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/k8s"
++	//"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker"
++	//"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/k8s"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/systemd"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/unix"
+-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/windows"
++	//"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/windows"
+ 	"github.com/spiffe/spire/pkg/common/catalog"
+ )
+ 
+@@ -28,11 +28,11 @@ func (repo *workloadAttestorRepository) Versions() []catalog.Version {
+ 
+ func (repo *workloadAttestorRepository) BuiltIns() []catalog.BuiltIn {
+ 	return []catalog.BuiltIn{
+-		docker.BuiltIn(),
+-		k8s.BuiltIn(),
++		//docker.BuiltIn(),
++		//k8s.BuiltIn(),
+ 		systemd.BuiltIn(),
+ 		unix.BuiltIn(),
+-		windows.BuiltIn(),
++		//windows.BuiltIn(),
+ 	}
+ }
+ 
+diff --git a/pkg/server/catalog/nodeattestor.go b/pkg/server/catalog/nodeattestor.go
+index 2e9d540a6..1cc37710d 100644
+--- a/pkg/server/catalog/nodeattestor.go
++++ b/pkg/server/catalog/nodeattestor.go
+@@ -3,14 +3,14 @@ package catalog
+ import (
+ 	"github.com/spiffe/spire/pkg/common/catalog"
+ 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/awsiid"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azureimds"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azuremsi"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/gcpiit"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/httpchallenge"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/awsiid"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azureimds"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azuremsi"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/gcpiit"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/httpchallenge"
+ 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/jointoken"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/k8spsat"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/sshpop"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/k8spsat"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/sshpop"
+ 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/tpmdevid"
+ 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/x509pop"
+ )
+@@ -35,14 +35,14 @@ func (repo *nodeAttestorRepository) Versions() []catalog.Version {
+ 
+ func (repo *nodeAttestorRepository) BuiltIns() []catalog.BuiltIn {
+ 	return []catalog.BuiltIn{
+-		awsiid.BuiltIn(),
+-		azuremsi.BuiltIn(),
+-		azureimds.BuiltIn(),
+-		gcpiit.BuiltIn(),
+-		httpchallenge.BuiltIn(),
++		//awsiid.BuiltIn(),
++		//azuremsi.BuiltIn(),
++		//azureimds.BuiltIn(),
++		//gcpiit.BuiltIn(),
++		//httpchallenge.BuiltIn(),
+ 		jointoken.BuiltIn(),
+-		k8spsat.BuiltIn(),
+-		sshpop.BuiltIn(),
++		//k8spsat.BuiltIn(),
++		//sshpop.BuiltIn(),
+ 		tpmdevid.BuiltIn(),
+ 		x509pop.BuiltIn(),
+ 	}
+-- 
+2.51.2
+

--- a/overlays/custom-packages/spire/default.nix
+++ b/overlays/custom-packages/spire/default.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{ prev }:
+prev.spire.overrideAttrs (_oldAttrs: {
+  patches = [
+    ./0001-remove-cloud-components-to-reduce-memory-footprint.patch
+  ];
+})

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -23,6 +23,7 @@
     memsocket = final.callPackage ./pkgs-by-name/memsocket/package.nix { };
     pci-binder = final.callPackage ./pkgs-by-name/pci-binder/package.nix { };
     rtl8126 = final.callPackage ./pkgs-by-name/rtl8126/package.nix { };
+    tpm-endorsement-certs = final.callPackage ./pkgs-by-name/tpm-endorsement-certs/package.nix { };
     update-docs-depends = final.callPackage ./pkgs-by-name/update-docs-depends/package.nix { };
     user-provision = final.callPackage ./pkgs-by-name/user-provision/package.nix { };
     wait-for-unit = final.callPackage ./pkgs-by-name/wait-for-unit/package.nix { };

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -1,9 +1,17 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
+let
+  python3PackagesOverride =
+    final: prev:
+    final.callPackage ./pkgs-by-name/tpm2-pytss/python3-packages.nix {
+      inherit (prev) python3Packages;
+      tpm2PytssCrossPatch = ./patches/tpm2-pytss-cross-cpp.patch;
+    };
+in
 {
   # keep-sorted start skip_lines=1
-  flake.overlays.own-pkgs-overlay = final: _prev: {
+  flake.overlays.own-pkgs-overlay = final: prev: {
     audit-rules = final.callPackage ./pkgs-by-name/audit-rules/package.nix { };
     chrome-extensions = final.callPackage ./chrome-extensions { };
     dendrite-pinecone = final.callPackage ./pkgs-by-name/dendrite-pinecone/package.nix { };
@@ -22,6 +30,7 @@
     make-checks = final.callPackage ./pkgs-by-name/make-checks/package.nix { };
     memsocket = final.callPackage ./pkgs-by-name/memsocket/package.nix { };
     pci-binder = final.callPackage ./pkgs-by-name/pci-binder/package.nix { };
+    python3Packages = python3PackagesOverride final prev;
     rtl8126 = final.callPackage ./pkgs-by-name/rtl8126/package.nix { };
     tpm-endorsement-certs = final.callPackage ./pkgs-by-name/tpm-endorsement-certs/package.nix { };
     update-docs-depends = final.callPackage ./pkgs-by-name/update-docs-depends/package.nix { };

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -26,6 +26,7 @@
     tpm-endorsement-certs = final.callPackage ./pkgs-by-name/tpm-endorsement-certs/package.nix { };
     update-docs-depends = final.callPackage ./pkgs-by-name/update-docs-depends/package.nix { };
     user-provision = final.callPackage ./pkgs-by-name/user-provision/package.nix { };
+    vtpm-abrmd-forwarder = final.callPackage ./pkgs-by-name/vtpm-abrmd-forwarder/package.nix { };
     wait-for-unit = final.callPackage ./pkgs-by-name/wait-for-unit/package.nix { };
     windows-launcher = final.callPackage ./pkgs-by-name/windows-launcher/package.nix { };
   };

--- a/packages/patches/tpm2-pytss-cross-cpp.patch
+++ b/packages/patches/tpm2-pytss-cross-cpp.patch
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+diff --git a/setup.py b/setup.py
+index 1b5f513..d660b9a 100644
+--- a/setup.py
++++ b/setup.py
+@@ -199,6 +199,7 @@
+             pdata = preprocess_file(
+                 header_path,
+                 cpp_args=["-std=c99", "-D__extension__=", "-D__attribute__(x)="],
++                cpp_path="@crossPrefix@-cpp",
+             )
+         parser = c_parser.CParser()
+         ast = parser.parse(pdata, "tss2_tpm2_types.h")
+@@ -238,6 +239,7 @@
+                             "-D__float128=long double",
+                             "-D_FORTIFY_SOURCE=0",
+                         ],
++                        cpp_path="@crossPrefix@-cpp",
+                     )
+                 parser = c_parser.CParser()
+                 past = parser.parse(pdata, "tss2_policy.h")

--- a/packages/pkgs-by-name/tpm-endorsement-certs/package.nix
+++ b/packages/pkgs-by-name/tpm-endorsement-certs/package.nix
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TPM Endorsement CA Certificates Package
+#
+# Downloads Microsoft's TrustedTpm.cab (containing root and intermediate CA
+# certificates from all approved TPM manufacturers) and produces per-vendor
+# PEM bundles. These are used by SPIRE's tpm_devid NodeAttestor to verify
+# that DevID keys reside in genuine TPMs.
+#
+# Output: $out/vendors/{AMD,Intel,Infineon,...}.pem and $out/all.pem
+#
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  cabextract,
+  openssl,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "tpm-endorsement-certs";
+  version = "2025-08-29"; # Date from cab contents
+
+  src = fetchurl {
+    url = "https://go.microsoft.com/fwlink/?linkid=2097925";
+    name = "TrustedTpm.cab";
+    hash = "sha256-tTmMgD3Ahj12rqccVbkmdiAz6RfD031Vp0Zsso1h2CY=";
+  };
+
+  dontUnpack = true;
+  nativeBuildInputs = [
+    cabextract
+    openssl
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir extracted
+    cabextract -d extracted "$src"
+    mkdir -p $out/vendors
+
+    for vendor_dir in extracted/*/; do
+      [ -d "$vendor_dir" ] || continue
+      vendor_name=$(basename "$vendor_dir")
+
+      # Skip non-vendor directories
+      case "$vendor_name" in
+        setup.*|*.txt|*.cmd|*.ps1) continue ;;
+      esac
+
+      pem_content=""
+
+      # Find all cert files in vendor dir (root + intermediate)
+      while IFS= read -r -d "" cert; do
+        # Try DER first (most common), fall back to PEM
+        converted=$(openssl x509 -inform DER -in "$cert" -outform PEM 2>/dev/null || \
+                    openssl x509 -inform PEM -in "$cert" -outform PEM 2>/dev/null || true)
+        if [ -n "$converted" ]; then
+          pem_content="$pem_content$converted"$'\n'
+        else
+          echo "WARNING: Could not convert $cert" >&2
+        fi
+      done < <(find "$vendor_dir" -type f \( -iname "*.cer" -o -iname "*.crt" -o -iname "*.der" \) -print0)
+
+      if [ -n "$pem_content" ]; then
+        printf '%s' "$pem_content" > "$out/vendors/$vendor_name.pem"
+        cert_count=$(grep -c 'BEGIN CERTIFICATE' "$out/vendors/$vendor_name.pem" || true)
+        echo "Wrote $cert_count certs for $vendor_name"
+      fi
+    done
+
+    # Combined all-vendors PEM
+    cat $out/vendors/*.pem > $out/all.pem
+    total=$(grep -c 'BEGIN CERTIFICATE' "$out/all.pem" || true)
+    echo "Total: $total certs across all vendors"
+
+    runHook postBuild
+  '';
+
+  # Everything is done in buildPhase writing directly to $out
+  installPhase = "true";
+
+  meta = {
+    description = "TPM manufacturer endorsement CA certificates from Microsoft TrustedTpm.cab";
+    homepage = "https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/component-updates/tpm-key-attestation";
+    license = lib.licenses.unfree; # Microsoft-distributed manufacturer certificates
+    platforms = lib.platforms.all;
+  };
+}

--- a/packages/pkgs-by-name/tpm2-pytss/package.nix
+++ b/packages/pkgs-by-name/tpm2-pytss/package.nix
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  python3Packages,
+  replaceVars,
+  stdenv,
+  tpm2PytssCrossPatch ? ../../../patches/tpm2-pytss-cross-cpp.patch,
+}:
+python3Packages.tpm2-pytss.overrideAttrs (old: {
+  patches = map (
+    p:
+    if lib.hasSuffix "cross.patch" (toString p) then
+      replaceVars tpm2PytssCrossPatch {
+        crossPrefix = stdenv.hostPlatform.config;
+      }
+    else
+      p
+  ) (old.patches or [ ]);
+})

--- a/packages/pkgs-by-name/tpm2-pytss/python3-packages.nix
+++ b/packages/pkgs-by-name/tpm2-pytss/python3-packages.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  callPackage,
+  python3Packages,
+  tpm2PytssCrossPatch,
+}:
+python3Packages
+// {
+  tpm2-pytss = callPackage ./package.nix {
+    inherit python3Packages;
+    inherit tpm2PytssCrossPatch;
+  };
+}

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/backend_helper.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/backend_helper.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+type backendHelper struct {
+	backendDevice string
+	ctx           unsafe.Pointer
+	mu            sync.Mutex
+
+	restartBackoff time.Duration
+	nextRestartAt  time.Time
+}
+
+func startBackendHelper(backendDevice string) (*backendHelper, error) {
+	h := &backendHelper{backendDevice: backendDevice}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if err := h.restartLocked(); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+func (h *backendHelper) Close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.closeLocked()
+}
+
+func (h *backendHelper) closeLocked() {
+	if h.ctx != nil {
+		tctiFinalize(h.ctx)
+		h.ctx = nil
+	}
+}
+
+func (h *backendHelper) restartLocked() error {
+	now := time.Now()
+	if !h.nextRestartAt.IsZero() && now.Before(h.nextRestartAt) {
+		return fmt.Errorf("backend context restart cooling down (%s)", time.Until(h.nextRestartAt).Round(10*time.Millisecond))
+	}
+
+	h.closeLocked()
+
+	ctx, err := tctiInit()
+	if err != nil {
+		if h.restartBackoff == 0 {
+			h.restartBackoff = helperRestartBackoffMin
+		} else {
+			h.restartBackoff *= 2
+			if h.restartBackoff > helperRestartBackoffMax {
+				h.restartBackoff = helperRestartBackoffMax
+			}
+		}
+		h.nextRestartAt = now.Add(h.restartBackoff)
+		return fmt.Errorf("backend context restart failed: %w (next retry in %s)", err, h.restartBackoff)
+	}
+
+	h.ctx = ctx
+	h.restartBackoff = 0
+	h.nextRestartAt = time.Time{}
+	return nil
+}
+
+func (h *backendHelper) Transact(req []byte) ([]byte, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.ctx == nil {
+		if err := h.restartLocked(); err != nil {
+			return nil, err
+		}
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= 2; attempt++ {
+		resp, err := tctiTransact(h.ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if attempt == 1 {
+			if rerr := h.restartLocked(); rerr != nil {
+				return nil, fmt.Errorf("backend context transact failed: %v; restart failed: %v", err, rerr)
+			}
+		}
+	}
+
+	return nil, lastErr
+}

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/backend_helper.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/backend_helper.go
@@ -20,13 +20,7 @@ type backendHelper struct {
 }
 
 func startBackendHelper(backendDevice string) (*backendHelper, error) {
-	h := &backendHelper{backendDevice: backendDevice}
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if err := h.restartLocked(); err != nil {
-		return nil, err
-	}
-	return h, nil
+	return &backendHelper{backendDevice: backendDevice}, nil
 }
 
 func (h *backendHelper) Close() {

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/go.mod
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/go.mod
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+module vtpm-abrmd-forwarder
+
+go 1.22

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/main.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/main.go
@@ -37,9 +37,46 @@ const (
 
 	helperRestartBackoffMin = 200 * time.Millisecond
 	helperRestartBackoffMax = 5 * time.Second
+
+	backendLockWaitDefault   = 250 * time.Millisecond
+	backendLockWaitGetRandom = 100 * time.Millisecond
+	backendBudgetDefault     = 1200 * time.Millisecond
+	backendBudgetGetRandom   = 300 * time.Millisecond
+	backendRetryPause        = 20 * time.Millisecond
+
+	backendBusyTripThreshold = 6
+	backendBusyCooldown      = 3 * time.Second
 )
 
 var errBackendBusy = errors.New("backend busy")
+
+type saturationGuard struct {
+	streak        int
+	cooldownUntil time.Time
+}
+
+func (g *saturationGuard) active(now time.Time) bool {
+	return now.Before(g.cooldownUntil)
+}
+
+func (g *saturationGuard) noteBusy(now time.Time) bool {
+	g.streak++
+	if g.streak < backendBusyTripThreshold {
+		return false
+	}
+
+	g.streak = 0
+	if now.Before(g.cooldownUntil) {
+		return false
+	}
+
+	g.cooldownUntil = now.Add(backendBusyCooldown)
+	return true
+}
+
+func (g *saturationGuard) noteSuccess() {
+	g.streak = 0
+}
 
 func main() {
 	var vmName string
@@ -140,8 +177,11 @@ func forwardProxyLoop(vmName string, proxyFD *os.File, helper *backendHelper, ba
 	var totalCmd uint64
 	var okCmd uint64
 	var backendErrCmd uint64
+	var backendBusyCmd uint64
+	var backendCircuitCmd uint64
 	var proxyWriteErrCmd uint64
 	var debugCmdCount int32
+	guard := &saturationGuard{}
 
 	for {
 		select {
@@ -197,8 +237,17 @@ func forwardProxyLoop(vmName string, proxyFD *os.File, helper *backendHelper, ba
 		}
 
 		start := time.Now()
-		resp, err := transactBackend(helper, backendLock, cmdCC, cmd)
-		if err != nil {
+		var (
+			resp       []byte
+			backendErr error
+		)
+		if guard.active(start) {
+			backendErr = errBackendBusy
+			backendCircuitCmd++
+		} else {
+			resp, backendErr = transactBackend(helper, backendLock, cmdCC, cmd)
+		}
+		if backendErr != nil {
 			backendErrCmd++
 			if err := writeAll(proxyFD, tpmRetryResponse(cmd)); err != nil {
 				proxyWriteErrCmd++
@@ -206,14 +255,19 @@ func forwardProxyLoop(vmName string, proxyFD *os.File, helper *backendHelper, ba
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
-			if errors.Is(err, errBackendBusy) {
+			if errors.Is(backendErr, errBackendBusy) {
+				backendBusyCmd++
+				if guard.noteBusy(time.Now()) {
+					log.Printf("backend saturation guard engaged vm=%s cooldown=%s", vmName, backendBusyCooldown)
+				}
 				log.Printf("backend busy cc=0x%08x(%s) dur=%s, replied TPM2_RC_RETRY", cmdCC, cmdName, time.Since(start).Round(time.Millisecond))
 			} else {
-				log.Printf("backend transact failed cc=0x%08x(%s) dur=%s (%v), replied TPM2_RC_RETRY", cmdCC, cmdName, time.Since(start).Round(time.Millisecond), err)
+				log.Printf("backend transact failed cc=0x%08x(%s) dur=%s (%v), replied TPM2_RC_RETRY", cmdCC, cmdName, time.Since(start).Round(time.Millisecond), backendErr)
 				time.Sleep(25 * time.Millisecond)
 			}
 			continue
 		}
+		guard.noteSuccess()
 		okCmd++
 
 		dur := time.Since(start)
@@ -237,16 +291,18 @@ func forwardProxyLoop(vmName string, proxyFD *os.File, helper *backendHelper, ba
 		}
 
 		if totalCmd%100 == 0 {
-			log.Printf("forwarder stats vm=%s total=%d ok=%d backend_err=%d write_err=%d", vmName, totalCmd, okCmd, backendErrCmd, proxyWriteErrCmd)
+			log.Printf("forwarder stats vm=%s total=%d ok=%d backend_err=%d backend_busy=%d circuit=%d write_err=%d", vmName, totalCmd, okCmd, backendErrCmd, backendBusyCmd, backendCircuitCmd, proxyWriteErrCmd)
 		}
 	}
 }
 
 func transactBackend(helper *backendHelper, backendLock *os.File, cmdCC uint32, cmd []byte) ([]byte, error) {
 	var lastErr error
-	lockWait := 1500 * time.Millisecond
+	lockWait := backendLockWaitDefault
+	budget := backendBudgetDefault
 	if cmdCC == tpm2GetRandomCC {
-		lockWait = 1200 * time.Millisecond
+		lockWait = backendLockWaitGetRandom
+		budget = backendBudgetGetRandom
 	}
 
 	if err := acquireBackendLock(backendLock, lockWait); err != nil {
@@ -256,17 +312,22 @@ func transactBackend(helper *backendHelper, backendLock *os.File, cmdCC uint32, 
 		_ = syscall.Flock(int(backendLock.Fd()), syscall.LOCK_UN)
 	}()
 
-	for attempt := 1; attempt <= 6; attempt++ {
+	deadline := time.Now().Add(budget)
+	for attempt := 1; attempt <= 2; attempt++ {
+		if time.Now().After(deadline) {
+			return nil, errBackendBusy
+		}
+
 		resp, err := helper.Transact(cmd)
 		if err != nil {
 			lastErr = err
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(backendRetryPause)
 			continue
 		}
 
 		if isTransientRC(resp) {
 			lastErr = fmt.Errorf("transient rc=0x%08x", binary.BigEndian.Uint32(resp[6:10]))
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(backendRetryPause)
 			continue
 		}
 

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/main.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/main.go
@@ -1,0 +1,312 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const (
+	// _IOWR(0xa1, 0x00, struct vtpm_proxy_new_dev)
+	// struct size: 5 * __u32 = 20 bytes
+	vtpmProxyIOCNewDev = 0xC014A100
+	vtpmProxyFlagTPM2  = 1
+
+	tpm2SetLocalityCC = 0x20001000
+	tpm2SelfTestCC    = 0x00000143
+	tpm2GetCapCC      = 0x0000017A
+	tpm2GetRandomCC   = 0x0000017B
+	tpm2RCRetry       = 0x00000922
+	tpm2RCYielded     = 0x00000908
+	tpm2RCTesting     = 0x0000090A
+
+	maxTPMPacketSize = 64 * 1024
+
+	helperRestartBackoffMin = 200 * time.Millisecond
+	helperRestartBackoffMax = 5 * time.Second
+)
+
+var errBackendBusy = errors.New("backend busy")
+
+func main() {
+	var vmName string
+	var backendDevice string
+	var linkPath string
+
+	flag.StringVar(&vmName, "vm-name", "", "VM name")
+	flag.StringVar(&backendDevice, "backend-device", "/dev/tpmrm0", "Host TPM device")
+	flag.StringVar(&linkPath, "link-path", "", "Path exposed to VM qemu args")
+	flag.Parse()
+
+	if vmName == "" {
+		log.Fatal("--vm-name is required")
+	}
+	if linkPath == "" {
+		log.Fatal("--link-path is required")
+	}
+
+	info, err := os.Stat(backendDevice)
+	if err != nil {
+		log.Fatalf("backend device not available: %v", err)
+	}
+	if info.Mode()&os.ModeDevice == 0 {
+		log.Fatalf("backend path is not a device: %s", backendDevice)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		log.Fatalf("failed to create runtime directory: %v", err)
+	}
+
+	if err := os.RemoveAll(linkPath); err != nil {
+		log.Fatalf("failed to cleanup old link: %v", err)
+	}
+
+	vtpmCtl, err := os.OpenFile("/dev/vtpmx", os.O_RDWR, 0)
+	if err != nil {
+		log.Fatalf("failed to open /dev/vtpmx: %v", err)
+	}
+	defer vtpmCtl.Close()
+
+	newDev, proxyFD, guestTPMPath, err := allocateUsableVTPM(vtpmCtl, vmName)
+	if err != nil {
+		log.Fatalf("failed to allocate usable vTPM: %v", err)
+	}
+	defer proxyFD.Close()
+
+	helper, err := startBackendHelper(backendDevice)
+	if err != nil {
+		log.Fatalf("failed to start backend helper: %v", err)
+	}
+	defer helper.Close()
+
+	backendLock, err := os.OpenFile("/run/ghaf-vtpm/backend.lock", os.O_CREATE|os.O_RDWR, 0o660)
+	if err != nil {
+		log.Fatalf("failed to open backend lock: %v", err)
+	}
+	defer backendLock.Close()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	errCh := make(chan error, 1)
+	stopCh := make(chan struct{})
+	var once sync.Once
+
+	go forwardProxyLoop(vmName, proxyFD, helper, backendLock, stopCh)
+
+	if err := os.Symlink(guestTPMPath, linkPath); err != nil {
+		log.Fatalf("failed to create link %s -> %s: %v", linkPath, guestTPMPath, err)
+	}
+
+	log.Printf(
+		"vm=%s link=%s guest_tpm=%s backend=%s vtpm=(num=%d major=%d minor=%d)",
+		vmName,
+		linkPath,
+		guestTPMPath,
+		backendDevice,
+		newDev.TPMNum,
+		newDev.Major,
+		newDev.Minor,
+	)
+	sdNotify("READY=1")
+
+	select {
+	case sig := <-sigCh:
+		once.Do(func() { close(stopCh) })
+		fmt.Printf("received signal %s, exiting\n", sig.String())
+	case err := <-errCh:
+		once.Do(func() { close(stopCh) })
+		log.Printf("forwarder exiting due to error: %v", err)
+		time.Sleep(250 * time.Millisecond)
+		os.Exit(1)
+	}
+}
+
+func forwardProxyLoop(vmName string, proxyFD *os.File, helper *backendHelper, backendLock *os.File, stopCh <-chan struct{}) {
+	idleBackoff := 20 * time.Millisecond
+	var totalCmd uint64
+	var okCmd uint64
+	var backendErrCmd uint64
+	var proxyWriteErrCmd uint64
+	var debugCmdCount int32
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		cmd, err := readTPMPacketProxy(proxyFD)
+		if err != nil {
+			if isIdleProxyReadError(err) {
+				time.Sleep(idleBackoff)
+				if idleBackoff < 500*time.Millisecond {
+					idleBackoff *= 2
+				}
+				continue
+			}
+			idleBackoff = 20 * time.Millisecond
+			log.Printf("proxy read failed: %v", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		idleBackoff = 20 * time.Millisecond
+
+		cmdCC := uint32(0)
+		if len(cmd) >= 10 {
+			cmdCC = binary.BigEndian.Uint32(cmd[6:10])
+		}
+		cmdName := tpm2CommandName(cmdCC)
+
+		if atomic.LoadInt32(&debugCmdCount) < 10 {
+			log.Printf("proxy cmd size=%d cc=0x%08x(%s) bytes=%x", len(cmd), cmdCC, cmdName, cmd)
+			atomic.AddInt32(&debugCmdCount, 1)
+		}
+		totalCmd++
+
+		if isSetLocalityCommand(cmd) {
+			if err := writeAll(proxyFD, tpmSuccessResponse(cmd)); err != nil {
+				log.Printf("proxy write failed for set-locality: %v", err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			continue
+		}
+
+		if isSelfTestCommand(cmd) {
+			if err := writeAll(proxyFD, tpmSuccessResponse(cmd)); err != nil {
+				log.Printf("proxy write failed for self-test: %v", err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			continue
+		}
+
+		start := time.Now()
+		resp, err := transactBackend(helper, backendLock, cmdCC, cmd)
+		if err != nil {
+			backendErrCmd++
+			if err := writeAll(proxyFD, tpmRetryResponse(cmd)); err != nil {
+				proxyWriteErrCmd++
+				log.Printf("proxy write failed while sending retry cc=0x%08x(%s): %v", cmdCC, cmdName, err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			if errors.Is(err, errBackendBusy) {
+				log.Printf("backend busy cc=0x%08x(%s) dur=%s, replied TPM2_RC_RETRY", cmdCC, cmdName, time.Since(start).Round(time.Millisecond))
+			} else {
+				log.Printf("backend transact failed cc=0x%08x(%s) dur=%s (%v), replied TPM2_RC_RETRY", cmdCC, cmdName, time.Since(start).Round(time.Millisecond), err)
+				time.Sleep(25 * time.Millisecond)
+			}
+			continue
+		}
+		okCmd++
+
+		dur := time.Since(start)
+		if dur > 2*time.Second {
+			rc := uint32(0)
+			if len(resp) >= 10 {
+				rc = binary.BigEndian.Uint32(resp[6:10])
+			}
+			log.Printf("slow backend response cc=0x%08x(%s) rc=0x%08x dur=%s", cmdCC, cmdName, rc, dur.Round(time.Millisecond))
+		}
+
+		if atomic.LoadInt32(&debugCmdCount) <= 10 {
+			log.Printf("backend resp size=%d", len(resp))
+		}
+
+		if err := writeAll(proxyFD, resp); err != nil {
+			proxyWriteErrCmd++
+			log.Printf("proxy write failed cc=0x%08x(%s) dur=%s: %v", cmdCC, cmdName, dur.Round(time.Millisecond), err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		if totalCmd%100 == 0 {
+			log.Printf("forwarder stats vm=%s total=%d ok=%d backend_err=%d write_err=%d", vmName, totalCmd, okCmd, backendErrCmd, proxyWriteErrCmd)
+		}
+	}
+}
+
+func transactBackend(helper *backendHelper, backendLock *os.File, cmdCC uint32, cmd []byte) ([]byte, error) {
+	var lastErr error
+	lockWait := 1500 * time.Millisecond
+	if cmdCC == tpm2GetRandomCC {
+		lockWait = 1200 * time.Millisecond
+	}
+
+	if err := acquireBackendLock(backendLock, lockWait); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = syscall.Flock(int(backendLock.Fd()), syscall.LOCK_UN)
+	}()
+
+	for attempt := 1; attempt <= 6; attempt++ {
+		resp, err := helper.Transact(cmd)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+
+		if isTransientRC(resp) {
+			lastErr = fmt.Errorf("transient rc=0x%08x", binary.BigEndian.Uint32(resp[6:10]))
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		return resp, nil
+	}
+
+	if lastErr == nil {
+		lastErr = io.ErrUnexpectedEOF
+	}
+	return nil, lastErr
+}
+
+func acquireBackendLock(backendLock *os.File, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		err := syscall.Flock(int(backendLock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return errBackendBusy
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func tpm2CommandName(cc uint32) string {
+	switch cc {
+	case tpm2SetLocalityCC:
+		return "SetLocality"
+	case tpm2SelfTestCC:
+		return "SelfTest"
+	case tpm2GetCapCC:
+		return "GetCapability"
+	case tpm2GetRandomCC:
+		return "GetRandom"
+	default:
+		return "unknown"
+	}
+}

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/package.nix
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/package.nix
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  stdenv,
+  go,
+  pkg-config,
+  tpm2-tss,
+  tpm2-abrmd,
+}:
+stdenv.mkDerivation {
+  pname = "vtpm-abrmd-forwarder";
+  version = "0.1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    go
+    pkg-config
+  ];
+
+  buildInputs = [
+    tpm2-tss
+    tpm2-abrmd
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME="$TMPDIR"
+    export GOCACHE="$TMPDIR/go-cache"
+    export GO111MODULE=on
+    export CGO_ENABLED=1
+    go build -trimpath -o vtpm-abrmd-forwarder \
+      ./main.go \
+      ./backend_helper.go \
+      ./systemd_notify.go \
+      ./tpm_proto.go \
+      ./tcti_tabrmd.go \
+      ./vtpm_proxy.go
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/bin"
+    install -m0755 vtpm-abrmd-forwarder "$out/bin/vtpm-abrmd-forwarder"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Per-VM TPM forwarder scaffold for abrmd muxing";
+    mainProgram = "vtpm-abrmd-forwarder";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/package.nix
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/package.nix
@@ -30,6 +30,15 @@ stdenv.mkDerivation {
     export GOCACHE="$TMPDIR/go-cache"
     export GO111MODULE=on
     export CGO_ENABLED=1
+    export GOOS=linux
+    export GOARCH=${
+      if stdenv.hostPlatform.isAarch64 then
+        "arm64"
+      else if stdenv.hostPlatform.isx86_64 then
+        "amd64"
+      else
+        throw "unsupported platform for vtpm-abrmd-forwarder"
+    }
     go build -trimpath -o vtpm-abrmd-forwarder \
       ./main.go \
       ./backend_helper.go \

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/systemd_notify.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/systemd_notify.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"log"
+	"net"
+	"os"
+	"strings"
+)
+
+func sdNotify(state string) {
+	sock := os.Getenv("NOTIFY_SOCKET")
+	if sock == "" {
+		return
+	}
+
+	addr := sock
+	if strings.HasPrefix(addr, "@") {
+		addr = "\x00" + strings.TrimPrefix(addr, "@")
+	}
+
+	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: addr, Net: "unixgram"})
+	if err != nil {
+		log.Printf("sd_notify dial failed: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte(state)); err != nil {
+		log.Printf("sd_notify write failed: %v", err)
+	}
+}

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/tcti_tabrmd.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/tcti_tabrmd.go
@@ -47,8 +47,8 @@ static uint32_t tcti_transmit(void *ctx, size_t len, uint8_t *buf) {
   return Tss2_Tcti_Transmit((TSS2_TCTI_CONTEXT *)ctx, len, buf);
 }
 
-static uint32_t tcti_receive(void *ctx, size_t *len, uint8_t *buf) {
-  return Tss2_Tcti_Receive((TSS2_TCTI_CONTEXT *)ctx, len, buf, TSS2_TCTI_TIMEOUT_BLOCK);
+static uint32_t tcti_receive(void *ctx, size_t *len, uint8_t *buf, int32_t timeout_ms) {
+  return Tss2_Tcti_Receive((TSS2_TCTI_CONTEXT *)ctx, len, buf, timeout_ms);
 }
 
 static uint32_t rc_try_again(void) {
@@ -65,6 +65,11 @@ import (
 	"fmt"
 	"time"
 	"unsafe"
+)
+
+const (
+	tctiReceiveSlice = 250 * time.Millisecond
+	tctiReceiveTotal = 1200 * time.Millisecond
 )
 
 func tctiInit() (unsafe.Pointer, error) {
@@ -90,10 +95,16 @@ func tctiTransact(ctx unsafe.Pointer, req []byte) ([]byte, error) {
 		return nil, fmt.Errorf("Transmit failed rc=0x%08x", rc)
 	}
 
+	receiveDeadline := time.Now().Add(tctiReceiveTotal)
 	for {
+		if time.Now().After(receiveDeadline) {
+			return nil, fmt.Errorf("Receive timed out after %s", tctiReceiveTotal)
+		}
+
 		resp := make([]byte, 4096)
 		got := C.size_t(len(resp))
-		rc = uint32(C.tcti_receive(ctx, &got, (*C.uint8_t)(unsafe.Pointer(&resp[0]))))
+		timeoutMs := C.int32_t(tctiReceiveSlice / time.Millisecond)
+		rc = uint32(C.tcti_receive(ctx, &got, (*C.uint8_t)(unsafe.Pointer(&resp[0])), timeoutMs))
 
 		if rc == uint32(C.rc_try_again()) {
 			time.Sleep(10 * time.Millisecond)
@@ -103,7 +114,7 @@ func tctiTransact(ctx unsafe.Pointer, req []byte) ([]byte, error) {
 		if rc == uint32(C.rc_insufficient_buffer()) && int(got) > len(resp) && int(got) <= maxTPMPacketSize {
 			resp = make([]byte, int(got))
 			got = C.size_t(len(resp))
-			rc = uint32(C.tcti_receive(ctx, &got, (*C.uint8_t)(unsafe.Pointer(&resp[0]))))
+			rc = uint32(C.tcti_receive(ctx, &got, (*C.uint8_t)(unsafe.Pointer(&resp[0])), timeoutMs))
 			if rc == uint32(C.rc_try_again()) {
 				time.Sleep(10 * time.Millisecond)
 				continue

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/tcti_tabrmd.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/tcti_tabrmd.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+/*
+#cgo pkg-config: tss2-tcti-tabrmd
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tss2/tss2_tcti.h>
+
+TSS2_RC Tss2_Tcti_Tabrmd_Init(TSS2_TCTI_CONTEXT *tcti_context, size_t *size, const char *conf);
+
+static uint32_t tcti_init(void **out_ctx) {
+  const char *conf = "bus_type=system";
+  size_t ctx_size = 0;
+  TSS2_RC rc = Tss2_Tcti_Tabrmd_Init(NULL, &ctx_size, conf);
+  if (rc != TSS2_RC_SUCCESS || ctx_size == 0) {
+    return rc;
+  }
+
+  TSS2_TCTI_CONTEXT *ctx = (TSS2_TCTI_CONTEXT *)calloc(1, ctx_size);
+  if (!ctx) {
+    return 0xFFFFFFFF;
+  }
+
+  rc = Tss2_Tcti_Tabrmd_Init(ctx, &ctx_size, conf);
+  if (rc != TSS2_RC_SUCCESS) {
+    free(ctx);
+    return rc;
+  }
+
+  *out_ctx = ctx;
+  return TSS2_RC_SUCCESS;
+}
+
+static void tcti_finalize(void *ctx) {
+  if (!ctx) {
+    return;
+  }
+  Tss2_Tcti_Finalize((TSS2_TCTI_CONTEXT *)ctx);
+  free(ctx);
+}
+
+static uint32_t tcti_transmit(void *ctx, size_t len, uint8_t *buf) {
+  return Tss2_Tcti_Transmit((TSS2_TCTI_CONTEXT *)ctx, len, buf);
+}
+
+static uint32_t tcti_receive(void *ctx, size_t *len, uint8_t *buf) {
+  return Tss2_Tcti_Receive((TSS2_TCTI_CONTEXT *)ctx, len, buf, TSS2_TCTI_TIMEOUT_BLOCK);
+}
+
+static uint32_t rc_try_again(void) {
+  return TSS2_TCTI_RC_TRY_AGAIN;
+}
+
+static uint32_t rc_insufficient_buffer(void) {
+  return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"time"
+	"unsafe"
+)
+
+func tctiInit() (unsafe.Pointer, error) {
+	var ctx unsafe.Pointer
+	rc := uint32(C.tcti_init((*unsafe.Pointer)(unsafe.Pointer(&ctx))))
+	if rc != 0 || ctx == nil {
+		return nil, fmt.Errorf("Tcti_Tabrmd_Init failed rc=0x%08x", rc)
+	}
+	return ctx, nil
+}
+
+func tctiFinalize(ctx unsafe.Pointer) {
+	C.tcti_finalize(ctx)
+}
+
+func tctiTransact(ctx unsafe.Pointer, req []byte) ([]byte, error) {
+	if len(req) == 0 {
+		return nil, fmt.Errorf("empty request")
+	}
+
+	rc := uint32(C.tcti_transmit(ctx, C.size_t(len(req)), (*C.uint8_t)(unsafe.Pointer(&req[0]))))
+	if rc != 0 {
+		return nil, fmt.Errorf("Transmit failed rc=0x%08x", rc)
+	}
+
+	for {
+		resp := make([]byte, 4096)
+		got := C.size_t(len(resp))
+		rc = uint32(C.tcti_receive(ctx, &got, (*C.uint8_t)(unsafe.Pointer(&resp[0]))))
+
+		if rc == uint32(C.rc_try_again()) {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+
+		if rc == uint32(C.rc_insufficient_buffer()) && int(got) > len(resp) && int(got) <= maxTPMPacketSize {
+			resp = make([]byte, int(got))
+			got = C.size_t(len(resp))
+			rc = uint32(C.tcti_receive(ctx, &got, (*C.uint8_t)(unsafe.Pointer(&resp[0]))))
+			if rc == uint32(C.rc_try_again()) {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+		}
+
+		if rc != 0 {
+			return nil, fmt.Errorf("Receive failed rc=0x%08x", rc)
+		}
+
+		n := int(got)
+		if n <= 0 || n > maxTPMPacketSize {
+			return nil, fmt.Errorf("invalid response size %d", n)
+		}
+
+		return resp[:n], nil
+	}
+}

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/tpm_proto.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/tpm_proto.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+)
+
+func isSetLocalityCommand(cmd []byte) bool {
+	if len(cmd) < 10 {
+		return false
+	}
+	cc := binary.BigEndian.Uint32(cmd[6:10])
+	return cc == tpm2SetLocalityCC
+}
+
+func isSelfTestCommand(cmd []byte) bool {
+	if len(cmd) < 10 {
+		return false
+	}
+	cc := binary.BigEndian.Uint32(cmd[6:10])
+	return cc == tpm2SelfTestCC
+}
+
+func tpmRetryResponse(cmd []byte) []byte {
+	resp := make([]byte, 10)
+	binary.BigEndian.PutUint16(resp[0:2], binary.BigEndian.Uint16(cmd[0:2]))
+	binary.BigEndian.PutUint32(resp[2:6], uint32(len(resp)))
+	binary.BigEndian.PutUint32(resp[6:10], tpm2RCRetry)
+	return resp
+}
+
+func tpmSuccessResponse(cmd []byte) []byte {
+	tagA := byte(0x80)
+	tagB := byte(0x01)
+	if len(cmd) >= 2 {
+		tagA = cmd[0]
+		tagB = cmd[1]
+	}
+	return []byte{tagA, tagB, 0x00, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x00}
+}
+
+func writeAll(f *os.File, buf []byte) error {
+	n, err := f.Write(buf)
+	if err != nil {
+		return err
+	}
+	if n != len(buf) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func readTPMPacketProxy(f *os.File) ([]byte, error) {
+	buf := make([]byte, maxTPMPacketSize)
+	n, err := f.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, io.EOF
+	}
+	if n < 6 {
+		return nil, fmt.Errorf("short TPM header (%d bytes)", n)
+	}
+
+	want := int(binary.BigEndian.Uint32(buf[2:6]))
+	if want <= 0 || want > maxTPMPacketSize {
+		return nil, fmt.Errorf("invalid TPM packet size: %d", want)
+	}
+	if want < 6 {
+		return nil, fmt.Errorf("invalid TPM packet size: %d", want)
+	}
+	if want > n {
+		return nil, fmt.Errorf("short TPM packet read: got %d bytes, expected %d", n, want)
+	}
+
+	out := make([]byte, want)
+	copy(out, buf[:want])
+	return out, nil
+}
+
+func isIdleProxyReadError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ENODEV) || errors.Is(err, syscall.EIO) {
+		return true
+	}
+	if strings.Contains(err.Error(), "short TPM header") || strings.Contains(err.Error(), "short TPM packet read") {
+		return true
+	}
+	return false
+}
+
+func isTransientRC(resp []byte) bool {
+	if len(resp) < 10 {
+		return false
+	}
+	rc := binary.BigEndian.Uint32(resp[6:10])
+	return rc == tpm2RCRetry || rc == tpm2RCYielded || rc == tpm2RCTesting
+}

--- a/packages/pkgs-by-name/vtpm-abrmd-forwarder/vtpm_proxy.go
+++ b/packages/pkgs-by-name/vtpm-abrmd-forwarder/vtpm_proxy.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+type vtpmProxyNewDev struct {
+	Flags  uint32
+	TPMNum uint32
+	FD     uint32
+	Major  uint32
+	Minor  uint32
+}
+
+func chmodTPMNode(path string) error {
+	if err := os.Chmod(path, 0o660); err != nil {
+		return err
+	}
+
+	grp, err := user.LookupGroup("kvm")
+	if err != nil {
+		return err
+	}
+	gid, err := strconv.Atoi(grp.Gid)
+	if err != nil {
+		return err
+	}
+
+	return os.Chown(path, -1, gid)
+}
+
+func allocateUsableVTPM(vtpmCtl *os.File, vmName string) (vtpmProxyNewDev, *os.File, string, error) {
+	var lastErr error
+
+	for attempt := 1; attempt <= 8; attempt++ {
+		newDev := vtpmProxyNewDev{Flags: vtpmProxyFlagTPM2}
+		_, _, errno := syscall.Syscall(
+			syscall.SYS_IOCTL,
+			vtpmCtl.Fd(),
+			uintptr(vtpmProxyIOCNewDev),
+			uintptr(unsafe.Pointer(&newDev)),
+		)
+		if errno != 0 {
+			lastErr = errno
+			time.Sleep(150 * time.Millisecond)
+			continue
+		}
+
+		proxyFD := os.NewFile(uintptr(newDev.FD), fmt.Sprintf("vtpm-proxy-%s", vmName))
+		if proxyFD == nil {
+			lastErr = errors.New("failed to create proxy fd handle")
+			time.Sleep(150 * time.Millisecond)
+			continue
+		}
+
+		guestTPMPath := fmt.Sprintf("/dev/tpm%d", newDev.TPMNum)
+		if err := ensureTPMNode(guestTPMPath, newDev.Major, newDev.Minor); err != nil {
+			_ = proxyFD.Close()
+			return vtpmProxyNewDev{}, nil, "", err
+		}
+		if err := chmodTPMNode(guestTPMPath); err != nil {
+			log.Printf("warning: could not adjust TPM node permissions: %v", err)
+		}
+
+		return newDev, proxyFD, guestTPMPath, nil
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("vTPM allocation failed")
+	}
+	return vtpmProxyNewDev{}, nil, "", lastErr
+}
+
+func ensureTPMNode(path string, major, minor uint32) error {
+	wantDev := makeLinuxDev(major, minor)
+
+	if info, err := os.Stat(path); err == nil {
+		if info.Mode()&os.ModeDevice == 0 {
+			return fmt.Errorf("existing path is not a device: %s", path)
+		}
+
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("failed to inspect existing device node: %s", path)
+		}
+
+		if uint64(st.Rdev) == wantDev {
+			return nil
+		}
+
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("failed to replace stale TPM node %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	mode := uint32(syscall.S_IFCHR | 0o660)
+	dev := int(wantDev)
+	if err := syscall.Mknod(path, mode, dev); err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func makeLinuxDev(major, minor uint32) uint64 {
+	maj := uint64(major)
+	min := uint64(minor)
+	return (min & 0xff) | ((maj & 0xfff) << 8) | ((min &^ 0xff) << 12) | ((maj &^ 0xfff) << 32)
+}


### PR DESCRIPTION
## Summary
- add host-side TPM mux infrastructure (`vtpm-abrmd-forwarder`, `tpm-mux.nix`, unit ordering/ready signaling) and switch system VMs (`admin`, `audio`, `gui`, `net`) to muxed TPM on non-riscv64
- harden SPIFFE TPM DevID provisioning/signing by validating cert-to-key matches, regenerating stale certs, and improving provisioning ordering/recovery paths
- add agent-side guard to clear stale join-token cache when TPM DevID mode is selected, and document TPM mux architecture/operations in docs

## Verification
- runtime validation on reflashed target: forwarder units active, system VMs booting with muxed `/dev/tpm0`, TPM command loops, and SPIRE TPM DevID attestation recovery for `audio-vm`, `gui-vm`, and `net-vm`

## Notes
- intermittent TPM backend contention still appears under load (`backend busy` / slow responses), but the new mux path and attestation recovery logic are now functional and recoverable after reprovision

## Manual Runtime Validation 

Build, lint, and cross-compilation checks are covered by CI/CD.
Manual validation below focuses only on runtime behavior of TPM mux, SPIFFE TPM DevID, and Jetson fTPM/vTPM integration.

### 1) Host TPM Mux Readiness

On deployed host, verify TPM backend and per-VM forwarders are active:

```bash
systemctl status tpm2-abrmd
systemctl status ghaf-vtpm-forwarder-admin-vm ghaf-vtpm-forwarder-net-vm
# x86 targets also:
systemctl status ghaf-vtpm-forwarder-audio-vm ghaf-vtpm-forwarder-gui-vm
ls -l /run/ghaf-vtpm/
```

Expected:
- forwarders active for enabled system VMs
- `/run/ghaf-vtpm/<vm>.tpm` endpoints present

### 2) VM Startup Ordering

```bash
systemctl status microvm@admin-vm microvm@net-vm
# x86 targets also:
systemctl status microvm@audio-vm microvm@gui-vm
```

Expected:
- VM units start after matching `ghaf-vtpm-forwarder-<vm>.service`

### 3) VM TPM Smoke Tests

Run in each enabled system VM:

```bash
ls -l /dev/tpm0 /dev/tpmrm0
tpm2_getrandom 8
tpm2_getcap properties-fixed
tpm2_pcrread sha256:0
```

Expected:
- `/dev/tpm0` and `/dev/tpmrm0` available
- TPM commands succeed reliably after settle

### 4) Concurrent TPM Stress Check

Run loops concurrently in multiple VMs:

```bash
for i in $(seq 1 100); do tpm2_getrandom 8 >/dev/null || echo FAIL-$i; done
```

Monitor host in parallel:

```bash
journalctl -u ghaf-vtpm-forwarder-admin-vm -u ghaf-vtpm-forwarder-net-vm -f
# x86 add audio/gui forwarders
dmesg -w | grep -i tpm
```

Expected:
- no persistent forwarder crash/restart loops
- transient contention may occur, but path recovers

### 5) SPIFFE TPM DevID End-to-End

In each TPM-attesting VM:

```bash
systemctl restart spire-devid-provision
systemctl restart spire-agent
journalctl -u spire-devid-provision -u spire-agent -n 300 --no-pager
```

On SPIRE server side:

```bash
journalctl -u spire-server -n 300 --no-pager
```

Expected:
- successful node attestation via `tpm_devid`
- restart-safe behavior (no permanent failure loops)

### 6) Jetson-Specific Runtime Checks

```bash
modprobe tpm_ftpm_tee || true
modprobe tpm_vtpm_proxy || true
ls -l /dev/tpm0 /dev/tpmrm0 /dev/vtpmx

systemctl status ghaf-provision-ek-certs ghaf-export-ek-endorsement-bundle
ls -l /persist/common/spire/ca/
```

Expected:
- `/dev/vtpmx` available with vTPM proxy module loaded
- EK provisioning/export services complete
- endorsement bundle present for SPIFFE TPM attestation path

### Pass Criteria

Manual runtime validation is considered complete when:
- TPM mux forwarders are healthy and correctly ordered
- target VMs can execute TPM commands through mux path
- SPIFFE `tpm_devid` attestation succeeds for required VMs
- Jetson fTPM/vTPM runtime path and EK bundle flow are operational
