### PR TITLE
feat(balloon): Update ghaf-mem-manager, add qemu mux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -274,15 +274,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1775822544,
-        "narHash": "sha256-yxh8N8kPWNVPl4x2C72yR6nTDT8qBMZvCCB3twNEiJI=",
-        "owner": "tiiuae",
+        "lastModified": 1778068300,
+        "narHash": "sha256-g4Gssa/WoOuOEeIEjXlkRt19INY8sR7xISDo/j+WdCc=",
+        "owner": "slakkala",
         "repo": "ghafpkgs",
-        "rev": "62beb072731b0e9a356766b21abcee24562fd4a0",
+        "rev": "02b2f3540665c4904d76298e4d38fc0b368aaf33",
         "type": "github"
       },
       "original": {
-        "owner": "tiiuae",
+        "owner": "slakkala",
+        "ref": "feat/mem-manager-mplex-oom",
         "repo": "ghafpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
 
     # A set of useful nix packages and utilities for ghaf
     ghafpkgs = {
-      url = "github:tiiuae/ghafpkgs";
+      url = "github:slakkala/ghafpkgs/feat/mem-manager-mplex-oom";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/modules/hardware/passthrough/vhotplug.nix
+++ b/modules/hardware/passthrough/vhotplug.nix
@@ -20,13 +20,18 @@ let
     vmName: vmParams:
     let
       vmConfig = lib.ghaf.vm.getConfig vmParams;
+      vmType = if vmConfig != null then vmConfig.microvm.hypervisor else "qemu";
     in
     {
       name = vmName;
-      type = if vmConfig != null then vmConfig.microvm.hypervisor else "qemu";
-      socket = "${config.microvm.stateDir}/${vmName}/${
-        if vmConfig != null then vmConfig.microvm.socket else "microvm.sock"
-      }";
+      type = vmType;
+      socket =
+        if vmType == "qemu" then
+          "${config.microvm.stateDir}/${vmName}/${vmName}.mux"
+        else
+          "${config.microvm.stateDir}/${vmName}/${
+            if vmConfig != null then vmConfig.microvm.socket else "microvm.sock"
+          }";
     }
   ) config.microvm.vms;
 in

--- a/modules/microvm/host/mem-manager.nix
+++ b/modules/microvm/host/mem-manager.nix
@@ -21,6 +21,8 @@ in
 {
   _file = ./mem-manager.nix;
 
+  services.dbus.packages = [ pkgs.ghaf-mem-manager ];
+
   systemd.services =
     builtins.foldl'
       (
@@ -37,20 +39,51 @@ in
           lib.optionalAttrs (appvmConfig != null) {
             "ghaf-mem-manager-${name}" = {
               description = "Manage MicroVM '${name}' memory levels";
-              after = [ "microvm@${name}.service" ];
-              requires = [ "microvm@${name}.service" ];
+              after = [
+                "dbus.service"
+                "ghaf-mem-manager.service"
+                "ghaf-qemu-mplex-${name}.service"
+                "microvm@${name}.service"
+              ];
+              requires = [
+                "dbus.service"
+                "ghaf-mem-manager.service"
+                "ghaf-qemu-mplex-${name}.service"
+                "microvm@${name}.service"
+              ];
               serviceConfig = {
-                Type = "simple";
-                WorkingDirectory = "${config.microvm.stateDir}/${name}";
-                ExecStart = "${pkgs.ghaf-mem-manager}/bin/ghaf-mem-manager -s ${name}.sock -m ${
-                  toString (appvmConfig.mem * 1024 * 1024)
-                } -M ${toString (microvmConfig.mem * 1024 * 1024)}";
+                Type = "oneshot";
+                ExecStart = ''
+                  ${lib.getExe' pkgs.systemd "busctl"} --system call \
+                    ae.tii.MemManager \
+                    / \
+                    ae.tii.MemManager \
+                    AttachVm \
+                    stt \
+                    ${config.microvm.stateDir}/${name}/${name}.mux \
+                    ${toString (appvmConfig.mem * 1024 * 1024)} \
+                    ${toString (microvmConfig.mem * 1024 * 1024)}
+                '';
               };
             };
           }
         )
       )
       {
+        ghaf-mem-manager = {
+          description = "Ghaf memory manager daemon";
+          after = [ "dbus.service" ];
+          wants = [ "dbus.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "simple";
+            ExecStart = "${pkgs.ghaf-mem-manager}/bin/ghaf-mem-managerd";
+            Restart = "on-failure";
+            RestartSec = "1s";
+            Environment = [ "RUST_LOG=trace" ];
+          };
+        };
+
         balloon-manager =
           let
             balloonvmnames = map (name: "ghaf-mem-manager-" + name + ".service") balloonvms;

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -33,6 +33,7 @@ let
   hasAudioVmAcpiPath =
     (lib.hasAttr "audio-vm" config.microvm.vms)
     && (config.ghaf.hardware.definition.audio.acpiPath != null);
+  microvmNames = lib.attrNames config.microvm.vms;
 in
 {
   _file = ./microvm-host.nix;
@@ -213,7 +214,42 @@ in
                 Restart = "on-abnormal";
               };
             }
-          ) { } (lib.attrNames config.microvm.vms);
+          ) { } microvmNames;
+
+          qemuMplexServices = lib.foldl' (
+            result: name:
+            let
+              vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${name};
+              vmHypervisor = if vmConfig != null then (vmConfig.microvm.hypervisor or "qemu") else "qemu";
+              qemuSocketPath = "${config.microvm.stateDir}/${name}/${
+                if vmConfig != null then vmConfig.microvm.socket else "microvm.sock"
+              }";
+              muxSocketPath = "${config.microvm.stateDir}/${name}/${name}.mux";
+            in
+            result
+            // lib.optionalAttrs (vmHypervisor == "qemu") {
+              "ghaf-qemu-mplex-${name}" = {
+                description = "QEMU QMP mux for ${name}";
+                wantedBy = [ "microvms.target" ];
+                requires = [ "install-microvm-${name}.service" ];
+                after = [
+                  "local-fs.target"
+                  "install-microvm-${name}.service"
+                ];
+                before = [ "microvm@${name}.service" ];
+                serviceConfig = {
+                  Type = "notify";
+                  User = "microvm";
+                  Group = "kvm";
+                  Restart = "always";
+                  RestartSec = "1";
+                  ExecStart = "${lib.getExe pkgs.ghaf-qemu-mplex} ${qemuSocketPath} ${muxSocketPath}";
+                  Environment = [ "RUST_LOG=debug" ];
+                };
+                startLimitIntervalSec = 0;
+              };
+            }
+          ) { } microvmNames;
 
           vmsWithEncryptedStorage = lib.filterAttrs (
             _name: vm:
@@ -281,6 +317,7 @@ in
           # Device-id and machine-id generation moved to ghaf.identity.dynamicHostName module
         }
         // patchedMicrovmServices
+        // qemuMplexServices
         // vmstorageSetupServices;
     })
     (mkIf cfg.sharedVmDirectory.enable {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Update ghaf-mem-manager and add a QEMU socket multiplexer to monitor and react to VM balloon change events.

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

[SSRCSP-7264](https://jira.tii.ae/browse/SSRCSP-7264)

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
1. cause memory load on different VMs
2. observe VM memory sizes change
