### PR TITLE
fix(audit): gate verbose audit OSPP success rules

### DIFF
--- a/modules/common/security/audit/rules/common.nix
+++ b/modules/common/security/audit/rules/common.nix
@@ -86,10 +86,6 @@ lib.optionals config.nix.enable [
   # V-268100
   "-a always,exit -F arch=b64 -S ${chmodSyscalls} -F auid>=1000 -F auid!=unset -F key=perm_mod"
 
-  ## === Common :: OSPP-derived ===
-  # 11-loginuid.rules && V-268119
-  "--loginuid-immutable"
-
   ## === Common :: Other ===
   "-a always,exit -F arch=b64 -F path=/etc/machine-id -F perm=wa -F key=identity"
   "-w /etc/ssh -p rwxa -k ssh_config_access"
@@ -250,194 +246,195 @@ lib.optionals config.nix.enable [
   ##
   ## Site action. Can be assisted by a cron job
 ]
-++ lib.optionals config.ghaf.security.audit.enableOspp [
+++ lib.optionals config.ghaf.security.audit.enableOspp (
+  [
+    ## Operating System Protection Profile (OSPP)v4.2 ##
 
-  ## Operating System Protection Profile (OSPP)v4.2 ##
+    ## The purpose of these rules is to meet the requirements for Operating
+    ## System Protection Profile (OSPP)v4.2. These rules depends on having
+    ## the following rule files copied to /etc/audit/rules.d:
+    ##
+    ## 10-base-config.rules, 11-loginuid.rules,
+    ## 30-ospp-v42-1-create-failed.rules, 30-ospp-v42-1-create-success.rules,
+    ## 30-ospp-v42-2-modify-failed.rules, 30-ospp-v42-2-modify-success.rules,
+    ## 30-ospp-v42-3-access-failed.rules, 30-ospp-v42-3-access-success.rules,
+    ## 30-ospp-v42-4-delete-failed.rules, 30-ospp-v42-4-delete-success.rules,
+    ## 30-ospp-v42-5-perm-change-failed.rules,
+    ## 30-ospp-v42-5-perm-change-success.rules,
+    ## 30-ospp-v42-6-owner-change-failed.rules,
+    ## 30-ospp-v42-6-owner-change-success.rules
+    ##
+    ## original copies may be found in /usr/share/audit-rules
 
-  ## The purpose of these rules is to meet the requirements for Operating
-  ## System Protection Profile (OSPP)v4.2. These rules depends on having
-  ## the following rule files copied to /etc/audit/rules.d:
-  ##
-  ## 10-base-config.rules, 11-loginuid.rules,
-  ## 30-ospp-v42-1-create-failed.rules, 30-ospp-v42-1-create-success.rules,
-  ## 30-ospp-v42-2-modify-failed.rules, 30-ospp-v42-2-modify-success.rules,
-  ## 30-ospp-v42-3-access-failed.rules, 30-ospp-v42-3-access-success.rules,
-  ## 30-ospp-v42-4-delete-failed.rules, 30-ospp-v42-4-delete-success.rules,
-  ## 30-ospp-v42-5-perm-change-failed.rules,
-  ## 30-ospp-v42-5-perm-change-success.rules,
-  ## 30-ospp-v42-6-owner-change-failed.rules,
-  ## 30-ospp-v42-6-owner-change-success.rules
-  ##
-  ## original copies may be found in /usr/share/audit-rules
+    ## 10-base-config.rules:
+    # handled by nixos module
 
-  ## 10-base-config.rules:
-  # handled by nixos module
+    ## 11-loginuid.rules && V-268119
+    "--loginuid-immutable"
 
-  ## 11-loginuid.rules
-  # Handled in common rules - V-268119
+    ## 30-ospp-v42-1-create-failed.rules
+    ## Unsuccessful file creation (open with O_CREAT)
+    "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
+  ]
+  ++ lib.optionals (!isAarch64) [
+    "-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
+    "-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
+  ]
+  ++ [
+    "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
+  ]
+  ++ lib.optionals (!isAarch64) [
+    "-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
+    "-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
+  ]
+  ++ [
+    ## 30-ospp-v42-2-modify-failed.rules
+    ## Unsuccessful file modifications (open for write or truncate)
+    "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
+    "-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
+    "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
+    "-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
+  ]
+  ++ lib.optionals (!isAarch64) [
+    "-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
+    "-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
+  ]
+  ++ [
+    ## 30-ospp-v42-2-modify-success.rules
+    ## Successful file modifications (open for write or truncate)
+    "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F success=1 -F auid!=unset -F key=successful-modification"
+    "-a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid!=unset -F key=successful-modification"
+  ]
+  ++ lib.optionals (!isAarch64) [
+    "-a always,exit -F arch=b64 -S open -F a1&01003 -F success=1 -F auid!=unset -F key=successful-modification"
+  ]
+  ++ [
 
-  ## 30-ospp-v42-1-create-failed.rules
-  ## Unsuccessful file creation (open with O_CREAT)
-  "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
-]
-++ lib.optionals (!isAarch64) [
-  "-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
-  "-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid!=unset -F key=unsuccessful-create"
-]
-++ [
-  "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
-]
-++ lib.optionals (!isAarch64) [
-  "-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
-  "-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid!=unset -F key=unsuccessful-create"
-]
-++ [
-  ## 30-ospp-v42-1-create-success.rules
-  ## Successful file creation (open with O_CREAT)
-  "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F success=1 -F auid!=unset -F key=successful-create"
-]
-++ lib.optionals (!isAarch64) [
-  "-a always,exit -F arch=b64 -S open -F a1&0100 -F success=1 -F auid!=unset -F key=successful-create"
-  "-a always,exit -F arch=b64 -S creat -F success=1 -F auid!=unset -F key=successful-create"
-]
-++ [
+    ## 30-ospp-v42-3-access-failed.rules
+    ## Unsuccessful file access
+    "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access"
+    "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access"
 
-  ## 30-ospp-v42-2-modify-failed.rules
-  ## Unsuccessful file modifications (open for write or truncate)
-  "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
-  "-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
-  "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
-  "-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
-]
-++ lib.optionals (!isAarch64) [
-  "-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid!=unset -F key=unsuccessful-modification"
-  "-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid!=unset -F key=unsuccessful-modification"
-]
-++ [
-  ## 30-ospp-v42-2-modify-success.rules
-  ## Successful file modifications (open for write or truncate)
-  "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F success=1 -F auid!=unset -F key=successful-modification"
-  "-a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid!=unset -F key=successful-modification"
-]
-++ lib.optionals (!isAarch64) [
-  "-a always,exit -F arch=b64 -S open -F a1&01003 -F success=1 -F auid!=unset -F key=successful-modification"
-]
-++ [
+    ## 30-ospp-v42-4-delete-failed.rules
+    ## Unsuccessful file delete
+    "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F exit=-EACCES -F auid!=unset -F key=unsuccessful-delete"
+    "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F exit=-EPERM -F auid!=unset -F key=unsuccessful-delete"
 
-  ## 30-ospp-v42-3-access-failed.rules
-  ## Unsuccessful file access
-  "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access"
-  "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access"
+    ## 30-ospp-v42-4-delete-success.rules
+    ## Successful file delete
+    "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F success=1 -F auid!=unset -F key=successful-delete"
 
-  ## 30-ospp-v42-4-delete-failed.rules
-  ## Unsuccessful file delete
-  "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F exit=-EACCES -F auid!=unset -F key=unsuccessful-delete"
-  "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F exit=-EPERM -F auid!=unset -F key=unsuccessful-delete"
+    ## 30-ospp-v42-5-perm-change-failed.rules
+    ## Unsuccessful permission change
+    "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change"
+    "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change"
 
-  ## 30-ospp-v42-4-delete-success.rules
-  ## Successful file delete
-  "-a always,exit -F arch=b64 -S ${osppDeleteSyscalls} -F success=1 -F auid!=unset -F key=successful-delete"
+    ## 30-ospp-v42-5-perm-change-success.rules
+    ## Successful permission change
+    "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change"
 
-  ## 30-ospp-v42-5-perm-change-failed.rules
-  ## Unsuccessful permission change
-  "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change"
-  "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change"
+    ## 30-ospp-v42-6-owner-change-failed.rules
+    ## Unsuccessful ownership change
+    "-a always,exit -F arch=b64 -S ${chownSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change"
+    "-a always,exit -F arch=b64 -S ${chownSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change"
 
-  ## 30-ospp-v42-5-perm-change-success.rules
-  ## Successful permission change
-  "-a always,exit -F arch=b64 -S ${osppPermChangeSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change"
+    ## 30-ospp-v42-6-owner-change-success.rules
+    ## Successful ownership change
+    "-a always,exit -F arch=b64 -S ${chownSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change"
 
-  ## 30-ospp-v42-6-owner-change-failed.rules
-  ## Unsuccessful ownership change
-  "-a always,exit -F arch=b64 -S ${chownSyscalls} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change"
-  "-a always,exit -F arch=b64 -S ${chownSyscalls} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change"
+    ## User add delete modify. This is covered by pam. However, someone could
+    ## open a file and directly create or modify a user, so we'll watch passwd and
+    ## shadow for writes
+    "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify"
+    "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify"
+  ]
+  ++ lib.optionals (!isAarch64) [
+    "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify"
+    "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify"
+  ]
+  ++ [
 
-  ## 30-ospp-v42-6-owner-change-success.rules
-  ## Successful ownership change
-  "-a always,exit -F arch=b64 -S ${chownSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change"
+    ## User enable and disable. This is entirely handled by pam.
+    ## Group add delete modify. This is covered by pam. However, someone could
+    ## open a file and directly create or modify a user, so we'll watch group and
+    ## gshadow for writes
+    "-a always,exit -F arch=b64 -F path=${
+      if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+    }/passwd -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify"
+    "-a always,exit -F arch=b64 -F path=${
+      if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+    }/shadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify"
+    "-a always,exit -F arch=b64 -F path=${
+      if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
+    }/group -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify"
+    # "-a always,exit -F arch=b64 -F path=${if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"}/gshadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify"
 
-  ## User add delete modify. This is covered by pam. However, someone could
-  ## open a file and directly create or modify a user, so we'll watch passwd and
-  ## shadow for writes
-  "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify"
-  "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify"
-]
-++ lib.optionals (!isAarch64) [
-  "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify"
-  "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify"
-]
-++ [
+    ## Use of special rights for config changes. This would be use of setuid
+    ## programs that relate to user accts. This is not all setuid apps because
+    ## requirements are only for ones that affect system configuration.
+    ## TODO Handle wrappers / setuid binaries
+    # "-a always,exit -F arch=b64 -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F path=/usr/sbin/grub2-set-bootflag -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
 
-  ## User enable and disable. This is entirely handled by pam.
-  ## Group add delete modify. This is covered by pam. However, someone could
-  ## open a file and directly create or modify a user, so we'll watch group and
-  ## gshadow for writes
-  "-a always,exit -F arch=b64 -F path=${
-    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
-  }/passwd -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify"
-  "-a always,exit -F arch=b64 -F path=${
-    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
-  }/shadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify"
-  "-a always,exit -F arch=b64 -F path=${
-    if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"
-  }/group -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify"
-  # "-a always,exit -F arch=b64 -F path=${if config.services.userborn.enable then config.services.userborn.passwordFilesLocation else "/etc"}/gshadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify"
+    ## Privilege escalation via su or sudo. This is entirely handled by pam.
+    ## Special case for systemd-run. It is not audit aware, specifically watch it
+    "-a always,exit -F arch=b64 -F path=${pkgs.systemd}/bin/systemd-run -F perm=x -F auid!=unset -F key=maybe-escalation"
 
