### PR TITLE
optimize(eval): make cross target packages lazy

### DIFF
--- a/targets/imx8mp-evk/flake-module.nix
+++ b/targets/imx8mp-evk/flake-module.nix
@@ -11,6 +11,14 @@
 let
   inherit (inputs) nixos-hardware;
   name = "nxp-imx8mp-evk";
+  lazyPackage =
+    name: drv:
+    (lib.lazyDerivation {
+      derivation = drv;
+    })
+    // {
+      inherit name;
+    };
   nxp-imx8mp-evk =
     variant: extraModules:
     let
@@ -94,7 +102,7 @@ let
       hostConfiguration = tgt.hostConfiguration.extendModules {
         modules = [ self.nixosModules.cross-compilation-from-x86_64 ];
       };
-      package = hostConfiguration.config.system.build.sdImage;
+      package = lazyPackage name hostConfiguration.config.system.build.sdImage;
     };
 
   crossTargets = map generate-cross-from-x86_64 targets;

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -12,6 +12,14 @@
 let
   inherit (inputs) jetpack-nixos;
   system = "aarch64-linux";
+  lazyPackage =
+    name: drv:
+    (lib.lazyDerivation {
+      derivation = drv;
+    })
+    // {
+      inherit name;
+    };
 
   # Unified Ghaf configuration builder
   ghaf-configuration = self.builders.mkGhafConfiguration {
@@ -160,7 +168,7 @@ let
       hostConfiguration = tgt.hostConfiguration.extendModules {
         modules = [ self.nixosModules.cross-compilation-from-x86_64 ];
       };
-      package = hostConfiguration.config.system.build.ghafImage;
+      package = lazyPackage name hostConfiguration.config.system.build.ghafImage;
     };
 
   # Add nodemoapps targets
@@ -180,16 +188,20 @@ in
         // builtins.listToAttrs (
           map (
             t:
-            lib.nameValuePair "${t.name}-flash-script" t.hostConfiguration.pkgs.nvidia-jetpack.legacyFlashScript
+            lib.nameValuePair "${t.name}-flash-script" (
+              lazyPackage "${t.name}-flash-script" t.hostConfiguration.pkgs.nvidia-jetpack.legacyFlashScript
+            )
           ) crossTargets
         )
         // builtins.listToAttrs (
           map (
             t:
-            lib.nameValuePair "${t.name}-flash-qspi"
-              (t.hostConfiguration.extendModules {
-                modules = [ { ghaf.hardware.nvidia.orin.flashScriptOverrides.onlyQSPI = true; } ];
-              }).pkgs.nvidia-jetpack.flashScript
+            lib.nameValuePair "${t.name}-flash-qspi" (
+              lazyPackage "${t.name}-flash-qspi"
+                (t.hostConfiguration.extendModules {
+                  modules = [ { ghaf.hardware.nvidia.orin.flashScriptOverrides.onlyQSPI = true; } ];
+                }).pkgs.nvidia-jetpack.flashScript
+            )
           ) crossTargets
         );
     };


### PR DESCRIPTION
`nix flake show` forces `packages.*.<name>.name` for every exported package. The cross outputs for i.MX8MP and Jetson Orin currently point directly at `system.build` image derivations and flash helpers, so showing the flake instantiates the full cross target `hostConfiguration` fixpoints.

Wrap those generated x86_64 cross image, flash-script, and flash-qspi exports with `lib.lazyDerivation` and restore the public `name` attribute on the wrapper. That keeps the existing package attribute paths and installable behavior intact, but delays construction of the backing derivation until something actually needs it.

This trims the evaluation cost of `nix flake show` without renaming or removing any package outputs. On a host with 32 CPUs and 62 GiB RAM, `nix flake show --no-eval-cache` dropped from 32.58 s / 10.80 GiB on `main` to 11.17 s / 4.07 GiB with this change.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [X] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [X] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
