### PR TITLE
feat(power): add GPU suspend option

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -5,6 +5,7 @@
   config,
   pkgs,
   lib,
+  options,
   ...
 }:
 let
@@ -93,6 +94,21 @@ let
     ) config.microvm.vms
   );
 
+  # List of VMs that should run kernel GPU suspend when the host suspends
+  gpuSuspendVms = lib.attrNames (
+    filterAttrs (
+      _n: v:
+      let
+        vmConfig = lib.ghaf.vm.getConfig v;
+      in
+      vmConfig != null
+      && vmConfig.ghaf.services.power-manager.enable
+      && vmConfig.ghaf.services.power-manager.vm.enable
+      && vmConfig.ghaf.services.power-manager.gui.enable
+      && vmConfig.ghaf.services.power-manager.gui.gpuSuspend
+    ) config.microvm.vms
+  );
+
   # Host suspend actions
   host-suspend-actions = pkgs.writeShellApplication {
     name = "host-suspend-actions";
@@ -101,6 +117,7 @@ let
       pkgs.systemd
       pkgs.coreutils
       pkgs.grpcurl
+      pkgs.socat
       pkgs.vhotplug
       pkgs.wait-for-unit
     ];
@@ -173,6 +190,30 @@ let
                 echo "Fallback: restarting $vm_name..."
                 systemctl restart microvm@"$vm_name".service
               fi
+              ;;
+            *)
+              echo "Invalid action: $action"
+              echo "Usage: $0 <VM Name> <suspend-action> (suspend|resume)"
+              exit 1
+              ;;
+          esac
+          ;;
+
+        gpu-suspend)
+          case "$action" in
+            suspend)
+              echo "Signaling kernel GPU suspend to $vm_name..."
+              ${givc-cli} start service --vm "$vm_name" gpu-suspend.service &
+              sleep 1
+              ;;
+            resume)
+              wake_socket="${config.microvm.stateDir}/$vm_name/vm-wake.sock"
+              echo "Signaling kernel GPU resume to $vm_name..."
+              if [ ! -S "$wake_socket" ]; then
+                echo "Wake socket $wake_socket does not exist, $vm_name will resume after fallback timeout (${toString cfg.gui.gpuSuspendDuration}s)"
+                exit 1
+              fi
+              printf 'resume\n' | socat -u - "UNIX-CONNECT:$wake_socket"
               ;;
             *)
               echo "Invalid action: $action"
@@ -527,6 +568,29 @@ in
         If running in a VM and GIVC is enabled, it replaces the default systemd actions for suspend, poweroff, and
         reboot with givc commands.
       '';
