### PR TITLE
fix(intel-laptop): add store disk variants and fix PCI hotplug

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775055530,
-        "narHash": "sha256-DhnBTuGn8g7cAlEoesnyoFnS6MFfzpfhUteLgy1rFpo=",
+        "lastModified": 1777319010,
+        "narHash": "sha256-8NVTCQmY93KfnJDL+r7WpfXr3zqyl98YpJiVuQyqx78=",
         "owner": "tiiuae",
         "repo": "vhotplug",
-        "rev": "206a228d7804a2e9175ad15854d4d2c9ff69c213",
+        "rev": "c3474a98f251f6e7cdff4ba5030a755d4dd8c35c",
         "type": "github"
       },
       "original": {

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -154,6 +154,38 @@ let
     })
 
     (ghaf-configuration {
+      name = "intel-laptop-low-mem-storeDisk";
+      inherit system;
+      profile = "laptop-x86";
+      hardwareModule = self.nixosModules.hardware-intel-laptop;
+      variant = "debug";
+      extraModules = commonModules;
+      extraConfig = {
+        reference.profiles.mvp-user-trial.enable = true;
+        partitioning.disko.enable = true;
+        virtualization.microvm.storeOnDisk = true;
+      };
+      vmConfig = {
+        sysvms.guivm.mem = 6144;
+        appvms.flatpak.mem = 5120;
+      };
+    })
+
+    (ghaf-configuration {
+      name = "intel-laptop-storeDisk";
+      inherit system;
+      profile = "laptop-x86";
+      hardwareModule = self.nixosModules.hardware-intel-laptop;
+      variant = "debug";
+      extraModules = commonModules;
+      extraConfig = {
+        reference.profiles.mvp-user-trial.enable = true;
+        partitioning.disko.enable = true;
+        virtualization.microvm.storeOnDisk = true;
+      };
+    })
+
+    (ghaf-configuration {
       name = "lenovo-t14-amd-gen5";
       inherit system;
       profile = "laptop-x86";
@@ -409,6 +441,38 @@ let
       vmConfig = {
         sysvms.guivm.mem = 6144;
         appvms.flatpak.mem = 5120;
+      };
+    })
+
+    (ghaf-configuration {
+      name = "intel-laptop-low-mem-storeDisk";
+      inherit system;
+      profile = "laptop-x86";
+      hardwareModule = self.nixosModules.hardware-intel-laptop;
+      variant = "release";
+      extraModules = commonModules;
+      extraConfig = {
+        reference.profiles.mvp-user-trial.enable = true;
+        partitioning.disko.enable = true;
+        virtualization.microvm.storeOnDisk = true;
+      };
+      vmConfig = {
+        sysvms.guivm.mem = 6144;
+        appvms.flatpak.mem = 5120;
+      };
+    })
+
+    (ghaf-configuration {
+      name = "intel-laptop-storeDisk";
+      inherit system;
+      profile = "laptop-x86";
+      hardwareModule = self.nixosModules.hardware-intel-laptop;
+      variant = "release";
+      extraModules = commonModules;
+      extraConfig = {
+        reference.profiles.mvp-user-trial.enable = true;
+        partitioning.disko.enable = true;
+        virtualization.microvm.storeOnDisk = true;
       };
     })
 


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This adds intel-laptop configurations with store disk enabled and fixes a problem with PCI hotplug in audiovm.

### Type of Change
- [x] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-8335

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

- Build and test store disk variants of the intel-laptop configurations (e.g., intel-laptop-store-disk-debug) and make sure everything works fine.
- Test that sound work properly after suspend/resume cycle on system 76 when using the intel-laptop image. Details can be found in SSRCSP-8335.
