### PR TITLE
audit: fix syscall rules for aarch64 and FSS audit path

### DIFF
--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -83,6 +83,8 @@ let
     ;
   cfg = config.ghaf.logging.fss;
   loggingEnabled = config.ghaf.logging.enable;
+  fssBasePath =
+    if config.ghaf.type == "host" then "/persist/common/journal-fss" else "/etc/common/journal-fss";
 
   # Script to setup FSS keys on first boot
   setupScript = pkgs.writeShellApplication {
@@ -318,10 +320,8 @@ in
       default =
         let
           componentName = config.networking.hostName;
-          basePath =
-            if config.ghaf.type == "host" then "/persist/common/journal-fss" else "/etc/common/journal-fss";
         in
-        "${basePath}/${componentName}";
+        "${fssBasePath}/${componentName}";
       description = ''
         Directory to store FSS keys and metadata for this component.
 
@@ -515,8 +515,8 @@ in
 
     # Audit rules to monitor FSS key and journal access
     ghaf.security.audit.extraRules = [
-      # Monitor FSS key directory for any write or attribute changes
-      "-w ${cfg.keyPath} -p wa -k journal_fss_keys"
+      # Monitor shared FSS key tree.
+      "-w ${fssBasePath} -p wa -k journal_fss_keys"
       # Monitor sealed journal logs for tampering attempts
       "-w /var/log/journal -p wa -k journal_sealed_logs"
       # Monitor machine-id reads (critical for journal path resolution)

--- a/modules/common/security/audit/rules/common.nix
+++ b/modules/common/security/audit/rules/common.nix
@@ -7,8 +7,24 @@
   ...
 }:
 let
-  passwordFilesLocation =
-    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc";
+  inherit (pkgs.stdenv.hostPlatform) isAarch64;
+  chownSyscalls = if isAarch64 then "fchown,fchownat" else "chown,fchown,lchown,fchownat";
+  chmodSyscalls = if isAarch64 then "fchmod,fchmodat" else "chmod,fchmod,fchmodat";
+  deleteSyscalls = if isAarch64 then "unlinkat,renameat" else "rename,unlink,rmdir,renameat,unlinkat";
+  osppDeleteSyscalls = if isAarch64 then "unlinkat,renameat" else "unlink,unlinkat,rename,renameat";
+  accessSyscalls =
+    if isAarch64 then
+      "truncate,ftruncate,openat,open_by_handle_at"
+    else
+      "open,creat,truncate,ftruncate,openat,open_by_handle_at";
+  stigAccessSyscalls =
+    if isAarch64 then
+      "truncate,ftruncate,openat,openat2,open_by_handle_at"
+    else
+      "open,truncate,ftruncate,creat,openat,openat2,open_by_handle_at";
+  osppAccessSyscalls =
+    if isAarch64 then "openat,openat2,open_by_handle_at" else "open,openat,openat2,open_by_handle_at";
+  osppPermChangeSyscalls = "${chmodSyscalls},setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr";
 in
 [
   ## === Common :: Nix/NixOS-specific ===
@@ -52,16 +68,16 @@ in
   "-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=-1 -k perm_mod"
   "-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod"
   # V-268099
-  "-a always,exit -F arch=b64 -S chown,fchown,lchown,fchownat -F auid>=1000 -F auid!=unset -F key=perm_mod"
+  "-a always,exit -F arch=b64 -S ${chownSyscalls} -F auid>=1000 -F auid!=unset -F key=perm_mod"
   # V-268098
-  "-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access"
-  "-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access"
+  "-a always,exit -F arch=b64 -S ${accessSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access"
+  "-a always,exit -F arch=b64 -S ${accessSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access"
   # V-268096
   "-a always,exit -F arch=b64 -S init_module,finit_module,delete_module -F auid>=1000 -F auid!=unset -k module_chng"
   # V-268095
-  "-a always,exit -F arch=b64 -S rename,unlink,rmdir,renameat,unlinkat -F auid>=1000 -F auid!=unset -k delete"
+  "-a always,exit -F arch=b64 -S ${deleteSyscalls} -F auid>=1000 -F auid!=unset -k delete"
   # V-268100
-  "-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod"
+  "-a always,exit -F arch=b64 -S ${chmodSyscalls} -F auid>=1000 -F auid!=unset -F key=perm_mod"
 
   ## === Common :: OSPP-derived ===
   # 11-loginuid.rules && V-268119
@@ -132,9 +148,15 @@ in
   "-a always,exit -F arch=b64 -F path=/etc/localtime -F perm=wa -F key=time-change"
   ## Things that affect identity
   # Handled in common rules - V-268167
-  "-a always,exit -F arch=b64 -F path=${passwordFilesLocation}/group -F perm=wa -F key=identity"
-  "-a always,exit -F arch=b64 -F path=${passwordFilesLocation}/passwd -F perm=wa -F key=identity"
-  "-a always,exit -F arch=b64 -F path=${passwordFilesLocation}/shadow -F perm=wa -F key=identity"
+  "-a always,exit -F arch=b64 -F path=${
+    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+  }/group -F perm=wa -F key=identity"
+  "-a always,exit -F arch=b64 -F path=${
+    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+  }/passwd -F perm=wa -F key=identity"
+  "-a always,exit -F arch=b64 -F path=${
+    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+  }/shadow -F perm=wa -F key=identity"
   ## Things that could affect system locale
   "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=system-locale"
   "-a always,exit -F arch=b64 -F path=/etc/issue -F perm=wa -F key=system-locale"
