### PR TITLE
fix(dell-latitude-7330): resolve black screen on boot

### DIFF
--- a/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330.nix
+++ b/modules/reference/hardware/dell-latitude/definitions/dell-latitude-7330.nix
@@ -9,14 +9,22 @@
 
   # Host configuration
   host = {
-    kernelConfig.kernelParams = [
-      "intel_iommu=on,sm_on"
-      "iommu=pt"
-      "acpi_backlight=vendor"
-      "acpi_osi=linux"
-      #"module_blacklist=e1000e,i2c_i801,i915,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,spi_intel_pci"
-      "module_blacklist=bluetooth,btusb"
-    ];
+    kernelConfig = {
+      kernelParams = [
+        "intel_iommu=on,sm_on"
+        "iommu=pt"
+        "acpi_backlight=vendor"
+        "acpi_osi=linux"
+        #"module_blacklist=e1000e,i2c_i801,i915,iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,spi_intel_pci"
+        "module_blacklist=bluetooth,btusb"
+      ];
+      stage1.kernelModules = [
+        # Load i915 in the host initrd as a hardware workaround: some laptop models
+        # need the host to initialize the display pipeline early, otherwise the GUI VM
+        # may boot with a broken or non-functional screen.
+        "i915"
+      ];
+    };
   };
 
   # Input devices

--- a/modules/reference/hardware/intel-laptop/extra-config-host.nix
+++ b/modules/reference/hardware/intel-laptop/extra-config-host.nix
@@ -9,4 +9,7 @@
     mode = lib.mkDefault "auto";
     s2idleModels = [ "System76 Darter Pro" ];
   };
+
+  # Add system76 and system76-io kernel modules to host
+  hardware.system76.kernel-modules.enable = true;
 }


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This is a workaround to fix the black screen issue on the rugged laptop by preloading the i915 driver on the host before passing the GPU to the GUIVM allowing the screen to initialize correctly.

Also, System76 drivers are enabled in the intel-laptop target. They are used to create System76-specific devices such as hwmon fan control, keyboard backlight, ACPI hotkeys, etc. They do not seem to be currently used in Ghaf but may become useful in the future.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-8268

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

Build and run dell-latitude-7330 image and make sure it boots correctly.
