### PR TITLE
feat(spire): add x509pop attestation support

### DIFF
--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -436,7 +436,7 @@ rec {
       };
 
       spire = {
-        enable = false;
+        enable = true;
         debug = false;
       };
 
@@ -529,7 +529,7 @@ rec {
       };
 
       spire = {
-        enable = false;
+        enable = true;
         debug = false;
       };
 

--- a/modules/common/security/spire/agent.nix
+++ b/modules/common/security/spire/agent.nix
@@ -6,18 +6,13 @@
   pkgs,
   ...
 }:
+with lib;
 let
   cfg = config.ghaf.security.spire.agent;
-  dataDir = "/var/lib/spire/agent";
-  runtimeDataDir = "/run/spire/agent";
-  inherit (lib)
-    getExe
-    mkIf
-    mkOption
-    mkEnableOption
-    optionalString
-    types
-    ;
+  runtimeDataDir = "/run/spire-agent";
+  dataDir = "${runtimeDataDir}";
+  credSourceDir = "/etc/givc";
+
   spire-package = config.ghaf.common.spire.package;
   healthCheckPort = toString config.ghaf.common.spire.server.healthCheckPort;
 
@@ -27,6 +22,14 @@ let
   joinTokenPlugin = optionalString (cfg.nodeAttestationMode == "join_token") ''
     NodeAttestor "join_token" {
       plugin_data {}
+    }
+  '';
+  x509popPlugin = optionalString (cfg.nodeAttestationMode == "x509pop") ''
+    NodeAttestor "x509pop" {
+      plugin_data {
+        private_key_path = "$CREDENTIALS_DIRECTORY/key.pem"
+        certificate_path = "$CREDENTIALS_DIRECTORY/cert.pem"
+      }
     }
   '';
   agentConf = ''
@@ -43,14 +46,13 @@ let
 
     plugins {
       ${joinTokenPlugin}
+      ${x509popPlugin}
 
       WorkloadAttestor "unix" {
         plugin_data {}
       }
-      KeyManager "disk" {
-        plugin_data {
-          directory = "${dataDir}/keys"
-        }
+      KeyManager "memory" {
+        plugin_data {}
       }
     }
   '';
@@ -73,13 +75,20 @@ let
         sleep 3
       done
 
+      echo "SPIRE Server is ready! Starting SPIRE Agent..."
+
+      while [ ! -e "${cfg.trustBundlePath}" ]; do
+        echo "Waiting for trust bundle..."
+        sleep 1
+      done
+
       if [ "$MODE" == "join_token" ]; then
         while [ ! -e "${cfg.settings.join_token.token}" ]; do
           echo "Waiting for server token..."
           sleep 1
         done
       fi
-      echo "SPIRE Server is ready! Starting SPIRE Agent..."
+
     '';
   };
 in
@@ -90,7 +99,7 @@ in
     enable = mkEnableOption "SPIRE agent";
     nodeAttestationMode = mkOption {
       type = types.spireNodeAttestationMode;
-      default = "join_token";
+      default = "x509pop";
       description = "Node attestation mode";
     };
     workloads = mkOption {
@@ -131,9 +140,13 @@ in
     systemd = {
       services = {
         spire-agent = {
-          requires = [ "network-online.target" ];
+          requires = [
+            "network-online.target"
+            "local-fs.target"
+          ];
           after = [
             "network-online.target"
+            "local-fs.target"
           ];
 
           unitConfig = {
@@ -141,6 +154,8 @@ in
           };
 
           serviceConfig = {
+            RuntimeDirectory = mkForce "spire-agent";
+            StateDirectory = mkForce "spire-agent";
             ExecStartPre = getExe server-health;
             NoNewPrivileges = true;
             PrivateTmp = true;
@@ -150,12 +165,17 @@ in
               "${dataDir}"
               "${runtimeDataDir}"
             ];
+          }
+          // optionalAttrs (cfg.nodeAttestationMode == "x509pop") {
+            LoadCredential = [
+              "key.pem:${credSourceDir}/key.pem"
+              "cert.pem:${credSourceDir}/cert.pem"
+            ];
           };
         };
       };
       tmpfiles.rules = [
-        "d /run/spire 0755 root root - -"
-        "d ${runtimeDataDir} 2750 spire-agent spire-agent - -"
+        "d ${runtimeDataDir} 0755 spire-agent spire-agent - -"
       ];
     };
   };

