### PR TITLE
fix(suspend): fix lid close suspend not resuming properly

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -303,8 +303,8 @@ in
         description = ''
           Whether to enable system suspension.
 
-            If disabled, the system will not respond to suspend requests, and all VMs with a
-            power management profile enabled are prohibited to perform any suspend action.
+          If disabled, the system will not respond to suspend requests, and all VMs with a
+          power management profile enabled are prohibited to perform any suspend action.
         '';
       };
 
@@ -323,6 +323,22 @@ in
           To check which modes are supported, run `cat /sys/power/mem_sleep`.
 
           More info: https://docs.kernel.org/admin-guide/pm/sleep-states.html
+        '';
+      };
+
+      extraSuspendCommands = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Additional shell commands to execute before the system suspends.
+        '';
+      };
+
+      extraResumeCommands = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Additional shell commands to execute after the system resumes from suspension.
         '';
       };
     };
@@ -451,18 +467,28 @@ in
       systemd.sleep.settings.Sleep = genericSleepConf;
 
       powerManagement = optionalAttrs cfg.vm.enable {
-        powerDownCommands = optionalString cfg.vm.pciSuspend (
-          concatMapStringsSep "\n" (service: ''
-            echo "Stopping service ${service}..."
-            systemctl stop ${service}
-          '') cfg.vm.pciSuspendServices
-        );
-        resumeCommands = optionalString cfg.vm.pciSuspend (
-          concatMapStringsSep "\n" (service: ''
-            echo "Starting service ${service}..."
-            systemctl start ${service}
-          '') cfg.vm.pciSuspendServices
-        );
+        powerDownCommands =
+          optionalString cfg.vm.pciSuspend (
+            concatMapStringsSep "\n" (service: ''
+              echo "Stopping service ${service}..."
+              systemctl stop ${service}
+            '') cfg.vm.pciSuspendServices
+          )
+          + optionalString (cfg.suspend.extraSuspendCommands != "") ''
+            # config.ghaf.services.power-manager.suspend.extraSuspendCommands
+            ${cfg.suspend.extraSuspendCommands}
+          '';
+        resumeCommands =
+          optionalString cfg.vm.pciSuspend (
+            concatMapStringsSep "\n" (service: ''
+              echo "Starting service ${service}..."
+              systemctl start ${service}
+            '') cfg.vm.pciSuspendServices
+          )
+          + optionalString (cfg.suspend.extraResumeCommands != "") ''
+            # config.ghaf.services.power-manager.suspend.extraResumeCommands
+            ${cfg.suspend.extraResumeCommands}
+          '';
       };
 
       systemd.services.systemd-suspend.serviceConfig = {
@@ -493,6 +519,9 @@ in
       powerManagement = {
         powerDownCommands = lib.mkBefore ''
           ${getExe ghaf-powercontrol} fake-turn-off-displays '*'
+
+          # config.ghaf.services.power-manager.suspend.extraSuspendCommands
+          ${cfg.suspend.extraSuspendCommands}
         '';
       };
 
@@ -535,12 +564,20 @@ in
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
-            ExecStop = "${getExe ghaf-powercontrol} fake-turn-on-displays '*'";
+            ExecStop =
+              let
+                resumeActions = pkgs.writeShellScriptBin "resume-actions" ''
+                  ${getExe ghaf-powercontrol} fake-turn-on-displays '*'
+
+                  # config.ghaf.services.power-manager.suspend.extraResumeCommands
+                  ${cfg.suspend.extraResumeCommands}
+                '';
+              in
+              getExe resumeActions;
           };
         };
       };
 
-      services.upower.ignoreLid = true;
       # Logind configuration for desktop
       services.logind.settings.Login =
         let
@@ -561,7 +598,6 @@ in
 
     # Host power management
     (mkIf cfg.host.enable {
-      services.upower.ignoreLid = true;
       # Host still handles power buttons in most situations
       services.logind.settings.Login = {
         HandleLidSwitch = mkDefault "ignore";

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -13,6 +13,7 @@ let
     mkOption
     types
     getExe
+    getExe'
     literalExpression
     ;
 
@@ -334,6 +335,18 @@ in
     fonts.packages = [
       pkgs.inter
     ];
+
+    ghaf.services.power-manager.suspend = {
+      # Stop and restart cosmic-idle to prevent double suspend after resume
+      # We stop the process first, then kill it after resuming from suspension
+      # This way we avoid race conditions
+      extraSuspendCommands = ''
+        kill -STOP $(${getExe' pkgs.procps "pidof"} cosmic-idle) || true
+      '';
+      extraResumeCommands = ''
+        kill $(${getExe' pkgs.procps "pidof"} cosmic-idle) || true
+      '';
+    };
 
     systemd.user.services = {
       autostart = {

--- a/packages/ghaf-powercontrol/package.nix
+++ b/packages/ghaf-powercontrol/package.nix
@@ -70,15 +70,6 @@ writeShellApplication {
       local display_name=''${2:-'*'}
       local uid
 
-      # Determine the UID of the user session to operate on
-      uid=$(loginctl list-sessions --json=short | jq -e '.[] | select(.seat != null) | .uid')
-      if [ -n "$uid" ]; then
-        echo "Using session UID: $uid"
-      else
-        echo "Error: Could not determine user session UID"
-        return 1
-      fi
-
       case "$action" in
         on|off)
           local cmd="wlopm --$action '$display_name'"
@@ -97,13 +88,19 @@ writeShellApplication {
 
       echo "Attempting to turn displays '$display_name' $action..."
 
-      # Try without setting WAYLAND_DISPLAY
-      if [ -n "$WAYLAND_DISPLAY" ]; then
-        # Try without setting WAYLAND_DISPLAY
-        if eval "$cmd"; then
-          echo "Displays turned $action successfully on wayland socket $WAYLAND_DISPLAY"
-          return 0
-        fi
+      # Optimistically try without setting WAYLAND_DISPLAY first
+      if eval "$cmd"; then
+        echo "Displays turned $action successfully"
+        return 0
+      fi
+
+      # Determine the UID of the user session to operate on
+      uid=$(loginctl list-sessions --json=short | jq -e '.[] | select(.seat != null) | .uid')
+      if [ -n "$uid" ]; then
+        echo "Using session UID: $uid"
+      else
+        echo "ERROR: Could not determine user session UID"
+        return 1
       fi
 
       echo "Searching for a valid Wayland socket..."


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Adjusted ghaf-powercontrol to first try the given command as-is before attempting to find the correct wayland socket to operate on

Added an action to kill cosmic-idle after resuming from suspend to prevent running idle actions after a longer suspension period

systemd 259.3 contains a bug in systemd-logind, which causes loginctl to not be able to fetch the current user seat/session properly This manifested in a stuck 0% backlight brightness on our systems due to ghaf-powercontrol having a mandatory loginctl check before the brightnessctl command is run

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

Fixes https://jira.tii.ae/browse/SSRCSP-8311

Upstream systemd issue and patch:
Issue - https://github.com/systemd/systemd/issues/41562
Patch - https://github.com/systemd/systemd/pull/41563

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify https://jira.tii.ae/browse/SSRCSP-8311 is fixed
