### PR TITLE
fix(sys-tray): hide waypipe apps to tray on window close

### DIFF
--- a/modules/reference/appvms/flatpak.nix
+++ b/modules/reference/appvms/flatpak.nix
@@ -37,6 +37,13 @@ let
 
       case "$action" in
         run)
+          # Ensure session D-Bus is available so apps can detect the SNI tray
+          # watcher (org.kde.StatusNotifierWatcher) and show tray-related settings.
+          # GIVC services run without a user session environment, so we derive
+          # the bus address from XDG_RUNTIME_DIR or fall back to UID 1000.
+          _uid=$(id -u)
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/''${_uid}/bus"
+          export XDG_RUNTIME_DIR="/run/user/''${_uid}"
           FLATPAK_APPS="/var/lib/flatpak/exports/share/applications"
           desktop_file=$(find "$FLATPAK_APPS" -name "$app.desktop" 2>/dev/null | head -n 1)
 


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Some of Flatpak apps (Telegram, signal,etc.) launched via GIVC do not have a user session environment.
As a result, `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR` are unset,
which prevents apps from discovering the SNI tray watcher
(`org.kde.StatusNotifierWatcher`) and showing system tray icons or
tray-related settings. Set `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR` in the `run` case
of `flatpak-manager` before launching the app
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1.1. Tray icons should appear from comms-vm (element-desktop) and flatpak-vm (discord, spotify, signal, etc.)
| App | Icon | Clicks (Left and/or Right) | Notes |
|-----|------|-------------|-------|
| [Flatpak]Discord | ✓ | ✓ | |
| [Flatpak]Zoom | ✓ | ✓ | |
| [Flatpak]Teams (portal) | ✓ | ✓ | |
| [comms]Element | ✓ | ✓ | |
| [Flatpak]Spotify | ✓ | ✓ | X closes the app. It is an [upstream issue](https://github.com/pop-os/cosmic-epoch/issues/3428) |
| [Flatpak]Telegram | ✓ | ✓ |Log in and "X" will not terminate the app |
| [Flatpak]Signal | ✓ | ✓ |Log in and enable "General -> Minimize to system tray" settings. Then "X" will not terminate the app|
