### PR TITLE
givc: systray support via dbus proxy

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -274,11 +274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774521892,
-        "narHash": "sha256-9WDVYMybGpuosQ1lWBeZ6D73h7kgacYBxhqQKe72qv8=",
+        "lastModified": 1775822544,
+        "narHash": "sha256-yxh8N8kPWNVPl4x2C72yR6nTDT8qBMZvCCB3twNEiJI=",
         "owner": "tiiuae",
         "repo": "ghafpkgs",
-        "rev": "46fcd9c3d27dcce04b64bc8161bef434018ea3cc",
+        "rev": "62beb072731b0e9a356766b21abcee24562fd4a0",
         "type": "github"
       },
       "original": {

--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -60,6 +60,11 @@ in
         default = [ ];
         description = "List of app hosts currently enabled.";
       };
+      sniVms = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "List of app VMs that have SNI tray icon forwarding enabled.";
+      };
       extraNetworking = {
         hosts = mkOption {
           type = types.attrsOf lib.types.networking;
@@ -190,6 +195,17 @@ in
                   vmConfig = lib.ghaf.vm.getConfig v;
                 in
                 lib.optionalString (vmConfig != null && vmConfig.ghaf.type == "app-vm") n
+              ) config.microvm.vms
+            );
+            sniVms = lib.lists.remove "" (
+              lib.attrsets.mapAttrsToList (
+                n: v:
+                let
+                  vmConfig = lib.ghaf.vm.getConfig v;
+                in
+                lib.optionalString (
+                  vmConfig != null && vmConfig.ghaf.type == "app-vm" && (vmConfig.ghaf.givc.sni.enable or false)
+                ) n
               ) config.microvm.vms
             );
             hardware = {

--- a/modules/givc/appvm.nix
+++ b/modules/givc/appvm.nix
@@ -53,7 +53,6 @@ in
       };
       capabilities = {
         inherit (cfg) applications;
-
         policy = mkIf policycfg.enable {
           enable = true;
           inherit (policycfg) storePath;

--- a/modules/givc/guivm.nix
+++ b/modules/givc/guivm.nix
@@ -112,6 +112,7 @@ in
         };
       };
     };
+
     systemd.services.dbus-proxy-networkmanager = {
       description = "DBus proxy for Network Manager ${guivmName}";
       # Wait for GIVC to create the socket before starting
@@ -136,14 +137,14 @@ in
               --source-object-path /org/freedesktop/NetworkManager \
               --proxy-bus-name org.freedesktop.NetworkManager \
               --source-bus-type session \
-              --target-bus-type system \
-              --nm-mode
+              --target-bus-type system
           ''
         ];
       };
       startLimitIntervalSec = 0;
       wantedBy = [ "multi-user.target" ];
     };
