### PR TITLE
fix(power): fix double suspend on lid close

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -200,6 +200,66 @@ let
     '';
   };
 
+  gui-vm-suspend = pkgs.writeShellApplication {
+    name = "gui-vm-suspend";
+    runtimeInputs = [
+      pkgs.systemd
+      pkgs.coreutils
+      pkgs.gawk
+    ];
+    text = ''
+      restart_logind() {
+        systemctl restart systemd-logind
+        sleep 0.3
+        local job_ids
+        job_ids=$(systemctl list-jobs --no-legend \
+          | awk '$2 == "sleep.target" || $2 == "suspend.target" || $2 == "systemd-suspend.service" { print $1 }' \
+          | tr '\n' ' ')
+        for id in $job_ids; do
+          systemctl cancel "$id" && echo "Cancelled suspend job ID $id" || true
+        done
+      }
+
+      is_lid_open() {
+        local state
+        state=$(busctl get-property "org.freedesktop.login1" "/org/freedesktop/login1" \
+          "org.freedesktop.login1.Manager" "LidClosed" | \
+              awk 'NR == 1 { print $2 == "true" ? "closed" : "open" }')
+        echo "Lid state: $state"
+        [ "$state" == "open" ]
+      }
+
+      wait_for_lid_open() {
+        is_lid_open && return 0
+
+        echo "Waiting up to 5 seconds for lid to open..."
+        local deadline=$(( SECONDS + 5 ))
+        while (( SECONDS < deadline )); do
+          sleep 0.5
+          if is_lid_open; then
+            echo "Lid opened, proceeding with resume"
+            return 0
+          fi
+        done
+
+        echo "Lid still closed after 5 seconds, attempting to restart logind..."
+        restart_logind
+        if is_lid_open; then
+          echo "Lid opened after logind restart"
+          return 0
+        fi
+        echo "Lid still closed after logind restart, proceeding with resume anyway"
+      }
+
+      echo "Forwarding suspension to host..."
+      ${givc-cli} suspend
+
+      echo "Host resumed from suspension"
+
+      wait_for_lid_open
+    '';
+  };
+
   guest-power-actions = pkgs.writeShellApplication {
     name = "guest-power-actions";
     runtimeInputs = [
@@ -588,57 +648,63 @@ in
       };
 
       # Override systemd actions for suspend, poweroff, and reboot
-      systemd.services = optionalAttrs (cfg.vm.enable && useGivc) {
-        # Replace systemd-sleep with GIVC suspend
-        systemd-suspend.serviceConfig.ExecStart = [
-          ""
-          "${givc-cli} suspend"
-        ];
+      systemd.services =
+        optionalAttrs (cfg.vm.enable && useGivc) {
+          systemd-suspend.serviceConfig.ExecStart = [
+            ""
+            "${getExe gui-vm-suspend}"
+          ];
 
-        # Intercept reboot or poweroff actions and relay it to the host
-        gui-shutdown-interceptor = {
-          description = "Ghaf GUI shutdown interceptor";
-          wantedBy = [
-            "shutdown.target"
-          ];
-          before = [
-            "shutdown.target"
-          ];
-          unitConfig.DefaultDependencies = false;
-          serviceConfig = {
-            Type = "oneshot";
-            ExecStart = "${getExe guest-shutdown-interceptor}";
+          # Intercept reboot or poweroff actions and relay it to the host
+          gui-shutdown-interceptor = {
+            description = "Ghaf GUI Shutdown Interceptor";
+            wantedBy = [
+              "shutdown.target"
+            ];
+            before = [
+              "shutdown.target"
+            ];
+            unitConfig.DefaultDependencies = false;
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = "${getExe guest-shutdown-interceptor}";
+            };
           };
+
+          resume-actions = {
+            description = "Resume Actions";
+            wantedBy = [
+              "sleep.target"
+            ];
+            before = [
+              "sleep.target"
+            ];
+            unitConfig = {
+              DefaultDependencies = false;
+              StopWhenUnneeded = true;
+            };
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStop =
+                let
+                  resumeActions = pkgs.writeShellScriptBin "resume-actions" ''
+                    ${getExe ghaf-powercontrol} fake-turn-on-displays '*'
+
+                    # config.ghaf.services.power-manager.suspend.extraResumeCommands
+                    ${cfg.suspend.extraResumeCommands}
+                  '';
+                in
+                getExe resumeActions;
+            };
+          };
+        }
+        // {
+          # Ensure systemd-logind never crashes during suspension
+          # Ref. https://github.com/systemd/systemd/issues/41562
+          # TODO: Remove when fixed
+          systemd-logind.serviceConfig.WatchdogSec = lib.mkForce 0;
         };
-
-        resume-actions = {
-          description = "Resume Actions";
-          wantedBy = [
-            "sleep.target"
-          ];
-          before = [
-            "sleep.target"
-          ];
-          unitConfig = {
-            DefaultDependencies = false;
-            StopWhenUnneeded = true;
-          };
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            ExecStop =
-              let
-                resumeActions = pkgs.writeShellScriptBin "resume-actions" ''
-                  ${getExe ghaf-powercontrol} fake-turn-on-displays '*'
-
-                  # config.ghaf.services.power-manager.suspend.extraResumeCommands
-                  ${cfg.suspend.extraResumeCommands}
-                '';
-              in
-              getExe resumeActions;
-          };
-        };
-      };
 
       # Logind configuration for desktop
       services.logind.settings.Login =


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

**Adjusted gui-vm suspend behavior:**
   - After calling `givc-cli suspend`, gui-vm's `systemd-suspend.service` will now wait for logind to report lid state as "open" for up to 5 seconds
   - After 5 seconds, if the lid state is still "closed" according to logind, `systemd-logind` will be restarted.
     This is quite drastic and may need to be adjusted to limit the time to 2-3 seconds instead

These changes prevent `systemd-logind` from queuing another suspend right after the lid is opened but `logind` has not yet detected a SW_LID event from the host

On systems with no lid device (desktop targets), logind should technically report the lid state as "open" at all times, so none of these checks should be hit during resume. This is not tested. 

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

May be an alternative/follow-up to #1938

Fixes https://jira.tii.ae/browse/SSRCSP-8402

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify system does not double suspend (https://jira.tii.ae/browse/SSRCSP-8402)
   - It's important to note that suspension may behave differently depending on the duration - short (2-5 min) and long (15+ min) suspensions should be tested separately
2. (Optional) observe `journalctl -f -u systemd-suspend.service` output in gui-vm during/after suspension
