### PR TITLE
fix(qemu): use host clock for lid polling

### DIFF
--- a/packages/pkgs-by-name/ghaf-qemu/patches/0004-hw-acpi-Introduce-the-QEMU-lid-button.patch
+++ b/packages/pkgs-by-name/ghaf-qemu/patches/0004-hw-acpi-Introduce-the-QEMU-lid-button.patch
@@ -430,16 +430,16 @@ index 0000000000..dfe86af713
 +        Object *obj = object_resolve_path_type("", TYPE_ACPI_DEVICE_IF, NULL);
 +        acpi_send_event(DEVICE(obj), ACPI_BUTTON_CHANGE_STATUS);
 +    }
-+    timer_mod(s->probe_state_timer, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) +
++    timer_mod(s->probe_state_timer, qemu_clock_get_ms(QEMU_CLOCK_HOST) +
 +              s->probe_state_interval);
 +}
 +
 +static void button_probe_state_timer_init(BUTTONState *s)
 +{
 +    if (s->enable_procfs && s->probe_state_interval > 0) {
-+        s->probe_state_timer = timer_new_ms(QEMU_CLOCK_VIRTUAL,
++        s->probe_state_timer = timer_new_ms(QEMU_CLOCK_HOST,
 +                                            button_probe_state, s);
-+        timer_mod(s->probe_state_timer, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) +
++        timer_mod(s->probe_state_timer, qemu_clock_get_ms(QEMU_CLOCK_HOST) +
 +                  s->probe_state_interval);
 +    }
 +}


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

The QEMU lid button polls host procfs state to mirror the physical lid into gui-vm. Using `QEMU_CLOCK_VIRTUAL` can delay the poll after host s2idle resume, leaving gui-vm with a stale closed lid state long enough for logind to trigger another suspend.

Use `QEMU_CLOCK_HOST` so the poll timer follows host elapsed time and expires promptly after the QEMU process is thawed.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

Fixes https://jira.tii.ae/browse/SSRCSP-8402

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. With the patched build, close the lid, then open it after the laptop suspends.
2. After lid is opened, the host resumes and stays awake.