+
     services.dbus.packages = [ pkgs.networkmanager ];
     ghaf.security.audit.extraRules = [
       "-w /etc/givc/ -p wa -k givc-${hostName}"

--- a/modules/microvm/common/sni.nix
+++ b/modules/microvm/common/sni.nix
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# SNI (StatusNotifierItem) system tray forwarding via GIVC socket proxy.
+#
+# Appvm side  — Port is auto-assigned based on this VM's position in
+#               ghaf.common.appHosts (alphabetical, portBase + index).
+#
+# Guivm side  — Generates one socket proxy entry and one dbus-proxy-sni
+#               systemd service per entry in ghaf.common.appHosts.
+#               Services are activated on-demand via systemd path units,
+#               so VMs without SNI do not cause repeated restart failures.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  sniCfg = config.ghaf.givc.sni;
+  inherit (lib)
+    getExe
+    listToAttrs
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    nameValuePair
+    types
+    optionalString
+    ;
+  inherit (config.ghaf.networking) hosts;
+  inherit (config.networking) hostName;
+  guivmName = "gui-vm";
+  appUserUid = toString config.ghaf.users.appUser.uid;
+  homedUid = toString config.ghaf.users.homedUser.uid;
+
+  # Port map: built from sniCfg.vms so ports start at portBase regardless of
+  # where the VM falls in the full appHosts list.
+  # sniCfg.vms defaults to ghaf.common.sniVms which is the same on all VMs,
+  # so appvm and guivm will always agree on port assignments.
+  portMap = listToAttrs (
+    lib.imap0 (i: vmName: nameValuePair vmName (toString (sniCfg.portBase + i))) sniCfg.vms
+  );
+
+  # Guivm-side source descriptors: one per SNI-capable VM
+  sniSources = map (vmName: {
+    inherit vmName;
+    port = portMap.${vmName};
+    socket = "/tmp/dbusproxy-sni-${vmName}.sock";
+  }) sniCfg.vms;
+
+in
+{
+  _file = ./sni.nix;
+
+  options.ghaf.givc.sni = {
+    enable = mkEnableOption "SNI (StatusNotifierItem) tray icon forwarding via GIVC socket proxy";
+
+    portBase = mkOption {
+      type = types.int;
+      default = 9030;
+      description = ''
+        Base TCP port for SNI socket proxy tunnels.
+        Each appvm in ghaf.common.appHosts (alphabetical order) gets
+        portBase + index as its dedicated port on gui-vm.
+      '';
+    };
+
+    socket = mkOption {
+      type = types.str;
+      default = "/tmp/dbusproxy_sni.sock";
+      description = "Local unix socket path for the SNI dbusproxy on the appvm side.";
+    };
+
+    vms = mkOption {
+      type = types.listOf types.str;
+      default = config.ghaf.common.sniVms;
+      defaultText = lib.literalExpression "config.ghaf.common.sniVms";
+      description = ''
+        Appvms that have SNI enabled, as seen from the gui-vm side.
+        Defaults to ghaf.common.sniVms which is auto-derived at host level
+        from each appvm's ghaf.givc.sni.enable setting.
+        Only these VMs will get a socket proxy entry and a dbus-proxy-sni
+        service on gui-vm. Ports are derived from their position in
+        ghaf.common.appHosts to stay consistent with the appvm side.
+      '';
+    };
+  };
+
+  config = mkMerge [
+
+    # Appvm side
+    (mkIf (sniCfg.enable && config.ghaf.givc.appvm.enable && config.ghaf.givc.enable) (
+      let
+        appVmPort = portMap.${hostName};
+      in
+      {
+        # Tunnel the local SNI dbusproxy socket to gui-vm at our auto-assigned port
+        givc.appvm.capabilities.socketProxy = {
+          enable = true;
+          sockets = [
+            {
+              transport = {
+                name = guivmName;
+                addr = hosts.${guivmName}.ipv4;
+                port = appVmPort;
+                protocol = "tcp";
+              };
+              inherit (sniCfg) socket;
+            }
+          ];
+        };
+
+        # SNI renamer: runs on the real session bus, owns org.kde.StatusNotifierWatcher,
+        # and acquires dot-based well-known names (org.kde.StatusNotifierItem.proxy_<pid>_<n>)
+        # for every SNI app — including apps such as Element and Discord that register
+        # with their unique D-Bus name (:1.X) instead of a well-known name.
+        # This lets the GIVC tunnel xdg-dbus-proxy run with filter=true and
+        # --talk=org.kde.StatusNotifierItem.* (which requires dot-separated names).
+        systemd.services.dbus-proxy-sni-renamer = {
+          description = "SNI renamer for ${hostName}: bridge unique-name tray apps to well-known names";
+          after = [ "dbus.socket" ];
+          requires = [ "dbus.socket" ];
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig = {
+            Type = "exec";
+            Restart = "always";
+            RestartSec = "30s";
+            User = appUserUid;
+            Environment = [
+              "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${appUserUid}/bus"
+              "XDG_DATA_DIRS=/run/current-system/sw/share"
+            ];
+            ExecStart = "${lib.getExe pkgs.dbus-proxy} --renamer-mode";
+          };
+          startLimitIntervalSec = 0;
+        };
+
+        # dbusproxy: expose a filtered session bus socket for the GIVC tunnel
+        givc.dbusproxy = {
+          enable = true;
+          session = {
+            enable = true;
+            user = config.ghaf.users.appUser.name;
+            inherit (sniCfg) socket;
+            policy = {
+              own = [ "org.kde.StatusNotifierWatcher" ];
+              talk = [
+                # Talk to renamer-assigned item names (org.kde.StatusNotifierItem.proxy_*)
+                # Receive StatusNotifierItemRegistered/Unregistered signals from renamer (org.kde.StatusNotifierWatcher)
+                # Well-known names such as org.kde.StatusNotifierItem-6-2
+                "org.kde.*"
+              ];
+            };
+          };
+        };
+      }
+    ))
+
+    # Guivm side
+    (mkIf
+      (sniCfg.enable && config.ghaf.givc.guivm.enable && config.ghaf.givc.enable && sniSources != [ ])
+      {
+
+        # Socket proxy entries: one per appvm in appHosts
+        givc.sysvm.capabilities.socketProxy.sockets = map (src: {
+          transport = {
+            name = src.vmName;
+            addr = hosts.${src.vmName}.ipv4;
+            inherit (src) port;
+            protocol = "tcp";
+          };
+          inherit (src) socket;
+        }) sniSources;
+
+        # Path units: activate the dbus-proxy-sni service only when the tunnel
+        # socket actually appears (i.e., the appvm has SNI enabled and is running).
+        # This prevents restart-loops for appvms that have SNI disabled.
+        systemd.paths = listToAttrs (
+          map (
+            src:
+            nameValuePair "dbus-proxy-sni-${src.vmName}" {
+              description = "Watch for SNI tunnel socket from ${src.vmName}";
+              wantedBy = [ "graphical.target" ];
+              pathConfig = {
+                PathExists = src.socket;
+                Unit = "dbus-proxy-sni-${src.vmName}.service";
+              };
+            }
+          ) sniSources
+        );
+
+        # One dbus-proxy-sni service per appvm: bridges the GIVC tunnel socket
+        # (system bus) to the user session bus so the compositor sees the tray icons.
+        # Activated on-demand by the corresponding path unit above.
+        systemd.services = listToAttrs (
+          map (
+            src:
+            nameValuePair "dbus-proxy-sni-${src.vmName}" {
+              description = "DBus proxy for SNI tray icons from ${src.vmName}";
+              after = [ "user-login.service" ];
+              serviceConfig = {
+                Type = "exec";
+                Restart = "on-failure";
+                RestartSec = "5s";
+                Environment = [
+                  "DBUS_SYSTEM_BUS_ADDRESS=unix:path=${src.socket}"
+                  "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${homedUid}/bus"
+                ];
+                User = homedUid;
+                ExecStart = ''
+                  ${getExe pkgs.dbus-proxy} \
+                    --sni-mode \
+                    --source-bus-type system \
+                    --target-bus-type session ${optionalString config.ghaf.profiles.debug.enable "--log-level=verbose"}
+                '';
+              };
+            }
+          ) sniSources
+        );
+      }
+    )
+
+  ];
+}

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -37,6 +37,7 @@ _: {
       ./common/waypipe.nix
       ./common/xdghandlers.nix
       ./common/xdgitems.nix
+      ./common/sni.nix
     ];
 
     # GUI VM base module for layered composition

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -141,6 +141,7 @@ in
       debug = globalConfig.givc.debug or false;
     };
     givc.guivm.enable = true;
