### PR TITLE
fix(logging): add journal service_name relabel fallbacks

### DIFF
--- a/modules/common/logging/client.nix
+++ b/modules/common/logging/client.nix
@@ -97,9 +97,37 @@ in
             source_labels = ["__journal__hostname"]
             target_label  = "host"
           }
+          // Populate service_name before Loki falls back to the journal source job.
+          // Later rules are more specific and override earlier fallback values.
+          rule {
+            source_labels = ["__journal__comm"]
+            target_label  = "service_name"
+            regex         = "(.+)"
+          }
+          rule {
+            source_labels = ["__journal_syslog_identifier"]
+            target_label  = "service_name"
+            regex         = "(.+)"
+          }
+          rule {
+            source_labels = ["__journal__systemd_user_unit"]
+            target_label  = "service_name"
+            regex         = "(.+)"
+          }
           rule {
             source_labels = ["__journal__systemd_unit"]
             target_label  = "service_name"
+            regex         = "(.+)"
+          }
+          rule {
+            source_labels = ["__journal_user_unit"]
+            target_label  = "service_name"
+            regex         = "(.+)"
+          }
+          rule {
+            source_labels = ["__journal_unit"]
+            target_label  = "service_name"
+            regex         = "(.+)"
           }
           rule {
             source_labels = ["__journal__transport"]

--- a/modules/common/logging/server.nix
+++ b/modules/common/logging/server.nix
@@ -198,9 +198,37 @@ in
               source_labels = ["__journal__hostname"]
               target_label  = "host"
             }
+            // Populate service_name before Loki falls back to the journal source job.
+            // Later rules are more specific and override earlier fallback values.
+            rule {
+              source_labels = ["__journal__comm"]
+              target_label  = "service_name"
+              regex         = "(.+)"
+            }
+            rule {
+              source_labels = ["__journal_syslog_identifier"]
+              target_label  = "service_name"
+              regex         = "(.+)"
+            }
+            rule {
+              source_labels = ["__journal__systemd_user_unit"]
+              target_label  = "service_name"
+              regex         = "(.+)"
+            }
             rule {
               source_labels = ["__journal__systemd_unit"]
               target_label  = "service_name"
+              regex         = "(.+)"
+            }
+            rule {
+              source_labels = ["__journal_user_unit"]
+              target_label  = "service_name"
+              regex         = "(.+)"
+            }
+            rule {
+              source_labels = ["__journal_unit"]
+              target_label  = "service_name"
+              regex         = "(.+)"
             }
             rule {
               source_labels = ["__journal__transport"]


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This PR improves `service_name` classification for Ghaf logs collected through Alloy/journald.

Previously, Alloy only mapped `__journal__systemd_unit` into `service_name`. When that field was missing, Loki fell back to the journal source job name, causing a large portion of logs to appear as `service_name=loki.source.journal.journal`. 

This PR updates both the logging client and server Alloy relabel rules to populate `service_name` from additional journald metadata fields, including `_COMM`, `SYSLOG_IDENTIFIER`, systemd user unit, systemd unit, user unit, and unit fields. 

In target testing, this improved classification for ~40k logs from boot, assigning them to more specific services instead of the generic `loki.source.journal.journal` label.

Note: this PR does not reduce the number of logs being generated. It improves visibility into which services are producing them, making it easier to identify the highest-volume sources and reduce noisy logging in follow-up work.


<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-8258
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Deploy this PR to a target and boot it.
2. Open Grafana logs.
3. Search for: `service_name="loki.source.journal.journal"`
4. Confirm this fallback label is much less frequent than before.
5. Filter by service_name and confirm logs are now split across more specific services.