--- a/modules/common/security/spire/server.nix
+++ b/modules/common/security/spire/server.nix
@@ -6,22 +6,15 @@
   pkgs,
   ...
 }:
+with lib;
 let
   cfg = config.ghaf.security.spire.server;
-  inherit (lib)
-    filterAttrs
-    getExe
-    mkIf
-    mkOption
-    mkEnableOption
-    types
-    optionalString
-    concatMapStringsSep
-    ;
-  runtimeDataDir = "/run/spire/server";
+  runtimeDataDir = "/run/spire-server";
   tokenDir = "/etc/common/spire/tokens";
-  socketPath = "${runtimeDataDir}/public/api.sock";
-  dataDir = "/var/lib/spire/server";
+  credSourceDir = "/etc/givc";
+  socketPath = "${runtimeDataDir}/api.sock";
+  dataDir = "${runtimeDataDir}";
+
   spire-package = config.ghaf.common.spire.package;
   spireAgents = config.ghaf.common.spire.agents;
   inherit (config.ghaf.common.spire.server) healthCheckPort;
@@ -31,9 +24,18 @@ let
     mode: builtins.attrNames (filterAttrs (_vm: cfg: (cfg.nodeAttestationMode == mode)) spireAgents);
 
   joinTokenVMs = getVMsByAttestation "join_token";
+  x509popVMs = getVMsByAttestation "x509pop";
+
   joinTokenPlugin = optionalString (builtins.length joinTokenVMs > 0) ''
     NodeAttestor "join_token" {
       plugin_data {}
+    }
+  '';
+  x509popPlugin = optionalString (builtins.length x509popVMs > 0) ''
+    NodeAttestor "x509pop" {
+      plugin_data {
+        ca_bundle_path = "$CREDENTIALS_DIRECTORY/ca-cert.pem"
+      }
     }
   '';
 
@@ -60,12 +62,11 @@ let
           connection_string = "${dataDir}/datastore.sqlite3"
         }
       }
-      KeyManager "disk" {
-        plugin_data {
-          keys_path = "${dataDir}/keys.json"
-        }
+      KeyManager "memory" {
+        plugin_data {}
       }
       ${joinTokenPlugin}
+      ${x509popPlugin}
     }
   '';
 