+      gpuSuspend = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether the host should trigger kernel GPU suspend for this VM before host suspend.
+        '';
+      };
+      gpuSuspendDuration = mkOption {
+        type = types.ints.positive;
+        default = 20;
+        description = ''
+          Duration in seconds for the kernel GPU suspend pm_test delay.
+          This is used as a fallback timeout if the socket wakeup signal is not received.
+        '';
+      };
+      fakeDisplaySuspend = mkOption {
+        type = types.bool;
+        default = !cfg.gui.gpuSuspend;
+        defaultText = literalExpression "!config.ghaf.services.power-manager.gui.gpuSuspend";
+        description = ''
+          Whether to use ghaf-powercontrol to fake display off and on during GUI suspend and resume.
+        '';
+      };
     };
     host = {
       enable = mkEnableOption ''
@@ -638,7 +702,6 @@ in
 
     # GUI power management profile
     (mkIf cfg.gui.enable {
-
       # Shutdown displays early before suspend
       powerManagement = {
         powerDownCommands = lib.mkBefore (
@@ -647,7 +710,9 @@ in
               _is_shutdown=0
             else
               _is_shutdown=1
-              ${getExe ghaf-powercontrol} fake-turn-off-displays '*'
+              ${optionalString cfg.gui.fakeDisplaySuspend ''
+                ${getExe ghaf-powercontrol} fake-turn-off-displays '*'
+              ''}
             fi
           ''
           + optionalString (cfg.suspend.extraSuspendCommands != "") ''
@@ -659,9 +724,14 @@ in
         );
       };
 
+      # Allow the host power manager to trigger kernel GPU suspend in the GUI VM
+      givc.sysvm.capabilities.services = optionals (cfg.vm.enable && useGivc && cfg.gui.gpuSuspend) [
+        "gpu-suspend.service"
+      ];
+
       # Override systemd actions for suspend, poweroff, and reboot
-      systemd.services =
-        optionalAttrs (cfg.vm.enable && useGivc) {
+      systemd.services = optionalAttrs (cfg.vm.enable && useGivc) (
+        {
           systemd-suspend.serviceConfig.ExecStart = [
             ""
             "${getExe gui-vm-suspend}"
@@ -702,7 +772,9 @@ in
               ExecStop =
                 let
                   resumeActions = pkgs.writeShellScriptBin "resume-actions" ''
-                    ${getExe ghaf-powercontrol} fake-turn-on-displays '*'
+                    ${optionalString cfg.gui.fakeDisplaySuspend ''
+                      ${getExe ghaf-powercontrol} fake-turn-on-displays '*'
+                    ''}
 
                     # config.ghaf.services.power-manager.suspend.extraResumeCommands
                     ${cfg.suspend.extraResumeCommands}
@@ -717,7 +789,44 @@ in
           # Ref. https://github.com/systemd/systemd/issues/41562
           # TODO: Remove when fixed
           systemd-logind.serviceConfig.WatchdogSec = lib.mkForce 0;
-        };
+        }
+        // optionalAttrs cfg.gui.gpuSuspend {
+          gpu-suspend = {
+            description = "GPU suspend for GUI VM";
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart =
+                let
+                  guestGpuSuspend = pkgs.writeShellApplication {
+                    name = "guest-gpu-suspend";
+                    runtimeInputs = [
+                      pkgs.coreutils
+                    ];
+                    text = ''
+                      echo "Activating kernel GPU suspend"
+                      # Use pm_test_delay as a fallback timeout if the socket wakeup signal is not received
+                      echo ${toString cfg.gui.gpuSuspendDuration} > /sys/module/suspend/parameters/pm_test_delay
+                      # Limit pm_test suspend/resume to the GPU and serial wakeup device
+                      echo 1 > /sys/module/suspend/parameters/pm_test_gpu_only
+                      echo devices > /sys/power/pm_test
+                      # Enable ttyS1 as the wakeup source used by the host
+                      echo enabled > /sys/class/tty/ttyS1/power/wakeup
+                      cat /dev/ttyS1 > /dev/null &
+                      # Arm wakeup_count so incoming ttyS1 data is treated as a wakeup event
+                      wc=$(cat /sys/power/wakeup_count)
+                      echo "$wc" > /sys/power/wakeup_count
+                      # Enter suspend and wait for the host wakeup signal
+                      echo freeze > /sys/power/state
+                      echo "GPU resumed"
+                      echo 0 > /sys/module/suspend/parameters/pm_test_gpu_only
+                    '';
+                  };
+                in
+                getExe guestGpuSuspend;
+            };
+          };
+        }
+      );
 
       # Logind configuration for desktop
       services.logind.settings.Login =
@@ -739,6 +848,16 @@ in
           # TODO: Investigate root cause
           InhibitDelayMaxSec = 1;
         };
+    })
+
+    (optionalAttrs (options ? microvm && options.microvm ? qemu) {
+      # Serial device (ttyS1) for wakeup from kernel GPU suspend
+      microvm.qemu.extraArgs = mkIf (cfg.gui.enable && cfg.vm.enable && cfg.gui.gpuSuspend) [
+        "-chardev"
+        "socket,id=wake0,path=vm-wake.sock,server=on,wait=off"
+        "-device"
+        "isa-serial,chardev=wake0,index=1"
+      ];
     })
 
     # Host power management
@@ -768,7 +887,8 @@ in
             wants =
               map (vmName: "pre-sleep-poweroff@${vmName}.service") powerOffVms
               ++ map (vmName: "pre-sleep-fake-suspend@${vmName}.service") fakeSuspendVms
-              ++ map (vmName: "pre-sleep-pci-suspend@${vmName}.service") pciSuspendVms;
+              ++ map (vmName: "pre-sleep-pci-suspend@${vmName}.service") pciSuspendVms
+              ++ map (vmName: "pre-sleep-gpu-suspend@${vmName}.service") gpuSuspendVms;
           };
           "post-resume-actions" = {
             description = "Target for post-resume host actions";
@@ -777,7 +897,8 @@ in
             wants =
               map (vmName: "post-resume-poweroff@${vmName}.service") powerOffVms
               ++ map (vmName: "post-resume-fake-suspend@${vmName}.service") fakeSuspendVms
-              ++ map (vmName: "post-resume-pci-suspend@${vmName}.service") pciSuspendVms;
+              ++ map (vmName: "post-resume-pci-suspend@${vmName}.service") pciSuspendVms
+              ++ map (vmName: "post-resume-gpu-suspend@${vmName}.service") gpuSuspendVms;
           };
         };
 
