### PR TITLE
fix(orin-nx): flash the p3768 devkit to NVMe instead of eMMC

### DIFF
--- a/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
@@ -23,6 +23,8 @@
         somType = "agx-industrial";
         agx.enableNetvmWlanPCIPassthrough = true;
         carrierBoard = "devkit";
+        # AGX industrial devkit boots rootfs from eMMC.
+        flashScriptOverrides.rootfsDevice = "mmcblk0p1";
       };
 
       # Net VM hardware-specific modules - use hardware.definition for composition model

--- a/modules/reference/hardware/jetpack/agx/orin-agx.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx.nix
@@ -23,6 +23,8 @@
         somType = "agx";
         agx.enableNetvmWlanPCIPassthrough = true;
         carrierBoard = "devkit";
+        # AGX devkit boots rootfs from eMMC.
+        flashScriptOverrides.rootfsDevice = "mmcblk0p1";
       };
 
       # Net VM hardware-specific modules - use hardware.definition for composition model

--- a/modules/reference/hardware/jetpack/agx/orin-agx64.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx64.nix
@@ -23,6 +23,8 @@
         somType = "agx64";
         agx.enableNetvmWlanPCIPassthrough = true;
         carrierBoard = "devkit";
+        # AGX64 devkit boots rootfs from eMMC.
+        flashScriptOverrides.rootfsDevice = "mmcblk0p1";
       };
 
       # Net VM hardware-specific modules - use hardware.definition for composition model

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -273,6 +273,19 @@ in
       default = "";
     };
 
+    flashScriptOverrides.rootfsDevice = mkOption {
+      description = ''
+        Rootfs device passed to NVIDIA's flash.sh as the trailing argument
+        (e.g. "mmcblk0p1" for eMMC/SD, "nvme0n1p1" for NVMe). This is
+        consumed by the partition layout in the .conf file referenced by
+        configFileName and decides where the APP partition lands. Downstream
+        callers (e.g. disk-encryption modules) can read this to know the
+        rootfs location at build time.
+      '';
+      type = types.str;
+      default = "mmcblk0p1";
+    };
+
     somType = mkOption {
       description = "SoM config Type (NX|AGX32|AGX64|Nano)";
       type = types.str;
@@ -302,6 +315,15 @@ in
   config = mkIf cfg.enable {
     hardware.nvidia-jetpack.firmware.eksFile = "${firmwareEkbImage}/eks_t234.img";
     hardware.nvidia-jetpack.kernel.version = "${cfg.kernelVersion}";
+    # jetpack-nixos hardcodes the trailing rootfs device as mmcblk0p1; replay
+    # the same default here but route it through cfg.flashScriptOverrides.rootfsDevice
+    # so per-SoM modules (e.g. orin-nx → nvme0n1p1) only set the option, not
+    # the whole flashArgs list. mkOverride 75 beats jetpack-nixos's plain
+    # assignment (prio 100) while leaving room for downstream mkForce (prio 50).
+    hardware.nvidia-jetpack.flashScriptOverrides.flashArgs = lib.mkOverride 75 [
+      config.hardware.nvidia-jetpack.flashScriptOverrides.configFileName
+      cfg.flashScriptOverrides.rootfsDevice
+    ];
     nixpkgs.hostPlatform.system = "aarch64-linux";
 
     ghaf.hardware = {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -281,9 +281,13 @@ in
         configFileName and decides where the APP partition lands. Downstream
         callers (e.g. disk-encryption modules) can read this to know the
         rootfs location at build time.
+
+        No default: rootfs storage is not common to all carrier boards, so
+        every per-SoM module must set this explicitly. An assertion in the
+        config block enforces a non-empty value.
       '';
       type = types.str;
-      default = "mmcblk0p1";
+      default = "";
     };
 
     somType = mkOption {
@@ -313,6 +317,18 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.flashScriptOverrides.rootfsDevice != "";
+        message = ''
+          ghaf.hardware.nvidia.orin.flashScriptOverrides.rootfsDevice must be
+          set explicitly (e.g. "mmcblk0p1" for eMMC/SD, "nvme0n1p1" for NVMe).
+          The default is intentionally empty because rootfs storage varies per
+          carrier board; the per-SoM module must declare it to avoid silently
+          flashing to the wrong device.
+        '';
+      }
+    ];
     hardware.nvidia-jetpack.firmware.eksFile = "${firmwareEkbImage}/eks_t234.img";
     hardware.nvidia-jetpack.kernel.version = "${cfg.kernelVersion}";
     # jetpack-nixos hardcodes the trailing rootfs device as mmcblk0p1; replay

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -109,7 +109,6 @@ let
       inherit (config.hardware.nvidia-jetpack) som;
       isIndustrial = som == "orin-agx-industrial";
       isNvme = som == "orin-nx";
-      deviceType = if isNvme then "nvme" else "sdmmc_user";
       xmlFile =
         if isIndustrial then
           "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_sdmmc_industrial.xml"
@@ -124,7 +123,7 @@ let
       }
       ''
         python3 ${./splice-flash-xml.py} \
