### PR TITLE
jetson: Add support for UKI image generation

### DIFF
--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -11,6 +11,12 @@
 # EFI-directory and proper kind of structure, it finds the EFI-applications and
 # boots them successfully.
 #
+# When ghaf.image.sdcard.uki.enable is set, the ESP is populated with a Unified
+# Kernel Image (Type #2 BLS entry) instead of the traditional Type #1 entry
+# produced by mk-esp-contents.py. The UKI bundles kernel, initrd, cmdline, DTB,
+# and os-release into a single PE/COFF binary discovered automatically by
+# systemd-boot from EFI/Linux/.
+#
 {
   config,
   pkgs,
@@ -18,74 +24,161 @@
   lib,
   ...
 }:
+let
+  cfg = config.ghaf.image.sdcard;
+  inherit (pkgs.stdenv.hostPlatform) efiArch;
+  fdtPath = "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
+in
 {
   imports = [ (modulesPath + "/installer/sd-card/sd-image.nix") ];
 
-  boot.loader.grub.enable = false;
-  hardware.enableAllHardware = lib.mkForce false;
+  options.ghaf.image.sdcard.uki = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Populate the SD image ESP with a Unified Kernel Image (Type #2 BLS
+        entry) instead of the traditional Type #1 entries from
+        mk-esp-contents.py.
 
-  sdImage =
-    let
-      # TODO do we really need replaceVars just to set the python string in the
-      # shbang?
-      mkESPContentSource = pkgs.replaceVars ./mk-esp-contents.py {
-        inherit (pkgs.buildPackages) python3;
-      };
-      mkESPContent =
-        pkgs.runCommand "mk-esp-contents"
-          {
-            nativeBuildInputs = with pkgs; [
-              mypy
-              python3
-            ];
-          }
-          ''
-            install -m755 ${mkESPContentSource} $out
-            mypy \
-              --no-implicit-optional \
-              --disallow-untyped-calls \
-              --disallow-untyped-defs \
-              $out
-          '';
-      fdtPath = "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
-    in
-    {
-      firmwareSize = 256;
-      populateFirmwareCommands = ''
-        mkdir -pv firmware
-        ${mkESPContent} \
-          --toplevel ${config.system.build.toplevel} \
-          --output firmware/ \
-          --device-tree ${fdtPath}
-      '';
-      populateRootCommands = "";
-      postBuildCommands = ''
-        fdisk_output=$(fdisk -l "$img")
+        The UKI bundles kernel, initrd, cmdline, DTB, and os-release into a
+        single PE/COFF binary that systemd-boot discovers automatically from
+        EFI/Linux/.
 
-        # Offsets and sizes are in 512 byte sectors
-        blocksize=512
-
-        # ESP partition offset and sector count
-        part_esp=$(echo -n "$fdisk_output" | tail -n 2 | head -n 1 | tr -s ' ')
-        part_esp_begin=$(echo -n "$part_esp" | cut -d ' ' -f2)
-        part_esp_count=$(echo -n "$part_esp" | cut -d ' ' -f4)
-
-        # root-partition offset and sector count
-        part_root=$(echo -n "$fdisk_output" | tail -n 1 | head -n 1 | tr -s ' ')
-        part_root_begin=$(echo -n "$part_root" | cut -d ' ' -f3)
-        part_root_count=$(echo -n "$part_root" | cut -d ' ' -f4)
-
-        echo -n $part_esp_begin > $out/esp.offset
-        echo -n $part_esp_count > $out/esp.size
-        echo -n $part_root_begin > $out/root.offset
-        echo -n $part_root_count > $out/root.size
+        Note: Enabling this produces an image without bootloader-level
+        generation rollback. A single UKI is placed in the ESP.
       '';
     };
 
-  #TODO: should we use the default
-  #https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/sd-card/sd-image.nix#L177
-  fileSystems."/boot" = {
-    device = "/dev/disk/by-label/${config.sdImage.firmwarePartitionName}";
-    fsType = "vfat";
+    dtbPadding = lib.mkOption {
+      type = lib.types.int;
+      default = 65536;
+      description = ''
+        Extra padding bytes added to the device tree blob.
+        systemd-stub needs room in the FDT for runtime modifications
+        (e.g. adding /chosen properties). Increase if firmware rejects
+        the DTB with "Invalid header detected on UEFI supplied FDT".
+      '';
+    };
+  };
+
+  config = {
+    boot.loader.grub.enable = false;
+    hardware.enableAllHardware = lib.mkForce false;
+
+    # Jetson-specific UKI build configuration
+    boot.uki.settings = lib.mkIf cfg.uki.enable (
+      let
+        # When packed in a UKI, the dtb needs some padding to avoid error:
+        # "Invalid header detected on UEFI supplied FDT"
+        # The default value of 64K for dtbPadding should be more than enough.
+        paddedDtb =
+          pkgs.runCommand "padded-dtb"
+            {
+              nativeBuildInputs = [ pkgs.dtc ];
+            }
+            ''
+              mkdir -p $out
+              dtc -I dtb -O dtb -p ${toString cfg.uki.dtbPadding} ${fdtPath} -o $out/padded.dtb
+            '';
+      in
+      {
+        UKI = {
+          DeviceTree = "${paddedDtb}/padded.dtb";
+        };
+      }
+    );
+
+    sdImage =
+      let
+        # Type #1 BLS entry (uses mk-esp-contents.py)
+        # TODO do we really need replaceVars just to set the python string in the
+        # shbang?
+        mkESPContentSource = pkgs.replaceVars ./mk-esp-contents.py {
+          inherit (pkgs.buildPackages) python3;
+        };
+        mkESPContent =
+          pkgs.runCommand "mk-esp-contents"
+            {
+              nativeBuildInputs = with pkgs; [
+                mypy
+                python3
+              ];
+            }
+            ''
+              install -m755 ${mkESPContentSource} $out
+              mypy \
+                --no-implicit-optional \
+                --disallow-untyped-calls \
+                --disallow-untyped-defs \
+                $out
+            '';
+      in
+      {
+        firmwareSize = if cfg.uki.enable then 512 else 256;
+
+        populateFirmwareCommands =
+          if cfg.uki.enable then
+            ''
+              mkdir -pv firmware/EFI/BOOT
+              mkdir -pv firmware/EFI/Linux
+              mkdir -pv firmware/loader
+
+              # Install systemd-boot as the UEFI bootloader
+              cp -v ${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi \
+                    firmware/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI
+
+              # Install the UKI (Type #2 entry). systemd-boot discovers it
+              # automatically from EFI/Linux/
+              cp -v ${config.system.build.uki}/${config.system.boot.loader.ukiFile} \
+                    firmware/EFI/Linux/${config.system.boot.loader.ukiFile}
+
+              # Minimal loader configuration
+              cat > firmware/loader/loader.conf << EOF
+              timeout 0
+              editor no
+              console-mode keep
+              EOF
+            ''
+          else
+            ''
+              mkdir -pv firmware
+              ${mkESPContent} \
+                --toplevel ${config.system.build.toplevel} \
+                --output firmware/ \
+                --device-tree ${fdtPath}
+            '';
+
+        populateRootCommands = "";
+
+        postBuildCommands = ''
+          fdisk_output=$(fdisk -l "$img")
+
+          # Offsets and sizes are in 512 byte sectors
+          blocksize=512
+
+          # ESP partition offset and sector count
+          part_esp=$(echo -n "$fdisk_output" | tail -n 2 | head -n 1 | tr -s ' ')
+          part_esp_begin=$(echo -n "$part_esp" | cut -d ' ' -f2)
+          part_esp_count=$(echo -n "$part_esp" | cut -d ' ' -f4)
+
+          # root-partition offset and sector count
+          part_root=$(echo -n "$fdisk_output" | tail -n 1 | head -n 1 | tr -s ' ')
+          part_root_begin=$(echo -n "$part_root" | cut -d ' ' -f3)
+          part_root_count=$(echo -n "$part_root" | cut -d ' ' -f4)
+
+          echo -n $part_esp_begin > $out/esp.offset
+          echo -n $part_esp_count > $out/esp.size
+          echo -n $part_root_begin > $out/root.offset
+          echo -n $part_root_count > $out/root.size
+        '';
+      };
+
+    #TODO: should we use the default
+    #https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/sd-card/sd-image.nix#L177
+    fileSystems."/boot" = {
+      device = "/dev/disk/by-label/${config.sdImage.firmwarePartitionName}";
+      fsType = "vfat";
+    };
   };
 }


### PR DESCRIPTION
This PR adds an option to populate the SD card image EFI System Partition (ESP) with a Unified Kernel Image (UKI).

When `ghaf.image.sdcard.uki.enable` is set to `true`, the ESP is populated with a single UKI binary instead of the traditional Type #1 BLS entry produced by `mk-esp-contents.py` with separate kernel, initrd and DTB binaries.

The UKI (Type #2 BLS entry) bundles kernel, initrd, cmdline, DTB, and os-release into a single binary that systemd-boot discovers automatically from EFI/Linux/.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--

-->
The runtime functionality has only been verified in an Nvidia Orin NX chip.

In order to test the UKI functionality, enable it in `targets/nvidia-jetson-orin/flake-module.nix` by adding line 86 in `nvidia-jetson-orin-nx` config :

```
File: ./targets/nvidia-jetson-orin/flake-module.nix

[...]
 77     (ghaf-configuration {
 78       name = "nvidia-jetson-orin-nx";
 79       inherit system;
 80       profile = "orin";
 81       hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-nx;
 82       variant = "debug";
 83       extraModules = commonModules;
 84       extraConfig = {
 85         reference.profiles.mvp-orinuser-trial.enable = true;
 86         image.sdcard.uki.enable = true;
 87       };
 88     })
```
From an x86 host, you can build with:
```
$ nix build .#nvidia-jetson-orin-nx-debug-from-x86_64 
```

After the build finishes, decompress the result to facilitate inspection:
```
$ zstd -o /tmp/sd_nix.img -d result/sd-image/nixos-image-sd-card-<date>.<hash>-aarch64-linux.img.zst 
```
Find the offset of the first partition (img1), which belongs to ESP, using the following command:
```
$ fdisk -l /tmp/sd_nix.img

Disk /tmp/sd_nix.img: 10.96 GiB, 11772657664 bytes, 22993472 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x2178694e

Device           Boot   Start      End  Sectors  Size Id Type
/tmp/sd_nix.img1        16384  1064959  1048576  512M  b W95 FAT32
/tmp/sd_nix.img2 *    1064960 22993471 21928512 10.5G 83 Linux
```
The previous command shows a sector size of 512 bytes, and starting sector for img1 as 16384. With this info, the ESP can be mounted using the following command:
```
$ sudo mount -o loop,offset=$((16384 * 512)) /tmp/sd_nix.img /mnt/tmp 
```
First verify that the directory structure is correct:
```
$ tree /mnt/tmp
/mnt/tmp
├── EFI
│   ├── BOOT
│   │   └── BOOTAA64.EFI
│   └── Linux
│       └── nixos.efi
└── loader
    └── loader.conf

```

Then we can verify each section of the UKI (`/mnt/tmp/EFI/Linux/nixos.efi`) by using objdump. For example to inspect the first bytes of the kernel command line and the DTB, do the following:
```
# Check the embedded kernel command line arguments
$ aarch64-linux-gnu-objdump -s -j .cmdline /mnt/tmp/EFI/Linux/nixos.efi | head


/mnt/tmp/EFI/Linux/nixos.efi:     file format pei-aarch64-little

Contents of section .cmdline:
 1d1fa5000 696e6974 3d2f6e69 782f7374 6f72652f  init=/nix/store/
 1d1fa5010 67706a61 306d6332 66316331 71706479  gpja0mc2f1c1qpdy
 1d1fa5020 7a686a37 79703762 72717838 6e727677  zhj7yp7brqx8nrvw
 1d1fa5030 2d6e6978 6f732d73 79737465 6d2d6768  -nixos-system-gh
 1d1fa5040 61662d68 6f73742d 73642d63 6172642d  af-host-sd-card-
 1d1fa5050 32362e30 352e3230 32363033 31382e62  26.05.20260318.b

# Do a sanity check for the DTB, verifying it starts with: 0xd00dfeed
$ aarch64-linux-gnu-objdump -s -j .dtb /mnt/tmp/EFI/Linux/nixos.efi | head 


/mnt/tmp/EFI/Linux/nixos.efi:     file format pei-aarch64-little

Contents of section .dtb:
 1d1fa6000 d00dfeed 0004d477 00000038 000390cc  .......w...8....
 1d1fa6010 00000028 00000011 00000010 00000000  ...(............
 1d1fa6020 000043ab 00039094 00000000 00000000  ..C.............
 1d1fa6030 00000000 00000000 00000001 00000000  ................
 1d1fa6040 00000003 0000003f 00000000 6e766964  .......?....nvid
 1d1fa6050 69612c70 33373638 2d303030 302b7033  ia,p3768-0000+p3

[...]
```

To verify runtime functionality the image contents need to be flashed to the appropriate partitions, then the board should boot to a NixOS login shell.
