### PR TITLE
refactor(microvm/power): default to SIGTERM to stop VMs, adjust shutdown

### DIFF
--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -164,7 +164,7 @@ in
     };
     gracefulShutdown = mkOption {
       type = types.bool;
-      default = config.ghaf.givc.enable;
+      default = config.ghaf.givc.enable && config.ghaf.type != "app-vm";
       defaultText = "config.ghaf.givc.enable";
       description = ''
         If true, the microvm ExecStop logic for this VM will be overridden
@@ -174,6 +174,17 @@ in
         This option only has effect if the power manager module is enabled
         on the host:
         `ghaf.services.power-manager.host.enable = true;`
+      '';
+    };
+    shutdownLast = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If true, this VM will stop after all other VMs during shutdown or reboot.
+
+        Only one VM should have this enabled. If multiple VMs enable it, each
+        will be ordered after all others but with no defined order among
+        themselves.
       '';
     };
   };

--- a/modules/common/firewall/attack-mitigation.nix
+++ b/modules/common/firewall/attack-mitigation.nix
@@ -39,7 +39,7 @@ in
     ssh = mkOption {
       type = types.submodule {
         options = {
-          enable = mkEnableOption "Enable SSH flood mitigation";
+          enable = mkEnableOption "SSH flood mitigation";
           rule = mkOption {
             type = floodType;
             default = {
@@ -64,7 +64,7 @@ in
     ping = mkOption {
       type = types.submodule {
         options = {
-          enable = mkEnableOption "Enable Ping flood mitigation" // {
+          enable = mkEnableOption "Ping flood mitigation" // {
             default = true;
           };
           rule = mkOption {

--- a/modules/common/security/audit/default.nix
+++ b/modules/common/security/audit/default.nix
@@ -28,7 +28,7 @@ in
   _file = ./default.nix;
 
   options.ghaf.security.audit = {
-    enable = mkEnableOption "Enable audit support";
+    enable = mkEnableOption "audit support";
     debug = mkOption {
       type = types.bool;
       default = true; # for now

--- a/modules/common/security/ssh-tarpit/default.nix
+++ b/modules/common/security/ssh-tarpit/default.nix
@@ -21,7 +21,7 @@ in
   _file = ./default.nix;
 
   options.ghaf.security.ssh-tarpit = {
-    enable = mkEnableOption "Enable ssh tarpit";
+    enable = mkEnableOption "SSH tarpit";
     listenAddress = mkOption {
       type = types.str;
       default = "0.0.0.0";

--- a/modules/common/services/audio/default.nix
+++ b/modules/common/services/audio/default.nix
@@ -13,7 +13,7 @@
   ];
 
   options.ghaf.services.audio = {
-    enable = lib.mkEnableOption "Enable Ghaf audio services";
+    enable = lib.mkEnableOption "Ghaf audio services";
     role = lib.mkOption {
       type = lib.types.enum [
         "server"

--- a/modules/common/services/disks.nix
+++ b/modules/common/services/disks.nix
@@ -20,7 +20,7 @@ in
   _file = ./disks.nix;
 
   options.ghaf.services.disks = {
-    enable = mkEnableOption "Enable disk mount daemon";
+    enable = mkEnableOption "disk mount daemon";
 
     fileManager = mkOption {
       type = types.str;

--- a/modules/common/services/fprint.nix
+++ b/modules/common/services/fprint.nix
@@ -14,7 +14,7 @@ in
   _file = ./fprint.nix;
 
   options.ghaf.services.fprint = {
-    enable = mkEnableOption "Enable fingerprint reader support";
+    enable = mkEnableOption "fingerprint reader support";
   };
 
   config = mkIf cfg.enable {

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -83,6 +83,16 @@ let
     ) config.microvm.vms
   );
 
+  gracefulShutdownVms = lib.attrNames (
+    filterAttrs (
+      _: vm:
+      let
+        vmConfig = lib.ghaf.vm.getConfig vm;
+      in
+      vmConfig != null && vmConfig.ghaf.gracefulShutdown
+    ) config.microvm.vms
+  );
+
   # Host suspend actions
   host-suspend-actions = pkgs.writeShellApplication {
     name = "host-suspend-actions";
@@ -264,15 +274,17 @@ let
     name = "guest-power-actions";
     runtimeInputs = [
       pkgs.pci-binder
+      pkgs.systemd
     ];
     text = ''
       case "$1" in
         reboot|poweroff)
           # Signal host to power off or reboot the system
-          ${givc-cli} "$1" &
-          # This is a workaround since the givc-cli does support async requests,
-          # and does not return when starting a reboot or poweroff target
-          sleep 1
+          systemd-run --no-block -u "signal-$1-host" \
+            -p DefaultDependencies=no -p TimeoutSec=5 \
+            -- ${givc-cli} "$1"
+          # This is a workaround since givc-cli does not support async requests,
+          # and may not return (or return an error) when requesting reboot or shutdown
           ;;
         suspend)
           # Script to unbind PCI devices for suspend
@@ -668,6 +680,7 @@ in
             serviceConfig = {
               Type = "oneshot";
               ExecStart = "${getExe guest-shutdown-interceptor}";
+              TimeoutSec = 5;
             };
           };
 
@@ -864,62 +877,116 @@ in
           # since system VMs are expected to power off quickly.
           (mkIf useGivc (
             lib.listToAttrs (
-              map
-                (
-                  vmName:
-                  nameValuePair "microvm@${vmName}" {
-                    serviceConfig = {
-                      TimeoutStopSec = "30";
-                      ExecStop =
-                        let
-                          sysvm-stop = pkgs.writeShellScript "sysvm-stop" ''
-                            # Check if this stop is part of a real shutdown or suspend.
-                            # During a nixos-rebuild switch, affected services (system vms) are restarted
-                            # which causes their ExecStop actions to be executed
-                            # If no real reboot/suspend job is queued, we can assume the VM should be
-                            # restarted without requesting the host itself to reboot
-                            jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
-                            if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start'; then
-                              echo "No shutdown/suspend in progress, skipping graceful shutdown for '${vmName}' (likely a rebuild)"
-                              kill -15 $MAINPID 2>/dev/null
-                              while kill -0 $MAINPID 2>/dev/null; do
-                                sleep 1
-                              done
-                              exit 0
-                            fi
-
-                            echo "Starting poweroff target for system VM '${vmName}'"
-                            vm=''${${vmName}/-vm/}
-                            ${givc-cli} start service --vm '${vmName}' poweroff.target &
-
-                            echo "Waiting for system VM '${vmName}' with QEMU PID=$MAINPID to stop"
+              map (
+                vmName:
+                nameValuePair "microvm@${vmName}" {
+                  serviceConfig = {
+                    TimeoutStopSec = "30";
+                    ExecStop =
+                      let
+                        sysvm-stop = pkgs.writeShellScript "sysvm-stop" ''
+                          # Check if this stop is part of a real shutdown or suspend.
+                          # During a nixos-rebuild switch, affected services (system vms) are restarted
+                          # which causes their ExecStop actions to be executed
+                          # If no real reboot/suspend job is queued, we can assume the VM should be
+                          # restarted without requesting the host itself to reboot
+                          jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
+                          if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start'; then
+                            echo "No shutdown/suspend in progress, skipping graceful shutdown for '${vmName}' (likely a rebuild)"
+                            kill -15 $MAINPID 2>/dev/null
                             while kill -0 $MAINPID 2>/dev/null; do
                               sleep 1
                             done
-                            echo "System VM '${vmName}' with QEMU PID=$MAINPID stopped"
-                          '';
-                        in
-                        [
-                          # Clear previous microvm ExecStop logic
-                          ""
-                          # '+' allows the sysvm-stop script to be executed with full privileges
-                          "+${sysvm-stop}"
-                        ];
-                    };
-                  }
-                )
-                (
-                  lib.attrNames (
-                    filterAttrs (
-                      _: vm:
-                      let
-                        vmConfig = lib.ghaf.vm.getConfig vm;
+                            exit 0
+                          fi
+
+                          echo "Starting poweroff target for system VM '${vmName}'"
+                          vm=''${${vmName}/-vm/}
+                          ${givc-cli} start service --vm '${vmName}' poweroff.target &
+
+                          echo "Waiting for system VM '${vmName}' with QEMU PID=$MAINPID to stop"
+                          while kill -0 $MAINPID 2>/dev/null; do
+                            sleep 1
+                          done
+                          echo "System VM '${vmName}' with QEMU PID=$MAINPID stopped"
+                        '';
                       in
-                      vmConfig != null && vmConfig.ghaf.type == "system-vm" && vmConfig.ghaf.gracefulShutdown
-                    ) config.microvm.vms
-                  )
-                )
+                      [
+                        # Clear previous microvm ExecStop logic
+                        ""
+                        # '+' allows the sysvm-stop script to be executed with full privileges
+                        "+${sysvm-stop}"
+                      ];
+                  };
+                }
+              ) gracefulShutdownVms
             )
+          ))
+          # Handle app-vms shutdown
+          (lib.listToAttrs (
+            map
+              (
+                vmName:
+                nameValuePair "microvm@${vmName}" {
+                  serviceConfig = {
+                    TimeoutStopSec = "30";
+                    ExecStop =
+                      let
+                        ghaf-vm-stop = pkgs.writeShellScript "ghaf-vm-stop" ''
+                          echo "Sending SIGTERM to VM '${vmName}'"
+                          kill -15 $MAINPID 2>/dev/null
+
+                          echo "Waiting for VM '${vmName}' with QEMU PID=$MAINPID to stop"
+                          while kill -0 $MAINPID 2>/dev/null; do
+                            sleep 1
+                          done
+
+                          echo "VM '${vmName}' with QEMU PID=$MAINPID stopped"
+                        '';
+                      in
+                      [
+                        # Clear previous microvm ExecStop logic
+                        ""
+                        # '+' allows the ghaf-vm-stop script to be executed with full privileges
+                        "+${ghaf-vm-stop}"
+                      ];
+                  };
+                }
+              )
+              (
+                lib.attrNames (
+                  filterAttrs (
+                    _: vm:
+                    let
+                      vmConfig = lib.ghaf.vm.getConfig vm;
+                    in
+                    vmConfig != null && vmConfig.ghaf.type != "system-vm"
+                  ) config.microvm.vms
+                )
+              )
+          ))
+          # Handle VMs with shutdownLast enabled
+          (lib.listToAttrs (
+            map
+              (
+                vmName:
+                lib.nameValuePair "microvm@${vmName}" {
+                  before = map (n: "microvm@${n}.service") (
+                    lib.filter (n: n != vmName) (lib.attrNames config.microvm.vms)
+                  );
+                }
+              )
+              (
+                lib.attrNames (
+                  lib.filterAttrs (
+                    _: vm:
+                    let
+                      vmConfig = lib.ghaf.vm.getConfig vm;
+                    in
+                    vmConfig != null && vmConfig.ghaf.shutdownLast
+                  ) config.microvm.vms
+                )
+              )
           ))
         ];
       };

--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -196,7 +196,7 @@ in
   _file = ./base.nix;
 
   options.ghaf.systemd = {
-    enable = mkEnableOption "Enable minimal systemd configuration.";
+    enable = mkEnableOption "the minimal systemd configuration.";
 
     withName = mkOption {
       description = "Set systemd name.";

--- a/modules/desktop/guivm/default.nix
+++ b/modules/desktop/guivm/default.nix
@@ -16,7 +16,7 @@
 #
 # Feature modules auto-include based on:
 #   - boot-ui.nix: globalConfig.graphics.boot.enable
-#   - shared-folders.nix: config.ghaf.storagevm.shared-folders.enable (VM-local)
+#   - shared-directories.nix: config.ghaf.storagevm.shared-directories.enable (VM-local)
 #   - shared-mem.nix: globalConfig.shm.enable
 #   - ghaf-intro.nix: hostConfig.reference.desktop.ghaf-intro.enable
 #
@@ -32,7 +32,7 @@
     # All feature modules use mkIf internally to conditionally enable
     # based on their respective globalConfig flags
     ./boot-ui.nix
-    ./shared-folders.nix
+    ./shared-directories.nix
     ./shared-mem.nix
     ./ghaf-intro.nix
   ];

--- a/modules/desktop/guivm/shared-directories.nix
+++ b/modules/desktop/guivm/shared-directories.nix
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# GUI VM Shared Folders Feature Module
+# GUI VM Shared Directories Feature Module
 #
-# This module configures the vinotify guest service for shared folder
+# This module configures the vinotify guest service for shared directory
 # change notifications. This allows the file manager to automatically
-# refresh when files change in shared folders.
+# refresh when files change in shared directories.
 #
-# This module is auto-included when config.ghaf.storagevm.shared-folders.enable is true.
+# This module is auto-included when config.ghaf.storagevm.shared-directories.enable is true.
 #
 {
   config,
@@ -16,15 +16,15 @@
   ...
 }:
 let
-  # Only enable if shared folders are enabled in the VM's own config
-  # (set by guivm-base.nix: ghaf.storagevm.shared-folders.enable = true)
-  sharedFoldersEnabled = config.ghaf.storagevm.shared-folders.enable or false;
+  # Only enable if shared directories are enabled in the VM's own config
+  # (set by guivm-base.nix: ghaf.storagevm.shared-directories.enable = true)
+  sharedFoldersEnabled = config.ghaf.storagevm.shared-directories.enable or false;
 in
 {
-  _file = ./shared-folders.nix;
+  _file = ./shared-directories.nix;
 
   config = lib.mkIf sharedFoldersEnabled {
-    # Receive shared folder inotify events from the host to automatically refresh the file manager
+    # Receive shared directory inotify events from the host to automatically refresh the file manager
     systemd.services.vinotify = {
       enable = true;
       description = "vinotify";

--- a/modules/desktop/intel-gpu/default.nix
+++ b/modules/desktop/intel-gpu/default.nix
@@ -14,7 +14,7 @@ in
   _file = ./default.nix;
 
   options.ghaf.graphics.intel-setup = {
-    enable = lib.mkEnableOption "Enable Intel GPU setup";
+    enable = lib.mkEnableOption "Intel GPU setup";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/desktop/nvidia-gpu/default.nix
+++ b/modules/desktop/nvidia-gpu/default.nix
@@ -29,7 +29,7 @@ in
   ];
 
   options.ghaf.graphics.nvidia-setup = {
-    enable = lib.mkEnableOption "Enable Nvidia setup";
+    enable = lib.mkEnableOption "Nvidia setup";
     withIntegratedGPU = lib.mkOption {
       type = lib.types.bool;
       default = false;

--- a/modules/development/nix.nix
+++ b/modules/development/nix.nix
@@ -20,7 +20,7 @@ in
       default = null;
       description = "Path to the nixpkgs repository";
     };
-    automatic-gc.enable = mkEnableOption "Enable automatic garbage collection";
+    automatic-gc.enable = mkEnableOption "automatic garbage collection";
   };
 
   config.nix = {

--- a/modules/givc/adminvm.nix
+++ b/modules/givc/adminvm.nix
@@ -50,7 +50,7 @@ in
   _file = ./adminvm.nix;
 
   options.ghaf.givc.adminvm = {
-    enable = mkEnableOption "Enable adminvm givc module.";
+    enable = mkEnableOption "the adminvm GIVC module.";
   };
 
   config = mkIf (cfg.enable && config.ghaf.givc.enable) {
@@ -90,13 +90,9 @@ in
         admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
       };
 
-      capabilities = {
-        services = [
-          "poweroff.target"
-          "reboot.target"
-        ];
-      };
-
+      capabilities.services = lib.optionals config.ghaf.gracefulShutdown [
+        "poweroff.target"
+      ];
     };
 
     ghaf.security.audit.extraRules = [

--- a/modules/givc/appvm.nix
+++ b/modules/givc/appvm.nix
@@ -22,7 +22,7 @@ in
   _file = ./appvm.nix;
 
   options.ghaf.givc.appvm = {
-    enable = mkEnableOption "Enable appvm givc module.";
+    enable = mkEnableOption "the appvm GIVC module.";
     applications = mkOption {
       type = types.listOf types.attrs;
       default = [ { } ];

--- a/modules/givc/audiovm.nix
+++ b/modules/givc/audiovm.nix
@@ -23,7 +23,7 @@ in
   _file = ./audiovm.nix;
 
   options.ghaf.givc.audiovm = {
-    enable = mkEnableOption "Enable audiovm givc module.";
+    enable = mkEnableOption "the audiovm givc module.";
   };
 
   config = mkIf (cfg.enable && config.ghaf.givc.enable) {
@@ -47,17 +47,17 @@ in
         admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
       };
       capabilities = {
-        services = [
-          "poweroff.target"
-          "reboot.target"
-        ]
-        ++ optionals config.ghaf.services.power-manager.vm.enable [
-          "suspend.target"
-          "systemd-suspend.service"
-        ];
+        services =
+          optionals config.ghaf.gracefulShutdown [
+            "poweroff.target"
+          ]
+          ++ optionals config.ghaf.services.power-manager.vm.enable [
+            "suspend.target"
+            "systemd-suspend.service"
+          ];
         socketProxy = {
           enable = true;
-          sockets = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
+          sockets = optionals (builtins.elem guivmName config.ghaf.common.vms) [
             {
               transport = {
                 name = guivmName;
@@ -80,7 +80,7 @@ in
         };
         eventProxy = {
           enable = true;
-          events = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
+          events = optionals (builtins.elem guivmName config.ghaf.common.vms) [
             {
               transport = {
                 name = guivmName;

--- a/modules/givc/common.nix
+++ b/modules/givc/common.nix
@@ -50,8 +50,8 @@ in
   _file = ./common.nix;
 
   options.ghaf.givc = {
-    enable = mkEnableOption "Enable gRPC inter-vm communication";
-    debug = mkEnableOption "Enable givc debug mode";
+    enable = mkEnableOption "gRPC inter-vm communication (GIVC)";
+    debug = mkEnableOption "GIVC debug mode";
     enableTls = mkOption {
       description = "Enable TLS for gRPC communication globally, or disable for debugging.";
       type = types.bool;

--- a/modules/givc/guivm.nix
+++ b/modules/givc/guivm.nix
@@ -25,7 +25,7 @@ in
   _file = ./guivm.nix;
 
   options.ghaf.givc.guivm = {
-    enable = mkEnableOption "Enable guivm givc module.";
+    enable = mkEnableOption "the guivm GIVC module.";
   };
 
   config = mkIf (cfg.enable && config.ghaf.givc.enable) {
@@ -52,10 +52,6 @@ in
         tls.enable = config.ghaf.givc.enableTls;
       };
       capabilities = {
-        services = [
-          "reboot.target"
-          "poweroff.target"
-        ];
         socketProxy = {
           enable = true;
           sockets =

--- a/modules/givc/host.nix
+++ b/modules/givc/host.nix
@@ -20,7 +20,7 @@ in
   _file = ./host.nix;
 
   options.ghaf.givc.host = {
-    enable = mkEnableOption "Enable host givc module.";
+    enable = mkEnableOption "the host GIVC module.";
   };
 
   config = mkIf (cfg.enable && config.ghaf.givc.enable) {

--- a/modules/givc/netvm.nix
+++ b/modules/givc/netvm.nix
@@ -22,7 +22,7 @@ in
   _file = ./netvm.nix;
 
   options.ghaf.givc.netvm = {
-    enable = mkEnableOption "Enable netvm givc module.";
+    enable = mkEnableOption "the netvm GIVC module.";
   };
 
   config = mkIf (cfg.enable && config.ghaf.givc.enable) {
@@ -47,22 +47,22 @@ in
         admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
       };
       capabilities = {
-        services = [
-          "poweroff.target"
-          "reboot.target"
-        ]
-        ++ optionals config.ghaf.services.power-manager.vm.enable [
-          "suspend.target"
-          "systemd-suspend.service"
-        ]
-        ++ optionals config.ghaf.services.performance.net.tuned.enable [
-          "net-powersave.service"
-          "net-balanced.service"
-          "net-performance.service"
-          "net-powersave-battery.service"
-          "net-balanced-battery.service"
-          "net-performance-battery.service"
-        ];
+        services =
+          optionals config.ghaf.gracefulShutdown [
+            "poweroff.target"
+          ]
+          ++ optionals config.ghaf.services.power-manager.vm.enable [
+            "suspend.target"
+            "systemd-suspend.service"
+          ]
+          ++ optionals config.ghaf.services.performance.net.tuned.enable [
+            "net-powersave.service"
+            "net-balanced.service"
+            "net-performance.service"
+            "net-powersave-battery.service"
+            "net-balanced-battery.service"
+            "net-performance-battery.service"
+          ];
         hwid.enable = true;
 
         socketProxy = {

--- a/modules/hardware/passthrough/vhotplug.nix
+++ b/modules/hardware/passthrough/vhotplug.nix
@@ -34,7 +34,7 @@ in
   _file = ./vhotplug.nix;
 
   options.ghaf.hardware.passthrough.vhotplug = {
-    enable = mkEnableOption "Enable hot plugging of USB devices";
+    enable = mkEnableOption "the hot plugging of USB devices";
 
     usbRules = mkOption {
       type = types.listOf types.attrs;

--- a/modules/microvm/common/shared-directory.nix
+++ b/modules/microvm/common/shared-directory.nix
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 { lib, config, ... }:
 let
-  cfg = config.ghaf.storagevm.shared-folders;
+  cfg = config.ghaf.storagevm.shared-directories;
   inherit (lib) mkEnableOption;
   shared-mountPath = "/tmp/shared/shares";
   userDir =
@@ -10,8 +10,8 @@ let
 in
 {
   _file = ./shared-directory.nix;
-  options.ghaf.storagevm.shared-folders = {
-    enable = mkEnableOption "Enable shared directory";
+  options.ghaf.storagevm.shared-directories = {
+    enable = mkEnableOption "shared directory";
     isGuiVm = mkEnableOption "Indicate if the VM is the GUI VM";
   };
 

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -310,7 +310,7 @@ in
           startLimitIntervalSec = 0;
         };
 
-        # Shared folders guest config is now provided by guivm-desktop-features module
+        # Shared directories guest config is now provided by guivm-desktop-features module
         # See: modules/desktop/guivm/shared-directories.nix
       }
     )

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -63,7 +63,7 @@ in
 
       vms = mkOption {
         description = ''
-          List of names of virtual machines for which unsafe shared folder will be enabled.
+          List of names of virtual machines for which unsafe shared directory will be enabled.
         '';
         type = types.listOf types.str;
         default = [ ];
@@ -205,18 +205,6 @@ in
 
       systemd.services =
         let
-          patchedMicrovmServices = lib.foldl' (
-            result: name:
-            result
-            // {
-              # Prevent microvm restart if shutdown internally. If set to 'on-failure', 'microvm-shutdown'
-              # in ExecStop of the microvm@ service fails and causes the service to restart.
-              "microvm@${name}".serviceConfig = {
-                Restart = "on-abnormal";
-              };
-            }
-          ) { } (lib.attrNames config.microvm.vms);
-
           vmsWithEncryptedStorage = lib.filterAttrs (
             _name: vm:
             let
@@ -282,7 +270,6 @@ in
         {
           # Device-id and machine-id generation moved to ghaf.identity.dynamicHostName module
         }
-        // patchedMicrovmServices
         // vmstorageSetupServices;
     })
     (mkIf cfg.sharedVmDirectory.enable {
@@ -307,8 +294,8 @@ in
         && config.ghaf.virtualization.microvm.guivm.enable
       )
       {
-        # Enable passthrough of the shared folder inotify events from the host to the GUI VM
-        # This is required for the file manager to refresh the shared folder content when it is updated from AppVMs
+        # Enable passthrough of the shared directory inotify events from the host to the GUI VM
+        # This is required for the file manager to refresh the shared directory content when it is updated from AppVMs
         systemd.services.vinotify = {
           enable = true;
           description = "vinotify";
@@ -324,7 +311,7 @@ in
         };
 
         # Shared folders guest config is now provided by guivm-desktop-features module
-        # See: modules/desktop/guivm/shared-folders.nix
+        # See: modules/desktop/guivm/shared-directories.nix
       }
     )
     (mkIf (cfg.enable && config.services.userborn.enable) {

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -182,6 +182,10 @@ in
     services.timezone.enable = lib.mkDefault (
       timezoneEnabled && globalConfig.platform.timeZone == null
     );
+
+    # Make sure admin-vm is the last to shutdown
+    # This is done to allow servicing GIVC requests until the very end
+    shutdownLast = true;
   };
 
   time.timeZone = lib.mkIf (!timezoneEnabled) (lib.mkDefault globalConfig.platform.timeZone);

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -202,7 +202,7 @@ in
                   mode = "0700";
                 }
               ];
-          shared-folders.enable =
+          shared-directories.enable =
             (sharedVmDirectory.enable or false) && builtins.elem vmName (sharedVmDirectory.vms or [ ]);
           encryption.enable = globalConfig.storage.encryption.enable or false;
         };

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -144,7 +144,7 @@ in
     storagevm = {
       enable = true;
       name = vmName;
-      shared-folders = {
+      shared-directories = {
         enable = true;
         isGuiVm = true;
       };

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -14,7 +14,7 @@ in
   _file = ./laptop-x86.nix;
 
   options.ghaf.profiles.laptop-x86 = {
-    enable = lib.mkEnableOption "Enable the basic x86 laptop config";
+    enable = lib.mkEnableOption "the basic x86 laptop config";
 
     # GUI VM base configuration for profiles to extend
     guivmBase = lib.mkOption {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -34,7 +34,7 @@ in
   _file = ./orin.nix;
 
   options.ghaf.profiles.orin = {
-    enable = lib.mkEnableOption "Enable the basic nvidia orin config";
+    enable = lib.mkEnableOption "the basic Nvidia Orin config";
 
     # Net VM base configuration for profiles to extend
     netvmBase = lib.mkOption {

--- a/modules/reference/appvms/default.nix
+++ b/modules/reference/appvms/default.nix
@@ -31,7 +31,7 @@ in
     ./media.nix
   ];
 
-  options.ghaf.reference.appvms.enable = lib.mkEnableOption "Enable the Ghaf reference appvms module";
+  options.ghaf.reference.appvms.enable = lib.mkEnableOption "the Ghaf reference appvms module";
 
   config = lib.mkIf cfg.enable {
     # Enable the main appvm module

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/pci-passthrough-common.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/pci-passthrough-common.nix
@@ -8,7 +8,7 @@ in
   _file = ./pci-passthrough-common.nix;
 
   options.ghaf.hardware.nvidia.orin.enablePCIPassthroughCommon =
-    lib.mkEnableOption "Enable common options related to PCI passthrough on Orin AGX and NX";
+    lib.mkEnableOption "common options related to PCI passthrough on Orin AGX and NX";
   config = lib.mkIf cfg.enablePCIPassthroughCommon {
     boot.kernelModules = [
       "vfio_pci"

--- a/modules/reference/personalize/keys.nix
+++ b/modules/reference/personalize/keys.nix
@@ -12,7 +12,7 @@ in
   _file = ./keys.nix;
 
   options.ghaf.reference.personalize.keys = {
-    enable = mkEnableOption "Enable personalization of keys for dev team";
+    enable = mkEnableOption "personalization of keys for dev team";
   };
 
   config = mkIf cfg.enable {

--- a/modules/reference/profiles/mvp-orinuser-trial-extras.nix
+++ b/modules/reference/profiles/mvp-orinuser-trial-extras.nix
@@ -10,7 +10,7 @@ in
   imports = [ ./mvp-orinuser-trial.nix ];
 
   options.ghaf.reference.profiles.mvp-orinuser-trial-extras = {
-    enable = lib.mkEnableOption "Enable the mvp orin configuration for apps and services";
+    enable = lib.mkEnableOption "the mvp Orin configuration for apps and services";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/reference/profiles/mvp-orinuser-trial.nix
+++ b/modules/reference/profiles/mvp-orinuser-trial.nix
@@ -12,7 +12,7 @@ in
   _file = ./mvp-orinuser-trial.nix;
 
   options.ghaf.reference.profiles.mvp-orinuser-trial = {
-    enable = lib.mkEnableOption "Enable the mvp configuration for apps and services";
+    enable = lib.mkEnableOption "the mvp configuration for apps and services";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/reference/profiles/mvp-user-trial-extras.nix
+++ b/modules/reference/profiles/mvp-user-trial-extras.nix
@@ -10,7 +10,7 @@ in
   imports = [ ./mvp-user-trial.nix ];
 
   options.ghaf.reference.profiles.mvp-user-trial-extras = {
-    enable = lib.mkEnableOption "Enable the mvp configuration for apps and services";
+    enable = lib.mkEnableOption "the mvp configuration for apps and services";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -14,7 +14,7 @@ in
   _file = ./mvp-user-trial.nix;
 
   options.ghaf.reference.profiles.mvp-user-trial = {
-    enable = lib.mkEnableOption "Enable the mvp configuration for apps and services";
+    enable = lib.mkEnableOption "the mvp configuration for apps and services";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/reference/programs/chromium.nix
+++ b/modules/reference/programs/chromium.nix
@@ -13,7 +13,7 @@ in
   _file = ./chromium.nix;
 
   options.ghaf.reference.programs.chromium = {
-    enable = lib.mkEnableOption "Enable Chromium program settings";
+    enable = lib.mkEnableOption "Chromium program settings";
     openInNormalExtension = lib.mkEnableOption "browser extension to open links in the normal browser";
   };
   config = lib.mkIf cfg.enable {

--- a/modules/reference/services/chromecast/chromecast.nix
+++ b/modules/reference/services/chromecast/chromecast.nix
@@ -24,7 +24,7 @@ in
   _file = ./chromecast.nix;
 
   options.ghaf.reference.services.chromecast = {
-    enable = mkEnableOption "Enable chromecast service";
+    enable = mkEnableOption "the Chromecast service";
 
     externalNic = mkOption {
       type = types.str;

--- a/modules/reference/services/default.nix
+++ b/modules/reference/services/default.nix
@@ -29,8 +29,8 @@ in
   ];
   options.ghaf.reference.services = {
     enable = mkEnableOption "Ghaf reference services";
-    dendrite = mkEnableOption "dendrite-pinecone service";
-    proxy-business = mkEnableOption "Enable the proxy server service";
+    dendrite = mkEnableOption "the dendrite-pinecone service";
+    proxy-business = mkEnableOption "the proxy server service";
     google-chromecast = mkOption {
       description = "Google Chromecast service configuration";
       type = types.submodule {

--- a/modules/reference/services/dendrite-pinecone/dendrite-pinecone.nix
+++ b/modules/reference/services/dendrite-pinecone/dendrite-pinecone.nix
@@ -19,7 +19,7 @@ in
   _file = ./dendrite-pinecone.nix;
 
   options.ghaf.reference.services.dendrite-pinecone = {
-    enable = mkEnableOption "Enable dendrite pinecone module";
+    enable = mkEnableOption "the dendrite pinecone module";
 
     externalNic = mkOption {
       type = types.str;

--- a/modules/reference/services/nw-packet-forwarder/nw-packet-forwarder.nix
+++ b/modules/reference/services/nw-packet-forwarder/nw-packet-forwarder.nix
@@ -79,12 +79,12 @@ in
       description = "nw-packet-forwarder chromecast configuration";
       type = types.submodule {
         options = {
-          enable = mkEnableOption "Enable chromecast feature";
+          enable = mkEnableOption "the Chromecast feature";
 
           vmName = mkOption {
             type = types.str;
             example = "chrome-vm";
-            description = "The name of the chromium/chrome VM to setup chromecast for.";
+            description = "The name of the chromium/chrome VM to setup Chromecast for.";
             default = "chrome-vm";
           };
         };

--- a/modules/reference/services/ollama/ollama.nix
+++ b/modules/reference/services/ollama/ollama.nix
@@ -13,7 +13,7 @@ in
   _file = ./ollama.nix;
 
   options.ghaf.reference.services.ollama = {
-    enable = mkEnableOption "Enable the ollama service";
+    enable = mkEnableOption "the Ollama service";
   };
 
   config = mkIf cfg.enable {

--- a/modules/reference/services/proxy-server/3proxy-config.nix
+++ b/modules/reference/services/proxy-server/3proxy-config.nix
@@ -75,7 +75,7 @@ in
   _file = ./3proxy-config.nix;
 
   options.ghaf.reference.services.proxy-server = {
-    enable = mkEnableOption "Enable proxy server module";
+    enable = mkEnableOption "the proxy server module";
     internalAddress = lib.mkOption {
       type = lib.types.str;
       default = config.ghaf.networking.hosts."net-vm".ipv4;

--- a/modules/reference/services/wireguard-gui/wireguard-gui.nix
+++ b/modules/reference/services/wireguard-gui/wireguard-gui.nix
@@ -31,7 +31,7 @@ in
   _file = ./wireguard-gui.nix;
 
   options.ghaf.reference.services.wireguard-gui = {
-    enable = lib.mkEnableOption "Enable the Wireguard GUI service";
+    enable = lib.mkEnableOption "the Wireguard GUI service";
     serverPorts = lib.mkOption {
       type = lib.types.listOf lib.types.port;
       default = [ ];

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -236,7 +236,9 @@ let
                   };
                 };
                 capabilities = {
-                  services = [ ];
+                  services = lib.optionals config.ghaf.gracefulShutdown [
+                    "poweroff.target"
+                  ];
                   eventProxy.enable = lib.mkForce false;
                 };
               };


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Removed microvm service overrides from microvm-host config
- Added overrides for microvm services' ExecStop behavior in power-manager cfg to do the following:
   - System VMs (and admin-vm) are stopped by calling their respective `poweroff.target`
   - admin-vm is stopped _**last**_ to allow servicing GIVC requests until shutdown is complete
   - App VMs are stopped using SIGTERM
- Added a shutdownLast option and enabled it for `admin-vm`
- Adjusted `gui-vm` shutdown to not wait for the givc call to host to succeed/finish

With these changes, all VMs are now expected to shutdown relatively cleanly and never timeout on `ExecStop`.
In addition, `admin-vm` will always be the last to shutdown, which allows any pre-existing GIVC calls to finish before the system powers off.
`gui-vm` will no longer delay system shutdown by waiting on the blocking givc-cli call to the host

### Other:

Refactored all syntactically incorrect uses of `mkEnableOption`, which implicitly prepends a "Whether to enable" string to any given description.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Verify shutdown/reboot does not cause any VMs to timeout:
   - Initiate shutdown/reboot via GUI
   - Wait for it to complete
   - Boot and check the shutdown logs on the host to ensure no `microvm@.service` timed out:
      ```sh
      journalctl -b -1 -r | grep -i timeout
      # Output should be minimal and not include any microvm@.service timeouts
      ```
2. Verify shutdown/reboot takes <=30 seconds.
    30s is the default configured timeout for all VMs.
    If the full shutdown sequence takes 30s, it may indicate a timeout in one or more VMs