### PR TITLE
fix(shutdown): fix backlight going to 0% on shutdown

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -525,7 +525,9 @@ in
           )
           + optionalString (cfg.suspend.extraSuspendCommands != "") ''
             # config.ghaf.services.power-manager.suspend.extraSuspendCommands
-            ${cfg.suspend.extraSuspendCommands}
+            if ! ${getExe' pkgs.systemd "systemctl"} list-jobs | grep -qE 'poweroff.target.*start|reboot.target.*start'; then
+              ${cfg.suspend.extraSuspendCommands}
+            fi
           '';
         resumeCommands =
           optionalString cfg.vm.pciSuspend (
@@ -566,12 +568,22 @@ in
 
       # Shutdown displays early before suspend
       powerManagement = {
-        powerDownCommands = lib.mkBefore ''
-          ${getExe ghaf-powercontrol} fake-turn-off-displays '*'
-
-          # config.ghaf.services.power-manager.suspend.extraSuspendCommands
-          ${cfg.suspend.extraSuspendCommands}
-        '';
+        powerDownCommands = lib.mkBefore (
+          ''
+            if ${getExe' pkgs.systemd "systemctl"} list-jobs | grep -qE 'poweroff.target.*start|reboot.target.*start'; then
+              _is_shutdown=0
+            else
+              _is_shutdown=1
+              ${getExe ghaf-powercontrol} fake-turn-off-displays '*'
+            fi
+          ''
+          + optionalString (cfg.suspend.extraSuspendCommands != "") ''
+            # config.ghaf.services.power-manager.suspend.extraSuspendCommands
+            if [ $_is_shutdown -ne 0 ]; then
+              ${cfg.suspend.extraSuspendCommands}
+            fi
+          ''
+        );
       };
 
       # Override systemd actions for suspend, poweroff, and reboot


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Adjusted gui-vm power config to turn down backlight brightness only during suspension
- Adjusted power manager config `extraSuspendCommands` option to run the commands only during suspension

Fixes an issue where backlight brightness would be set to the lowest possible value on every boot

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

Fixes https://jira.tii.ae/browse/SSRCSP-8347

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify https://jira.tii.ae/browse/SSRCSP-8347 is fixed
2. Verify backlight still turns off (gets set to 0% brightness) on suspend and restored on resume
