### PR TITLE
fix(flash-script): fix prebuilt bmap detection

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -20,23 +20,26 @@
           devshell = {
             name = "Ghaf devshell";
             meta.description = "Ghaf development environment";
-            packages = [
-              pkgs.jq
-              pkgs.nix-eval-jobs
-              pkgs.nix-fast-build
-              pkgs.nix-output-monitor
-              pkgs.nix-tree
-              pkgs.nixVersions.latest
-              pkgs.reuse
-              pkgs.prefetch-npm-deps
-              config.treefmt.build.wrapper
-              self'.legacyPackages.ghaf-build-helper
-              self'.legacyPackages.flash-script
-              self'.legacyPackages.update-docs-depends
-              pkgs.cachix
-            ]
-            ++ config.pre-commit.settings.enabledPackages
-            ++ lib.attrValues config.treefmt.build.programs; # make all the trefmt packages available
+            packages =
+              with pkgs;
+              [
+                bmaptool
+                cachix
+                config.treefmt.build.wrapper
+                jq
+                nix-eval-jobs
+                nix-fast-build
+                nix-output-monitor
+                nix-tree
+                nixVersions.latest
+                prefetch-npm-deps
+                reuse
+                self'.legacyPackages.flash-script
+                self'.legacyPackages.ghaf-build-helper
+                self'.legacyPackages.update-docs-depends
+              ]
+              ++ config.pre-commit.settings.enabledPackages
+              ++ lib.attrValues config.treefmt.build.programs; # make all the treefmt packages available
 
             startup.hook.text = config.pre-commit.installationScript;
           };

--- a/packages/pkgs-by-name/flash-script/flash.sh
+++ b/packages/pkgs-by-name/flash-script/flash.sh
@@ -204,13 +204,12 @@ dd_with_progress() {
 flash_zst_with_bmap() {
   wipe_device
   TEMP_DIR="$(mktemp -d -t ghaf-flash.XXXXXX)"
-  sparse_name="$(basename "$FILENAME")"
-  sparse_name="${sparse_name%.zst}.raw"
-  SPARSE_IMAGE="$TEMP_DIR/$sparse_name"
+  SPARSE_IMAGE="$(basename "$FILENAME")"
+  SPARSE_IMAGE="$TEMP_DIR/${SPARSE_IMAGE%%.*}.raw"
 
   echo "Preparing sparse image for faster flashing..."
   zstdcat "$FILENAME" | dd_with_progress of="$SPARSE_IMAGE" bs=32M conv=sparse,fsync iflag=fullblock status=none
-  PREBUILT_BMAP="${FILENAME%.zst}.bmap"
+  PREBUILT_BMAP="${FILENAME%%.*}.bmap"
   if [ -f "$PREBUILT_BMAP" ]; then
     SPARSE_BMAP="$PREBUILT_BMAP"
     echo "Using prebuilt block map: $SPARSE_BMAP"


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Minor fix to the flash script so it properly detects the prebuilt bmap when the name is formatted as `<name>.bmap`

Shaves off a few seconds of total flash time by skipping the block map generation

Other:
Added `bmaptool` to devshell by request

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify flash script still works as intended and now skips generating the block map if one is already available:
   ```sh
   sudo ghaf-flash -d /dev/sdX -i result/disk1.raw.zst -f
   ```