@@ -832,6 +953,7 @@ in
                     "poweroff"
                     "fake-suspend"
                     "pci-suspend"
+                    "gpu-suspend"
                   ]
               )
             )

--- a/modules/hardware/x86_64-generic/kernel/guest/default.nix
+++ b/modules/hardware/x86_64-generic/kernel/guest/default.nix
@@ -16,6 +16,9 @@ let
   };
 
   cfg = config.ghaf.guest.kernel.hardening;
+  gpuSuspend =
+    (config.ghaf.services.power-manager.gui.enable or false)
+    && (config.ghaf.services.power-manager.gui.gpuSuspend or false);
 in
 {
   options.ghaf.guest.kernel.hardening = {
@@ -35,5 +38,12 @@ in
   config = lib.mkIf pkgs.stdenv.hostPlatform.isx86_64 {
     boot.kernelPackages =
       if cfg.enable then pkgs.linuxPackagesFor guest_hardened_kernel else pkgs.linuxPackages_latest;
+
+    boot.kernelPatches = lib.optionals gpuSuspend [
+      {
+        name = "kernel-pm-test-gpu-suspend";
+        patch = ./patches/kernel-pm-test-gpu-suspend.patch;
+      }
+    ];
   };
 }

--- a/modules/hardware/x86_64-generic/kernel/guest/patches/kernel-pm-test-gpu-suspend.patch
+++ b/modules/hardware/x86_64-generic/kernel/guest/patches/kernel-pm-test-gpu-suspend.patch
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+diff --git a/drivers/base/power/main.c b/drivers/base/power/main.c
+index 189de5250f25..e44f33d35432 100644
+--- a/drivers/base/power/main.c
++++ b/drivers/base/power/main.c
+@@ -35,6 +35,8 @@
+ #include <linux/devfreq.h>
+ #include <linux/timer.h>
+ #include <linux/nmi.h>
++#include <linux/pci.h>
++#include <linux/tty.h>
+ 
+ #include "../base.h"
+ #include "power.h"
+@@ -63,6 +65,73 @@ static pm_message_t pm_transition;
+ static DEFINE_MUTEX(async_wip_mtx);
+ static int async_error;
+ 
++static bool dpm_pm_test_device_is_intel_display(struct device *dev)
++{
++	if (dev_is_pci(dev)) {
++		struct pci_dev *pdev = to_pci_dev(dev);
++
++		if (pdev->vendor == PCI_VENDOR_ID_INTEL &&
++		    (pdev->class >> 16) == PCI_BASE_CLASS_DISPLAY) {
++			dev_info(dev, "pm_test: allowing Intel GPU PCI device\n");
++			return true;
++		}
++	}
++
++	return false;
++}
++
++static bool dpm_pm_test_device_is_serial(struct device *dev)
++{
++#if IS_ENABLED(CONFIG_TTY)
++	if (dev->class == &tty_class && strstarts(dev_name(dev), "ttyS")) {
++		dev_info(dev, "pm_test: allowing serial ttyS class device\n");
++		return true;
++	}
++#endif
++
++	if (dev->bus && !strcmp(dev->bus->name, "serial-base")) {
++		dev_info(dev, "pm_test: allowing serial-base device\n");
++		return true;
++	}
++
++	if (dev->driver) {
++		const char *name = dev->driver->name;
++
++		if (!strcmp(name, "serial")) {
++			dev_info(dev, "pm_test: allowing serial driver device\n");
++			return true;
++		}
++		if (strstarts(name, "8250")) {
++			dev_info(dev, "pm_test: allowing 8250 driver device\n");
++			return true;
++		}
++		if (strstr(name, "serial")) {
++			dev_info(dev, "pm_test: allowing serial-named driver device\n");
++			return true;
++		}
++	}
++
++	return false;
++}
++
++static bool dpm_pm_test_device_is_selected(struct device *dev)
++{
++	return dpm_pm_test_device_is_intel_display(dev) ||
++	       dpm_pm_test_device_is_serial(dev);
++}
++
++static bool dpm_pm_test_selected_only(pm_message_t state)
++{
++	return (state.event == PM_EVENT_SUSPEND ||
++		state.event == PM_EVENT_RESUME) && pm_test_gpu_only_enabled();
++}
++
++static bool dpm_pm_test_skip_device(struct device *dev, pm_message_t state)
++{
++	return dpm_pm_test_selected_only(state) &&
++	       !dpm_pm_test_device_is_selected(dev);
++}
++
+ /**
+  * pm_hibernate_is_recovering - if recovering from hibernate due to error.
+  *
+@@ -113,6 +182,7 @@ void device_pm_sleep_init(struct device *dev)
+ 	dev->power.is_suspended = false;
+ 	dev->power.is_noirq_suspended = false;
+ 	dev->power.is_late_suspended = false;
++	dev->power.pm_test_skipped = false;
+ 	init_completion(&dev->power.completion);
+ 	complete_all(&dev->power.completion);
+ 	dev->power.wakeup = NULL;
+@@ -1195,8 +1265,10 @@ void dpm_resume(pm_message_t state)
+ 	if (READ_ONCE(async_error))
+ 		dpm_save_failed_step(SUSPEND_RESUME);
+ 
+-	cpufreq_resume();
+-	devfreq_resume();
++	if (!dpm_pm_test_selected_only(state)) {
++		cpufreq_resume();
++		devfreq_resume();
++	}
+ 	trace_suspend_resume(TPS("dpm_resume"), state.event, false);
+ }
+ 
+@@ -1264,16 +1336,22 @@ void dpm_complete(pm_message_t state)
+ 	mutex_lock(&dpm_list_mtx);
+ 	while (!list_empty(&dpm_prepared_list)) {
+ 		struct device *dev = to_device(dpm_prepared_list.prev);
++		bool pm_test_skip = dev->power.pm_test_skipped;
+ 
+ 		get_device(dev);
+ 		dev->power.is_prepared = false;
++		dev->power.pm_test_skipped = false;
+ 		list_move(&dev->power.entry, &list);
+ 
+ 		mutex_unlock(&dpm_list_mtx);
+ 
+-		trace_device_pm_callback_start(dev, "", state.event);
+-		device_complete(dev, state);
+-		trace_device_pm_callback_end(dev, 0);
++		if (pm_test_skip) {
++			dev_dbg(dev, "pm_test: skipping outside GPU/serial allowlist complete\n");
++		} else {
++			trace_device_pm_callback_start(dev, "", state.event);
++			device_complete(dev, state);
++			trace_device_pm_callback_end(dev, 0);
++		}
+ 
+ 		put_device(dev);
+ 
+@@ -1873,6 +1951,11 @@ static void device_suspend(struct device *dev, pm_message_t state, bool async)
+ 	TRACE_DEVICE(dev);
+ 	TRACE_SUSPEND(0);
+ 
++	if (dev->power.pm_test_skipped) {
++		dev_dbg(dev, "pm_test: skipping outside GPU/serial allowlist suspend\n");
++		goto Complete;
++	}
++
+ 	dpm_wait_for_subordinate(dev, async);
+ 
+ 	if (READ_ONCE(async_error)) {
+@@ -2014,8 +2097,10 @@ int dpm_suspend(pm_message_t state)
+ 	trace_suspend_resume(TPS("dpm_suspend"), state.event, true);
+ 	might_sleep();
+ 
+-	devfreq_suspend();
+-	cpufreq_suspend();
++	if (!dpm_pm_test_selected_only(state)) {
++		devfreq_suspend();
++		cpufreq_suspend();
++	}
+ 
+ 	pm_transition = state;
+ 	async_error = 0;
+@@ -2229,19 +2314,28 @@ int dpm_prepare(pm_message_t state)
+ 	mutex_lock(&dpm_list_mtx);
+ 	while (!list_empty(&dpm_list) && !error) {
+ 		struct device *dev = to_device(dpm_list.next);
++		bool pm_test_skip;
+ 
+ 		get_device(dev);
+ 
+ 		mutex_unlock(&dpm_list_mtx);
+ 
+-		trace_device_pm_callback_start(dev, "", state.event);
+-		error = device_prepare(dev, state);
+-		trace_device_pm_callback_end(dev, error);
++		pm_test_skip = dpm_pm_test_skip_device(dev, state);
++		if (pm_test_skip) {
++			dev_dbg(dev, "pm_test: skipping outside GPU/serial allowlist prepare\n");
++			error = 0;
++		} else {
++			trace_device_pm_callback_start(dev, "", state.event);
++			error = device_prepare(dev, state);
++			trace_device_pm_callback_end(dev, error);
++		}
+ 
+ 		mutex_lock(&dpm_list_mtx);
+ 
++		dev->power.pm_test_skipped = false;
+ 		if (!error) {
+-			dev->power.is_prepared = true;
++			dev->power.pm_test_skipped = pm_test_skip;
++			dev->power.is_prepared = !pm_test_skip;
+ 			if (!list_empty(&dev->power.entry))
+ 				list_move_tail(&dev->power.entry, &dpm_prepared_list);
+ 		} else if (error == -EAGAIN) {
+diff --git a/include/linux/pm.h b/include/linux/pm.h
+index afcaaa37a812..1238e6fa89b6 100644
+--- a/include/linux/pm.h
++++ b/include/linux/pm.h
+@@ -688,6 +688,7 @@ struct dev_pm_info {
+ 	bool			smart_suspend:1;	/* Owned by the PM core */
+ 	bool			must_resume:1;		/* Owned by the PM core */
+ 	bool			may_skip_resume:1;	/* Set by subsystems */
++	bool			pm_test_skipped:1;	/* Owned by the PM core */
+ 	bool			out_band_wakeup:1;
+ 	bool			strict_midlayer:1;
+ #else
+@@ -828,6 +829,14 @@ extern int dpm_suspend_noirq(pm_message_t state);
+ extern int dpm_suspend_late(pm_message_t state);
+ extern int dpm_suspend(pm_message_t state);
+ extern int dpm_prepare(pm_message_t state);
++#ifdef CONFIG_SUSPEND
++extern bool pm_test_gpu_only_enabled(void);
++#else
++static inline bool pm_test_gpu_only_enabled(void)
++{
++	return false;
++}
++#endif
+ 
+ extern void __suspend_report_result(const char *function, struct device *dev, void *fn, int ret);
+ 
+diff --git a/kernel/power/suspend.c b/kernel/power/suspend.c
+index 57c44268698f..0ff9b43e0544 100644
+--- a/kernel/power/suspend.c
++++ b/kernel/power/suspend.c
+@@ -334,6 +334,22 @@ static bool platform_suspend_again(suspend_state_t state)
+ 		suspend_ops->suspend_again() : false;
+ }
+ 
++#ifdef CONFIG_PM_SLEEP_DEBUG
++static bool pm_test_gpu_only;
++module_param(pm_test_gpu_only, bool, 0644);
++MODULE_PARM_DESC(pm_test_gpu_only,
++		 "Restrict pm_test=devices to Intel GPU and serial devices");
++#endif
++
++bool pm_test_gpu_only_enabled(void)
++{
++#ifdef CONFIG_PM_SLEEP_DEBUG
++	return pm_test_gpu_only && pm_test_level == TEST_DEVICES;
++#else
++	return false;
++#endif
++}
++
+ #ifdef CONFIG_PM_DEBUG
+ static unsigned int pm_test_delay = 5;
+ module_param(pm_test_delay, uint, 0644);

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -335,6 +335,7 @@ in
     systemPackages = [
       pkgs.ctrl-panel
       pkgs.waypipe
+      pkgs.wlopm
     ]
     # For GIVC debugging/testing
     ++ lib.optional (globalConfig.debug.enable or false) pkgs.givc-cli


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This adds an experimental GPU suspend mode to the power management module.