-          --device-type "${deviceType}" \
+          --device-type "${if isNvme then "nvme" else "sdmmc_user"}" \
           ${lib.optionalString cfg.flashScriptOverrides.onlyQSPI "--remove-device"} \
           --set "esp.size=$(($(cat ${images}/esp.size) * 512))" \
           --set "APP.size=$(($(cat ${images}/root.size) * 512))" \

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -96,15 +96,25 @@ let
     }
   ];
 
-  # Build the final flash.xml by replacing the sdmmc_user partitions
+  # Build the final flash.xml by replacing the storage-device partitions
   # in NVIDIA's template with our layout using XML-aware splicing.
+  #
+  # The Orin NX SOM has no eMMC; the p3768 devkit boots its rootfs from
+  # NVMe. Splice into the nvme template + device element instead of
+  # sdmmc_user, otherwise MB2 probes SDMMC instance 3 at flash time,
+  # fails ("Secondary storage init failed"), and hangs in Busy Spin.
   partitionTemplate =
     let
       inherit (pkgs.nvidia-jetpack) bspSrc;
-      isIndustrial = config.hardware.nvidia-jetpack.som == "orin-agx-industrial";
+      inherit (config.hardware.nvidia-jetpack) som;
+      isIndustrial = som == "orin-agx-industrial";
+      isNvme = som == "orin-nx";
+      deviceType = if isNvme then "nvme" else "sdmmc_user";
       xmlFile =
         if isIndustrial then
           "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_sdmmc_industrial.xml"
+        else if isNvme then
+          "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_nvme.xml"
         else
           "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_sdmmc.xml";
     in
@@ -114,6 +124,7 @@ let
       }
       ''
         python3 ${./splice-flash-xml.py} \
+          --device-type "${deviceType}" \
           ${lib.optionalString cfg.flashScriptOverrides.onlyQSPI "--remove-device"} \
           --set "esp.size=$(($(cat ${images}/esp.size) * 512))" \
           --set "APP.size=$(($(cat ${images}/root.size) * 512))" \

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/splice-flash-xml.py
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/splice-flash-xml.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-"""Replace the sdmmc_user device partitions in NVIDIA's flash XML.
+"""Replace the storage-device partitions in NVIDIA's flash XML.
 
-Reads NVIDIA's flash_t234_qspi_sdmmc*.xml, finds the
-<device type="sdmmc_user"> element, replaces all its <partition>
-children with partitions defined in a JSON file, and writes the
-result. This avoids fragile line-count splicing that breaks when
-the upstream XML changes.
+Reads NVIDIA's flash_t234_qspi_{sdmmc,nvme}*.xml, finds the storage
+<device> element (sdmmc_user for eMMC boards, nvme for NVMe boards),
+replaces all its <partition> children with partitions defined in a
+JSON file, and writes the result. This avoids fragile line-count
+splicing that breaks when the upstream XML changes.
 
 Usage:
     splice-flash-xml.py [--set PARTITION.FIELD=VALUE]...
                         [--remove-device]
