### PR TITLE
jetson: prevent invalid RTC from rewinding host clock

### DIFF
--- a/docs/src/content/docs/ghaf/dev/ref/build_and_run.mdx
+++ b/docs/src/content/docs/ghaf/dev/ref/build_and_run.mdx
@@ -107,6 +107,10 @@ This is the primary reference device for Ghaf on AArch64 architecture, built usi
    sudo ./flash.sh
    ```
 
+<Aside type="note">
+  **Jetson boot time and clock sync**: Some Jetson boards may expose an RTC value that is not valid after a cold boot. Ghaf prevents invalid RTC data from rewinding host wall clock time during boot. When the RTC device appears, Ghaf can seed system time from RTC only when the RTC value is plausible: at or above the persisted `/var/lib/systemd/timesync/clock` anchor and not more than 180 days ahead. Native `systemd-timesyncd` then converges to network time when available.
+</Aside>
+
 ## Alternative Build Targets
 
 ## Virtual Machine (For Testing)

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -5,10 +5,73 @@
 {
   lib,
   config,
+  pkgs,
   ...
 }:
 let
   cfg = config.ghaf.hardware.nvidia.orin;
+  rtcSeedAnchorPath = "/var/lib/systemd/timesync/clock";
+  rtcSeedMaxAheadSeconds = 180 * 24 * 60 * 60;
+  rtcSeedMinEpochSeconds = 1704067200; # 2024-01-01T00:00:00Z
+  rtcSeedTimeFromRtc = pkgs.writeShellApplication {
+    name = "ghaf-seed-time-from-rtc";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = ''
+      rtc_device="$1"
+      rtc_since_epoch_path="/sys/class/rtc/$rtc_device/since_epoch"
+      anchor_path=${lib.escapeShellArg rtcSeedAnchorPath}
+      max_ahead_seconds=${toString rtcSeedMaxAheadSeconds}
+      min_epoch_seconds=${toString rtcSeedMinEpochSeconds}
+
+      skip() {
+        echo "RTC seed skipped: $*"
+        exit 0
+      }
+
+      if [ ! -f "$anchor_path" ]; then
+        skip "$anchor_path is missing or not a regular file"
+      fi
+
+      if [ ! -r "$rtc_since_epoch_path" ]; then
+        skip "$rtc_since_epoch_path not readable"
+      fi
+
+      rtc_epoch="$(tr -d '\n' < "$rtc_since_epoch_path")"
+      if ! [[ "$rtc_epoch" =~ ^[0-9]+$ ]]; then
+        skip "non-numeric RTC epoch '$rtc_epoch'"
+      fi
+
+      if [ "$rtc_epoch" -lt "$min_epoch_seconds" ]; then
+        skip "RTC epoch $rtc_epoch below minimum $min_epoch_seconds"
+      fi
+
+      anchor_epoch="$(stat -c %Y "$anchor_path" 2>/dev/null || echo 0)"
+      if ! [[ "$anchor_epoch" =~ ^[0-9]+$ ]]; then
+        skip "invalid anchor mtime '$anchor_epoch'"
+      fi
+
+      if [ "$anchor_epoch" -le 0 ]; then
+        skip "anchor mtime is not positive ($anchor_epoch)"
+      fi
+
+      if [ "$rtc_epoch" -lt "$anchor_epoch" ]; then
+        skip "RTC epoch $rtc_epoch is behind anchor $anchor_epoch"
+      fi
+
+      ahead_seconds=$((rtc_epoch - anchor_epoch))
+      if [ "$ahead_seconds" -gt "$max_ahead_seconds" ]; then
+        skip "RTC ahead by $ahead_seconds seconds (> $max_ahead_seconds)"
+      fi
+
+      current_epoch="$(date -u +%s)"
+      if [ "$rtc_epoch" -le "$current_epoch" ]; then
+        skip "system time already >= RTC (now=$current_epoch rtc=$rtc_epoch)"
+      fi
+
+      date -u -s "@$rtc_epoch" >/dev/null
+      echo "RTC seed applied: system time set to epoch $rtc_epoch from $rtc_device"
+    '';
+  };
   inherit (lib)
     mkEnableOption
     mkOption
@@ -85,7 +148,33 @@ in
             VIRTIO_VSOCKETS_COMMON = yes;
           };
         }
+        {
+          name = "disable-rtc-hctosys";
+          patch = null;
+          structuredExtraConfig = with lib.kernel; {
+            RTC_HCTOSYS = lib.mkForce no;
+          };
+        }
       ];
+    };
+
+    services.udev.extraRules = ''
+      SUBSYSTEM=="rtc", KERNEL=="rtc0", TEST=="${rtcSeedAnchorPath}", TAG+="systemd", ENV{SYSTEMD_WANTS}+="ghaf-seed-time-from-rtc@%k.service"
+    '';
+
+    systemd.services."ghaf-seed-time-from-rtc@" = {
+      description = "Seed system time from plausible RTC value (%I)";
+      unitConfig = {
+        ConditionPathExists = [
+          "/sys/class/rtc/%I/since_epoch"
+          rtcSeedAnchorPath
+        ];
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = false;
+        ExecStart = "${lib.getExe rtcSeedTimeFromRtc} %I";
+      };
     };
 
     services.nvpmodel = {


### PR DESCRIPTION
## Summary
- Prevent boot-time wall-clock rewind on Jetson Orin by disabling kernel RTC hctosys (`RTC_HCTOSYS=n`) for this hardware path.
- Add a udev-triggered one-shot (`ghaf-seed-time-from-rtc@`) that optionally seeds system time from `rtc0` only when the RTC value is plausible relative to `/var/lib/systemd/timesync/clock` (not behind anchor, not more than 180 days ahead, and above minimum epoch).
- Keep native `systemd-timesyncd` workflow and persisted timesync anchor

## Why This Fixes Root Cause
`nvvrs-pseq-rtc` can register as `rtc0` early at boot and provide an invalid epoch-like value that rewinds wall clock time. Disabling kernel hctosys prevents this early rewind path. Time recovery remains native: optional bounded RTC seeding when rtc0 appears and then normal `systemd-timesyncd` synchronization.


## Manual Testing Steps
1. Build and flash image:
   - `nix build .#nvidia-jetson-orin-agx-debug-from-x86_64-flash-script`
   - Flash and boot Jetson host.