@@ -192,27 +193,54 @@ in
 
     systemd = {
       tmpfiles.rules = [
-        "d /run/spire 0755 root root - -"
         "d ${runtimeDataDir} 0755 root root - -"
-        "d ${runtimeDataDir}/public 0755 root root - -"
-        "d ${runtimeDataDir}/private 0755 root root - -"
         "d ${tokenDir} 0755 root root - -"
       ];
 
       services = {
+        spire-server-setup =
+          let
+            setupScript = pkgs.writeShellScript "spire-agent-setup" ''
+              ${pkgs.coreutils}/bin/rm -f ${cfg.trustBundlePath}
+            '';
+          in
+          {
+            description = "SPIRE server setup";
+            wantedBy = [ "spire-server.service" ];
+            before = [ "spire-server.service" ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = "${setupScript}";
+              RemainAfterExit = true;
+            };
+          };
         spire-server = {
-          after = [ "network-online.target" ];
-          wants = [ "network-online.target" ];
+          requires = [
+            "network-online.target"
+            "local-fs.target"
+            "spire-server-setup.service"
+          ];
+          after = [
+            "network-online.target"
+            "local-fs.target"
+            "spire-server-setup.service"
+          ];
+
           serviceConfig = {
-            NoNewPrivileges = true;
-            ProtectSystem = "strict";
-            ProtectHome = true;
+            RuntimeDirectory = mkForce "spire-server";
+            StateDirectory = mkForce "spire-server";
             ReadWritePaths = [
               "${dataDir}"
               "${runtimeDataDir}"
             ];
+          }
+          // optionalAttrs (builtins.length x509popVMs > 0) {
+            LoadCredential = [
+              "ca-cert.pem:${credSourceDir}/ca-cert.pem"
+            ];
           };
         };
+
         spire-generate-join-tokens = mkIf (builtins.length joinTokenVMs > 0) {
           description = "Generate SPIRE join tokens for Ghaf VMs (PoC)";
           wantedBy = [ "multi-user.target" ];
@@ -246,8 +274,8 @@ in
           wantedBy = [ "multi-user.target" ];
           after = [
             "spire-server.service"
-            "spire-generate-join-tokens.service"
-          ];
+          ]
+          ++ optionals (builtins.length joinTokenVMs > 0) [ "spire-generate-join-tokens.service" ];
           wants = [ "spire-server.service" ];
 
           serviceConfig = {

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -143,9 +143,9 @@ in
         security.spire.agent = {
           inherit (config.ghaf.global-config.spire) enable;
           logLevel = if config.ghaf.global-config.spire.debug then "DEBUG" else "INFO";
-          nodeAttestationMode = "join_token";
-          trustBundlePath = "/persist/common/spire/bundle.pem";
+          nodeAttestationMode = if config.ghaf.global-config.givc.enable then "x509pop" else "join_token";
           settings.join_token.token = "/persist/common/spire/tokens/${config.networking.hostName}.token";
+          trustBundlePath = "/persist/common/spire/bundle.pem";
         };
       };
 

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -197,7 +197,7 @@ in
     optimize.enable = false;
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;
-    mem = lib.mkDefault 512;
+    mem = lib.mkDefault 1024;
     #TODO: Add back support cloud-hypervisor
     #the system fails to switch root to the stage2 with cloud-hypervisor
     hypervisor = "qemu";

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -174,7 +174,7 @@ in
         agent = {
           enable = globalConfig.spire.enable or false;
           logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-          nodeAttestationMode = "join_token";
+          nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
         };
       };
     };

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -266,7 +266,7 @@ in
           spire.agent = {
             enable = globalConfig.spire.enable or false;
             logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-            nodeAttestationMode = "join_token";
+            nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
           };
         };
       };

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -158,6 +158,7 @@ in
       spire.agent = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
+        nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
       };
     };
 

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -269,7 +269,7 @@ in
       spire.agent = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = "join_token";
+        nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
       };
     };
   };

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -172,10 +172,11 @@ in
 
       # Audit - from globalConfig
       audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+
       spire.agent = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = "join_token";
+        nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
       };
     };
 


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Enable x509pop node attestation in Spire.
Givc certificates are used for initial authentication.
x509pop attestation is enabled for agents.

Also Fixes: [PR1837](https://jira.tii.ae/browse/SSRCSP-8326)

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. After installation check status of spire-agent service in each VM. It should be running fine and should show attestation successful using x509pop method.
- In each vm login as `ghaf` user
- Run below command to check agent status, service should be active and running state:

```
$> systemctl status spire-agent.service
```

- Run below command for service log, it should not have any error, and log should show something like 'attestation success using x509pop':

```
$> journalctl -b 0 -u spire-agent.service
```

2. in admin-vm, spire-server should also be in running state without any error.

- Run below command in `admin-vm` to check server status, service should be active and running state:

```
$> systemctl status spire-server.service
```
- Run below command for service log, it should not have any error, and log should show attestation requests from agents:

```
$> journalctl -b 0 -u spire-server.service
```

3. bug reported here should disappear:
https://jira.tii.ae/browse/SSRCSP-8326

