### PR TITLE
cross: drop gfortran from fftw in cross-compilation overlay

### DIFF
--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -4,6 +4,16 @@
 # This overlay is for specific fixes needed only to enable cross-compilation.
 #
 (final: prev: {
+  # Remove gfortran from FFTW to avoid cross-compiling the entire Fortran
+  # toolchain. FFTW is pulled in by PipeWire for audio processing. The Fortran
+  # wrapper generation is only needed when building docs (--disable-doc already
+  # strips the Fortran codegen step). Ghaf does not use the Fortran bindings.
+  fftwFloat = prev.fftwFloat.overrideAttrs (old: {
+    nativeBuildInputs = builtins.filter (d: !(final.lib.hasPrefix "gfortran" (d.pname or ""))) (
+      old.nativeBuildInputs or [ ]
+    );
+  });
+
   # Fix for setuptools-rust cross-compilation hook mismatch.
   # When building Python packages natively (host == target), the setuptools-rust
   # hook was incorrectly setting PYO3_CROSS_LIB_DIR to pythonOnTargetForTarget


### PR DESCRIPTION
## Summary

- Remove gfortran from `fftwFloat.nativeBuildInputs` in the cross-compilation overlay
- PipeWire → fftwFloat (fftw-single) → gfortran dependency chain forces cross-compilation of the entire Fortran toolchain for aarch64, which is not in the binary cache
- Ghaf does not use FFTW Fortran bindings; the Fortran wrapper is only generated when docs are enabled (`--disable-doc` is already set for cross builds)

## Test plan

- [ ] `nix build --dry-run .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64` no longer includes `aarch64-unknown-linux-gnu-gfortran` in derivations to build
- [ ] Full cross build of Jetson Orin target succeeds
- [ ] Audio (PipeWire) functionality unaffected on target

