### PR TITLE
fix(audio-applet): fix audio applet not working after resume

### DIFF
--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -335,6 +335,13 @@ in
       pkgs.inter
     ];
 
+    ghaf.services.power-manager.suspend.extraResumeCommands =
+      # Workaround for https://github.com/pop-os/cosmic-applets/issues/1390
+      # TODO: Remove when upstream issue is fixed
+      ''
+        ${lib.getExe' pkgs.busybox "killall"} -q cosmic-panel || true
+      '';
+
     systemd.user.services = {
       autostart = {
         description = "Ghaf autostart";
@@ -439,6 +446,9 @@ in
       after = [ "cosmic-session.target" ];
       wantedBy = [ "cosmic-session.target" ];
     };
+
+    # TODO: Remove when https://github.com/systemd/systemd/pull/41563 is available
+    systemd.services.systemd-logind.serviceConfig.watchdogSec = lib.mkForce 0;
 
     # Below we adjust the default services from desktopManager.cosmic
 


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Restart cosmic-panel on resume in order to restart cosmic-applet-audio**
   - Added a resume action to cosmic config to restart cosmic-applet-audio
     This fixes an issue where cosmic-applet-audio fails to reconnect to pipewire after suspend/resume cycle, which kills the pipewire socket and service

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify audio applet is usable after a suspend/resume cycle
