### PR TITLE
fix(audit): keep audit records out of journald text

### DIFF
--- a/modules/common/security/apparmor/default.nix
+++ b/modules/common/security/apparmor/default.nix
@@ -26,6 +26,13 @@ in
   config = lib.mkIf cfg.enable {
     security.apparmor.enable = true;
     security.apparmor.killUnconfinedConfinables = lib.mkDefault true;
+    # Keep AppArmor before BPF in the generated lsm= kernel parameter.
+    security.lsm = lib.mkForce [
+      "landlock"
+      "yama"
+      "apparmor"
+      "bpf"
+    ];
     services.dbus.apparmor = "enabled";
   };
 }

--- a/modules/common/security/audit/default.nix
+++ b/modules/common/security/audit/default.nix
@@ -103,6 +103,12 @@ in
     ];
 
     systemd = {
+      # Keep audit records in auditd's log file only and do not duplicate them into journald.
+      sockets.systemd-journald-audit = {
+        enable = false;
+        wantedBy = lib.mkForce [ ];
+      };
+
       services.audit-rules-nixos = {
         serviceConfig.ExecStart =
           let


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
This PR reduces audit log noise in the remote logging pipeline while preserving local audit visibility. Specifically, this PR does two things:

- Keeps audit records out of `journald`, so they are no longer forwarded to Grafana through the journal path. In test scenarios, we were seeing around 120k audit log lines in Grafana over a 30-minute period. The full audit trail remains stored under `/var/log/audit/` and reachable with tools such as `ausearch`.

- Fixes the LSM ordering so AppArmor is placed before BPF. With BPF ordered first, AppArmor could fail to provide the expected subject context to audit, causing `audit: error in audit_log_subj_ctx` messages.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets
https://jira.tii.ae/browse/SSRCSP-8142
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Audit logs should not appear on Grafana. They should still be visible on the device.
2. At any VM, run the following command:
2.1.  `sudo ausearch -ts recent -i --just-one`
3. You should expect to see something like this:
```
[ghaf@gui-vm:~]$ sudo ausearch -ts recent -i --just-one
----
node=gui-vm type=PROCTITLE msg=audit(05/07/2026 14:54:01.910:2500) : proctitle=(systemd) 
node=gui-vm type=PATH msg=audit(05/07/2026 14:54:01.910:2500) : item=0 name=/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/background.slice inode=10536 dev=00:16 mode=dir,755 ouid=asd ogid=asd rdev=00:00 nametype=NORMAL cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0 
node=gui-vm type=CWD msg=audit(05/07/2026 14:54:01.910:2500) : cwd=/ 
node=gui-vm type=SYSCALL msg=audit(05/07/2026 14:54:01.910:2500) : arch=x86_64 syscall=removexattr success=no exit=ENODATA(No data available) a0=0x562e4c337280 a1=0x7fbfc6a0ec2f a2=0x0 a3=0x0 items=1 ppid=1 pid=2374 auid=asd uid=asd gid=asd euid=asd suid=asd fsuid=asd egid=asd sgid=asd fsgid=asd tty=(none) ses=4 comm=systemd exe=/nix/store/d4w8dn7zscp1gykdrxrrcdwjn80lbck6-guivm-systemd-259.3/lib/systemd/systemd key=perm_mod 
```
4. When searching on Grafana, you should **not** see any line related to the audit rule terms (i.e., `PROCTITLE`, `PATH`, `CWD`, `SYSCALL`, `perm_mod` - the key from the rule from the previous `ausearch` command).