### PR TITLE
fix(power): keep display on during suspension; virtiofs: enable cache

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -131,7 +131,7 @@ let
               ${givc-cli} start service --vm "$vm_name" suspend.target &
               # Wait until suspend is active
               ${getExe pkgs.wait-for-unit} ${config.ghaf.networking.hosts.admin-vm.ipv4} 9001 \
-              "$vm_name" systemd-suspend.service 5 \
+              "$vm_name" systemd-suspend.service 10 \
               activating start
               ;;
             resume)
@@ -492,8 +492,7 @@ in
       # Shutdown displays early before suspend
       powerManagement = {
         powerDownCommands = lib.mkBefore ''
-          ${getExe ghaf-powercontrol} turn-on-displays '*'
-          ${getExe ghaf-powercontrol} turn-off-displays '*'
+          ${getExe ghaf-powercontrol} fake-turn-off-displays '*'
         '';
       };
 
@@ -536,11 +535,12 @@ in
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
-            ExecStop = "${getExe ghaf-powercontrol} turn-on-displays '*'";
+            ExecStop = "${getExe ghaf-powercontrol} fake-turn-on-displays '*'";
           };
         };
       };
 
+      services.upower.ignoreLid = true;
       # Logind configuration for desktop
       services.logind.settings.Login =
         let
@@ -549,7 +549,6 @@ in
         mkDefault {
           HandleLidSwitch = lidEvent;
           HandleLidSwitchDocked = "ignore";
-          HandleLidSwitchExternalPower = lidEvent;
           # Below keys are usually handled by host anyway
           HandleSuspendKey = "ignore";
           HandleHibernateKey = "ignore";
@@ -562,6 +561,7 @@ in
 
     # Host power management
     (mkIf cfg.host.enable {
+      services.upower.ignoreLid = true;
       # Host still handles power buttons in most situations
       services.logind.settings.Login = {
         HandleLidSwitch = mkDefault "ignore";

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -343,6 +343,7 @@ in
             source = "/nix/store";
             mountPoint = "/nix/.ro-store";
             proto = "virtiofs";
+            cache = "always";
           }
         ];
 

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -218,6 +218,7 @@ in
         source = "/nix/store";
         mountPoint = "/nix/.ro-store";
         proto = "virtiofs";
+        cache = "always";
       }
     ];
 

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -382,6 +382,7 @@ in
         source = "/nix/store";
         mountPoint = "/nix/.ro-store";
         proto = "virtiofs";
+        cache = "always";
       }
     ];
 

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -230,6 +230,7 @@ in
         source = "/nix/store";
         mountPoint = "/nix/.ro-store";
         proto = "virtiofs";
+        cache = "always";
       }
     ];
 

--- a/packages/ghaf-powercontrol/package.nix
+++ b/packages/ghaf-powercontrol/package.nix
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   writeShellApplication,
+  brightnessctl,
   lib,
   systemd,
   wlopm,
@@ -28,6 +29,7 @@ writeShellApplication {
     libnotify
     toybox
     jq
+    brightnessctl
   ]
   ++ (lib.optional useGivc givc-cli);
 
@@ -77,12 +79,21 @@ writeShellApplication {
         return 1
       fi
 
-      if [ "$action" != "on" ] && [ "$action" != "off" ]; then
-        echo "Error: First argument must be 'on' or 'off'"
-        return 1
-      fi
-
-      local cmd="wlopm --$action '$display_name'"
+      case "$action" in
+        on|off)
+          local cmd="wlopm --$action '$display_name'"
+          ;;
+        fake-off)
+          local cmd="brightnessctl -c backlight -s s 0"
+          ;;
+        fake-on)
+          local cmd="brightnessctl -c backlight -r || brightnessctl -c backlight s 100%"
+          ;;
+        *)
+          echo "Error: First argument must be one of 'on, off, fake-on, fake-off'"
+          exit 1
+          ;;
+      esac
 
       echo "Attempting to turn displays '$display_name' $action..."
 
@@ -147,6 +158,12 @@ writeShellApplication {
         ;;
       turn-on-displays)
         try_toggle_displays on "$2"
+        ;;
+      fake-turn-off-displays)
+        try_toggle_displays fake-off "$2"
+        ;;
+      fake-turn-on-displays)
+        try_toggle_displays fake-on "$2"
         ;;
       help|--help)
         help_msg


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Virtiofs changes:

Explicitly change the virtiofs cache setting from the default `auto` to `always` for `/nix/store` shares in Ghaf guests.

### Concerns:
Aggressive caching may introduce coherency issues on mutable shares, especially when the filesystem does **not** have exclusive access to the directory.
The Nix store, however, is immutable by design - paths are content-addressed and never modified in-place. This makes the coherency concern a non-issue, as there's nothing to go stale.

Reference manual for these options can be found here
https://gitlab.com/virtio-fs/virtiofsd
https://gitlab.com/virtio-fs/virtiofsd/-/blob/main/src/passthrough/mod.rs#L95

### Impact:
Expected benefits:
- Improved IO performance for repeated access to commonly shared libs - especially true for GUI libs in gui-vm
- Reduced virtiofsd CPU overhead - by default, the FUSE protocol uses close-to-open consistency. This means that any cached contents of the file are invalidated the next time that file is opened.
   With `cache` set to `always`, repeated reads are served from the guest memory directly, rather than through the FUSE client.
   
What this will **not** do:
- Improve guest cold boot times
- Speed up **first** time access of commonly shared libs
- Bring up general system responsiveness to the level of `storeDisk` - but it should be noticeably improved overall

## Suspension changes:

Dirty and hopefully temporary "fix" for recent suspension issues
It seems that i915 driver timeout occurs only if the built-in display is disabled before suspension.
This patch changes suspension behavior - suspending now does not turn off the display, but sets the backlight to 0% brightness via `brightnessctl s 0`

This behavior _may_ be explained by the fact that `wlopm --off` triggers a full DRM atomic disable that tears down i915 power wells, while `brightnessctl s 0` only writes to a PWM register that i915 never sees.

Tested manually - 15ish suspension cycles - no i915 driver crash.
Note: I did manual tests on a gen11 X1 with an OLED panel. All of our other targets use typical LCD panels, which may behave differently - for example, it may be so that "0% backlight brightness" does not result in a fully black "off" display, but rather a very dimly lit one.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
#### Virtiofs changes:
1. Ensure https://jira.tii.ae/browse/SSRCSP-8196 is **NOT** re-introduced
2. (Optional) Test and verify perf improvement similar to https://github.com/tiiuae/ghaf/pull/1817#issuecomment-4038757738
3. Test memory usage in affected VMs - all App VMs, gui-vm, net-vm, and audio-vm.
   Memory usage may increase overtime as VMs continue to run and `/nix/store` paths are being cached.
   Ideally, we should test the memory footprint of net-vm (sensitive to OOM issues) and gui-vm (more lib lookups than other VMs):
   1. Boot into Ghaf, wait for system to settle and inspect memory usage in net-vm and gui-vm
   2. Use the system as usual - open some apps, browse the net, etc. - for 2-3 hours
   3. Inspect memory usage in net-vm and gui-vm, verify no major OOM issues
   
#### Suspension changes:
1. Try to suspend any laptop device by either closing the lid or suspending manually
2. Verify device display is practically off - black screen, indistinguishable from being actually powered off
3. Verify device resumes from suspension without a graphics driver timeout
4. Repeat steps 1 and 3 - at least 10 times, letting the device sleep for at least 1 minute each time
5. Verify no issues even after multiple suspension attempts
6. Verify battery usage is not much higher during suspension compared to mainline.