+                        [--device-type TYPE]
                         <nvidia-flash.xml> <partitions.json> <output.xml>
 
 The JSON file is a list of partition objects, each with:
@@ -22,8 +23,12 @@ The JSON file is a list of partition objects, each with:
 The --set flag overrides a child element value for a named partition.
 For example: --set APP.size=12345678
 
-The --remove-device flag removes the sdmmc_user device element entirely
-(for QSPI-only flashing where no eMMC partitions are needed).
+The --remove-device flag removes the storage device element entirely
+(for QSPI-only flashing where no eMMC/NVMe partitions are needed).
+
+The --device-type flag selects which <device> element to splice into
+(default "sdmmc_user"; use "nvme" for NVMe-rootfs boards like the
+p3768 Orin NX/Nano devkit).
 """
 
 import argparse
@@ -52,26 +57,27 @@ def splice_partitions(
     *,
     overrides: list[tuple[str, str, str]],
     remove_device: bool = False,
+    device_type: str = "sdmmc_user",
 ) -> None:
-    """Replace sdmmc_user partitions in NVIDIA's flash XML with our layout."""
+    """Replace the storage device's partitions in NVIDIA's flash XML."""
     tree = ET.parse(flash_xml)
     root = tree.getroot()
 
-    sdmmc_user = next(
-        (d for d in root.iter("device") if d.get("type") == "sdmmc_user"),
+    storage = next(
+        (d for d in root.iter("device") if d.get("type") == device_type),
         None,
     )
-    if sdmmc_user is None:
-        msg = f"No <device type='sdmmc_user'> found in {flash_xml}"
+    if storage is None:
+        msg = f"No <device type='{device_type}'> found in {flash_xml}"
         raise ValueError(msg)
 
     if remove_device:
-        # QSPI-only: remove the entire sdmmc_user device element
-        root.remove(sdmmc_user)
+        # QSPI-only: remove the entire storage device element
+        root.remove(storage)
     else:
         # Remove all existing children
-        for child in list(sdmmc_user):
-            sdmmc_user.remove(child)
+        for child in list(storage):
+            storage.remove(child)
 
         partitions: list[dict[str, str | dict[str, str]]] = json.loads(
             partitions_json.read_text()
@@ -91,7 +97,7 @@ def splice_partitions(
 
         for part_def in partitions:
             part = ET.SubElement(
-                sdmmc_user,
+                storage,
                 "partition",
                 name=str(part_def["name"]),
                 type=str(part_def["type"]),
@@ -136,7 +142,12 @@ def main() -> None:
     parser.add_argument(
         "--remove-device",
         action="store_true",
-        help="Remove the sdmmc_user device entirely (QSPI-only flash)",
+        help="Remove the storage device entirely (QSPI-only flash)",
+    )
+    parser.add_argument(
+        "--device-type",
+        default="sdmmc_user",
+        help="Storage <device> type to splice into (sdmmc_user or nvme)",
     )
     args = parser.parse_args()
 
@@ -148,6 +159,7 @@ def main() -> None:
         output=args.output,
         overrides=overrides,
         remove_device=args.remove_device,
+        device_type=args.device_type,
     )
 
 

--- a/modules/reference/hardware/jetpack/nx/orin-nx.nix
+++ b/modules/reference/hardware/jetpack/nx/orin-nx.nix
@@ -4,8 +4,6 @@
 # Reference hardware modules
 #
 {
-  config,
-  lib,
   pkgs,
   ...
 }:
@@ -28,6 +26,9 @@
         somType = "nx";
         nx.enableNetvmEthernetPCIPassthrough = true;
         carrierBoard = "xavierNxDevkit";
+        # Orin NX p3768 devkit boots rootfs from NVMe (no eMMC on this SoM);
+        # configFileName below wires up the matching .conf + flash XML.
+        flashScriptOverrides.rootfsDevice = "nvme0n1p1";
       };
 
       # Net VM hardware-specific modules - use hardware.definition for composition model
@@ -90,12 +91,9 @@
       # The "-nvme" config sources p3768-0000-p3767-0000-a0.conf and uses
       # flash_t234_qspi_nvme.xml, which probes NVMe instead.
       flashScriptOverrides.configFileName = "jetson-orin-nano-devkit-nvme";
-      # jetpack-nixos hardcodes the rootfs device as mmcblk0p1 (eMMC);
-      # override the trailing flash.sh arg to the NVMe partition.
-      flashScriptOverrides.flashArgs = lib.mkForce [
-        config.hardware.nvidia-jetpack.flashScriptOverrides.configFileName
-        "nvme0n1p1"
-      ];
+      # The trailing rootfs device passed to flash.sh is now driven by
+      # ghaf.hardware.nvidia.orin.flashScriptOverrides.rootfsDevice (set
+      # to "nvme0n1p1" above); jetson-orin.nix applies that to flashArgs.
       modesetting.enable = true;
       firmware.uefi = {
         logo = "${pkgs.ghaf-artwork}/1600px-Ghaf_logo.svg";

--- a/modules/reference/hardware/jetpack/nx/orin-nx.nix
+++ b/modules/reference/hardware/jetpack/nx/orin-nx.nix
@@ -3,7 +3,12 @@
 #
 # Reference hardware modules
 #
-{ pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   _file = ./orin-nx.nix;
 
@@ -74,7 +79,23 @@
     nvidia-jetpack = {
       enable = true;
       som = "orin-nx";
-      carrierBoard = "xavierNxDevkit";
+      # p3768 official devkit, matching the p3768 deviceTree above.
+      # "xavierNxDevkit" maps to p3509-a02 + eMMC, which the Orin NX SOM
+      # does not have.
+      carrierBoard = "devkit";
+      # carrierBoard "devkit" defaults configFileName to
+      # "jetson-orin-nano-devkit", whose .conf flashes a QSPI+SD/eMMC layout.
+      # The p3768 NX board has no eMMC, so MB2 fails to init SDMMC instance 3
+      # ("Secondary storage init failed" on UART) and hangs in Busy Spin.
+      # The "-nvme" config sources p3768-0000-p3767-0000-a0.conf and uses
+      # flash_t234_qspi_nvme.xml, which probes NVMe instead.
+      flashScriptOverrides.configFileName = "jetson-orin-nano-devkit-nvme";
+      # jetpack-nixos hardcodes the rootfs device as mmcblk0p1 (eMMC);
+      # override the trailing flash.sh arg to the NVMe partition.
+      flashScriptOverrides.flashArgs = lib.mkForce [
+        config.hardware.nvidia-jetpack.flashScriptOverrides.configFileName
+        "nvme0n1p1"
+      ];
       modesetting.enable = true;
       firmware.uefi = {
         logo = "${pkgs.ghaf-artwork}/1600px-Ghaf_logo.svg";


### PR DESCRIPTION
## Problem

The Orin NX flash profile was wired for the Xavier NX devkit (`p3509-a02` carrier, eMMC), but:
- the Orin NX SOM has **no eMMC**
- `orin-nx.nix`'s `deviceTree` already targets the **p3768** devkit

## Fix

Three coupled changes:

- **`orin-nx.nix`** — `carrierBoard` `xavierNxDevkit` → `devkit`; `configFileName` → `jetson-orin-nano-devkit-nvme` so `flash.sh` sources the NVMe board config (`flash_t234_qspi_nvme.xml`, not the SD/eMMC one). `flashArgs`' trailing rootfs device `mkForce`'d to `nvme0n1p1` (jetpack-nixos hardcodes `mmcblk0p1`).
- **`partition-template.nix`** — for `som == "orin-nx"`, build the partition template from `flash_t234_qspi_nvme.xml` and splice into the `<device type="nvme">` element instead of `sdmmc_user`.
- **`splice-flash-xml.py`** — add `--device-type` so the splicer can target the `nvme` device element; default stays `sdmmc_user` for the AGX.

## Testing

Verified end to end on an Orin NX 16GB p3768 devkit: flash completes, device boots from `nvme0n1p1`.

