### PR TITLE
feat(verity): Implement wrapper for signing UKI kernels

### DIFF
--- a/modules/partitioning/mk-manifest.py
+++ b/modules/partitioning/mk-manifest.py
@@ -1,43 +1,91 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+"""Examples:
+
+  Build manifest and rename artifacts:
+    mk-manifest.py build --version 1.0 --system x86_64-linux \
+      --hash-file dm-verity-root-hash --root-image root.raw.zst \
+      --verity-image verity.raw.zst --kernel-image kernel.efi \
+      --manifest out/system_@v_@u.manifest \
+      --root-unpacked-size 123 --verity-unpacked-size 456
+
+  Sign kernel, link root/verity, write output to a new directory:
+    mk-manifest.py sign -o signed out/system_1.0_deadbeef.manifest -- \
+      --private-key key.pem --certificate cert.pem
+
+  Recompute kernel hash/size in-place:
+    mk-manifest.py rehash out/system_1.0_deadbeef.manifest
+"""
+
 import argparse
 import hashlib
 import json
 import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
 
-parser = argparse.ArgumentParser(
-    description="Rename verity artifacts and generate manifest."
+parser = argparse.ArgumentParser(description="Manage verity manifest artifacts.")
+subparsers = parser.add_subparsers(dest="command", required=True)
+
+build_parser = subparsers.add_parser(
+    "build", help="Rename artifacts and generate manifest."
 )
-parser.add_argument(
+build_parser.add_argument(
     "--version", required=True, help="Version string for @v placeholder."
 )
-parser.add_argument(
+build_parser.add_argument(
     "--system", required=True, help="System identifier (e.g. x86_64-linux)."
 )
-parser.add_argument(
+build_parser.add_argument(
     "--hash-file", required=True, help="Path to dm-verity root hash file."
 )
-parser.add_argument(
+build_parser.add_argument(
     "--root-image", required=True, help="Path to compressed root image."
 )
-parser.add_argument(
+build_parser.add_argument(
     "--verity-image", required=True, help="Path to compressed verity image."
 )
-parser.add_argument("--kernel-image", required=True, help="Path to kernel/UKI image.")
-parser.add_argument("--manifest", required=True, help="Output manifest path template.")
-parser.add_argument(
+build_parser.add_argument(
+    "--kernel-image", required=True, help="Path to kernel/UKI image."
+)
+build_parser.add_argument(
+    "--manifest", required=True, help="Output manifest path template."
+)
+build_parser.add_argument(
     "--root-unpacked-size",
     type=int,
     required=True,
     help="Uncompressed root image size in bytes.",
 )
-parser.add_argument(
+build_parser.add_argument(
     "--verity-unpacked-size",
     type=int,
     required=True,
     help="Uncompressed verity image size in bytes.",
 )
+
+sign_parser = subparsers.add_parser(
+    "sign", help="Sign kernel and write updated manifest/artifacts to output directory."
+)
+sign_parser.add_argument("-o", "--output", required=True, help="Output directory.")
+sign_parser.add_argument(
+    "--copy", action="store_true", help="Copy root/verity instead of symlinks."
+)
+sign_parser.add_argument("--systemd-sbsign", help="Path to systemd-sbsign binary.")
+sign_parser.add_argument("manifest", help="Input .manifest file.")
+sign_parser.add_argument(
+    "sbsign_args",
+    nargs=argparse.REMAINDER,
+    help="Arguments passed to systemd-sbsign after '--'.",
+)
+
+rehash_parser = subparsers.add_parser(
+    "rehash", help="Recompute kernel hash/size and update manifest in-place."
+)
+rehash_parser.add_argument("manifest", help="Input .manifest file to update.")
 
 
 def fixname(filename: str, version: str, fragment: str) -> str:
@@ -65,10 +113,24 @@ def file_size(path: str) -> int:
     return os.path.getsize(path)
 
 
-def main() -> None:
-    args = parser.parse_args()
+def load_manifest(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
 
-    with open(args.hash_file, "r", encoding="utf-8") as f:
+
+def save_manifest_atomic(path: Path, manifest: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    ) as tmp:
+        json.dump(manifest, tmp, indent=2, sort_keys=True)
+        tmp.write("\n")
+        tmp_name = tmp.name
+    os.replace(tmp_name, path)
+
+
+def parse_root_hash(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
         first_line = f.readline().strip()
     if not first_line:
         raise ValueError("hash_file first line is empty")
@@ -80,7 +142,15 @@ def main() -> None:
         raise ValueError(
             "hash_file must contain at least 64 hex characters in first line"
         )
-    root_verity_hash = root_verity_hash[:64]
+    return root_verity_hash[:64]
+
+
+def resolve_artifact_path(manifest_path: Path, rel_name: str) -> Path:
+    return manifest_path.parent / rel_name
+
+
+def cmd_build(args: argparse.Namespace) -> None:
+    root_verity_hash = parse_root_hash(args.hash_file)
 
     storehash = root_verity_hash[:16]
 
@@ -112,11 +182,89 @@ def main() -> None:
             "unpacked_size": file_size(kernel),
         },
     }
-    with open(
-        fixname(args.manifest, args.version, storehash), "w", encoding="utf-8"
-    ) as file:
-        json.dump(manifest, file, indent=2, sort_keys=True)
-        file.write("\n")
+    save_manifest_atomic(
+        Path(fixname(args.manifest, args.version, storehash)), manifest
+    )
+
+
+def cmd_sign(args: argparse.Namespace) -> None:
+    manifest_path = Path(args.manifest).resolve()
+    manifest = load_manifest(manifest_path)
+
+    outdir = Path(args.output).resolve()
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    root_file = manifest.get("root", {}).get("file")
+    verity_file = manifest.get("verity", {}).get("file")
+    kernel_file = manifest.get("kernel", {}).get("file")
+    if not root_file or not verity_file or not kernel_file:
+        raise ValueError("manifest must contain root.file, verity.file and kernel.file")
+
+    src_root = resolve_artifact_path(manifest_path, root_file)
+    src_verity = resolve_artifact_path(manifest_path, verity_file)
+    src_kernel = resolve_artifact_path(manifest_path, kernel_file)
+    for path in (src_root, src_verity, src_kernel):
+        if not path.is_file():
+            raise FileNotFoundError(f"artifact not found: {path}")
+
+    dst_root = outdir / src_root.name
+    dst_verity = outdir / src_verity.name
+    dst_kernel = outdir / src_kernel.name
+
+    if args.copy:
+        shutil.copy2(src_root, dst_root)
+        shutil.copy2(src_verity, dst_verity)
+    else:
+        if dst_root.exists() or dst_root.is_symlink():
+            dst_root.unlink()
+        if dst_verity.exists() or dst_verity.is_symlink():
+            dst_verity.unlink()
+        dst_root.symlink_to(src_root)
+        dst_verity.symlink_to(src_verity)
+
+    with tempfile.NamedTemporaryFile(
+        mode="wb",
+        dir=outdir,
+        prefix=f".{dst_kernel.name}.",
+        suffix=".tmp",
+    ) as tmp:
+        tmp_kernel_path = Path(tmp.name)
+        shutil.copy2(src_kernel, tmp_kernel_path)
+        signer = args.systemd_sbsign if args.systemd_sbsign else "systemd-sbsign"
+        cmd = [signer, *args.sbsign_args, "-o", str(dst_kernel), str(tmp_kernel_path)]
+        subprocess.run(cmd, check=True)
+
+    manifest["kernel"]["sha256"] = sha256_file(str(dst_kernel))
+    manifest["kernel"]["unpacked_size"] = file_size(str(dst_kernel))
+    save_manifest_atomic(outdir / manifest_path.name, manifest)
+
+
+def cmd_rehash(args: argparse.Namespace) -> None:
+    manifest_path = Path(args.manifest).resolve()
+    manifest = load_manifest(manifest_path)
+    kernel_file = manifest.get("kernel", {}).get("file")
+    if not kernel_file:
+        raise ValueError("manifest.kernel.file is missing or empty")
+    kernel_path = resolve_artifact_path(manifest_path, kernel_file)
+    if not kernel_path.is_file():
+        raise FileNotFoundError(f"kernel image not found: {kernel_path}")
+    manifest["kernel"]["sha256"] = sha256_file(str(kernel_path))
+    manifest["kernel"]["unpacked_size"] = file_size(str(kernel_path))
+    save_manifest_atomic(manifest_path, manifest)
+
+
+def main() -> None:
+    args = parser.parse_args()
+    if getattr(args, "sbsign_args", None) and args.sbsign_args[0] == "--":
+        args.sbsign_args = args.sbsign_args[1:]
+    if args.command == "build":
+        cmd_build(args)
+    elif args.command == "sign":
+        cmd_sign(args)
+    elif args.command == "rehash":
+        cmd_rehash(args)
+    else:
+        raise ValueError(f"unknown command: {args.command}")
 
 
 if __name__ == "__main__":

--- a/modules/partitioning/mk-manifest.py
+++ b/modules/partitioning/mk-manifest.py
@@ -187,6 +187,24 @@ def cmd_build(args: argparse.Namespace) -> None:
     )
 
 
+def link_or_add_indirect_gcroot(src: Path, dst: Path) -> None:
+    if dst.exists() or dst.is_symlink():
+        dst.unlink()
+    if str(src).startswith("/nix/store/"):
+        src_resolved = src.resolve()
+        store_root = Path(*src_resolved.parts[:4])
+        gcroot = dst.parent / f".{dst.name}.gcroot"
+        if gcroot.exists() or gcroot.is_symlink():
+            gcroot.unlink()
+        subprocess.run(
+            ["nix-store", "--realise", "--add-root", str(gcroot), str(store_root)],
+            check=True,
+        )
+        dst.symlink_to(src_resolved)
+    else:
+        dst.symlink_to(src)
+
+
 def cmd_sign(args: argparse.Namespace) -> None:
     manifest_path = Path(args.manifest).resolve()
     manifest = load_manifest(manifest_path)
@@ -215,12 +233,8 @@ def cmd_sign(args: argparse.Namespace) -> None:
         shutil.copy2(src_root, dst_root)
         shutil.copy2(src_verity, dst_verity)
     else:
-        if dst_root.exists() or dst_root.is_symlink():
-            dst_root.unlink()
-        if dst_verity.exists() or dst_verity.is_symlink():
-            dst_verity.unlink()
-        dst_root.symlink_to(src_root)
-        dst_verity.symlink_to(src_verity)
+        link_or_add_indirect_gcroot(src_root, dst_root)
+        link_or_add_indirect_gcroot(src_verity, dst_verity)
 
     with tempfile.NamedTemporaryFile(
         mode="wb",

--- a/modules/partitioning/verity-volume.nix
+++ b/modules/partitioning/verity-volume.nix
@@ -103,6 +103,7 @@ in
 
           # Create artifacts and manifest.
           ${pkgs.buildPackages.python3}/bin/python ${./mk-manifest.py} \
+            build \
             --version ${version} \
             --system ${config.nixpkgs.hostPlatform.system} \
             --hash-file $out/dm-verity-root-hash \

--- a/modules/partitioning/verity-volume.nix
+++ b/modules/partitioning/verity-volume.nix
@@ -104,7 +104,7 @@ in
           # Replace the placeholder with the real roothash in the target .raw file
           verityRoothash=$(cat $out/dm-verity-root-hash)
 
-          # SAFETY: root hash later validated in mk-manifest.py
+          # SAFETY: root hash later validated in ghaf-mk-manifest
           test -n "$verityRoothash" || (echo "bad root hash" >&2 && exit 1)
 
           # Create UKI kernel with embedded verityhash
@@ -123,7 +123,7 @@ in
               --output ${kernelImage} ${kernelImage}
           ''}
 
-          # FIXME: move compression into mk-manifest.py and compute unpacked sizes there.
+          # FIXME: move compression into ghaf-mk-manifest and compute unpacked sizes there.
           rootUnpackedSize=$(stat -c%s ${fsImage})
           verityUnpackedSize=$(stat -c%s ${verityImage})
 
@@ -131,8 +131,7 @@ in
           ${lib.getExe pkgs.buildPackages.zstd} -T''${cores} --compress $out/*raw --rm
 
           # Create artifacts and manifest.
-          ${pkgs.buildPackages.python3}/bin/python ${./mk-manifest.py} \
-            build \
+          ${pkgs.buildPackages.ghaf-mk-manifest}/bin/ghaf-mk-manifest build \
             --version ${version} \
             --system ${config.nixpkgs.hostPlatform.system} \
             --hash-file $out/dm-verity-root-hash \

--- a/modules/partitioning/verity-volume.nix
+++ b/modules/partitioning/verity-volume.nix
@@ -81,7 +81,7 @@ in
           # Replace the placeholder with the real roothash in the target .raw file
           verityRoothash=$(cat $out/dm-verity-root-hash)
 
-          # SAFETY: root hash later validated in mk-manifest.py
+          # SAFETY: root hash later validated in ghaf-mk-manifest
           test -n "$verityRoothash" || (echo "bad root hash" >&2 && exit 1)
 
           # Create UKI kernel with embedded verityhash
@@ -93,7 +93,7 @@ in
           # ${kernelImage} don't work for some reasons, so move kernel in place
           mv kernel.efi ${kernelImage}
 
-          # FIXME: move compression into mk-manifest.py and compute unpacked sizes there.
+          # FIXME: move compression into ghaf-mk-manifest and compute unpacked sizes there.
           rootUnpackedSize=$(stat -c%s ${fsImage})
           verityUnpackedSize=$(stat -c%s ${verityImage})
 
@@ -102,8 +102,7 @@ in
           rm -f $out/*raw
 
           # Create artifacts and manifest.
-          ${pkgs.buildPackages.python3}/bin/python ${./mk-manifest.py} \
-            build \
+          ${pkgs.buildPackages.ghaf-mk-manifest}/bin/ghaf-mk-manifest build \
             --version ${version} \
             --system ${config.nixpkgs.hostPlatform.system} \
             --hash-file $out/dm-verity-root-hash \

--- a/modules/partitioning/verity-volume.nix
+++ b/modules/partitioning/verity-volume.nix
@@ -132,6 +132,7 @@ in
 
           # Create artifacts and manifest.
           ${pkgs.buildPackages.python3}/bin/python ${./mk-manifest.py} \
+            build \
             --version ${version} \
             --system ${config.nixpkgs.hostPlatform.system} \
             --hash-file $out/dm-verity-root-hash \

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -14,6 +14,7 @@
     {
       pkgs,
       lib,
+      self',
       ...
     }:
     let
@@ -23,6 +24,11 @@
       #use the pkgs-by-name-for-flake-parts to get the packages
       # exposed to downstream projects
       pkgsDirectory = ./pkgs-by-name;
+
+      apps.ghaf-mk-manifest = {
+        type = "app";
+        program = "${self'.packages.ghaf-mk-manifest}/bin/ghaf-mk-manifest";
+      };
 
       # Generate comprehensive documentation with enhanced module coverage
       packages.doc =

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -14,6 +14,7 @@
     {
       pkgs,
       lib,
+      self',
       ...
     }:
     let
@@ -23,6 +24,11 @@
       #use the pkgs-by-name-for-flake-parts to get the packages
       # exposed to downstream projects
       pkgsDirectory = ./pkgs-by-name;
+
+      apps.mk-manifest = {
+        type = "app";
+        program = "${self'.packages.ghaf-mk-manifest}/bin/ghaf-mk-manifest";
+      };
 
       # Generate comprehensive documentation with enhanced module coverage
       packages.doc =

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -15,6 +15,7 @@
     ghaf-build-helper = final.callPackage ./pkgs-by-name/ghaf-build-helper/package.nix { };
     ghaf-installer = final.callPackage ./pkgs-by-name/ghaf-installer/package.nix { };
     ghaf-intro = final.callPackage ./pkgs-by-name/ghaf-intro/package.nix { };
+    ghaf-mk-manifest = final.callPackage ./pkgs-by-name/ghaf-mk-manifest/package.nix { };
     ghaf-open = final.callPackage ./pkgs-by-name/ghaf-open/package.nix { };
     ghaf-powercontrol = final.callPackage ./ghaf-powercontrol/package.nix { };
     ghaf-qemu = final.callPackage ./pkgs-by-name/ghaf-qemu/package.nix { };

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -16,6 +16,7 @@
     ghaf-build-helper = final.callPackage ./pkgs-by-name/ghaf-build-helper/package.nix { };
     ghaf-installer = final.callPackage ./pkgs-by-name/ghaf-installer/package.nix { };
     ghaf-intro = final.callPackage ./pkgs-by-name/ghaf-intro/package.nix { };
+    ghaf-mk-manifest = final.callPackage ./pkgs-by-name/ghaf-mk-manifest/package.nix { };
     ghaf-open = final.callPackage ./pkgs-by-name/ghaf-open/package.nix { };
     ghaf-powercontrol = final.callPackage ./ghaf-powercontrol/package.nix { };
     ghaf-qemu = final.callPackage ./pkgs-by-name/ghaf-qemu/package.nix { };

--- a/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
+++ b/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
@@ -4,18 +4,18 @@
 """Examples:
 
   Build manifest and rename artifacts:
-    mk-manifest.py build --version 1.0 --system x86_64-linux \
+    ghaf-mk-manifest build --version 1.0 --system x86_64-linux \
       --hash-file dm-verity-root-hash --root-image root.raw.zst \
       --verity-image verity.raw.zst --kernel-image kernel.efi \
       --manifest out/system_@v_@u.manifest \
       --root-unpacked-size 123 --verity-unpacked-size 456
 
   Sign kernel, link root/verity, write output to a new directory:
-    mk-manifest.py sign -o signed out/system_1.0_deadbeef.manifest -- \
+    ghaf-mk-manifest sign -o signed out/system_1.0_deadbeef.manifest -- \
       --private-key key.pem --certificate cert.pem
 
   Recompute kernel hash/size in-place:
-    mk-manifest.py rehash out/system_1.0_deadbeef.manifest
+    ghaf-mk-manifest rehash out/system_1.0_deadbeef.manifest
 """
 
 import argparse

--- a/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
+++ b/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
@@ -250,7 +250,13 @@ def cmd_sign(args: argparse.Namespace) -> None:
         tmp_kernel_path = Path(tmp.name)
         shutil.copy2(src_kernel, tmp_kernel_path)
         signer = args.systemd_sbsign if args.systemd_sbsign else "systemd-sbsign"
-        cmd = [signer, *args.sbsign_args, "-o", str(dst_kernel), str(tmp_kernel_path)]
+        cmd = [
+            signer,
+            *args.sbsign_args,
+            "--output",
+            str(dst_kernel),
+            str(tmp_kernel_path),
+        ]
         subprocess.run(cmd, check=True)
 
     manifest["kernel"]["sha256"] = sha256_file(str(dst_kernel))

--- a/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
+++ b/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
@@ -26,6 +26,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Any, cast
 
 parser = argparse.ArgumentParser(description="Manage verity manifest artifacts.")
 subparsers = parser.add_subparsers(dest="command", required=True)
@@ -113,12 +114,12 @@ def file_size(path: str) -> int:
     return os.path.getsize(path)
 
 
-def load_manifest(path: Path) -> dict:
+def load_manifest(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
+        return cast(dict[str, Any], json.load(f))
 
 
-def save_manifest_atomic(path: Path, manifest: dict) -> None:
+def save_manifest_atomic(path: Path, manifest: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(
         "w", encoding="utf-8", dir=path.parent, delete=False

--- a/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
+++ b/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
@@ -25,6 +25,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import sys
 from pathlib import Path
 from typing import Any, cast
 
@@ -279,6 +280,9 @@ def cmd_rehash(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
+    if len(sys.argv) == 1:
+        parser.print_help()
+        return
     args = parser.parse_args()
     if getattr(args, "sbsign_args", None) and args.sbsign_args[0] == "--":
         args.sbsign_args = args.sbsign_args[1:]

--- a/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
+++ b/packages/pkgs-by-name/ghaf-mk-manifest/mk-manifest.py
@@ -231,6 +231,10 @@ def cmd_sign(args: argparse.Namespace) -> None:
     dst_kernel = outdir / src_kernel.name
 
     if args.copy:
+        if dst_root.exists() or dst_root.is_symlink():
+            dst_root.unlink()
+        if dst_verity.exists() or dst_verity.is_symlink():
+            dst_verity.unlink()
         shutil.copy2(src_root, dst_root)
         shutil.copy2(src_verity, dst_verity)
     else:

--- a/packages/pkgs-by-name/ghaf-mk-manifest/package.nix
+++ b/packages/pkgs-by-name/ghaf-mk-manifest/package.nix
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  runCommand,
+  python3,
+  python3Packages,
+}:
+runCommand "ghaf-mk-manifest"
+  {
+    src = ./mk-manifest.py;
+    nativeBuildInputs = [
+      python3
+      python3Packages.mypy
+    ];
+  }
+  ''
+    mypy "$src"
+
+    install -Dm755 "$src" "$out/bin/ghaf-mk-manifest"
+    patchShebangs "$out/bin/ghaf-mk-manifest"
+  ''

--- a/packages/pkgs-by-name/ghaf-mk-manifest/package.nix
+++ b/packages/pkgs-by-name/ghaf-mk-manifest/package.nix
@@ -14,7 +14,7 @@ runCommand "ghaf-mk-manifest"
     ];
   }
   ''
-    mypy "$src"
+    mypy --strict "$src"
 
     install -Dm755 "$src" "$out/bin/ghaf-mk-manifest"
     patchShebangs "$out/bin/ghaf-mk-manifest"


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Enhance mk-manifest to include thin wrapper for systemd-sbsign and/or recalculate manifest hashes after signing

Need integration into CI/CD pipeline.
`nix run .#ghaf-mk-manifest sign -o ./signed  ./result/ghaf-....manifest` for `...-sysupdate` outputs

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

This PR have only build toolchain improvement, not user visible changes
`nix run .#ghaf-mk-manifest -- sign --help`

