### PR TITLE
chore(flake): update nixpkgs lock input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,11 +521,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773579282,
-        "narHash": "sha256-LWvZj9Bvm1EuoO6zbX4yjZebwnZNfeTbmCJGS7RGQ3Y=",
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a88de74db0e948139be4b46f9a94d64aa11391c",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update the `nixpkgs` input in `flake.lock` to a newer pinned revision.
- Previous lock update causes binary cache invalidations across a large part of the dependency graph.
- As a consequence, builds trigger massive rebuilds until substitute caches are warmed again.