@@ -186,8 +208,8 @@ in
 
   ##- Unauthorized access attempts to files (unsuccessful)
   # Handled partially in common rules - V-268098
-  "-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access"
-  "-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access"
+  "-a always,exit -F arch=b64 -S ${stigAccessSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access"
+  "-a always,exit -F arch=b64 -S ${stigAccessSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access"
 
   ##- Use of print command (unsuccessful and successful)
   ##- Export to media (successful)
@@ -198,8 +220,7 @@ in
 
   ##- System startup and shutdown (unsuccessful and successful)
   ##- Files and programs deleted by the user (successful and unsuccessful)
-  # Handled partially in common rules - V-268095
-  "-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F auid>=1000 -F auid!=unset -F key=delete"
+  # Handled in common rules - V-268095
 
   ##- All system administration actions
   ##- All security personnel actions
@@ -251,79 +272,109 @@ in
   ## 30-ospp-v42-1-create-failed.rules
   ## Unsuccessful file creation (open with O_CREAT)
   "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
+]
+++ lib.optionals (!isAarch64) [
   "-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
   "-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
+]
+++ [
   "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
+]
+++ lib.optionals (!isAarch64) [
   "-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
   "-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
+]
+++ [
   ## 30-ospp-v42-1-create-success.rules
   ## Successful file creation (open with O_CREAT)
   "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F success=1 -F auid!=unset -F key=successful-create"
+]
+++ lib.optionals (!isAarch64) [
   "-a always,exit -F arch=b64 -S open -F a1&0100 -F success=1 -F auid!=unset -F key=successful-create"
   "-a always,exit -F arch=b64 -S creat -F success=1 -F auid!=unset -F key=successful-create"
+]
+++ [
 
   ## 30-ospp-v42-2-modify-failed.rules
   ## Unsuccessful file modifications (open for write or truncate)
   "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
-  "-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
   "-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
   "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
-  "-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
   "-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
+]
+++ lib.optionals (!isAarch64) [
+  "-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
+  "-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
+]
+++ [
   ## 30-ospp-v42-2-modify-success.rules
   ## Successful file modifications (open for write or truncate)
   "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F success=1 -F auid!=unset -F key=successful-modification"
-  "-a always,exit -F arch=b64 -S open -F a1&01003 -F success=1 -F auid!=unset -F key=successful-modification"
   "-a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid!=unset -F key=successful-modification"
+]
+++ lib.optionals (!isAarch64) [
+  "-a always,exit -F arch=b64 -S open -F a1&01003 -F success=1 -F auid!=unset -F key=successful-modification"
+]
+++ [
 
   ## 30-ospp-v42-3-access-failed.rules
   ## Unsuccessful file access
-  "-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access"
-  "-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access"
+  "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access"
+  "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access"
 
   ## 30-ospp-v42-4-delete-failed.rules
   ## Unsuccessful file delete
-  "-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid!=unset -F key=unsuccessful-delete"
-  "-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid!=unset -F key=unsuccessful-delete"
+  "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F exit=-EACCES -F auid!=unset -F key=unsuccessful-delete"
+  "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F exit=-EPERM -F auid!=unset -F key=unsuccessful-delete"
 
   ## 30-ospp-v42-4-delete-success.rules
   ## Successful file delete
-  "-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid!=unset -F key=successful-delete"
+  "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F success=1 -F auid!=unset -F key=successful-delete"
 
   ## 30-ospp-v42-5-perm-change-failed.rules
   ## Unsuccessful permission change
-  "-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change"
-  "-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change"
+  "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change"
+  "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change"
 
   ## 30-ospp-v42-5-perm-change-success.rules
   ## Successful permission change
-  "-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change"
+  "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change"
 
   ## 30-ospp-v42-6-owner-change-failed.rules
   ## Unsuccessful ownership change
-  "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change"
-  "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change"
+  "-a always,exit -F arch=b64 -S ${chownSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change"
+  "-a always,exit -F arch=b64 -S ${chownSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change"
 
   ## 30-ospp-v42-6-owner-change-success.rules
   ## Successful ownership change
-  "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change"
+  "-a always,exit -F arch=b64 -S ${chownSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change"
 
   ## User add delete modify. This is covered by pam. However, someone could
   ## open a file and directly create or modify a user, so we'll watch passwd and
   ## shadow for writes
   "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify"
-  "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify"
   "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify"
+]
+++ lib.optionals (!isAarch64) [
+  "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify"
   "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify"
+]
+++ [
 
   ## User enable and disable. This is entirely handled by pam.
   ## Group add delete modify. This is covered by pam. However, someone could
   ## open a file and directly create or modify a user, so we'll watch group and
   ## gshadow for writes
-  "-a always,exit -F arch=b64 -F path=${passwordFilesLocation}/passwd -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify"
-  "-a always,exit -F arch=b64 -F path=${passwordFilesLocation}/shadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify"
-  "-a always,exit -F arch=b64 -F path=${passwordFilesLocation}/group -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify"
-  # "-a always,exit -F arch=b64 -F path=${passwordFilesLocation}/gshadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify"
+  "-a always,exit -F arch=b64 -F path=${
+    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+  }/passwd -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify"
+  "-a always,exit -F arch=b64 -F path=${
+    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+  }/shadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify"
+  "-a always,exit -F arch=b64 -F path=${
+    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+  }/group -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify"
+  # "-a always,exit -F arch=b64 -F path=${if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"}/gshadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify"
 
   ## Use of special rights for config changes. This would be use of setuid
   ## programs that relate to user accts. This is not all setuid apps because