-  ## Use of special rights for config changes. This would be use of setuid
-  ## programs that relate to user accts. This is not all setuid apps because
-  ## requirements are only for ones that affect system configuration.
-  ## TODO Handle wrappers / setuid binaries
-  # "-a always,exit -F arch=b64 -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F path=/usr/sbin/grub2-set-bootflag -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes"
+    ## Special case for pkexec. It is not audit aware, specifically watch it
+    # TODO Handle kexec
+    # "-a always,exit -F arch=b64 -F path=/usr/bin/pkexec -F perm=x -F key=maybe-escalation"
 
-  ## Privilege escalation via su or sudo. This is entirely handled by pam.
-  ## Special case for systemd-run. It is not audit aware, specifically watch it
-  "-a always,exit -F arch=b64 -F path=${pkgs.systemd}/bin/systemd-run -F perm=x -F auid!=unset -F key=maybe-escalation"
+    ## Watch for configuration changes to privilege escalation.
+    # COMMENT: No writes possible
+    # "-a always,exit -F arch=b64 -F path=/etc/sudoers -F perm=wa -F key=special-config-changes"
+    # "-a always,exit -F arch=b64 -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes"
 
-  ## Special case for pkexec. It is not audit aware, specifically watch it
-  # TODO Handle kexec
-  # "-a always,exit -F arch=b64 -F path=/usr/bin/pkexec -F perm=x -F key=maybe-escalation"
+    ## Audit log access
+    "-a always,exit -F arch=b64 -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail"
 