In Ghaf, the GPU is passed through to the GUIVM, which means the host cannot suspend it together with the rest of the system. Keeping the GPU running while everything else is suspended may leave it in an inconsistent state, preventing the driver from restoring it correctly on resume. In some cases, the screen stays black after resume and there are i915 crashes in the logs, although the issue is rare and difficult to reproduce consistently.

One possible solution would be suspending the GUIVM itself but that is currently not feasible because virtio-fs does not support suspend and it is unclear how well QEMU supports guest suspend in this setup.

As a workaround, this patch uses the [kernel pm_test mechanism](https://www.kernel.org/doc/Documentation/power/basic-pm-debugging.txt) which allows freezing all processes and suspending devices inside the guest without completing the full suspend sequence. A small kernel patch is added to suspend only the GPU. This allows the GUIVM to execute the GPU driver suspend and resume callbacks, which should gracefully transition the GPU into a suspended state, turn off the display and restore everything on resume.

The intended flow is:
- The system initiates suspend.
- The GUIVM receives a GIVC request and executes a pm_test suspend.
- All processes inside the GUIVM are frozen and the GPU driver suspend callback is executed.
- The host continues with the normal suspend flow and freezes all processes, including all QEMU instances.
- When the system resumes, the GUIVM is awakened by a wake-up signal from the host over the serial port.

Calling the GPU driver suspend and resume handlers may improve suspend reliability but it is still hard to say for sure because the issue is difficult to reproduce. At this stage, this mode should be considered experimental and requires more testing.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
Test all possible suspend and resume scenarios and make sure there are no issues similar to those reported by Rodrigo. Currently, GPU suspend mode is enabled for all targets.