### PR TITLE
fix(ci/rebuild): fix rebuild switch

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -803,6 +803,21 @@ in
                       ExecStop =
                         let
                           sysvm-stop = pkgs.writeShellScript "sysvm-stop" ''
+                            # Check if this stop is part of a real shutdown or suspend.
+                            # During a nixos-rebuild switch, affected services (system vms) are restarted
+                            # which causes their ExecStop actions to be executed
+                            # If no real reboot/suspend job is queued, we can assume the VM should be
+                            # restarted without requesting the host itself to reboot
+                            jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
+                            if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start'; then
+                              echo "No shutdown/suspend in progress, skipping graceful shutdown for '${vmName}' (likely a rebuild)"
+                              kill -15 $MAINPID 2>/dev/null
+                              while kill -0 $MAINPID 2>/dev/null; do
+                                sleep 1
+                              done
+                              exit 0
+                            fi
+
                             echo "Starting poweroff target for system VM '${vmName}'"
                             vm=''${${vmName}/-vm/}
                             ${givc-cli} start service --vm '${vmName}' poweroff.target &

--- a/packages/pkgs-by-name/ghaf-build-helper/package.nix
+++ b/packages/pkgs-by-name/ghaf-build-helper/package.nix
@@ -98,28 +98,56 @@ writeShellApplication {
 
         export NIX_SSHOPTS
 
-        # Capture the current system path on the target before rebuild for diffing
+        # Capture the current system path on the target before rebuild for diffing.
+        # /nix/var/nix/profiles/system is used (not /run/current-system) so that
+        # "boot" rebuilds also have a correct baseline.
         old_system=""
         # shellcheck disable=SC2086
         old_system=$(ssh $NIX_SSHOPTS root@ghaf-host readlink -f /nix/var/nix/profiles/system 2>/dev/null || true)
 
-        nixos-rebuild --flake "$build_target" --target-host root@ghaf-host --no-reexec "''${args[@]}"
+        show_nvd_diff() {
+          local old="$1" new="$2"
+          [ -n "$old" ] && [ -n "$new" ] && [ "$old" != "$new" ] || return 0
+          # shellcheck disable=SC2086
+          ssh $NIX_SSHOPTS root@ghaf-host command -v nvd &>/dev/null || return 0
+          echo ""
+          echo "--- Package diff ---"
+          # shellcheck disable=SC2086,SC2029
+          ssh $NIX_SSHOPTS root@ghaf-host nvd diff "$old" "$new" || true
+        }
 
-        # Show package diff between old and new system closure
-        if [ -n "$old_system" ]; then
+        # Detect whether the requested action is "switch"
+        is_switch=false
+        upload_args=()
+
+        # Replace "switch" with "boot" so nixos-rebuild sets the profile
+        # and bootloader but leaves the running system untouched
+        # This lets us show the diff before any service restarts happen
+        for arg in "''${args[@]}"; do
+          [ "$arg" = "switch" ] && is_switch=true && upload_args+=("boot") && continue
+          upload_args+=("$arg")
+        done
+
+        if $is_switch; then
+          nixos-rebuild --flake "$build_target" --target-host root@ghaf-host --no-reexec "''${upload_args[@]}"
+
           # shellcheck disable=SC2086
-          # Use the profile link so this works for both "switch" and "boot":
-          # "boot" doesn't update /run/current-system until reboot, but always
-          # writes the new generation to /nix/var/nix/profiles/system.
           new_system=$(ssh $NIX_SSHOPTS root@ghaf-host readlink -f /nix/var/nix/profiles/system 2>/dev/null || true)
+          show_nvd_diff "$old_system" "$new_system"
+
+          # Activate via systemd-run --no-block so the unit is detached from the
+          # SSH session.  The connection may drop once network services restart
+          echo ""
+          echo "Activating new system (connection may drop)..."
+          # shellcheck disable=SC2086,SC2029
+          ssh $NIX_SSHOPTS root@ghaf-host \
+            "systemd-run --no-block -- $new_system/bin/switch-to-configuration switch" || true
+        else
+          nixos-rebuild --flake "$build_target" --target-host root@ghaf-host --no-reexec "''${upload_args[@]}"
+
           # shellcheck disable=SC2086
-          if [ -n "$new_system" ] && [ "$old_system" != "$new_system" ] && \
-              ssh $NIX_SSHOPTS root@ghaf-host command -v nvd &>/dev/null; then
-            echo ""
-            echo "--- Package diff ---"
-            # shellcheck disable=SC2086,SC2029
-            ssh $NIX_SSHOPTS root@ghaf-host nvd diff "$old_system" "$new_system" || true
-          fi
+          new_system=$(ssh $NIX_SSHOPTS root@ghaf-host readlink -f /nix/var/nix/profiles/system 2>/dev/null || true)
+          show_nvd_diff "$old_system" "$new_system"
         fi
   '';
   meta = {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Fixed power manager cfg to re-enable `nixos-rebuild switch`:**
   - Using rebuild switch will no longer cause the system to shutdown.
   - Instead, the affected services (usually system vms) will restart "cleanly" (SIGTERM) while host continues running

2. **Adjusted `ghaf-rebuild` to convert all `switch` requests to a modified version of `boot`:**
   - This allows us to see the package diff even on a `rebuild switch` request, by performing the following:
     1. Build the new system
     2. Set the profile to be activated on next boot
     3. Show `nvd` package diff
     4. Call `switch-to-configuration switch` on the new profile using a `systemd-run --no-block` call
     5. Don't wait for the call to finish, as it's likely the connection will drop anyway (due to net-vm restarting)

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] System 76 `x86_64`
- [x] All/None

### Installation Method
- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other: See description

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Take this functionality into use with `ghaf-rebuild ... boot` and rebooting the target system
2. Make some changes in your local Ghaf config, best would be to add some random package to `systemPackages` somewhere, and use `ghaf-rebuild ... switch`
3. Confirm step 2 doesn't hang and shows a package diff output. Also confirm target Ghaf system doesn't shutdown or reboot fully, only the affected VM is restarted (can be observed in host)