2. Verify udev trigger and RTC seeding behavior:
   - `udevadm info -q property -p /sys/class/rtc/rtc0 | grep -E 'DEVNAME|SUBSYSTEM|SYSTEMD_WANTS'`
   - `systemctl status ghaf-seed-time-from-rtc@rtc0.service --no-pager -l`
   - `journalctl -b -u ghaf-seed-time-from-rtc@rtc0.service --no-pager`
3. Verify native timesync path:
   - `systemctl status systemd-timesyncd.service --no-pager -l`
   - `ls -ld /var/lib/systemd/timesync && stat /var/lib/systemd/timesync/clock`
   - `timedatectl show -p NTPSynchronized -p TimeUSec`
4. Verify boot logs for RTC regression symptoms:
   - `journalctl -b --no-pager | grep -E 'nvvrs-pseq-rtc|setting system clock|Time jumped backwards|RTC seed'`

## Verification 
On host:

- Udev trigger present for `rtc0`:
  - `DEVNAME=/dev/rtc0`
  - `SUBSYSTEM=rtc`
  - `SYSTEMD_WANTS=ghaf-seed-time-from-rtc@rtc0.service`
- RTC seed unit executed and skipped invalid RTC safely:
  - `RTC seed skipped: RTC epoch 47 below minimum 1704067200`
- `systemd-timesyncd` active and synchronized:
  - `Initial clock synchronization to Fri 2026-03-06 ... UTC`
  - `NTPSynchronized=yes`
- Timesync anchor writable and updated:
  - `/var/lib/systemd/timesync/clock` owned by `systemd-timesync:systemd-timesync`
  - mtime updated after sync.
- Boot log check:
  - `nvvrs-pseq-rtc ... registered as rtc0` observed.
  - No `setting system clock to 1970...` observed in this boot.
  - No startup-critical backward-jump churn observed in captured logs.