-  ## Watch for configuration changes to privilege escalation.
-  # COMMENT: No writes possible
-  # "-a always,exit -F arch=b64 -F path=/etc/sudoers -F perm=wa -F key=special-config-changes"
-  # "-a always,exit -F arch=b64 -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes"
+    ## Attempts to Alter Process and Session Initiation Information
+    # "-a always,exit -F arch=b64 -F path=/var/run/utmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session"
+    # "-a always,exit -F arch=b64 -F path=/var/log/btmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session"
+    "-a always,exit -F arch=b64 -F path=/var/log/wtmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session"
 
-  ## Audit log access
-  "-a always,exit -F arch=b64 -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail"
+    ## Attempts to modify MAC controls
+    ## COMMENT: N/A
+    # "-a always,exit -F arch=b64 -F dir=/etc/selinux/ -F perm=wa -F auid>=1000 -F auid!=unset -F key=MAC-policy"
 
-  ## Attempts to Alter Process and Session Initiation Information
-  # "-a always,exit -F arch=b64 -F path=/var/run/utmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session"
-  # "-a always,exit -F arch=b64 -F path=/var/log/btmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session"
-  "-a always,exit -F arch=b64 -F path=/var/log/wtmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session"
+    ## Software updates. This is entirely handled by rpm.
+    ## System start and shutdown. This is entirely handled by systemd
+    ## Kernel Module loading. This is handled in 43-module-load.rules
+    ## Application invocation. The requirements list an optional requirement
+    ## FPT_SRP_EXT.1 Software Restriction Policies. This event is intended to
+    ## state results from that policy. This would be handled entirely by
+    ## that daemon.
+  ]
+)
+++ lib.optionals config.ghaf.security.audit.enableVerboseOspp (
+  [
+    ## 30-ospp-v42-1-create-success.rules
+    ## Successful file creation (open with O_CREAT)
+    "-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F a2&0100 -F success=1 -F auid!=unset -F key=successful-create"
 
-  ## Attempts to modify MAC controls
-  ## COMMENT: N/A
-  # "-a always,exit -F arch=b64 -F dir=/etc/selinux/ -F perm=wa -F auid>=1000 -F auid!=unset -F key=MAC-policy"
-
-  ## Software updates. This is entirely handled by rpm.
-  ## System start and shutdown. This is entirely handled by systemd
-  ## Kernel Module loading. This is handled in 43-module-load.rules
-  ## Application invocation. The requirements list an optional requirement
-  ## FPT_SRP_EXT.1 Software Restriction Policies. This event is intended to
-  ## state results from that policy. This would be handled entirely by
-  ## that daemon.
-]
-++ lib.optionals config.ghaf.security.audit.enableVerboseOspp [
-  ## 30-ospp-v42-3-access-success.rules
-  ## Successful file access (any other opens) This has to go last.
-  ## This are likely to result in a whole lot of events
-  "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access"
-]
+    ## 30-ospp-v42-3-access-success.rules
+    ## Successful file access (any other opens) This has to go last.
+    ## This are likely to result in a whole lot of events
+    "-a always,exit -F arch=b64 -S ${osppAccessSyscalls} -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access"
+  ]
+  ++ lib.optionals (!isAarch64) [
+    "-a always,exit -F arch=b64 -S open -F a1&0100 -F success=1 -F auid!=unset -F key=successful-create"
+    "-a always,exit -F arch=b64 -S creat -F success=1 -F auid!=unset -F key=successful-create"
+  ]
+)

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -93,6 +93,7 @@ in
     storagevm = {
       enable = true;
       name = vmName;
+      maximumSize = 20 * 1024;
       files = [
         "/etc/locale-givc.conf"
         "/etc/timezone.conf"


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This PR fixes two contributing issues in the default audit configuration. First, OSPP rules were not properly gated, so some of them were still applied by default when they should not have been. Second, the `successful-create` OSPP audit rules were too verbose and generated excessive log volume during `ota-update` (https://jira.tii.ae/browse/SSRCSP-8302), which contributed to the logging service exhausting available space (e.g., 180k+ audit log entries).

This PR resolves that by:

- properly gating the OSPP rules so they are not enabled by default
- moving the `successful-create` OSPP audit rules behind `enableVerboseOspp` - which already had `successful-access` rule. 
- increasing the admin-vm storage size to provide more space during OTA/update flows

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-8302
https://jira.tii.ae/browse/SSRCSP-8142

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
0. Requires full re-installation
1. Log in into any VM
2. Run `sudo auditctl -l`
3. The audit rules under `enableOspp` (https://github.com/everton-dematos/ghaf/blob/pr_audit_ospp/modules/common/security/audit/rules/common.nix#L249) should not be listed
4. Run the `ota-update` command from https://jira.tii.ae/browse/SSRCSP-8302, it should not generate errors on alloy.