+    givc.sni.enable = true;
 
     # Storage - from globalConfig
     storagevm = {

--- a/modules/reference/appvms/comms.nix
+++ b/modules/reference/appvms/comms.nix
@@ -95,6 +95,7 @@ in
               # Open external URLs locally in comms-vm's browser instead of forwarding to a dedicated URL-handling VM
               xdghandlers.url = true;
               xdgitems.enable = lib.mkDefault true;
+              givc.sni.enable = true;
               # Disable serial debug console on comms-vm as it makes the serial device owned by
               # 'tty' group. gpsd runs hardcoded with effective gid of 'dialout' group, and thus
               # can't access the device if this is enabled.

--- a/modules/reference/appvms/flatpak.nix
+++ b/modules/reference/appvms/flatpak.nix
@@ -333,6 +333,7 @@ in
           ];
         extraModules = [
           {
+            ghaf.givc.sni.enable = true;
             services = {
               flatpak.enable = lib.mkDefault true;
               packagekit.enable = lib.mkDefault true;

--- a/overlays/custom-packages/element-desktop/element-main.patch
+++ b/overlays/custom-packages/element-desktop/element-main.patch
@@ -3,36 +3,39 @@
 @@ -448,11 +448,10 @@
          // https://www.electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
          backgroundColor: "#fff",
-
+ 
 -        titleBarStyle: process.platform === "darwin" ? "hidden" : "default",
          trafficLightPosition: { x: 9, y: 8 },
-
+ 
          icon: global.trayConfig.icon_path,
 -        show: false,
 +        show: true,
          autoHideMenuBar: store.get("autoHideMenuBar"),
-
+ 
          x: mainWindowState.x,
-@@ -478,7 +477,6 @@
+@@ -478,100 +477,42 @@
          app.exit(1);
      }
-
+ 
 -    void global.mainWindow.loadURL("vector://vector/webapp/");
-
-     if (process.platform === "darwin") {
-         setupMacosTitleBar(global.mainWindow);
-@@ -489,89 +487,34 @@
+-
+-    if (process.platform === "darwin") {
+-        setupMacosTitleBar(global.mainWindow);
+-    }
+-
+     // Handle spellchecker
+     // For some reason spellCheckerEnabled isn't persisted, so we have to use the store here
      global.mainWindow.webContents.session.setSpellCheckerEnabled(store.get("spellCheckerEnabled", true));
-
+ 
      // Create trayIcon icon
 -    if (store.get("minimizeToTray")) tray.create(global.trayConfig);
-+    //if (store.get("minimizeToTray")) tray.create(global.trayConfig);
-
++    tray.create(global.trayConfig);
+ 
 -    global.mainWindow.once("ready-to-show", () => {
 +    global.mainWindow.webContents.once('did-finish-load',function() {
          if (!global.mainWindow) return;
          mainWindowState.manage(global.mainWindow);
-
+ 
          if (!argv["hidden"]) {
              global.mainWindow.show();
 +            global.mainWindow.restore();
@@ -42,7 +45,7 @@
              global.mainWindow.hide();
          }
      });
-
+ 
 -    global.mainWindow.webContents.on("before-input-event", (event: Event, input: Input): void => {
 -        const exitShortcutPressed =
 -            input.type === "keyDown" && exitShortcuts.some((shortcutFn) => shortcutFn(input, process.platform));
@@ -76,17 +79,19 @@
 -        app.exit();
 -    });
 +    void global.mainWindow.loadURL("vector://vector/webapp/");
-
+ 
      global.mainWindow.on("closed", () => {
          global.mainWindow = null;
      });
-     global.mainWindow.on("close", async (e) => {
+-    global.mainWindow.on("close", async (e) => {
 -        // If we are not quitting and have a tray icon then minimize to tray
 -        if (!global.appQuitting && (tray.hasTray() || process.platform === "darwin")) {
 -            // On Mac, closing the window just hides it
 -            // (this is generally how single-window Mac apps
 -            // behave, eg. Mail.app)
--            e.preventDefault();
++    global.mainWindow.on("close", (e) => {
++        if (!global.appQuitting && tray.hasTray()) {
+             e.preventDefault();
 -
 -            if (global.mainWindow?.isFullScreen()) {
 -                global.mainWindow.once("leave-full-screen", () => global.mainWindow?.hide());
@@ -95,11 +100,12 @@
 -            } else {
 -                global.mainWindow?.hide();
 -            }
-
+-
 -            return false;
--        }
++            global.mainWindow?.hide();
+         }
      });
-
+ 
 -    if (process.platform === "win32") {
 -        // Handle forward/backward mouse buttons in Windows
 -        global.mainWindow.on("app-command", (e, cmd) => {
@@ -112,7 +118,7 @@
 -    }
 -
      webContentsHandler(global.mainWindow.webContents);
-
+ 
 +
      session.defaultSession.setDisplayMediaRequestHandler(
          (_, callback) => {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Adds SNI (StatusNotifierItem) system tray icon forwarding for app VMs via a GIVC dbus proxy tunnel.
* New modules/microvm/common/sni.nix: SNI (StatusNotifierItem) tray icon forwarding via GIVC dbus proxy tunnel, appvm + guivm sides
* ghaf.common.sniVms: auto-derived list of SNI-enabled app VMs for guivm port/service generation
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets
[SSRCSP-7982](https://jira.tii.ae/browse/SSRCSP-7982)
https://github.com/tiiuae/ghafpkgs/pull/223
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Tray icons should appear from comms-vm (element-desktop) and flatpak-vm (discord, spotify, slack, etc.)
**Note**: Some apps close when the "X" button is clicked instead of minimizing to tray 

| App | Icon | Clicks (Left and/or Right) | Notes |
|-----|------|-------------|-------|
| [Flatpak]Discord | ✓ | ✓ | |
| [Flatpak]Zoom | ✓ | ✓ | |
| [Flatpak]Teams (portal) | ✓ | ✓ | |
| [comms]Element | ✓ | ✓ | |
| [Flatpak]Spotify | ✓ | ✓ | X closes the app |
| [Flatpak]Telegram | ✓ | ✓ | X closes the app |
| [Flatpak]Slack | ✓ | ✓ | X closes the app |
 