@@ -381,5 +432,5 @@ in
   ## 30-ospp-v42-3-access-success.rules
   ## Successful file access (any other opens) This has to go last.
   ## This are likely to result in a whole lot of events
-  "-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access"
+  "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access"
 ]

--- a/modules/common/security/audit/rules/host.nix
+++ b/modules/common/security/audit/rules/host.nix
@@ -2,9 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   config,
+  pkgs,
   lib,
   ...
 }:
+let
+  inherit (pkgs.stdenv.hostPlatform) isAarch64;
+  nixStoreMutationSyscalls =
+    if isAarch64 then
+      "openat,truncate,renameat,linkat,unlinkat,symlinkat"
+    else
+      "open,openat,creat,truncate,rename,renameat,link,unlink,unlinkat,symlink";
+in
 [
   ## === Host :: Nix/NixOS-specific ===
   # Nix profiles & system generations (symlink flips = important)
@@ -35,5 +44,5 @@
 
   ## === Host :: nixos-rebuild ===
   # Nix store modifications
-  "-a always,exit -F arch=b64 -S open,openat,creat,truncate,rename,renameat,link,unlink,unlinkat,symlink -F dir=/nix/store -F perm=wa -k nixos_rebuild_store"
+  "-a always,exit -F arch=b64 -S ${nixStoreMutationSyscalls} -F dir=/nix/store -F perm=wa -k nixos_rebuild_store"
 ]


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
This PR fixes issues in the Ghaf `audit` configuration (https://jira.tii.ae/browse/SSRCSP-8066).

- Architecture-specific audit rules: Some syscall rules included syscalls not available on `aarch64`. The rules are now generated conditionally to ensure compatibility across architectures.
- FSS audit path fix: The audit rule now monitors the shared FSS base directory instead of the VM-specific key directory. This avoids failures during early boot when the VM-specific path may not yet exist.
- Tested on Nvidia AGX and Lenovo X1.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-8066

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Check systemctl status in `admin-vm` and `net-vm`
2. Expected output:
<img width="955" height="220" alt="image" src="https://github.com/user-attachments/assets/cdcf8078-9bae-4405-8d60-922e13045d09" />
