### PR TITLE
feat(ci/rebuild): add nvd diff print to ghaf-rebuild

### DIFF
--- a/modules/development/debug-tools.nix
+++ b/modules/development/debug-tools.nix
@@ -43,6 +43,9 @@ in
 
       # For debug complicated issues
       pkgs.strace
+
+      # For comparing NixOS system closure differences between generations
+      pkgs.nvd
     ]
     ++ rmDesktopEntries [
       pkgs.htop

--- a/packages/pkgs-by-name/ghaf-build-helper/package.nix
+++ b/packages/pkgs-by-name/ghaf-build-helper/package.nix
@@ -97,7 +97,30 @@ writeShellApplication {
         done
 
         export NIX_SSHOPTS
+
+        # Capture the current system path on the target before rebuild for diffing
+        old_system=""
+        # shellcheck disable=SC2086
+        old_system=$(ssh $NIX_SSHOPTS root@ghaf-host readlink -f /nix/var/nix/profiles/system 2>/dev/null || true)
+
         nixos-rebuild --flake "$build_target" --target-host root@ghaf-host --no-reexec "''${args[@]}"
+
+        # Show package diff between old and new system closure
+        if [ -n "$old_system" ]; then
+          # shellcheck disable=SC2086
+          # Use the profile link so this works for both "switch" and "boot":
+          # "boot" doesn't update /run/current-system until reboot, but always
+          # writes the new generation to /nix/var/nix/profiles/system.
+          new_system=$(ssh $NIX_SSHOPTS root@ghaf-host readlink -f /nix/var/nix/profiles/system 2>/dev/null || true)
+          # shellcheck disable=SC2086
+          if [ -n "$new_system" ] && [ "$old_system" != "$new_system" ] && \
+              ssh $NIX_SSHOPTS root@ghaf-host command -v nvd &>/dev/null; then
+            echo ""
+            echo "--- Package diff ---"
+            # shellcheck disable=SC2086,SC2029
+            ssh $NIX_SSHOPTS root@ghaf-host nvd diff "$old_system" "$new_system" || true
+          fi
+        fi
   '';
   meta = {
     description = "Helper script to use nixos-rebuild without persistent changes of the ssh configuration.";


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

- Added `nvd` diff prints to all `ghaf-rebuild` calls, when `nvd` is available
- Added `nvd` as a dependency in `modules/development/debug-tools.nix`


<details>

<summary>Example ghaf-rebuild output</summary>

```sh
$ ghaf-rebuild xxx.xxx.xxx.xxx .#intel-laptop-debug boot
building the system configuration...
copying 15 paths...
copying path '/nix/store/bnj3dj128avw60k9yklnxxzyiz884asi-nvd-0.2.4' to 'ssh://root@ghaf-host'...
...
copying path '/nix/store/jax7jknnfja6vdarsw2sv6s6mxa6shca-system-units' to 'ssh://root@ghaf-host'...
copying path '/nix/store/dj7ggficprajy2yq05qqqn3zbf3666rr-etc' to 'ssh://root@ghaf-host'...
copying path '/nix/store/w62bf5hcxkk6z98wnmai2k3kk0k9ak1k-nixos-system-ghaf-host-26.05.20260418.b12141e' to 'ssh://root@ghaf-host'...
Not checking switch inhibitors (action = boot)
Done. The new configuration is /nix/store/w62bf5hcxkk6z98wnmai2k3kk0k9ak1k-nixos-system-ghaf-host-26.05.20260418.b12141e

--- Package diff ---
<<< /nix/store/249b461mh0d451snd54p71pm8gs19z2r-nixos-system-ghaf-host-26.05.20260418.b12141e
>>> /nix/store/w62bf5hcxkk6z98wnmai2k3kk0k9ak1k-nixos-system-ghaf-host-26.05.20260418.b12141e
Added packages:
[A+]  #1  nvd  0.2.4
Closure size: 3577 -> 3578 (174 paths added, 173 paths removed, delta +1, disk usage +54.4KiB).
```

</details>

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
