### PR TITLE
fix(power): fix long shutdown

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -516,19 +516,20 @@ in
       systemd.sleep.settings.Sleep = genericSleepConf;
 
       powerManagement = optionalAttrs cfg.vm.enable {
-        powerDownCommands =
-          optionalString cfg.vm.pciSuspend (
-            concatMapStringsSep "\n" (service: ''
+        powerDownCommands = optionalString cfg.vm.pciSuspend ''
+          if ! ${getExe' pkgs.systemd "systemctl"} list-jobs | grep -qE 'poweroff.target.*start|reboot.target.*start'; then
+            echo "Stopping configured suspend services..."
+            ${concatMapStringsSep "\n" (service: ''
               echo "Stopping service ${service}..."
               systemctl stop ${service}
-            '') cfg.vm.pciSuspendServices
-          )
-          + optionalString (cfg.suspend.extraSuspendCommands != "") ''
-            # config.ghaf.services.power-manager.suspend.extraSuspendCommands
-            if ! ${getExe' pkgs.systemd "systemctl"} list-jobs | grep -qE 'poweroff.target.*start|reboot.target.*start'; then
+            '') cfg.vm.pciSuspendServices}
+            ${optionalString (cfg.suspend.extraSuspendCommands != "") ''
+              # config.ghaf.services.power-manager.suspend.extraSuspendCommands
+              echo "Executing configured extra suspend commands..."
               ${cfg.suspend.extraSuspendCommands}
-            fi
-          '';
+            ''}
+          fi
+        '';
         resumeCommands =
           optionalString cfg.vm.pciSuspend (
             concatMapStringsSep "\n" (service: ''


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Fix long shutdown/reboot caused by audio vm timeout:**
   audio-vm was timing out when shutdown was requested due to `pipewire.socket `failing to stop in the configured timeout of 30s
   
   This was likely caused by a systemd service teardown ordering issue - we manually set some `powerDownCommands` for system VMs such as audio-vm and net-vm, that involve stopping certain services.
   It seems that `pipewire.socket` was not quite ready to be stopped cleanly at the time we requested it to, causing a long wait/timeout. 
   
   The problem with our `powerDownCommands` assignments is that the commands are executed on suspend (good) **AND** on shutdown (bad).
   This patch addresses this behavior - the system VM specific `powerDownCommands` will be run only on suspend, while shutdown will be managed entirely by systemd itself and its' default service dependencies.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

Fixes https://jira.tii.ae/browse/SSRCSP-8341

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify https://jira.tii.ae/browse/SSRCSP-8341 is fixed
