### PR TITLE
fix(fss): log sealing reports bad message failure after reboot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ linux-*/
 gcroot/
 .pre-commit-config.yaml
 .aider*
+.codex
 .nixos-test-history
 uv-x86_64-unknown-linux-gnu/
 __pycache__/

--- a/docs/src/content/docs/ghaf/scs/fss.mdx
+++ b/docs/src/content/docs/ghaf/scs/fss.mdx
@@ -65,6 +65,52 @@ The verification key enables:
 - Audit by external parties without access to the live system
 - Disaster recovery verification
 
+## Lifecycle Receipts
+
+Ghaf FSS verification distinguishes active integrity failures from expected
+journald lifecycle artifacts using content-bound receipts. A receipt is a small
+TSV record written when FSS setup or recovery creates an archive that may later
+fail plain `journalctl --verify` even though it is not evidence of current
+active log corruption.
+
+Receipt schema:
+
+```text
+v1 <path> <inode> <size> <boot_id> <mtime> <sha256> <reason> <event_id>
+```
+
+Fields:
+
+| Field      | Meaning                                                     |
+| ---------- | ----------------------------------------------------------- |
+| `v1`       | Receipt schema version                                      |
+| `path`     | Journal archive path recorded at the lifecycle event        |
+| `inode`    | Inode observed when the receipt was created                 |
+| `size`     | Size observed when the receipt was created                  |
+| `boot_id`  | Boot ID that produced the receipt                           |
+| `mtime`    | Archive modification time observed at receipt creation      |
+| `sha256`   | Content hash used for verification-time identity matching   |
+| `reason`   | Lifecycle reason, such as `pre-activation-rotation`, recovery, or `unclean-shutdown` |
+| `event_id` | Event identifier tying receipts from the same operation together |
+
+Receipt classes:
+
+| Class                  | Producer                         | Verification behavior |
+| ---------------------- | -------------------------------- | --------------------- |
+| Pre-activation archive | `journal-fss-setup.service`      | Current-boot receipts become verified exceptions; earlier boot receipts warn |
+| Recovery archive       | `ghaf-journal-alloy-recover`     | Current-boot receipts become verified exceptions; earlier boot receipts warn |
+| Unclean shutdown       | journald recovery plus FSS setup | Matching `.journal~` archives become verified exceptions or warnings depending on boot |
+
+Validation is fail-closed:
+
+- A matching on-disk archive must have the recorded SHA256 content hash.
+- A present archive with different content is a receipt mismatch and fails
+  verification.
+- A missing archive is tolerated because journald retention may legitimately
+  delete old archives.
+- A receipt never exempts the live `system.journal`; active system journal
+  verification failures remain critical.
+
 ## Operations
 
 ### Manual Verification

--- a/docs/src/content/docs/ghaf/scs/fss.mdx
+++ b/docs/src/content/docs/ghaf/scs/fss.mdx
@@ -248,6 +248,17 @@ systemctl show journal-fss-setup --property=ConditionResult
 - Deletion of entire journal files (mitigated by remote log forwarding)
 - Real-time tampering before sealing (mitigated by short seal intervals)
 - Denial of service against logging
+- Local-root forgery of the on-host verification verdict. The setup and verify services trust
+  unauthenticated plaintext "receipt" and activation-state files under
+  `/var/log/journal/<machine-id>/` (root-owned, mode `0644`). A local-root attacker who tampers a
+  sealed archive can append a matching receipt line (its recorded `sha256` equals the tampered
+  content) to convert the on-host verdict from `AUDIT_LOG_INTEGRITY_FAIL` into a silent pass.
+  Authoritative tamper detection therefore requires **offline** `journalctl --verify --verify-key=`
+  against an exported archive using an off-host verification-key backup (see
+  [Offline Verification](#offline-verification)), which this attack cannot defeat.
+- The per-boot pre-activation window. Sealing is now activated at runtime, after the
+  clock-readiness barrier, rather than statically at journald start, so entries logged before
+  activation completes on each boot are collected but not yet FSS-trusted.
 
 ### Audit Integration
 

--- a/docs/src/content/docs/ghaf/scs/fss.mdx
+++ b/docs/src/content/docs/ghaf/scs/fss.mdx
@@ -159,9 +159,11 @@ Indicates an integrity or corruption issue:
 # Check which files failed
 journalctl --verify 2>&1 | grep FAIL
 
-# If only .journal~ files fail, these are temp files (not critical)
-# If only user-*.journal or system@*.journal fail while system.journal passes,
-# treat this as a warning and investigate journal rotation/recovery timing.
+# If only .journal~ files fail, these are temp files (not critical).
+# If a recorded bootstrap/recovery system@*.journal archive fails while
+# system.journal passes, fss-test and journal-fss-verify treat FSS as healthy.
+# If user-*.journal files fail while system.journal passes, treat this as a
+# warning and investigate journal rotation/recovery timing.
 # Active system.journal failures remain critical.
 ```
 

--- a/modules/common/logging/alloy-server.nix
+++ b/modules/common/logging/alloy-server.nix
@@ -113,10 +113,11 @@ in
       journald.extraConfig = mkIf config.ghaf.logging.journalRetention.enable ''
         MaxRetentionSec=${config.ghaf.logging.journalRetention.maxRetention}
         MaxFileSec=${config.ghaf.logging.journalRetention.MaxFileSec}
+        SyncIntervalSec=${config.ghaf.logging.journalRetention.syncInterval}
         SystemMaxUse=${config.ghaf.logging.journalRetention.maxDiskUsage}
         SystemMaxFileSize=100M
         Storage=persistent
-        ${optionalString config.ghaf.logging.fss.enable ''
+        ${optionalString config.ghaf.logging.fss.staticSealEnabled ''
           Seal=yes
         ''}
       '';

--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -14,6 +14,212 @@ let
     types
     ;
   recCfg = config.ghaf.logging.recovery;
+  loggingStackEnabled = config.ghaf.logging.enable || config.ghaf.logging.fss.enable;
+  clockReadyEnabled = config.ghaf.logging.fss.enable && recCfg.enable && recCfg.clockReady.enable;
+  fssActivationCfg = config.ghaf.logging.fss.activation;
+  fssActivationEnabled = config.ghaf.logging.fss.enable && fssActivationCfg.enable;
+  # Effective time-sync wait before FSS activation; only applies when the
+  # activation boundary is enabled. Computed once and reused below.
+  effectiveSyncWaitSeconds = if fssActivationEnabled then fssActivationCfg.syncWaitSeconds else 0;
+
+  ghafClockReady = pkgs.writeShellApplication {
+    name = "ghaf-clock-ready";
+    runtimeInputs = with pkgs; [
+      coreutils
+      gawk
+      systemd
+    ];
+    text = ''
+      stable_seconds="${toString recCfg.clockReady.stableSeconds}"
+      max_wait_seconds="${toString recCfg.clockReady.maxWaitSeconds}"
+      min_epoch="${toString recCfg.clockReady.minEpochSeconds}"
+      max_epoch="${toString recCfg.clockReady.maxEpochSeconds}"
+      ready_file="/run/ghaf-clock-ready"
+      state_file="/run/ghaf-clock-ready-state"
+      state_dir="/var/lib/ghaf/clock-ready"
+      anchor_file="$state_dir/last-good-realtime"
+
+      uptime_seconds() {
+        awk '{printf "%d\n", $1}' /proc/uptime
+      }
+
+      read_epoch_file() {
+        local path="$1"
+        local value=""
+
+        [ -r "$path" ] || return 0
+        value="$(tr -d '\n' < "$path" 2>/dev/null || true)"
+        case "$value" in
+        "" | *[!0-9]*) return 0 ;;
+        *) printf '%s\n' "$value" ;;
+        esac
+      }
+
+      write_state() {
+        local now_real now_up
+
+        now_real="$(date +%s)"
+        now_up="$(uptime_seconds)"
+        {
+          printf 'ready_established=%s\n' "$ready_established"
+          printf 'sync_result=%s\n' "$sync_result"
+          printf 'sync_value=%s\n' "$sync_value"
+          printf 'realtime=%s\n' "$now_real"
+          printf 'uptime_seconds=%s\n' "$now_up"
+          printf 'min_allowed=%s\n' "$min_allowed"
+          printf 'max_allowed=%s\n' "$max_epoch"
+          printf 'anchor_epoch=%s\n' "''${anchor_epoch:-}"
+          printf 'anchor_status=%s\n' "''${anchor_status:-unknown}"
+        } > "$state_file"
+        chmod 0644 "$state_file"
+      }
+
+      mkdir -p "$state_dir"
+
+      anchor_epoch="$(read_epoch_file "$anchor_file")"
+      anchor_status="missing"
+      min_allowed="$min_epoch"
+      if [ -n "$anchor_epoch" ] && [ "$anchor_epoch" -gt "$max_epoch" ]; then
+        echo "Clock readiness ignoring future-poisoned anchor $anchor_epoch above maximum $max_epoch"
+        anchor_status="ignored-future"
+        anchor_epoch=""
+      elif [ -n "$anchor_epoch" ] && [ "$anchor_epoch" -gt "$min_allowed" ]; then
+        min_allowed="$anchor_epoch"
+        anchor_status="accepted"
+      elif [ -n "$anchor_epoch" ]; then
+        anchor_status="below-minimum"
+      fi
+
+      start_up="$(uptime_seconds)"
+      last_real="$(date +%s)"
+      stable_since="$start_up"
+      ready_established=0
+      sync_result="not-started"
+      sync_value="unknown"
+
+      while true; do
+        sleep 1
+        now_up="$(uptime_seconds)"
+        now_real="$(date +%s)"
+
+        if [ "$now_real" -gt "$max_epoch" ]; then
+          stable_since=""
+          echo "Clock readiness waiting: realtime $now_real is above maximum $max_epoch"
+        elif [ "$now_real" -lt "$min_allowed" ]; then
+          stable_since=""
+          echo "Clock readiness waiting: realtime $now_real is below minimum $min_allowed"
+        elif [ "$now_real" -lt "$last_real" ]; then
+          stable_since=""
+          echo "Clock readiness waiting: realtime moved backwards from $last_real to $now_real"
+        else
+          if [ -z "$stable_since" ]; then
+            stable_since="$now_up"
+          fi
+
+          if [ "$((now_up - stable_since))" -ge "$stable_seconds" ]; then
+            echo "Clock readiness established after $stable_seconds stable seconds"
+            ready_established=1
+            break
+          fi
+        fi
+
+        last_real="$now_real"
+
+        if [ "$((now_up - start_up))" -ge "$max_wait_seconds" ]; then
+          echo "Clock readiness max wait reached; allowing boot to continue with realtime $now_real"
+          break
+        fi
+      done
+
+      # NTP synchronization is intentionally NOT awaited here. This barrier runs
+      # early (before systemd-journal-flush, which requires it, and before
+      # sysinit.target), so networking/timesyncd has not started yet and the NTP
+      # check could only ever hit its full timeout, stalling the journal flush on
+      # every boot. The sync wait is handled later by ghaf-clock-sync.service,
+      # which runs after networking and before journal-fss-setup.
+      sync_result="deferred"
+
+      now_real="$(date +%s)"
+      if [ "$now_real" -gt "$max_epoch" ]; then
+        echo "Clock readiness did not update last-good realtime: $now_real is above maximum $max_epoch"
+      elif [ "$now_real" -ge "$min_allowed" ]; then
+        printf '%s\n' "$now_real" > "$anchor_file"
+        chmod 0644 "$anchor_file"
+      elif [ "$ready_established" -eq 0 ]; then
+        echo "Clock readiness fallback did not update last-good realtime: $now_real is below $min_allowed"
+      fi
+
+      write_state
+      touch "$ready_file"
+      chmod 0644 "$ready_file"
+    '';
+  };
+
+  # Time-synchronization wait, split out of ghaf-clock-ready so it runs AFTER
+  # networking/timesyncd and does not block the early journal flush. It best-effort
+  # waits for NTP synchronization up to the configured bound before FSS activation,
+  # then releases boot regardless (clock readiness is a gate, not a time authority).
+  ghafClockSync = pkgs.writeShellApplication {
+    name = "ghaf-clock-sync";
+    runtimeInputs = with pkgs; [
+      coreutils
+      gawk
+      systemd
+    ];
+    text = ''
+      sync_wait_seconds="${toString effectiveSyncWaitSeconds}"
+      sync_state_file="/run/ghaf-clock-sync-state"
+      synced_file="/run/ghaf-clock-synced"
+
+      uptime_seconds() {
+        awk '{printf "%d\n", $1}' /proc/uptime
+      }
+
+      sync_result="not-started"
+      sync_value="unknown"
+
+      write_sync_state() {
+        {
+          printf 'sync_result=%s\n' "$sync_result"
+          printf 'sync_value=%s\n' "$sync_value"
+          printf 'sync_wait_seconds=%s\n' "$sync_wait_seconds"
+          printf 'realtime=%s\n' "$(date +%s)"
+          printf 'uptime_seconds=%s\n' "$(uptime_seconds)"
+        } > "$sync_state_file"
+        chmod 0644 "$sync_state_file"
+      }
+
+      if [ "$sync_wait_seconds" -le 0 ]; then
+        sync_result="disabled"
+      elif command -v timedatectl >/dev/null 2>&1; then
+        sync_start_up="$(uptime_seconds)"
+        while true; do
+          sync_value="$(timedatectl show -p NTPSynchronized --value 2>/dev/null || true)"
+          if [ "$sync_value" = "yes" ]; then
+            sync_result="synchronized"
+            echo "Clock sync observed system time synchronization"
+            break
+          fi
+
+          now_up="$(uptime_seconds)"
+          if [ "$((now_up - sync_start_up))" -ge "$sync_wait_seconds" ]; then
+            sync_result="timeout"
+            echo "Clock sync wait reached; allowing boot to continue with NTPSynchronized=''${sync_value:-unknown}"
+            break
+          fi
+
+          sleep 1
+        done
+      else
+        sync_result="timedatectl-unavailable"
+        echo "Clock sync could not check time synchronization: timedatectl unavailable"
+      fi
+
+      write_sync_state
+      touch "$synced_file"
+      chmod 0644 "$synced_file"
+    '';
+  };
 
   ghafClockJumpWatcher = pkgs.writeShellApplication {
     name = "ghaf-clock-jump-watcher";
@@ -60,7 +266,11 @@ let
     text = ''
       machine_id="$(cat /etc/machine-id)"
       state_dir="/var/log/journal/$machine_id"
-      recovery_archives_file="$state_dir/fss-recovery-archives"
+      recovery_receipts_file="$state_dir/fss-recovery-receipts"
+      activation_state_file="$state_dir/fss-activation-state"
+      activation_baseline_file="$state_dir/fss-baseline-boot"
+      fss_activation_enabled="${if fssActivationEnabled then "1" else "0"}"
+      max_recovery_receipts="${toString recCfg.maxReceipts}"
       stamp="/run/ghaf-journal-alloy-recover.stamp"
       now_ms="$(awk '{printf "%d\n", $1 * 1000}' /proc/uptime)"
       cooldown="${toString recCfg.cooldownSeconds}"
@@ -85,16 +295,80 @@ let
         done | sort -u
       }
 
-      append_unique_archive() {
+      current_boot_id() {
+        cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot
+      }
+
+      fss_activation_complete_current_boot() {
+        local state=""
+        local state_boot=""
+        local baseline_boot=""
+        local boot
+
+        [ "$fss_activation_enabled" = 1 ] || return 0
+        [ -r "$activation_state_file" ] || return 1
+        [ -r "$activation_baseline_file" ] || return 1
+
+        state="$(awk -F '\t' 'NR == 1 { print $1 }' "$activation_state_file")"
+        state_boot="$(awk -F '\t' 'NR == 1 { print $2 }' "$activation_state_file")"
+        baseline_boot="$(tr -d '[:space:]' < "$activation_baseline_file")"
+        boot="$(current_boot_id)"
+
+        [ "$state" = "active" ] \
+          && [ "$state_boot" = "$boot" ] \
+          && [ "$baseline_boot" = "$boot" ]
+      }
+
+      valid_sha256() {
+        printf '%s' "$1" | grep -Eq '^[0-9a-f]{64}$'
+      }
+
+      record_recovery_receipt() {
         local archive_path="$1"
+        local inode size mtime sha boot event
 
         [ -n "$archive_path" ] || return 0
+        [ -f "$archive_path" ] || return 0
 
-        if [ -f "$recovery_archives_file" ] && grep -Fxq "$archive_path" "$recovery_archives_file"; then
+        inode=$(stat -c %i "$archive_path" 2>/dev/null || true)
+        size=$(stat -c %s "$archive_path" 2>/dev/null || true)
+        mtime=$(stat -c %Y "$archive_path" 2>/dev/null || true)
+        sha=$(sha256sum "$archive_path" 2>/dev/null | cut -d' ' -f1 || true)
+        boot="$(current_boot_id)"
+        event="''${INVOCATION_ID:-$boot}"
+
+        if [ -z "$inode" ] || [ -z "$size" ] || [ -z "$mtime" ] || ! valid_sha256 "$sha"; then
+          echo "Could not record FSS recovery receipt for $archive_path: missing stat or sha256 evidence"
           return 0
         fi
 
-        printf '%s\n' "$archive_path" >> "$recovery_archives_file"
+        if [ -f "$recovery_receipts_file" ] \
+          && awk -F '\t' -v p="$archive_path" -v i="$inode" -v s="$size" \
+            '$2 == p && $3 == i && $4 == s { found = 1 } END { exit found ? 0 : 1 }' \
+            "$recovery_receipts_file"; then
+          return 0
+        fi
+
+        printf 'v1\t%s\t%s\t%s\t%s\t%s\t%s\tclock-jump-recovery\t%s\n' \
+          "$archive_path" "$inode" "$size" "$boot" "$mtime" "$sha" "$event" \
+          >> "$recovery_receipts_file"
+        chmod 0644 "$recovery_receipts_file"
+        echo "Recorded FSS recovery archive receipt: $archive_path"
+      }
+
+      prune_recovery_receipts() {
+        local total excess tmp
+
+        [ -f "$recovery_receipts_file" ] || return 0
+        total=$(wc -l < "$recovery_receipts_file" 2>/dev/null || echo 0)
+        [ "$total" -gt "$max_recovery_receipts" ] || return 0
+
+        excess=$((total - max_recovery_receipts))
+        tmp=$(mktemp)
+        tail -n "$max_recovery_receipts" "$recovery_receipts_file" > "$tmp"
+        mv "$tmp" "$recovery_receipts_file"
+        chmod 0644 "$recovery_receipts_file"
+        echo "Recovery receipts exceeded $max_recovery_receipts; evicted $excess oldest record(s)"
       }
 
       record_recovery_archives() {
@@ -102,8 +376,8 @@ let
         local archive_path
 
         mkdir -p "$state_dir"
-        touch "$recovery_archives_file"
-        chmod 0644 "$recovery_archives_file"
+        touch "$recovery_receipts_file"
+        chmod 0644 "$recovery_receipts_file"
 
         after_file="$(mktemp)"
         list_archived_system_journals > "$after_file"
@@ -111,14 +385,19 @@ let
         while IFS= read -r archive_path || [ -n "$archive_path" ]; do
           [ -n "$archive_path" ] || continue
           if ! grep -Fxq "$archive_path" "$before_file"; then
-            append_unique_archive "$archive_path"
+            record_recovery_receipt "$archive_path"
           fi
         done < "$after_file"
 
         rm -f "$after_file"
+        prune_recovery_receipts
       }
 
       trap cleanup EXIT
+      if ! fss_activation_complete_current_boot; then
+        echo "FSS activation is not complete for the current boot; skipping journal recovery"
+        exit 0
+      fi
       list_archived_system_journals > "$before_file"
 
       if [ -e "$stamp" ]; then
@@ -137,6 +416,9 @@ let
 
       systemd-tmpfiles --create --prefix /var/log/journal
       systemctl restart systemd-journald.service
+      record_recovery_archives
+      journalctl --rotate 2>/dev/null || true
+      journalctl --sync 2>/dev/null || true
       record_recovery_archives
 
       restart_if_installed() {
@@ -226,6 +508,18 @@ in
         type = types.str;
         default = "1day";
       };
+
+      syncInterval = mkOption {
+        description = ''
+          journald SyncIntervalSec: how often journal data is fsync'd to disk.
+          Lower values shrink the window of unsynced data lost on an unclean kill
+          (host crash, power loss, stop timeout), at the cost of more frequent
+          fsyncs. Relevant to FSS: an unsynced tail can leave a torn, unverifiable
+          sealed journal. systemd's default is 5m.
+        '';
+        type = types.str;
+        default = "30s";
+      };
     };
 
     recovery = {
@@ -250,16 +544,128 @@ in
         type = types.int;
         default = 60;
       };
+
+      maxReceipts = mkOption {
+        description = "Upper bound on retained content-bound recovery archive receipts.";
+        type = types.int;
+        default = 64;
+      };
+
+      clockReady = {
+        enable = (mkEnableOption "clock readiness barrier for persistent sealed logging") // {
+          default = true;
+        };
+
+        stableSeconds = mkOption {
+          description = "Consecutive seconds of non-decreasing realtime required before persistent logging is released.";
+          type = types.int;
+          default = 20;
+        };
+
+        maxWaitSeconds = mkOption {
+          description = "Maximum time to wait for clock readiness before allowing boot to continue.";
+          type = types.int;
+          default = 90;
+        };
+
+        minEpochSeconds = mkOption {
+          description = "Minimum plausible realtime epoch for clock readiness.";
+          type = types.int;
+          default = 1704067200; # 2024-01-01T00:00:00Z
+        };
+
+        maxEpochSeconds = mkOption {
+          description = "Maximum plausible realtime epoch for clock readiness; anchors above this are treated as corrupt.";
+          type = types.int;
+          default = 2524608000; # 2050-01-01T00:00:00Z
+        };
+      };
     };
   };
 
-  config = mkIf (config.ghaf.logging.enable && recCfg.enable) {
+  config = mkIf (loggingStackEnabled && recCfg.enable) {
+
+    ghaf.storagevm.directories = mkIf (clockReadyEnabled && config.ghaf.storagevm.enable) [
+      "/var/lib/ghaf/clock-ready"
+    ];
 
     systemd = {
+      targets.ghaf-clock-ready = mkIf clockReadyEnabled {
+        description = "Ghaf clock readiness barrier";
+        requires = [ "ghaf-clock-ready.service" ];
+        after = [ "ghaf-clock-ready.service" ];
+      };
+
+      services.ghaf-clock-ready = mkIf clockReadyEnabled {
+        description = "Wait for clock readiness before persistent sealed logging";
+        wantedBy = [ "ghaf-clock-ready.target" ];
+        before = [
+          "ghaf-clock-ready.target"
+          "systemd-journal-flush.service"
+          "journal-fss-setup.service"
+          "journal-fss-verify.service"
+          "alloy.service"
+        ];
+        after = [ "systemd-journald.service" ];
+        wants = [ "systemd-journald.service" ];
+
+        unitConfig = {
+          DefaultDependencies = false;
+          RequiresMountsFor = [ "/var/lib/ghaf/clock-ready" ];
+        };
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          TimeoutStartSec = "${toString (recCfg.clockReady.maxWaitSeconds + 30)}s";
+          ExecStart = lib.getExe ghafClockReady;
+        };
+      };
+
+      # Time-sync wait, ordered AFTER networking/timesyncd and BEFORE FSS setup,
+      # but deliberately not before systemd-journal-flush, so the early flush only
+      # waits on the fast clock-readiness barrier and never on the NTP timeout.
+      services.ghaf-clock-sync = mkIf clockReadyEnabled {
+        description = "Wait for time synchronization before FSS sealing activation";
+        wantedBy = [ "multi-user.target" ];
+        after = [
+          "ghaf-clock-ready.service"
+          "network-online.target"
+          "systemd-timesyncd.service"
+        ];
+        wants = [ "network-online.target" ];
+        before = [
+          "journal-fss-setup.service"
+          "journal-fss-verify.service"
+        ];
+
+        unitConfig = {
+          RequiresMountsFor = [ "/var/lib/ghaf/clock-ready" ];
+        };
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          TimeoutStartSec = "${toString (effectiveSyncWaitSeconds + 30)}s";
+          ExecStart = lib.getExe ghafClockSync;
+        };
+      };
+
+      services.systemd-journal-flush = mkIf clockReadyEnabled {
+        after = [ "ghaf-clock-ready.service" ];
+        requires = [ "ghaf-clock-ready.service" ];
+      };
+
       # Watcher: detects realtime jumps by comparing realtime vs monotonic progression
       services.ghaf-clock-jump-watcher = {
         description = "Detect realtime clock jumps and trigger journald/log-forwarder recovery";
         wantedBy = [ "multi-user.target" ];
+        after =
+          lib.optionals clockReadyEnabled [ "ghaf-clock-ready.service" ]
+          ++ lib.optionals fssActivationEnabled [ "journal-fss-setup.service" ];
+        wants =
+          lib.optionals clockReadyEnabled [ "ghaf-clock-ready.service" ]
+          ++ lib.optionals fssActivationEnabled [ "journal-fss-setup.service" ];
 
         serviceConfig = {
           Type = "simple";
@@ -271,6 +677,12 @@ in
 
       services.ghaf-journal-alloy-recover = {
         description = "Recover journald/log-forwarder after time jump";
+        after =
+          lib.optionals clockReadyEnabled [ "ghaf-clock-ready.service" ]
+          ++ lib.optionals fssActivationEnabled [ "journal-fss-setup.service" ];
+        wants =
+          lib.optionals clockReadyEnabled [ "ghaf-clock-ready.service" ]
+          ++ lib.optionals fssActivationEnabled [ "journal-fss-setup.service" ];
 
         unitConfig = {
           StartLimitIntervalSec = "0";
@@ -280,6 +692,17 @@ in
           Type = "oneshot";
           ExecStart = lib.getExe ghafJournalAlloyRecover;
         };
+      };
+
+      services.alloy = mkIf (clockReadyEnabled && config.services.alloy.enable) {
+        after = [
+          "ghaf-clock-ready.service"
+          "journal-fss-setup.service"
+        ];
+        wants = [
+          "ghaf-clock-ready.service"
+          "journal-fss-setup.service"
+        ];
       };
 
       tmpfiles.rules = [

--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -500,9 +500,20 @@ in
       };
 
       maxReceipts = mkOption {
-        description = "Upper bound on retained content-bound recovery archive receipts.";
         type = types.int;
         default = 64;
+        description = ''
+          Upper bound on retained content-bound recovery archive receipts.
+
+          The recovery path caps the receipt store at this many records, evicting
+          the oldest with a warning when exceeded. Receipts are matched against
+          on-disk archives by content (sha256) at verify time, so a receipt for a
+          deleted archive is harmless and is not dropped merely because the
+          archive is currently absent (transient absence would lose coverage).
+          Archives are owned by journald vacuum/rotation and are not deleted with
+          receipts; this cap is only the growth backstop against repeated clock-
+          jump recoveries, not a 1:1 archive index.
+        '';
       };
 
       clockReady = {
@@ -544,6 +555,10 @@ in
     ];
 
     systemd = {
+      # Barrier target: Requires the oneshot so the target is only reached on
+      # success. Consumers that must not fail-closed on a barrier IO error
+      # (notably systemd-journal-flush) depend on the service with Wants= below,
+      # not on this target.
       targets.ghaf-clock-ready = mkIf clockReadyEnabled {
         description = "Ghaf clock readiness barrier";
         requires = [ "ghaf-clock-ready.service" ];

--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -132,7 +132,7 @@ let
       done
 
       # NTP synchronization is intentionally NOT awaited here. This barrier runs
-      # early (before systemd-journal-flush, which requires it, and before
+      # early (before systemd-journal-flush, which wants it, and before
       # sysinit.target), so networking/timesyncd has not started yet and the NTP
       # check could only ever hit its full timeout, stalling the journal flush on
       # every boot. The sync wait is handled later by ghaf-clock-sync.service,
@@ -651,9 +651,12 @@ in
         };
       };
 
+      # Wants, not Requires: an IO error in the best-effort clock-readiness
+      # barrier (e.g. the anchor-file write) must not dependency-fail the
+      # journal flush and leave logs volatile for the boot.
       services.systemd-journal-flush = mkIf clockReadyEnabled {
         after = [ "ghaf-clock-ready.service" ];
-        requires = [ "ghaf-clock-ready.service" ];
+        wants = [ "ghaf-clock-ready.service" ];
       };
 
       # Watcher: detects realtime jumps by comparing realtime vs monotonic progression

--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -263,7 +263,13 @@ let
       gnugrep
       systemd
     ];
+    # /etc/fss-verify-classifier.sh is populated at runtime by fss.nix
+    # (unconditionally, since this consumer runs even when FSS is disabled);
+    # shellcheck cannot follow it statically.
+    excludeShellChecks = [ "SC1091" ];
     text = ''
+      source /etc/fss-verify-classifier.sh
+
       machine_id="$(cat /etc/machine-id)"
       state_dir="/var/log/journal/$machine_id"
       recovery_receipts_file="$state_dir/fss-recovery-receipts"
@@ -295,10 +301,6 @@ let
         done | sort -u
       }
 
-      current_boot_id() {
-        cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot
-      }
-
       fss_activation_complete_current_boot() {
         local state=""
         local state_boot=""
@@ -312,63 +314,15 @@ let
         state="$(awk -F '\t' 'NR == 1 { print $1 }' "$activation_state_file")"
         state_boot="$(awk -F '\t' 'NR == 1 { print $2 }' "$activation_state_file")"
         baseline_boot="$(tr -d '[:space:]' < "$activation_baseline_file")"
-        boot="$(current_boot_id)"
+        boot="$(fss_current_boot_id)"
 
         [ "$state" = "active" ] \
           && [ "$state_boot" = "$boot" ] \
           && [ "$baseline_boot" = "$boot" ]
       }
 
-      valid_sha256() {
-        printf '%s' "$1" | grep -Eq '^[0-9a-f]{64}$'
-      }
-
       record_recovery_receipt() {
-        local archive_path="$1"
-        local inode size mtime sha boot event
-
-        [ -n "$archive_path" ] || return 0
-        [ -f "$archive_path" ] || return 0
-
-        inode=$(stat -c %i "$archive_path" 2>/dev/null || true)
-        size=$(stat -c %s "$archive_path" 2>/dev/null || true)
-        mtime=$(stat -c %Y "$archive_path" 2>/dev/null || true)
-        sha=$(sha256sum "$archive_path" 2>/dev/null | cut -d' ' -f1 || true)
-        boot="$(current_boot_id)"
-        event="''${INVOCATION_ID:-$boot}"
-
-        if [ -z "$inode" ] || [ -z "$size" ] || [ -z "$mtime" ] || ! valid_sha256 "$sha"; then
-          echo "Could not record FSS recovery receipt for $archive_path: missing stat or sha256 evidence"
-          return 0
-        fi
-
-        if [ -f "$recovery_receipts_file" ] \
-          && awk -F '\t' -v p="$archive_path" -v i="$inode" -v s="$size" \
-            '$2 == p && $3 == i && $4 == s { found = 1 } END { exit found ? 0 : 1 }' \
-            "$recovery_receipts_file"; then
-          return 0
-        fi
-
-        printf 'v1\t%s\t%s\t%s\t%s\t%s\t%s\tclock-jump-recovery\t%s\n' \
-          "$archive_path" "$inode" "$size" "$boot" "$mtime" "$sha" "$event" \
-          >> "$recovery_receipts_file"
-        chmod 0644 "$recovery_receipts_file"
-        echo "Recorded FSS recovery archive receipt: $archive_path"
-      }
-
-      prune_recovery_receipts() {
-        local total excess tmp
-
-        [ -f "$recovery_receipts_file" ] || return 0
-        total=$(wc -l < "$recovery_receipts_file" 2>/dev/null || echo 0)
-        [ "$total" -gt "$max_recovery_receipts" ] || return 0
-
-        excess=$((total - max_recovery_receipts))
-        tmp=$(mktemp)
-        tail -n "$max_recovery_receipts" "$recovery_receipts_file" > "$tmp"
-        mv "$tmp" "$recovery_receipts_file"
-        chmod 0644 "$recovery_receipts_file"
-        echo "Recovery receipts exceeded $max_recovery_receipts; evicted $excess oldest record(s)"
+        fss_write_receipt "$recovery_receipts_file" "$1" "clock-jump-recovery" info "Recorded FSS recovery archive receipt"
       }
 
       record_recovery_archives() {
@@ -390,7 +344,7 @@ let
         done < "$after_file"
 
         rm -f "$after_file"
-        prune_recovery_receipts
+        fss_prune_receipt_file "$recovery_receipts_file" "$max_recovery_receipts" "Recovery"
       }
 
       trap cleanup EXIT

--- a/modules/common/logging/fss-verify-classifier.sh
+++ b/modules/common/logging/fss-verify-classifier.sh
@@ -105,10 +105,10 @@ fss_count_nonempty_lines() {
 
 fss_failure_bucket_for_path() {
   case "$1" in
+  */system.journal | */system.journal~) printf '%s' "active-system" ;;
+  */system@*.journal | */system@*.journal~) printf '%s' "archived-system" ;;
+  */user-[0-9]*.journal | */user-[0-9]*.journal~) printf '%s' "user-journal" ;;
   *.journal~) printf '%s' "temp" ;;
-  */system.journal) printf '%s' "active-system" ;;
-  */system@*.journal) printf '%s' "archived-system" ;;
-  */user-[0-9]*.journal) printf '%s' "user-journal" ;;
   *) printf '%s' "other" ;;
   esac
 }
@@ -171,6 +171,201 @@ fss_read_recorded_archive_list() {
   printf '%s' "$archive_paths"
 }
 
+# Lifecycle receipts.
+#
+# Each receipt is a TSV record describing one archived journal that was rotated
+# by a known lifecycle event, so the verifier can recognise expected exceptions
+# by content-bound identity rather than by path string alone. Schema (v1):
+#   schema_version  path  inode  size  boot_id  mtime  sha256  reason  event_id
+# shellcheck disable=SC2034  # read by the setup script that sources this library
+FSS_RECEIPT_SCHEMA_VERSION="v1"
+
+fss_valid_sha256() {
+  printf '%s' "$1" | grep -Eq '^[0-9a-f]{64}$'
+}
+
+# Read receipt records from a state file, dropping blank lines.
+fss_read_receipts() {
+  local state_file="$1"
+  [ -r "$state_file" ] && [ -s "$state_file" ] || return 0
+  grep -v '^[[:space:]]*$' "$state_file" || true
+}
+
+# Emit the deduplicated archive paths referenced by a set of receipt records.
+fss_receipt_paths() {
+  local records="$1"
+  local rec ver path rest paths=""
+
+  while IFS= read -r rec || [ -n "$rec" ]; do
+    [ -n "$rec" ] || continue
+    # shellcheck disable=SC2034  # ver/rest are positional placeholders
+    IFS=$'\t' read -r ver path rest <<<"$rec"
+    [ -n "$path" ] || continue
+    paths=$(fss_append_unique_line "$paths" "$path")
+  done <<<"$records"
+
+  printf '%s' "$paths"
+}
+
+# Print the boot_id recorded for a path; return non-zero when no receipt matches.
+fss_receipt_boot_for_path() {
+  local records="$1"
+  local needle="$2"
+  local rec ver path inode size boot rest
+
+  [ -n "$needle" ] || return 1
+  while IFS= read -r rec || [ -n "$rec" ]; do
+    [ -n "$rec" ] || continue
+    # shellcheck disable=SC2034  # ver/inode/size/rest are positional placeholders
+    IFS=$'\t' read -r ver path inode size boot rest <<<"$rec"
+    if [ "$path" = "$needle" ]; then
+      printf '%s' "$boot"
+      return 0
+    fi
+  done <<<"$records"
+
+  return 1
+}
+
+# Return success if any receipt was recorded for the specified boot id.
+fss_receipts_contain_boot() {
+  local records="$1"
+  local needle_boot="$2"
+  local rec ver path inode size boot rest
+
+  [ -n "$needle_boot" ] || return 1
+  while IFS= read -r rec || [ -n "$rec" ]; do
+    [ -n "$rec" ] || continue
+    # shellcheck disable=SC2034  # ver/path/inode/size/rest are positional placeholders
+    IFS=$'\t' read -r ver path inode size boot rest <<<"$rec"
+    if [ "$boot" = "$needle_boot" ]; then
+      return 0
+    fi
+  done <<<"$records"
+
+  return 1
+}
+
+# Return success if any receipt was recorded for a boot id other than the current one.
+fss_receipts_contain_other_boot() {
+  local records="$1"
+  local current_boot="$2"
+  local rec ver path inode size boot rest
+
+  [ -n "$current_boot" ] || return 1
+  while IFS= read -r rec || [ -n "$rec" ]; do
+    [ -n "$rec" ] || continue
+    # shellcheck disable=SC2034  # ver/path/inode/size/rest are positional placeholders
+    IFS=$'\t' read -r ver path inode size boot rest <<<"$rec"
+    if [ -n "$boot" ] && [ "$boot" != "$current_boot" ]; then
+      return 0
+    fi
+  done <<<"$records"
+
+  return 1
+}
+
+# Filter receipt records against the live filesystem, emitting only those whose
+# recorded content still matches the on-disk archive. Matching is by sha256
+# content identity (the durable evidence artifact), so it is stable across inode
+# changes (e.g. cross-filesystem moves) but rejects a substituted archive
+# (path reuse) or a vanished one. A missing/malformed sha is non-exculpatory:
+# the record is dropped rather than falling back to weaker size-only matching.
+# Requires real files; the pure policy decision does not call this so it stays
+# unit-testable on synthetic records.
+fss_filter_valid_receipts() {
+  local records="$1"
+  local rec ver path inode size boot mtime sha rest
+  local cur_sha
+
+  while IFS= read -r rec || [ -n "$rec" ]; do
+    [ -n "$rec" ] || continue
+    # shellcheck disable=SC2034  # ver/inode/size/boot/mtime/rest are positional placeholders
+    IFS=$'\t' read -r ver path inode size boot mtime sha rest <<<"$rec"
+    [ -n "$path" ] && [ -f "$path" ] || continue
+    fss_valid_sha256 "$sha" || continue
+    cur_sha=$(sha256sum "$path" 2>/dev/null | cut -d' ' -f1 || true)
+    [ "$cur_sha" = "$sha" ] || continue
+
+    printf '%s\n' "$rec"
+  done <<<"$records"
+}
+
+# Emit paths whose receipt still points at an on-disk archive but whose content no
+# longer matches the recorded receipt. Missing files are ignored here because
+# journald retention can legitimately delete archives; an existing mismatched file
+# is treated as substitution/path reuse and must fail closed.
+fss_receipt_mismatches() {
+  local records="$1"
+  local rec ver path inode size boot mtime sha rest
+  local cur_sha mismatches=""
+
+  while IFS= read -r rec || [ -n "$rec" ]; do
+    [ -n "$rec" ] || continue
+    # shellcheck disable=SC2034  # ver/inode/size/boot/mtime/rest are positional placeholders
+    IFS=$'\t' read -r ver path inode size boot mtime sha rest <<<"$rec"
+    [ -n "$path" ] && [ -f "$path" ] || continue
+    fss_valid_sha256 "$sha" || continue
+    cur_sha=$(sha256sum "$path" 2>/dev/null | cut -d' ' -f1 || true)
+    [ "$cur_sha" = "$sha" ] && continue
+
+    mismatches=$(fss_append_unique_line "$mismatches" "$path")
+  done <<<"$records"
+
+  printf '%s' "$mismatches"
+}
+
+fss_read_pre_activation_receipts() {
+  fss_read_receipts "$1"
+}
+
+fss_pre_activation_receipt_paths() {
+  fss_receipt_paths "$1"
+}
+
+fss_pre_activation_boot_for_path() {
+  fss_receipt_boot_for_path "$1" "$2"
+}
+
+fss_pre_activation_receipts_contain_boot() {
+  fss_receipts_contain_boot "$1" "$2"
+}
+
+fss_pre_activation_receipts_contain_other_boot() {
+  fss_receipts_contain_other_boot "$1" "$2"
+}
+
+fss_pre_activation_receipt_mismatches() {
+  fss_receipt_mismatches "$1"
+}
+
+# Unclean-shutdown receipts: journals journald itself reported as "corrupted or
+# uncleanly shut down" and renamed to <path>~ (host crash, power loss, stop-timeout
+# SIGKILL). Same v1 receipt schema and content-binding as the other classes.
+fss_read_unclean_shutdown_receipts() {
+  fss_read_receipts "$1"
+}
+
+fss_unclean_shutdown_receipt_paths() {
+  fss_receipt_paths "$1"
+}
+
+fss_unclean_shutdown_boot_for_path() {
+  fss_receipt_boot_for_path "$1" "$2"
+}
+
+fss_unclean_shutdown_receipts_contain_boot() {
+  fss_receipts_contain_boot "$1" "$2"
+}
+
+fss_unclean_shutdown_receipts_contain_other_boot() {
+  fss_receipts_contain_other_boot "$1" "$2"
+}
+
+fss_unclean_shutdown_receipt_mismatches() {
+  fss_receipt_mismatches "$1"
+}
+
 fss_matches_only_expected_archived_system_failure() {
   local expected_archive="$1"
   local archived_failures="${2:-$FSS_ARCHIVED_SYSTEM_FAILURES}"
@@ -213,6 +408,7 @@ fss_reset_classification() {
   FSS_FILESYSTEM_RESTRICTION=0
   FSS_VERDICT=""
   FSS_VERDICT_REASON=""
+  # shellcheck disable=SC2034  # read by consumers that source this library
   FSS_VERDICT_TAGS=""
 }
 
@@ -286,24 +482,87 @@ fss_classification_tags() {
 # Decide the verification policy verdict based on populated FSS_* state vars.
 # Inputs:
 #   $1 = expected pre-FSS archive path (single line, optional)
-#   $2 = expected recovery archive paths (newline-separated, optional)
+#   $2 = expected recovery receipt records (TSV, newline-separated, optional)
+#   $3 = pre-activation receipt records (TSV, newline-separated, optional)
+#   $4 = current boot_id (optional; distinguishes this boot's boundary from stale)
+#   $5 = journalctl --verify exit code (optional; nonzero unclassified exits fail)
 # Outputs (as globals):
-#   FSS_VERDICT        = pass | partial | fail
+#   FSS_VERDICT        = verified | verified-with-exception | warning | fail
 #   FSS_VERDICT_REASON = short human-readable reason
-#   FSS_VERDICT_TAGS   = classification tags augmented with PRE_FSS_ARCHIVE / RECOVERY_ARCHIVE
-# Requires fss_classify_verify_output to have been called first.
+#   FSS_VERDICT_TAGS   = classification tags augmented with PRE_FSS_ARCHIVE /
+#                        RECOVERY_ARCHIVE / PRE_ACTIVATION_ARCHIVE / PRE_ACTIVATION_STALE
+# Verdict semantics (per .idea/ Layer-5 policy states):
+#   verified                 - all journals verify, no exceptions.
+#   verified-with-exception  - only evidence-backed exceptions for THIS boot
+#                              (pre-FSS / recovery / current-boot insecure boot logs).
+#   warning                  - exceptions evidenced but from an earlier boot, or
+#                              user/temp/filesystem-only issues.
+#   fail                     - active-system failure, key defect, unclassified
+#                              failure, or an archived failure with no matching
+#                              receipt (unrecorded or content-substituted).
+# Receipt matching is content-bound: callers should pass receipts already filtered
+# against disk (see fss_filter_valid_receipts) so a substituted archive presents
+# as unmatched and fails closed. Requires fss_classify_verify_output first.
 fss_verify_policy_decision() {
   local expected_pre="${1-}"
-  local expected_recovery="${2-}"
-  local allowed_list="" archived_paths path
+  local recovery_receipts="${2-}"
+  local pre_activation_receipts="${3-}"
+  local current_boot="${4-}"
+  local verify_exit="${5:-0}"
+  local unclean_shutdown_receipts="${6-}"
+  local allowed_list="" recovery_paths pre_activation_paths unclean_paths archived_paths path boot
+  local recovery_seen=0 recovery_stale=0
+  local pre_activation_seen=0 pre_activation_stale=0 exception_seen=0
+  local unclean_seen=0 unclean_stale=0
 
   FSS_VERDICT_TAGS=$(fss_classification_tags)
   FSS_VERDICT_REASON=""
 
+  recovery_paths=$(fss_receipt_paths "$recovery_receipts")
+  pre_activation_paths=$(fss_pre_activation_receipt_paths "$pre_activation_receipts")
+  unclean_paths=$(fss_unclean_shutdown_receipt_paths "$unclean_shutdown_receipts")
+  if fss_pre_activation_receipts_contain_other_boot "$pre_activation_receipts" "$current_boot"; then
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_ARCHIVE")
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_STALE")
+    pre_activation_stale=1
+  fi
+  if fss_unclean_shutdown_receipts_contain_other_boot "$unclean_shutdown_receipts" "$current_boot"; then
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN")
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN_STALE")
+    unclean_stale=1
+  fi
+
   if [ -n "$expected_pre" ]; then
     allowed_list=$(fss_append_unique_line "$allowed_list" "$expected_pre")
   fi
-  allowed_list=$(fss_merge_path_lists "$allowed_list" "$expected_recovery")
+  allowed_list=$(fss_merge_path_lists "$allowed_list" "$recovery_paths")
+  allowed_list=$(fss_merge_path_lists "$allowed_list" "$pre_activation_paths")
+  allowed_list=$(fss_merge_path_lists "$allowed_list" "$unclean_paths")
+
+  # Carve a journald-attested, content-receipted unclean "system.journal~" corpse
+  # out of the fatal active-system set into the archived-exception track. The live
+  # system.journal has no '~', so it can never match an unclean receipt path and is
+  # never carved out; an unmatched .journal~ stays fatal. Receipts arrive already
+  # content-filtered (fss_filter_valid_receipts), so a substituted corpse has no
+  # surviving receipt -> not carved -> fails closed.
+  if [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ] && [ -n "$unclean_paths" ]; then
+    local active_keep="" active_line apath
+    while IFS= read -r active_line || [ -n "$active_line" ]; do
+      [ -n "$active_line" ] || continue
+      apath="${active_line#FAIL: }"
+      apath="${apath%% *}"
+      case "$apath" in
+      *.journal~)
+        if fss_path_list_contains "$unclean_paths" "$apath"; then
+          FSS_ARCHIVED_SYSTEM_FAILURES=$(fss_append_line "$FSS_ARCHIVED_SYSTEM_FAILURES" "$active_line")
+          continue
+        fi
+        ;;
+      esac
+      active_keep=$(fss_append_line "$active_keep" "$active_line")
+    done <<<"$FSS_ACTIVE_SYSTEM_FAILURES"
+    FSS_ACTIVE_SYSTEM_FAILURES="$active_keep"
+  fi
 
   if [ "$FSS_KEY_PARSE_ERROR" = 1 ] || [ "$FSS_KEY_REQUIRED_ERROR" = 1 ]; then
     FSS_VERDICT=fail
@@ -332,9 +591,34 @@ fss_verify_policy_decision() {
         [ -n "$path" ] || continue
         if [ "$path" = "$expected_pre" ]; then
           FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_FSS_ARCHIVE")
+          exception_seen=1
         fi
-        if fss_path_list_contains "$expected_recovery" "$path"; then
+        if boot=$(fss_receipt_boot_for_path "$recovery_receipts" "$path"); then
           FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "RECOVERY_ARCHIVE")
+          recovery_seen=1
+          exception_seen=1
+          if [ -n "$current_boot" ] && [ -n "$boot" ] && [ "$boot" != "$current_boot" ]; then
+            FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "RECOVERY_STALE")
+            recovery_stale=1
+          fi
+        fi
+        if boot=$(fss_pre_activation_boot_for_path "$pre_activation_receipts" "$path"); then
+          FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_ARCHIVE")
+          pre_activation_seen=1
+          exception_seen=1
+          if [ -n "$current_boot" ] && [ -n "$boot" ] && [ "$boot" != "$current_boot" ]; then
+            FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_STALE")
+            pre_activation_stale=1
+          fi
+        fi
+        if boot=$(fss_unclean_shutdown_boot_for_path "$unclean_shutdown_receipts" "$path"); then
+          FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN")
+          unclean_seen=1
+          exception_seen=1
+          if [ -n "$current_boot" ] && [ -n "$boot" ] && [ "$boot" != "$current_boot" ]; then
+            FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN_STALE")
+            unclean_stale=1
+          fi
         fi
       done <<<"$archived_paths"
     else
@@ -344,26 +628,96 @@ fss_verify_policy_decision() {
     fi
   fi
 
-  if [ "$archived_allowed" = 1 ] || [ -n "$FSS_USER_FAILURES" ]; then
-    FSS_VERDICT=partial
-    FSS_VERDICT_REASON="recorded archived-system and/or user exceptions only"
-    return 0
-  fi
-
   if [ "$FSS_FILESYSTEM_RESTRICTION" = 1 ]; then
-    FSS_VERDICT=partial
+    FSS_VERDICT=warning
     FSS_VERDICT_REASON="filesystem restrictions encountered"
     return 0
   fi
 
+  if [ "$archived_allowed" = 1 ] && [ -z "$FSS_USER_FAILURES" ]; then
+    if [ "$pre_activation_stale" = 1 ]; then
+      FSS_VERDICT=warning
+      FSS_VERDICT_REASON="insecure boot logs from an earlier boot"
+    elif [ "$recovery_stale" = 1 ]; then
+      FSS_VERDICT=warning
+      FSS_VERDICT_REASON="recovery archive from an earlier boot"
+    elif [ "$unclean_stale" = 1 ]; then
+      FSS_VERDICT=warning
+      FSS_VERDICT_REASON="unclean-shutdown journal from an earlier boot"
+    elif [ "$pre_activation_seen" = 1 ]; then
+      FSS_VERDICT=verified-with-exception
+      FSS_VERDICT_REASON="recorded insecure boot logs (current boot)"
+    elif [ "$recovery_seen" = 1 ]; then
+      FSS_VERDICT=verified-with-exception
+      FSS_VERDICT_REASON="recorded recovery archive (current boot)"
+    elif [ "$unclean_seen" = 1 ]; then
+      FSS_VERDICT=verified-with-exception
+      FSS_VERDICT_REASON="recorded unclean-shutdown journal (current boot)"
+    else
+      FSS_VERDICT=verified-with-exception
+      FSS_VERDICT_REASON="recorded archived-system exceptions only"
+    fi
+    return 0
+  fi
+
+  if [ -n "$FSS_USER_FAILURES" ]; then
+    FSS_VERDICT=warning
+    if [ "$exception_seen" = 1 ]; then
+      FSS_VERDICT_REASON="archived-system exceptions with user journal exceptions"
+    else
+      FSS_VERDICT_REASON="user journal exceptions only"
+    fi
+    return 0
+  fi
+
   if [ -n "$FSS_TEMP_FAILURES" ]; then
-    FSS_VERDICT=pass
+    FSS_VERDICT=warning
     FSS_VERDICT_REASON="temporary journal files ignored"
     return 0
   fi
 
+  if [ "$verify_exit" != 0 ]; then
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "VERIFY_EXIT_UNCLASSIFIED")
+    FSS_VERDICT=fail
+    FSS_VERDICT_REASON="journalctl verify exited nonzero without a classified exception"
+    return 0
+  fi
+
+  # A valid stale receipt remains on disk and journalctl emitted no failure for it:
+  # structurally readable but non-FSS-trusted logs left over from an earlier boot.
+  # Surface as a warning even if this boot also has an expected receipt.
+  if [ "$pre_activation_stale" = 1 ]; then
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_ARCHIVE")
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_STALE")
+    FSS_VERDICT=warning
+    FSS_VERDICT_REASON="insecure boot logs from an earlier boot"
+    return 0
+  fi
+
+  if [ "$unclean_stale" = 1 ]; then
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN")
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN_STALE")
+    FSS_VERDICT=warning
+    FSS_VERDICT_REASON="unclean-shutdown journal from an earlier boot"
+    return 0
+  fi
+
+  if fss_pre_activation_receipts_contain_boot "$pre_activation_receipts" "$current_boot"; then
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_ARCHIVE")
+    FSS_VERDICT=verified-with-exception
+    FSS_VERDICT_REASON="recorded insecure boot logs (current boot)"
+    return 0
+  fi
+
+  if fss_unclean_shutdown_receipts_contain_boot "$unclean_shutdown_receipts" "$current_boot"; then
+    FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN")
+    FSS_VERDICT=verified-with-exception
+    FSS_VERDICT_REASON="recorded unclean-shutdown journal (current boot)"
+    return 0
+  fi
+
   # shellcheck disable=SC2034  # read by consumers that source this library
-  FSS_VERDICT=pass
+  FSS_VERDICT=verified
   # shellcheck disable=SC2034
   FSS_VERDICT_REASON=""
 }

--- a/modules/common/logging/fss-verify-classifier.sh
+++ b/modules/common/logging/fss-verify-classifier.sh
@@ -580,19 +580,22 @@ fss_classification_tags() {
 #   $4 = current boot_id (optional; distinguishes this boot's boundary from stale)
 #   $5 = journalctl --verify exit code (optional; nonzero unclassified exits fail)
 # Outputs (as globals):
-#   FSS_VERDICT        = verified | verified-with-exception | warning | fail
+#   FSS_VERDICT        = verified | warning | fail
 #   FSS_VERDICT_REASON = short human-readable reason
 #   FSS_VERDICT_TAGS   = classification tags augmented with PRE_FSS_ARCHIVE /
 #                        RECOVERY_ARCHIVE / PRE_ACTIVATION_ARCHIVE / PRE_ACTIVATION_STALE
 # Verdict semantics (per .idea/ Layer-5 policy states):
-#   verified                 - all journals verify, no exceptions.
-#   verified-with-exception  - only evidence-backed exceptions for THIS boot
-#                              (pre-FSS / recovery / current-boot insecure boot logs).
-#   warning                  - exceptions evidenced but from an earlier boot, or
-#                              user/temp/filesystem-only issues.
-#   fail                     - active-system failure, key defect, unclassified
-#                              failure, or an archived failure with no matching
-#                              receipt (unrecorded or content-substituted).
+#   verified  - all journals verify, no exceptions.
+#   warning   - an evidence-backed exception was excused: either a current-boot
+#               pre-FSS/recovery/insecure-boot-logs receipt, or one from an
+#               earlier boot, or user/temp/filesystem-only issues. Receipts are
+#               unauthenticated root-writable files, so even a current-boot
+#               match is capped at warning rather than a silent pass -- offline
+#               verification against an off-host key is the authoritative
+#               backstop (see fss.mdx "does not protect against").
+#   fail      - active-system failure, key defect, unclassified failure, or an
+#               archived failure with no matching receipt (unrecorded or
+#               content-substituted).
 # Receipt matching is content-bound: callers should pass receipts already filtered
 # against disk (see fss_filter_valid_receipts) so a substituted archive presents
 # as unmatched and fails closed. Requires fss_classify_verify_output first.
@@ -738,16 +741,16 @@ fss_verify_policy_decision() {
       FSS_VERDICT=warning
       FSS_VERDICT_REASON="unclean-shutdown journal from an earlier boot"
     elif [ "$pre_activation_seen" = 1 ]; then
-      FSS_VERDICT=verified-with-exception
+      FSS_VERDICT=warning
       FSS_VERDICT_REASON="recorded insecure boot logs (current boot)"
     elif [ "$recovery_seen" = 1 ]; then
-      FSS_VERDICT=verified-with-exception
+      FSS_VERDICT=warning
       FSS_VERDICT_REASON="recorded recovery archive (current boot)"
     elif [ "$unclean_seen" = 1 ]; then
-      FSS_VERDICT=verified-with-exception
+      FSS_VERDICT=warning
       FSS_VERDICT_REASON="recorded unclean-shutdown journal (current boot)"
     else
-      FSS_VERDICT=verified-with-exception
+      FSS_VERDICT=warning
       FSS_VERDICT_REASON="recorded archived-system exceptions only"
     fi
     return 0
@@ -797,14 +800,14 @@ fss_verify_policy_decision() {
 
   if fss_pre_activation_receipts_contain_boot "$pre_activation_receipts" "$current_boot"; then
     FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_ARCHIVE")
-    FSS_VERDICT=verified-with-exception
+    FSS_VERDICT=warning
     FSS_VERDICT_REASON="recorded insecure boot logs (current boot)"
     return 0
   fi
 
   if fss_unclean_shutdown_receipts_contain_boot "$unclean_shutdown_receipts" "$current_boot"; then
     FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN")
-    FSS_VERDICT=verified-with-exception
+    FSS_VERDICT=warning
     FSS_VERDICT_REASON="recorded unclean-shutdown journal (current boot)"
     return 0
   fi

--- a/modules/common/logging/fss-verify-classifier.sh
+++ b/modules/common/logging/fss-verify-classifier.sh
@@ -184,6 +184,99 @@ fss_valid_sha256() {
   printf '%s' "$1" | grep -Eq '^[0-9a-f]{64}$'
 }
 
+fss_current_boot_id() {
+  cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot
+}
+
+# journald's effective Seal= setting, parsed from the merged config (last
+# matching directive wins, matching journald's own override semantics).
+fss_journald_effective_seal() {
+  systemd-analyze cat-config systemd/journald.conf 2>/dev/null |
+    awk -F= '
+      /^[[:space:]]*[#;]/ { next }
+      /^[[:space:]]*Seal[[:space:]]*=/ {
+        value = $2
+        sub(/^[[:space:]]*/, "", value)
+        sub(/[[:space:]]*[#;].*$/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        seal = tolower(value)
+      }
+      END { print seal }
+    '
+}
+
+fss_sealing_active_in_config() {
+  [ "$(fss_journald_effective_seal)" = "yes" ]
+}
+
+# Bound a receipt store by capping it to the newest max_lines records (the
+# file is append-ordered oldest-first). A receipt is NOT dropped merely
+# because its archive is currently absent: a receipt for a vanished archive
+# is harmless (fss_filter_valid_receipts ignores it, and a deleted archive
+# never appears as a verify failure), and dropping on transient absence
+# would lose coverage for an archive that returns. The cap is the growth
+# backstop; content substitution is caught at verify time.
+fss_prune_receipt_file() {
+  local receipt_file="$1"
+  local max_lines="$2"
+  local label="$3"
+  local tmp total excess
+
+  [ -f "$receipt_file" ] || return 0
+
+  total=$(wc -l <"$receipt_file" 2>/dev/null || echo 0)
+  [ "$total" -gt "$max_lines" ] || return 0
+
+  excess=$((total - max_lines))
+  tmp=$(mktemp)
+  tail -n "$max_lines" "$receipt_file" >"$tmp"
+  mv "$tmp" "$receipt_file"
+  chmod 0644 "$receipt_file"
+  fss_log warn "$label receipts exceeded $max_lines; evicted $excess oldest record(s)"
+}
+
+# Append a content-bound lifecycle receipt (schema: FSS_RECEIPT_SCHEMA_VERSION
+# above) for archive_path to receipt_file, deduped on physical archive
+# identity (path + inode + size). log_level/log_message are passed to
+# fss_log on a successful write; callers pass "" for either to stay silent.
+fss_write_receipt() {
+  local receipt_file="$1"
+  local archive_path="$2"
+  local reason="$3"
+  local log_level="${4-}"
+  local log_message="${5-}"
+  local inode size mtime sha boot event
+
+  [ -n "$archive_path" ] && [ -f "$archive_path" ] || return 0
+
+  inode=$(stat -c %i "$archive_path" 2>/dev/null || true)
+  size=$(stat -c %s "$archive_path" 2>/dev/null || true)
+  mtime=$(stat -c %Y "$archive_path" 2>/dev/null || true)
+  sha=$(sha256sum "$archive_path" 2>/dev/null | cut -d' ' -f1 || true)
+  boot=$(fss_current_boot_id)
+  event="${INVOCATION_ID:-$boot}"
+
+  if [ -z "$inode" ] || [ -z "$size" ] || [ -z "$mtime" ] || ! fss_valid_sha256 "$sha"; then
+    fss_log warn "Could not record lifecycle receipt for $archive_path: missing stat or sha256 evidence"
+    return 0
+  fi
+
+  # Dedupe on the physical archive identity (path + inode + size).
+  if [ -f "$receipt_file" ] &&
+    awk -F '\t' -v p="$archive_path" -v i="$inode" -v s="$size" \
+      '$2 == p && $3 == i && $4 == s { found = 1 } END { exit found ? 0 : 1 }' \
+      "$receipt_file"; then
+    return 0
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$FSS_RECEIPT_SCHEMA_VERSION" "$archive_path" "$inode" "$size" \
+    "$boot" "$mtime" "$sha" "$reason" "$event" \
+    >>"$receipt_file"
+  chmod 0644 "$receipt_file"
+  [ -n "$log_level" ] && [ -n "$log_message" ] && fss_log "$log_level" "$log_message: $archive_path"
+}
+
 # Read receipt records from a state file, dropping blank lines.
 fss_read_receipts() {
   local state_file="$1"

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -102,7 +102,6 @@ let
   hostPersistentJournalPath = "/persist/var/log/journal";
   fssBasePath =
     if config.ghaf.type == "host" then "/persist/common/journal-fss" else "/etc/common/journal-fss";
-  verifyClassifierLib = builtins.readFile ./fss-verify-classifier.sh;
   fssTriagePackage =
     pkgs.fss-triage or (pkgs.callPackage ../../../packages/pkgs-by-name/fss-triage/package.nix { });
 
@@ -127,13 +126,13 @@ let
       gnugrep
       util-linux
     ];
-    # The shared classifier library is sourced for fss_log and receipt helpers;
-    # its verify-only functions are intentionally unused here.
-    excludeShellChecks = [ "SC2329" ];
+    # /etc/fss-verify-classifier.sh is populated at runtime (see environment.etc
+    # below); shellcheck cannot follow it statically.
+    excludeShellChecks = [ "SC1091" ];
     text = ''
       export LC_ALL=C
 
-      ${verifyClassifierLib}
+      source /etc/fss-verify-classifier.sh
 
       KEY_DIR="${cfg.keyPath}"
       INIT_FILE="$KEY_DIR/initialized"
@@ -705,10 +704,6 @@ let
           && [ "$(activation_state_boot_id)" = "$(current_boot_id)" ]
       }
 
-      activation_state_active_current_boot() {
-        activation_state_record_current_boot
-      }
-
       activation_boundary_complete_current_boot() {
         activation_state_record_current_boot \
           && boot_baseline_current
@@ -918,6 +913,7 @@ let
       # archives this run spills out and never a pre-existing (possibly tampered)
       # one.
       SETUP_ARCHIVES_BEFORE=$(mktemp)
+      # shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
       cleanup_setup_tmp() {
         rm -f "$SETUP_ARCHIVES_BEFORE"
       }
@@ -1041,10 +1037,11 @@ let
       gnugrep
       gawk
     ];
-    # Shared classifier library: some helper functions are unused in this consumer.
-    excludeShellChecks = [ "SC2329" ];
+    # /etc/fss-verify-classifier.sh is populated at runtime (see environment.etc
+    # above); shellcheck cannot follow it statically.
+    excludeShellChecks = [ "SC1091" ];
     text = ''
-            ${verifyClassifierLib}
+            source /etc/fss-verify-classifier.sh
 
             audit_log() {
               printf '%s\n' "$2" | systemd-cat -t journal-fss -p "$1"
@@ -1456,6 +1453,11 @@ in
     environment.systemPackages = [
       fssTriagePackage
     ];
+
+    # Single on-disk copy of the verification/receipt classifier, sourced at
+    # runtime by journal-fss-setup, journal-fss-verify, fss-triage, and
+    # fss-test instead of each embedding its own build-time inlined copy.
+    environment.etc."fss-verify-classifier.sh".source = ./fss-verify-classifier.sh;
 
     # FSS is only meaningful for persistent journals. The journald sealing key
     # lives beside the journal files and is advanced by journald over time.

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -34,6 +34,18 @@
 # - Per-component isolation: Each component has independent FSS key pairs
 # - Offline verification: Verification keys can validate exported journal archives
 #
+# Caveats (per-boot activation boundary, ghaf.logging.fss.activation):
+# - Unsealed boot window: With activation enabled (default), entries written
+#   before sealing is activated after clock readiness are collected but NOT
+#   FSS-trusted. They are recorded as content-bound lifecycle receipts and pass
+#   verification as "verified-with-exception" only for the current boot; a
+#   pre-activation archive failing verification for an earlier boot is a warning,
+#   while one whose content no longer matches its receipt fails closed.
+# - Clock readiness is a boot gate and mitigation, not a trusted/authoritative
+#   time source. On offline devices activation occurs on an unsynchronised clock.
+# - FSS is a local primitive: it does not by itself defend against whole-file
+#   deletion, mutable-verification-key replacement, or cross-component ordering.
+#
 # Operational Notes:
 # -----------------
 # 1. First Boot (per component):
@@ -82,12 +94,17 @@ let
     optionalAttrs
     ;
   cfg = config.ghaf.logging.fss;
+  clockReadyEnabled =
+    cfg.enable && config.ghaf.logging.recovery.enable && config.ghaf.logging.recovery.clockReady.enable;
+  activationEnabled = cfg.activation.enable;
   loggingEnabled = config.ghaf.logging.enable;
   hasPersistentJournalStorage = config.ghaf.type == "host" || config.ghaf.storagevm.enable;
   hostPersistentJournalPath = "/persist/var/log/journal";
   fssBasePath =
     if config.ghaf.type == "host" then "/persist/common/journal-fss" else "/etc/common/journal-fss";
   verifyClassifierLib = builtins.readFile ./fss-verify-classifier.sh;
+  fssTriagePackage =
+    pkgs.fss-triage or (pkgs.callPackage ../../../packages/pkgs-by-name/fss-triage/package.nix { });
 
   preparePersistentJournalScript = pkgs.writeShellApplication {
     name = "journal-fss-prepare-persistent-journal";
@@ -107,7 +124,12 @@ let
       coreutils
       gawk
       findutils
+      gnugrep
+      util-linux
     ];
+    # The shared classifier library is sourced for fss_log and receipt helpers;
+    # its verify-only functions are intentionally unused here.
+    excludeShellChecks = [ "SC2329" ];
     text = ''
       export LC_ALL=C
 
@@ -119,6 +141,21 @@ let
       MACHINE_ID=$(cat /etc/machine-id)
       STATE_DIR="/var/log/journal/$MACHINE_ID"
       PRE_FSS_ARCHIVE_FILE="$STATE_DIR/fss-pre-fss-archive"
+      RECOVERY_RECEIPTS_FILE="$STATE_DIR/fss-recovery-receipts"
+      PRE_ACTIVATION_RECEIPTS_FILE="$STATE_DIR/fss-pre-activation-receipts"
+      UNCLEAN_SHUTDOWN_RECEIPTS_FILE="$STATE_DIR/fss-unclean-shutdown-receipts"
+      ACTIVATION_STATE_FILE="$STATE_DIR/fss-activation-state"
+      FSS_BOOT_BASELINE_FILE="$STATE_DIR/fss-baseline-boot"
+      ACTIVATION_ENABLED="${if activationEnabled then "1" else "0"}"
+      PRE_ACTIVATION_MAX_RECEIPTS="${toString cfg.activation.maxReceipts}"
+      RECOVERY_MAX_RECEIPTS="${toString config.ghaf.logging.recovery.maxReceipts}"
+      UNCLEAN_SHUTDOWN_MAX_RECEIPTS="${toString cfg.uncleanShutdown.maxReceipts}"
+      ACTIVATION_FAILED=0
+      ACTIVATION_RESTARTED_THIS_RUN=0
+      RECORD_PRE_ACTIVATION_THIS_RUN=0
+      SETUP_ARCHIVES_BEFORE=""
+      JOURNALD_RUNTIME_CONF_DIR="/run/systemd/journald.conf.d"
+      JOURNALD_FSS_RUNTIME_CONF="$JOURNALD_RUNTIME_CONF_DIR/90-ghaf-fss-activation.conf"
 
       clear_initialized_state() {
         rm -f "$INIT_FILE"
@@ -142,17 +179,344 @@ let
         fi
       }
 
+      receipt_file_has_path() {
+        local receipt_file="$1"
+        local needle="$2"
+
+        [ -n "$needle" ] && [ -f "$receipt_file" ] || return 1
+        awk -F '\t' -v p="$needle" '$2 == p { found = 1 } END { exit found ? 0 : 1 }' \
+          "$receipt_file"
+      }
+
+      pre_activation_receipt_has_path() {
+        local needle="$1"
+
+        receipt_file_has_path "$PRE_ACTIVATION_RECEIPTS_FILE" "$needle"
+      }
+
+      record_lifecycle_receipt() {
+        local receipt_file="$1"
+        local archive_path="$2"
+        local reason="$3"
+        local log_level="$4"
+        local log_message="$5"
+        local inode size mtime sha boot event
+
+        [ -n "$archive_path" ] && [ -f "$archive_path" ] || return 0
+
+        inode=$(stat -c %i "$archive_path" 2>/dev/null || true)
+        size=$(stat -c %s "$archive_path" 2>/dev/null || true)
+        mtime=$(stat -c %Y "$archive_path" 2>/dev/null || true)
+        sha=$(sha256sum "$archive_path" 2>/dev/null | cut -d' ' -f1 || true)
+        boot=$(current_boot_id)
+        event="''${INVOCATION_ID:-$boot}"
+
+        if [ -z "$inode" ] || [ -z "$size" ] || [ -z "$mtime" ] || ! fss_valid_sha256 "$sha"; then
+          fss_log warn "Could not record lifecycle receipt for $archive_path: missing stat or sha256 evidence"
+          return 0
+        fi
+
+        # Dedupe on the physical archive identity (path + inode + size).
+        if [ -f "$receipt_file" ] \
+          && awk -F '\t' -v p="$archive_path" -v i="$inode" -v s="$size" \
+            '$2 == p && $3 == i && $4 == s { found = 1 } END { exit found ? 0 : 1 }' \
+            "$receipt_file"; then
+          return 0
+        fi
+
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+          "$FSS_RECEIPT_SCHEMA_VERSION" "$archive_path" "$inode" "$size" \
+          "$boot" "$mtime" "$sha" "$reason" "$event" \
+          >> "$receipt_file"
+        chmod 0644 "$receipt_file"
+        fss_log "$log_level" "$log_message: $archive_path"
+      }
+
+      record_recovery_receipt() {
+        local archive_path="$1"
+        local reason="''${2:-clock-jump-recovery}"
+
+        [ -n "$archive_path" ] || return 0
+        [ -s "$PRE_FSS_ARCHIVE_FILE" ] && [ "$(tr -d '[:space:]' < "$PRE_FSS_ARCHIVE_FILE")" = "$archive_path" ] && return 0
+        if pre_activation_receipt_has_path "$archive_path"; then
+          return 0
+        fi
+        if receipt_file_has_path "$RECOVERY_RECEIPTS_FILE" "$archive_path"; then
+          return 0
+        fi
+
+        record_lifecycle_receipt \
+          "$RECOVERY_RECEIPTS_FILE" \
+          "$archive_path" \
+          "$reason" \
+          info \
+          "Recorded FSS recovery archive receipt"
+      }
+
+      # Record a content-bound lifecycle receipt for an archive rotated away at
+      # the per-boot activation boundary, so the verifier recognises an expected
+      # "insecure boot logs" exception by identity, not by path string alone.
+      # Schema is defined in fss-verify-classifier.sh (FSS_RECEIPT_SCHEMA_VERSION).
+      record_pre_activation_receipt() {
+        local archive_path="$1"
+        local reason="''${2:-pre-activation-rotation}"
+        record_lifecycle_receipt \
+          "$PRE_ACTIVATION_RECEIPTS_FILE" \
+          "$archive_path" \
+          "$reason" \
+          warn \
+          "Recorded insecure pre-activation journal receipt"
+      }
+
+      # Record content-bound receipts for journals that JOURNALD ITSELF reported as
+      # "corrupted or uncleanly shut down" in the current boot's log and renamed to
+      # <path>~. That message is journald's own attestation of a prior unclean kill
+      # (host crash, power loss, stop-timeout SIGKILL) — the unpreventable residual.
+      # The verifier treats a content-matched unclean receipt as
+      # verified-with-exception; an unmatched .journal~ or the live system.journal
+      # still fails closed. See fss-verify-classifier.sh policy.
+      record_unclean_shutdown_receipt() {
+        local archive_path="$1"
+        record_lifecycle_receipt \
+          "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" \
+          "$archive_path" \
+          "unclean-shutdown" \
+          warn \
+          "Recorded unclean-shutdown journal receipt"
+      }
+
+      # Journal paths journald named as uncleanly shut down in the current boot.
+      unclean_shutdown_named_paths() {
+        journalctl -b -u systemd-journald.service \
+          --grep="corrupted or uncleanly shut down, renaming and replacing" \
+          --output=cat --quiet --no-pager 2>/dev/null \
+          | grep -oE '/var/log/journal/[^ ]+\.journal' \
+          | sort -u
+      }
+
+      # For each journald-attested unclean path P, receipt its renamed corpse "P~"
+      # only if it exists on disk (record_lifecycle_receipt is content-bound and
+      # skips a missing file). The target always ends in '~', so it can never be the
+      # live system.journal — the active journal is never receipted here.
+      record_unclean_shutdown_journals() {
+        local named_path target
+        while IFS= read -r named_path || [ -n "$named_path" ]; do
+          [ -n "$named_path" ] || continue
+          target="''${named_path}~"
+          [ -f "$target" ] || continue
+          record_unclean_shutdown_receipt "$target"
+        done < <(unclean_shutdown_named_paths)
+      }
+
+      # Bound the receipt store by capping to the newest PRE_ACTIVATION_MAX_RECEIPTS
+      # records (the file is append-ordered oldest-first). Receipts are NOT dropped
+      # merely because an archive is currently absent: a receipt for a vanished
+      # archive is harmless (the verifier's fss_filter_valid_receipts ignores it,
+      # and a deleted archive never appears as a verify failure), and dropping on
+      # transient absence would lose coverage for an archive that returns. The cap
+      # is the growth backstop; content substitution is caught at verify time.
+      prune_pre_activation_receipts() {
+        local tmp total excess
+
+        [ -f "$PRE_ACTIVATION_RECEIPTS_FILE" ] || return 0
+
+        total=$(wc -l < "$PRE_ACTIVATION_RECEIPTS_FILE" 2>/dev/null || echo 0)
+        [ "$total" -gt "$PRE_ACTIVATION_MAX_RECEIPTS" ] || return 0
+
+        excess=$((total - PRE_ACTIVATION_MAX_RECEIPTS))
+        tmp=$(mktemp)
+        tail -n "$PRE_ACTIVATION_MAX_RECEIPTS" "$PRE_ACTIVATION_RECEIPTS_FILE" > "$tmp"
+        mv "$tmp" "$PRE_ACTIVATION_RECEIPTS_FILE"
+        chmod 0644 "$PRE_ACTIVATION_RECEIPTS_FILE"
+        fss_log warn "Pre-activation receipts exceeded $PRE_ACTIVATION_MAX_RECEIPTS; evicted $excess oldest record(s)"
+      }
+
+      prune_recovery_receipts() {
+        local tmp total excess
+
+        [ -f "$RECOVERY_RECEIPTS_FILE" ] || return 0
+
+        total=$(wc -l < "$RECOVERY_RECEIPTS_FILE" 2>/dev/null || echo 0)
+        [ "$total" -gt "$RECOVERY_MAX_RECEIPTS" ] || return 0
+
+        excess=$((total - RECOVERY_MAX_RECEIPTS))
+        tmp=$(mktemp)
+        tail -n "$RECOVERY_MAX_RECEIPTS" "$RECOVERY_RECEIPTS_FILE" > "$tmp"
+        mv "$tmp" "$RECOVERY_RECEIPTS_FILE"
+        chmod 0644 "$RECOVERY_RECEIPTS_FILE"
+        fss_log warn "Recovery receipts exceeded $RECOVERY_MAX_RECEIPTS; evicted $excess oldest record(s)"
+      }
+
+      prune_unclean_shutdown_receipts() {
+        local tmp total excess
+
+        [ -f "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" ] || return 0
+
+        total=$(wc -l < "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" 2>/dev/null || echo 0)
+        [ "$total" -gt "$UNCLEAN_SHUTDOWN_MAX_RECEIPTS" ] || return 0
+
+        excess=$((total - UNCLEAN_SHUTDOWN_MAX_RECEIPTS))
+        tmp=$(mktemp)
+        tail -n "$UNCLEAN_SHUTDOWN_MAX_RECEIPTS" "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" > "$tmp"
+        mv "$tmp" "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE"
+        chmod 0644 "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE"
+        fss_log warn "Unclean-shutdown receipts exceeded $UNCLEAN_SHUTDOWN_MAX_RECEIPTS; evicted $excess oldest record(s)"
+      }
+
+      record_fss_archive_metadata() {
+        local archive_path="$1"
+        local may_record_pre_fss_archive="''${2:-0}"
+
+        if [ "$may_record_pre_fss_archive" = 1 ]; then
+          if [ ! -s "$PRE_FSS_ARCHIVE_FILE" ]; then
+            write_pre_fss_archive_record "$archive_path"
+          else
+            record_recovery_receipt "$archive_path" "setup-recovery"
+          fi
+          return 0
+        fi
+
+        if [ ! -s "$PRE_FSS_ARCHIVE_FILE" ]; then
+          fss_log warn "Pre-FSS archive metadata missing; not recording setup rotation as pre-FSS archive: $archive_path"
+          return 0
+        fi
+
+        fss_log info "Pre-FSS archive already recorded; not adding setup rotation to recovery allowlist: $archive_path"
+      }
+
       list_archived_system_journals() {
         local journal_dir="$1"
 
         find "$journal_dir" -maxdepth 1 -type f -name 'system@*.journal' -print 2>/dev/null | sort
       }
 
-      record_rotated_pre_fss_archive() {
+      current_boot_id() {
+        cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot
+      }
+
+      boot_start_epoch() {
+        awk -v now="$(date +%s)" '{printf "%d\n", now - $1}' /proc/uptime
+      }
+
+      write_boot_baseline_record() {
+        printf '%s\n' "$(current_boot_id)" > "$FSS_BOOT_BASELINE_FILE"
+        chmod 0644 "$FSS_BOOT_BASELINE_FILE"
+      }
+
+      boot_baseline_current() {
+        [ -s "$FSS_BOOT_BASELINE_FILE" ] || return 1
+        [ "$(tr -d '[:space:]' < "$FSS_BOOT_BASELINE_FILE")" = "$(current_boot_id)" ]
+      }
+
+      current_boot_time_jump_epochs() {
+        {
+          journalctl -b -u systemd-journald.service \
+            --grep="Time jumped backwards, rotating" \
+            --output=short-unix \
+            --quiet \
+            --no-pager 2>/dev/null || true
+          journalctl -b -u systemd-journald.service \
+            --grep="Realtime clock jumped backwards relative to last journal entry, rotating" \
+            --output=short-unix \
+            --quiet \
+            --no-pager 2>/dev/null || true
+        } | awk '
+          $1 ~ /^[0-9]+([.][0-9]+)?$/ {
+            split($1, ts, ".")
+            print ts[1]
+          }
+        ' | sort -u
+      }
+
+      archive_mtime_matches_time_jump_epoch() {
+        local archive_mtime="$1"
+        local time_jump_epochs="$2"
+        local event_epoch=""
+        local window_sec=10
+        local lower=0
+        local upper=0
+
+        while IFS= read -r event_epoch || [ -n "$event_epoch" ]; do
+          case "$event_epoch" in
+          "" | *[!0-9]*) continue ;;
+          esac
+
+          lower=$((event_epoch - window_sec))
+          upper=$((event_epoch + window_sec))
+          if [ "$archive_mtime" -ge "$lower" ] && [ "$archive_mtime" -le "$upper" ]; then
+            return 0
+          fi
+        done <<< "$time_jump_epochs"
+
+        return 1
+      }
+
+      record_current_boot_time_jump_archives() {
+        local journal_dir="$1"
+        local cutoff_epoch="$2"
+        local boot_epoch archive_path archive_mtime time_jump_epochs
+
+        time_jump_epochs="$(current_boot_time_jump_epochs)"
+        [ -n "$time_jump_epochs" ] || return 0
+        boot_epoch="$(boot_start_epoch)"
+
+        while IFS= read -r archive_path || [ -n "$archive_path" ]; do
+          [ -n "$archive_path" ] || continue
+          if [ "$ACTIVATION_ENABLED" = 1 ]; then
+            [ -n "$SETUP_ARCHIVES_BEFORE" ] && [ -f "$SETUP_ARCHIVES_BEFORE" ] || continue
+            grep -Fxq "$archive_path" "$SETUP_ARCHIVES_BEFORE" 2>/dev/null || continue
+          fi
+          archive_mtime=$(stat -c %Y "$archive_path" 2>/dev/null || true)
+          [ -n "$archive_mtime" ] || continue
+
+          if [ "$archive_mtime" -ge "$boot_epoch" ] \
+            && [ "$archive_mtime" -le "$cutoff_epoch" ] \
+            && archive_mtime_matches_time_jump_epoch "$archive_mtime" "$time_jump_epochs"; then
+            if [ "$ACTIVATION_ENABLED" = 1 ]; then
+              record_pre_activation_receipt "$archive_path" "pre-activation-time-jump"
+            else
+              record_recovery_receipt "$archive_path" "clock-jump-recovery"
+            fi
+          fi
+        done < <(list_archived_system_journals "$journal_dir")
+      }
+
+      # Receipt archived system journals that newly appeared immediately after the
+      # activation restart, comparing against a snapshot taken at the start of the
+      # setup run (SETUP_ARCHIVES_BEFORE). Rotation candidates are receipted by
+      # record_rotated_fss_archive. Crucially, a pre-existing archive that fails
+      # verification — e.g. a tampered post-activation one — was present before
+      # the run, so it is NOT receipted and still fails closed.
+      record_setup_run_pre_activation_archives() {
+        local journal_dir="$1"
+        local archive_path
+
+        [ "$ACTIVATION_ENABLED" = 1 ] || return 0
+        [ "$RECORD_PRE_ACTIVATION_THIS_RUN" = 1 ] || return 0
+        [ -n "$SETUP_ARCHIVES_BEFORE" ] && [ -f "$SETUP_ARCHIVES_BEFORE" ] || return 0
+
+        while IFS= read -r archive_path || [ -n "$archive_path" ]; do
+          [ -n "$archive_path" ] || continue
+          grep -Fxq "$archive_path" "$SETUP_ARCHIVES_BEFORE" 2>/dev/null && continue
+          record_pre_activation_receipt "$archive_path" "pre-activation-restart"
+        done < <(list_archived_system_journals "$journal_dir")
+      }
+
+      harden_sealing_key() {
+        local sealing_key_file="$1"
+
+        [ -f "$sealing_key_file" ] || return 0
+        chown root:root "$sealing_key_file" 2>/dev/null || true
+        chmod 0600 "$sealing_key_file" 2>/dev/null || true
+      }
+
+      record_rotated_fss_archive() {
         local before_file="$1"
         local journal_dir="$2"
+        local may_record_pre_fss_archive="''${3:-0}"
         local archive_path=""
         local candidate=""
+        local candidate_count=0
         local after_file
 
         after_file=$(mktemp)
@@ -164,18 +528,29 @@ let
           fi
 
           if ! grep -Fxq "$archive_path" "$before_file"; then
-            if [ -n "$candidate" ]; then
-              fss_log warn "Multiple new archived system journals detected after rotation; not recording pre-FSS archive."
-              candidate=""
-              break
+            if [ "$RECORD_PRE_ACTIVATION_THIS_RUN" = 1 ]; then
+              record_pre_activation_receipt "$archive_path" "pre-activation-rotation"
             fi
 
+            candidate_count=$((candidate_count + 1))
             candidate="$archive_path"
           fi
         done < "$after_file"
 
         rm -f "$after_file"
-        write_pre_fss_archive_record "$candidate"
+        [ "$candidate_count" -gt 0 ] || return 0
+
+        if [ "$candidate_count" -gt 1 ]; then
+          fss_log warn "Multiple new archived system journals detected after rotation; not recording pre-FSS archive."
+          return 0
+        fi
+
+        if [ "$ACTIVATION_ENABLED" = 1 ] && [ "$may_record_pre_fss_archive" = 1 ] && [ -s "$PRE_FSS_ARCHIVE_FILE" ]; then
+          fss_log info "Pre-FSS archive already recorded; not adding activation rotation to recovery allowlist: $candidate"
+          return 0
+        fi
+
+        record_fss_archive_metadata "$candidate" "$may_record_pre_fss_archive"
       }
 
       backfill_pre_fss_archive_if_missing() {
@@ -236,36 +611,263 @@ let
       rotate_to_clean_fss_state() {
         local journal_dir="$1"
         local sealing_key_file="$2"
+        local force_rotation="''${3:-0}"
         local rotated_marker="$STATE_DIR/fss-rotated"
         local before_file
         local marker_mtime=""
         local key_mtime=""
+        local may_record_pre_fss_archive=0
+        local rotation_started=""
+
+        if [ "$ACTIVATION_ENABLED" = 1 ] && [ "$ACTIVATION_FAILED" = 1 ]; then
+          fss_log warn "Skipping FSS cleanup rotation because sealing activation failed"
+          return 0
+        fi
+
+        # Receipt any journals journald attested as uncleanly shut down this boot.
+        # Runs every setup invocation (dedup-safe); skipped above on activation
+        # failure so we never receipt anything when sealing did not take effect.
+        record_unclean_shutdown_journals
 
         marker_mtime=$(stat -c %Y "$rotated_marker" 2>/dev/null || true)
         key_mtime=$(stat -c %Y "$sealing_key_file" 2>/dev/null || true)
+        if [ "$force_rotation" = 1 ] || [ -z "$marker_mtime" ]; then
+          may_record_pre_fss_archive=1
+        fi
 
-        if [ -n "$marker_mtime" ] && [ -n "$key_mtime" ] && [ "$marker_mtime" -ge "$key_mtime" ]; then
+        if [ "$force_rotation" != 1 ] \
+          && [ "$ACTIVATION_RESTARTED_THIS_RUN" != 1 ] \
+          && activation_boundary_complete_current_boot \
+          && [ -n "$marker_mtime" ]; then
           backfill_pre_fss_archive_if_missing "$journal_dir"
+          return 0
+        fi
+
+        if [ "$force_rotation" != 1 ] \
+          && [ "$ACTIVATION_RESTARTED_THIS_RUN" != 1 ] \
+          && activation_state_record_current_boot \
+          && [ "$RECORD_PRE_ACTIVATION_THIS_RUN" != 1 ] \
+          && [ -n "$marker_mtime" ]; then
+          backfill_pre_fss_archive_if_missing "$journal_dir"
+          fss_log info "Restoring current boot FSS baseline without post-activation rotation"
+          write_boot_baseline_record
+          return 0
+        fi
+
+        if [ "$force_rotation" != 1 ] && [ -n "$marker_mtime" ]; then
+          backfill_pre_fss_archive_if_missing "$journal_dir"
+        fi
+
+        if [ "$force_rotation" != 1 ] \
+          && [ "$ACTIVATION_ENABLED" != 1 ] \
+          && [ -n "$marker_mtime" ] \
+          && [ -n "$key_mtime" ] \
+          && [ "$marker_mtime" -ge "$key_mtime" ]; then
           return 0
         fi
 
         before_file=$(mktemp)
         list_archived_system_journals "$journal_dir" > "$before_file"
+        rotation_started=$(date +%s)
+        record_current_boot_time_jump_archives "$journal_dir" "$rotation_started"
         fss_log info "Rotating journal to ensure clean FSS state..."
         journalctl --rotate 2>/dev/null || true
-        record_rotated_pre_fss_archive "$before_file" "$journal_dir"
+        journalctl --sync 2>/dev/null || true
+        record_rotated_fss_archive "$before_file" "$journal_dir" "$may_record_pre_fss_archive"
         rm -f "$before_file"
         touch "$rotated_marker"
         chmod 0644 "$rotated_marker"
+        write_boot_baseline_record
       }
 
+      write_activation_state() {
+        printf '%s\t%s\n' "$1" "$(current_boot_id)" > "$ACTIVATION_STATE_FILE"
+        chmod 0644 "$ACTIVATION_STATE_FILE"
+      }
+
+      runtime_fss_activation_config_present() {
+        [ -f "$JOURNALD_FSS_RUNTIME_CONF" ] \
+          && grep -Fxq "Seal=yes" "$JOURNALD_FSS_RUNTIME_CONF"
+      }
+
+      activation_state_value() {
+        [ -r "$ACTIVATION_STATE_FILE" ] || return 0
+        awk -F '\t' 'NR == 1 { print $1 }' "$ACTIVATION_STATE_FILE"
+      }
+
+      activation_state_boot_id() {
+        [ -r "$ACTIVATION_STATE_FILE" ] || return 0
+        awk -F '\t' 'NR == 1 { print $2 }' "$ACTIVATION_STATE_FILE"
+      }
+
+      activation_state_record_current_boot() {
+        [ "$(activation_state_value)" = "active" ] \
+          && [ "$(activation_state_boot_id)" = "$(current_boot_id)" ]
+      }
+
+      activation_state_active_current_boot() {
+        activation_state_record_current_boot
+      }
+
+      activation_boundary_complete_current_boot() {
+        activation_state_record_current_boot \
+          && boot_baseline_current
+      }
+
+      rotation_marker_present() {
+        local marker_mtime
+
+        marker_mtime=$(stat -c %Y "$STATE_DIR/fss-rotated" 2>/dev/null || true)
+        [ -n "$marker_mtime" ]
+      }
+
+      activation_boundary_recording_needed() {
+        [ "$ACTIVATION_ENABLED" = 1 ] || return 1
+        ! activation_state_record_current_boot
+      }
+
+      journald_activation_already_current() {
+        [ "$ACTIVATION_ENABLED" = 1 ] || return 1
+        runtime_fss_activation_config_present \
+          && activation_state_record_current_boot \
+          && rotation_marker_present \
+          && sealing_active_in_config
+      }
+
+      sealing_active_in_config() {
+        local effective_seal
+
+        effective_seal=$(
+          systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
+            | awk -F= '
+              /^[[:space:]]*[#;]/ { next }
+              /^[[:space:]]*Seal[[:space:]]*=/ {
+                value = $2
+                sub(/^[[:space:]]*/, "", value)
+                sub(/[[:space:]]*[#;].*$/, "", value)
+                sub(/[[:space:]]*$/, "", value)
+                seal = tolower(value)
+              }
+              END { print seal }
+            '
+        )
+        [ "$effective_seal" = "yes" ]
+      }
+
+      # Restart journald so it loads the FSS sealing key, and (when activation is
+      # enabled) confirm sealing actually took effect. Returns non-zero if the
+      # runtime drop-in cannot be written, the restart fails, or sealing cannot be
+      # confirmed afterwards, so the caller can fail the setup closed rather than
+      # leaving an unsealed journal that looks "set up".
       restart_journald_for_fss_activation() {
+        local restart_ok=1
+
+        if [ "$ACTIVATION_ENABLED" = 1 ]; then
+          if ! install -d -m 0755 "$JOURNALD_RUNTIME_CONF_DIR" \
+            || ! printf '%s\n' '[Journal]' 'Seal=yes' > "$JOURNALD_FSS_RUNTIME_CONF"; then
+            fss_log fail "Failed to write runtime journald FSS activation config: $JOURNALD_FSS_RUNTIME_CONF"
+            write_activation_state failed
+            return 1
+          fi
+          chmod 0644 "$JOURNALD_FSS_RUNTIME_CONF"
+          fss_log info "Wrote runtime journald FSS activation config: $JOURNALD_FSS_RUNTIME_CONF"
+        fi
+
         # Journald only loads the FSS sealing key at startup. If setup previously
         # failed before this restart, later retries must still reload journald.
         fss_log info "Restarting journald to enable sealing..."
+        systemctl reset-failed \
+          systemd-journald.service \
+          systemd-journald.socket \
+          systemd-journald-dev-log.socket \
+          systemd-journald-audit.socket >/dev/null 2>&1 || true
         if ! systemctl restart systemd-journald; then
-          fss_log warn "Journald restart failed - sealing may not be active"
+          fss_log fail "Journald restart failed - sealing may not be active"
+          restart_ok=0
         fi
+
+        if [ "$ACTIVATION_ENABLED" != 1 ]; then
+          write_activation_state disabled
+          return 0
+        fi
+
+        if [ "$restart_ok" = 1 ] && sealing_active_in_config; then
+          ACTIVATION_RESTARTED_THIS_RUN=1
+          write_activation_state active
+          fss_log info "Confirmed journald sealing is active after restart"
+          return 0
+        fi
+
+        fss_log fail "Journald sealing could not be confirmed after restart; failing closed"
+        write_activation_state failed
+        return 1
+      }
+
+      verify_live_sealing_after_activation() {
+        local verify_key verify_output verify_exit marker
+
+        [ "$ACTIVATION_ENABLED" = 1 ] || return 0
+        [ "$ACTIVATION_RESTARTED_THIS_RUN" = 1 ] || return 0
+        [ "$ACTIVATION_FAILED" = 0 ] || return 1
+        [ -s "$VERIFY_KEY_FILE" ] && [ -r "$VERIFY_KEY_FILE" ] || return 0
+
+        marker="FSS activation live sealing probe $(current_boot_id) $$"
+        logger -t journal-fss "$marker" 2>/dev/null || true
+        journalctl --sync 2>/dev/null || true
+
+        verify_key=$(tr -d '[:space:]' < "$VERIFY_KEY_FILE")
+        verify_exit=0
+        verify_output=$(journalctl --verify --verify-key="$verify_key" 2>&1) || verify_exit=$?
+        fss_classify_verify_output "$verify_output"
+
+        if [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ] \
+          || [ -n "$FSS_OTHER_FAILURES" ] \
+          || [ "$FSS_KEY_PARSE_ERROR" = 1 ] \
+          || [ "$FSS_KEY_REQUIRED_ERROR" = 1 ]; then
+          fss_log fail "Live active-journal verification failed after FSS activation"
+          printf '%s\n' "$verify_output" | fss_log_block
+          write_activation_state failed
+          return 1
+        fi
+
+        if [ "$verify_exit" -ne 0 ] \
+          && [ -z "$FSS_ARCHIVED_SYSTEM_FAILURES" ] \
+          && [ -z "$FSS_USER_FAILURES" ] \
+          && [ -z "$FSS_TEMP_FAILURES" ] \
+          && [ "$FSS_FILESYSTEM_RESTRICTION" = 0 ]; then
+          fss_log fail "journalctl --verify exited $verify_exit after FSS activation without a classified exception"
+          printf '%s\n' "$verify_output" | fss_log_block
+          write_activation_state failed
+          return 1
+        fi
+
+        fss_log info "Confirmed active system journal verifies after FSS activation"
+      }
+
+      activate_journald_for_fss_setup() {
+        if journald_activation_already_current; then
+          fss_log info "Journald FSS activation is already active for this boot; skipping restart"
+          return 0
+        fi
+
+        if restart_journald_for_fss_activation; then
+          journalctl --sync 2>/dev/null || true
+          record_setup_run_pre_activation_archives "$JOURNAL_DIR"
+        else
+          ACTIVATION_FAILED=1
+        fi
+      }
+
+      # Exit the setup service, failing closed if sealing activation did not take
+      # effect. journald keeps running either way; a non-zero exit makes the
+      # unsealed state visible (failed unit + journal-fss-verify alert) instead of
+      # silently passing.
+      finish_setup() {
+        if [ "$ACTIVATION_FAILED" = 1 ]; then
+          fss_log fail "FSS setup finished but sealing activation failed; logs are unsealed"
+          exit 1
+        fi
+        exit 0
       }
 
       ensure_verification_key_ready() {
@@ -311,23 +913,50 @@ let
       chmod 0755 "/var/log/journal" 2>/dev/null || true
       chmod 2755 "$STATE_DIR" 2>/dev/null || true
 
+      # Snapshot archived system journals present before this setup run touches
+      # journald, so record_setup_run_pre_activation_archives can receipt only the
+      # archives this run spills out and never a pre-existing (possibly tampered)
+      # one.
+      SETUP_ARCHIVES_BEFORE=$(mktemp)
+      cleanup_setup_tmp() {
+        rm -f "$SETUP_ARCHIVES_BEFORE"
+      }
+      trap cleanup_setup_tmp EXIT
+      list_archived_system_journals "$JOURNAL_DIR" > "$SETUP_ARCHIVES_BEFORE" 2>/dev/null || true
+      if activation_boundary_recording_needed; then
+        RECORD_PRE_ACTIVATION_THIS_RUN=1
+      fi
+
       # Check if FSS keys already exist
       if [ -f "$FSS_KEY_FILE" ]; then
         fss_log info "FSS sealing key already exists at $FSS_KEY_FILE"
+        harden_sealing_key "$FSS_KEY_FILE"
         if ! ensure_verification_key_ready; then
           # Keep sentinel so verify service can detect and alert on KEY_MISSING periodically
           fss_log warn "Verification key missing but sealing key present. Verify service will alert."
           publish_setup_state
+          if [ "$ACTIVATION_ENABLED" = 1 ]; then
+            activate_journald_for_fss_setup
+            prune_pre_activation_receipts
+            prune_recovery_receipts
+            prune_unclean_shutdown_receipts
+          fi
           exit 1
         fi
         fss_log info "Setup already complete, verification key present, creating sentinel file"
         publish_setup_state
-        if [ ! -f "$STATE_DIR/fss-rotated" ]; then
-          restart_journald_for_fss_activation
+        if [ "$ACTIVATION_ENABLED" = 1 ] || [ ! -f "$STATE_DIR/fss-rotated" ]; then
+          activate_journald_for_fss_setup
         fi
         # One-time rotation to move pre-FSS entries to archive (fixes "Bad message")
         rotate_to_clean_fss_state "$JOURNAL_DIR" "$FSS_KEY_FILE"
-        exit 0
+        prune_pre_activation_receipts
+        prune_recovery_receipts
+        prune_unclean_shutdown_receipts
+        if ! verify_live_sealing_after_activation; then
+          ACTIVATION_FAILED=1
+        fi
+        finish_setup
       fi
 
       # Generate new FSS keys
@@ -364,30 +993,41 @@ let
         fss_log fail "FSS key generation failed - key file not found at $FSS_KEY_FILE"
         exit 1
       fi
+      harden_sealing_key "$FSS_KEY_FILE"
 
       if ! ensure_verification_key_ready; then
         # The sealing key exists now, so keep verify enabled to emit KEY_MISSING
         # even when verification key export failed during initial setup.
         fss_log warn "Verification key missing after key generation. Verify service will alert."
-        restart_journald_for_fss_activation
-        rotate_to_clean_fss_state "$JOURNAL_DIR" "$FSS_KEY_FILE"
+        activate_journald_for_fss_setup
+        rotate_to_clean_fss_state "$JOURNAL_DIR" "$FSS_KEY_FILE" 1
+        prune_pre_activation_receipts
+        prune_recovery_receipts
+        prune_unclean_shutdown_receipts
         publish_setup_state
         exit 1
       fi
 
       # Restart journald to pick up the new FSS key
       # Journald only checks for FSS keys at startup, so rotation alone is insufficient
-      restart_journald_for_fss_activation
+      activate_journald_for_fss_setup
 
       # Rotate so active journal starts clean with FSS (pre-FSS entries become archive)
-      rotate_to_clean_fss_state "$JOURNAL_DIR" "$FSS_KEY_FILE"
+      rotate_to_clean_fss_state "$JOURNAL_DIR" "$FSS_KEY_FILE" 1
+      prune_pre_activation_receipts
+      prune_recovery_receipts
+      prune_unclean_shutdown_receipts
 
       # Create sentinel file to prevent re-initialization
       publish_setup_state
+      if ! verify_live_sealing_after_activation; then
+        ACTIVATION_FAILED=1
+      fi
 
       fss_log pass "Forward Secure Sealing initialization complete"
       fss_log info "Sealing key: $FSS_KEY_FILE"
       fss_log info "Verification key: $VERIFY_KEY_FILE"
+      finish_setup
     '';
   };
 
@@ -396,14 +1036,37 @@ let
     name = "journal-fss-verify";
     runtimeInputs = with pkgs; [
       systemd
+      coreutils
       util-linux
       gnugrep
+      gawk
     ];
+    # Shared classifier library: some helper functions are unused in this consumer.
+    excludeShellChecks = [ "SC2329" ];
     text = ''
             ${verifyClassifierLib}
 
             audit_log() {
               printf '%s\n' "$2" | systemd-cat -t journal-fss -p "$1"
+            }
+
+            journald_effective_seal() {
+              systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
+                | awk -F= '
+                  /^[[:space:]]*[#;]/ { next }
+                  /^[[:space:]]*Seal[[:space:]]*=/ {
+                    value = $2
+                    sub(/^[[:space:]]*/, "", value)
+                    sub(/[[:space:]]*[#;].*$/, "", value)
+                    sub(/[[:space:]]*$/, "", value)
+                    seal = tolower(value)
+                  }
+                  END { print seal }
+                '
+            }
+
+            sealing_active_in_config() {
+              [ "$(journald_effective_seal)" = "yes" ]
             }
 
             fss_log info "Verifying journal integrity with Forward Secure Sealing..."
@@ -422,16 +1085,92 @@ let
 
             MACHINE_ID=$(cat /etc/machine-id)
             PRE_FSS_ARCHIVE_FILE="/var/log/journal/$MACHINE_ID/fss-pre-fss-archive"
-            RECOVERY_ARCHIVES_FILE="/var/log/journal/$MACHINE_ID/fss-recovery-archives"
-            VERIFY_KEY=$(cat "$VERIFY_KEY_FILE")
+            RECOVERY_RECEIPTS_FILE="/var/log/journal/$MACHINE_ID/fss-recovery-receipts"
+            PRE_ACTIVATION_RECEIPTS_FILE="/var/log/journal/$MACHINE_ID/fss-pre-activation-receipts"
+            UNCLEAN_SHUTDOWN_RECEIPTS_FILE="/var/log/journal/$MACHINE_ID/fss-unclean-shutdown-receipts"
+            ACTIVATION_STATE_FILE="/var/log/journal/$MACHINE_ID/fss-activation-state"
+            FSS_BOOT_BASELINE_FILE="/var/log/journal/$MACHINE_ID/fss-baseline-boot"
+            CURRENT_BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot)
+            ACTIVATION_ENABLED="${if activationEnabled then "1" else "0"}"
+            VERIFY_KEY=$(tr -d '[:space:]' < "$VERIFY_KEY_FILE")
+
+            if [ "$ACTIVATION_ENABLED" = 1 ]; then
+              ACTIVATION_STATE=""
+              ACTIVATION_BOOT_ID=""
+              ACTIVATION_BASELINE_BOOT_ID=""
+              if [ -r "$ACTIVATION_STATE_FILE" ]; then
+                ACTIVATION_STATE=$(awk -F '\t' 'NR == 1 { print $1 }' "$ACTIVATION_STATE_FILE")
+                ACTIVATION_BOOT_ID=$(awk -F '\t' 'NR == 1 { print $2 }' "$ACTIVATION_STATE_FILE")
+              fi
+              if [ -r "$FSS_BOOT_BASELINE_FILE" ]; then
+                ACTIVATION_BASELINE_BOOT_ID=$(tr -d '[:space:]' < "$FSS_BOOT_BASELINE_FILE")
+              fi
+
+              if [ "$ACTIVATION_STATE" = "failed" ]; then
+                audit_log crit "AUDIT_LOG_INTEGRITY_FAIL: FSS activation failed; journald sealing not confirmed [ACTIVATION_FAILED]"
+                fss_log fail "Journal integrity verification: FAILED (FSS sealing was not activated; logs are unsealed)"
+                exit 1
+              fi
+
+              if [ "$ACTIVATION_STATE" != "active" ] \
+                || [ "$ACTIVATION_BOOT_ID" != "$CURRENT_BOOT_ID" ] \
+                || [ "$ACTIVATION_BASELINE_BOOT_ID" != "$CURRENT_BOOT_ID" ]; then
+                audit_log crit "AUDIT_LOG_INTEGRITY_FAIL: FSS activation is not active for the current boot [ACTIVATION_STALE]"
+                fss_log fail "Journal integrity verification: FAILED (FSS activation state is not active for current boot; state=''${ACTIVATION_STATE:-missing} boot=''${ACTIVATION_BOOT_ID:-missing} baseline=''${ACTIVATION_BASELINE_BOOT_ID:-missing})"
+                exit 1
+              fi
+
+              if ! sealing_active_in_config; then
+                audit_log crit "AUDIT_LOG_INTEGRITY_FAIL: FSS activation failed; effective journald Seal setting is not yes [ACTIVATION_FAILED]"
+                fss_log fail "Journal integrity verification: FAILED (effective journald Seal setting is not yes)"
+                exit 1
+              fi
+            fi
 
             VERIFY_EXIT=0
             VERIFY_OUTPUT=$(journalctl --verify --verify-key="$VERIFY_KEY" 2>&1) || VERIFY_EXIT=$?
 
+            # Content-bind lifecycle receipts to disk. Missing archives may be
+            # journald retention, but an existing path with different content is
+            # substitution/path reuse and fails even if journalctl is clean.
+            RAW_RECOVERY_RECEIPTS=$(fss_read_receipts "$RECOVERY_RECEIPTS_FILE")
+            RECOVERY_RECEIPT_MISMATCHES=$(fss_receipt_mismatches "$RAW_RECOVERY_RECEIPTS")
+            if [ -n "$RECOVERY_RECEIPT_MISMATCHES" ]; then
+              audit_log crit "AUDIT_LOG_INTEGRITY_FAIL: Recovery receipt content mismatch [RECOVERY_RECEIPT_MISMATCH]"
+              fss_log fail "Journal integrity verification: FAILED (recovery receipt content mismatch)"
+              printf 'Mismatched receipt paths:\n%s\n' "$RECOVERY_RECEIPT_MISMATCHES" | fss_log_block
+              exit 1
+            fi
+            RECOVERY_RECEIPTS=$(fss_filter_valid_receipts "$RAW_RECOVERY_RECEIPTS")
+
+            RAW_PRE_ACTIVATION_RECEIPTS=$(fss_read_pre_activation_receipts "$PRE_ACTIVATION_RECEIPTS_FILE")
+            PRE_ACTIVATION_RECEIPT_MISMATCHES=$(fss_pre_activation_receipt_mismatches "$RAW_PRE_ACTIVATION_RECEIPTS")
+            if [ -n "$PRE_ACTIVATION_RECEIPT_MISMATCHES" ]; then
+              audit_log crit "AUDIT_LOG_INTEGRITY_FAIL: Pre-activation receipt content mismatch [PRE_ACTIVATION_RECEIPT_MISMATCH]"
+              fss_log fail "Journal integrity verification: FAILED (pre-activation receipt content mismatch)"
+              printf 'Mismatched receipt paths:\n%s\n' "$PRE_ACTIVATION_RECEIPT_MISMATCHES" | fss_log_block
+              exit 1
+            fi
+            PRE_ACTIVATION_RECEIPTS=$(fss_filter_valid_receipts "$RAW_PRE_ACTIVATION_RECEIPTS")
+
+            RAW_UNCLEAN_RECEIPTS=$(fss_read_unclean_shutdown_receipts "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE")
+            UNCLEAN_RECEIPT_MISMATCHES=$(fss_unclean_shutdown_receipt_mismatches "$RAW_UNCLEAN_RECEIPTS")
+            if [ -n "$UNCLEAN_RECEIPT_MISMATCHES" ]; then
+              audit_log crit "AUDIT_LOG_INTEGRITY_FAIL: Unclean-shutdown receipt content mismatch [UNCLEAN_SHUTDOWN_RECEIPT_MISMATCH]"
+              fss_log fail "Journal integrity verification: FAILED (unclean-shutdown receipt content mismatch)"
+              printf 'Mismatched receipt paths:\n%s\n' "$UNCLEAN_RECEIPT_MISMATCHES" | fss_log_block
+              exit 1
+            fi
+            UNCLEAN_RECEIPTS=$(fss_filter_valid_receipts "$RAW_UNCLEAN_RECEIPTS")
+
             fss_classify_verify_output "$VERIFY_OUTPUT"
             fss_verify_policy_decision \
               "$(fss_read_recorded_pre_fss_archive "$PRE_FSS_ARCHIVE_FILE")" \
-              "$(fss_read_recorded_archive_list "$RECOVERY_ARCHIVES_FILE")"
+              "$RECOVERY_RECEIPTS" \
+              "$PRE_ACTIVATION_RECEIPTS" \
+              "$CURRENT_BOOT_ID" \
+              "$VERIFY_EXIT" \
+              "$UNCLEAN_RECEIPTS"
 
             case "$FSS_VERDICT" in
             fail)
@@ -451,21 +1190,25 @@ let
               fi
               exit 1
               ;;
-            partial)
-              audit_log warning "WARNING: Journal integrity verification PARTIAL [$FSS_VERDICT_TAGS]"
-              fss_log warn "Journal integrity verification: PARTIAL ($FSS_VERDICT_REASON)"
+            warning)
+              audit_log warning "WARNING: Journal integrity verification raised warnings [$FSS_VERDICT_TAGS]"
+              fss_log warn "Journal integrity verification: WARNING ($FSS_VERDICT_REASON)"
               fss_log_block <<EOF
       Output: $VERIFY_OUTPUT
       EOF
               exit 0
               ;;
-            pass)
-              audit_log info "AUDIT_LOG_VERIFY_COMPLETED: Journal integrity verification passed"
-              if [ -n "$FSS_VERDICT_REASON" ]; then
-                fss_log pass "Journal integrity verification: PASSED ($FSS_VERDICT_REASON)"
-              else
-                fss_log pass "Journal integrity verification: PASSED"
+            verified-with-exception)
+              audit_log notice "AUDIT_LOG_VERIFY_COMPLETED: Journal integrity verified with recorded exception [$FSS_VERDICT_TAGS]"
+              fss_log pass "Journal integrity verification: VERIFIED WITH EXCEPTION ($FSS_VERDICT_REASON)"
+              if [ "$VERIFY_EXIT" -ne 0 ]; then
+                fss_log info "Note: journalctl --verify returned exit $VERIFY_EXIT without critical errors [$FSS_VERDICT_TAGS]"
               fi
+              exit 0
+              ;;
+            verified)
+              audit_log info "AUDIT_LOG_VERIFY_COMPLETED: Journal integrity verification passed"
+              fss_log pass "Journal integrity verification: VERIFIED"
               if [ "$VERIFY_EXIT" -ne 0 ]; then
                 fss_log info "Note: journalctl --verify returned exit $VERIFY_EXIT without critical errors [$FSS_VERDICT_TAGS]"
               fi
@@ -493,6 +1236,97 @@ in
         FSS provides cryptographic tamper-evidence for audit logs
         using HMAC-based sealing chains. Any tampering will break
         the chain and be detected during verification.
+      '';
+    };
+
+    activation = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Enable an explicit per-boot FSS activation boundary.
+
+          When enabled, journald is explicitly configured with Seal=no during
+          early boot. The FSS setup service writes a runtime journald drop-in,
+          restarts journald, and rotates logs after clock readiness so entries
+          before that point are treated as collected but not FSS-trusted.
+
+          Entries written before activation land in archives that are recorded as
+          content-bound lifecycle receipts (see activation.maxReceipts) and pass
+          verification as "verified-with-exception" for the current boot. An
+          earlier-boot receipt is downgraded to "warning"; a content mismatch
+          fails closed.
+
+          Security note: enabling this trades a per-boot window of unsealed logs
+          (between journald start and activation) for resilience against the
+          journald wall-clock-jump corruption. Disabling it restores static
+          Seal=yes from early boot. This defaults to true, so upgrading an
+          existing FSS deployment moves it from sealed-from-boot to
+          activate-after-clock-ready; sealing then depends on the setup service
+          completing each boot, and the verifier fails closed if it cannot
+          confirm sealing took effect.
+        '';
+      };
+
+      syncWaitSeconds = mkOption {
+        type = types.int;
+        default = 120;
+        description = ''
+          Maximum number of seconds to wait for system time synchronization
+          (timedatectl NTPSynchronized) after local clock readiness before
+          activating FSS sealing.
+
+          This is a best-effort soft gate, not a hard requirement: on an offline
+          device NTP never synchronises, so activation proceeds anyway once this
+          timeout elapses, sealing on the local (possibly unsynchronised) clock.
+          Clock readiness is a boot gate and mitigation, not a trusted time
+          source.
+        '';
+      };
+
+      maxReceipts = mkOption {
+        type = types.int;
+        default = 64;
+        description = ''
+          Upper bound on retained pre-activation lifecycle receipts.
+
+          The setup service caps the receipt store at this many records, evicting
+          the oldest with a warning when exceeded. Receipts are matched against
+          on-disk archives by content (sha256) at verify time, so a receipt for a
+          deleted archive is harmless; this cap is the growth backstop against
+          frequent reboots.
+        '';
+      };
+    };
+
+    uncleanShutdown = {
+      maxReceipts = mkOption {
+        type = types.int;
+        default = 64;
+        description = ''
+          Upper bound on retained unclean-shutdown lifecycle receipts.
+
+          The setup service records a content-bound receipt for each journal that
+          journald itself reported as uncleanly shut down (host crash, power loss,
+          stop-timeout SIGKILL), and caps the store at this many records. Receipts
+          are matched by sha256 at verify time, so a receipt for a deleted archive
+          is harmless; this is the growth backstop against repeated unclean kills.
+        '';
+      };
+    };
+
+    staticSealEnabled = mkOption {
+      type = types.bool;
+      internal = true;
+      readOnly = true;
+      default = cfg.enable && !cfg.activation.enable;
+      description = ''
+        Whether journald is statically sealed (Seal=yes) from early boot.
+
+        Single source of truth shared by the host, client, and server journald
+        configs so the static-seal condition cannot drift between them. False
+        when the per-boot activation boundary (activation.enable) is in effect,
+        because sealing is then activated at runtime by the FSS setup service.
       '';
     };
 
@@ -619,11 +1453,15 @@ in
     # regardless of profile settings (audit is fundamental to FSS functionality)
     ghaf.security.audit.enable = lib.mkForce true;
 
+    environment.systemPackages = [
+      fssTriagePackage
+    ];
+
     # FSS is only meaningful for persistent journals. The journald sealing key
     # lives beside the journal files and is advanced by journald over time.
     services.journald.extraConfig = lib.mkAfter ''
       Storage=persistent
-      Seal=yes
+      Seal=${if cfg.staticSealEnabled then "yes" else "no"}
     '';
 
     ghaf.storagevm.preserveLogs = mkIf (config.ghaf.type != "host") true;
@@ -701,12 +1539,25 @@ in
             "systemd-journald.service"
             "systemd-journal-flush.service"
           ]
+          ++ lib.optionals clockReadyEnabled [
+            "ghaf-clock-ready.service"
+            # Wait for the time-sync barrier (after networking) before activating
+            # sealing, without making the early journal flush wait on it.
+            "ghaf-clock-sync.service"
+          ]
           ++ lib.optionals (config.ghaf.type == "host") [
             "var-log-journal.mount"
           ];
           wants = [
             "systemd-journald.service"
             "systemd-journal-flush.service"
+          ]
+          ++ lib.optionals clockReadyEnabled [
+            "ghaf-clock-ready.service"
+            "ghaf-clock-sync.service"
+          ];
+          requires = lib.optionals clockReadyEnabled [
+            "ghaf-clock-ready.service"
           ];
 
           unitConfig = {
@@ -714,6 +1565,7 @@ in
               cfg.keyPath
               "/var/log/journal"
             ];
+            StartLimitIntervalSec = "0";
           };
 
           serviceConfig = {
@@ -731,15 +1583,25 @@ in
           after = [
             "systemd-journald.service"
             "journal-fss-setup.service"
+          ]
+          ++ lib.optionals clockReadyEnabled [
+            "ghaf-clock-ready.service"
           ];
           wants = [
             "systemd-journald.service"
             "journal-fss-setup.service"
+          ]
+          ++ lib.optionals clockReadyEnabled [
+            "ghaf-clock-ready.service"
+          ];
+          requires = lib.optionals clockReadyEnabled [
+            "ghaf-clock-ready.service"
           ];
 
           unitConfig = {
             # Only run if FSS setup has completed successfully
             ConditionPathExists = "${cfg.keyPath}/initialized";
+            StartLimitIntervalSec = "0";
           };
 
           serviceConfig = {

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -37,10 +37,11 @@
 # Caveats (per-boot activation boundary, ghaf.logging.fss.activation):
 # - Unsealed boot window: With activation enabled (default), entries written
 #   before sealing is activated after clock readiness are collected but NOT
-#   FSS-trusted. They are recorded as content-bound lifecycle receipts and pass
-#   verification as "verified-with-exception" only for the current boot; a
-#   pre-activation archive failing verification for an earlier boot is a warning,
-#   while one whose content no longer matches its receipt fails closed.
+#   FSS-trusted. They are recorded as content-bound lifecycle receipts and
+#   verification surfaces a matching current-boot receipt as a warning (never
+#   a silent pass, since receipts are unauthenticated root-writable files); a
+#   pre-activation archive failing verification for an earlier boot is also a
+#   warning, while one whose content no longer matches its receipt fails closed.
 # - Clock readiness is a boot gate and mitigation, not a trusted/authoritative
 #   time source. On offline devices activation occurs on an unsynchronised clock.
 # - FSS is a local primitive: it does not by itself defend against whole-file
@@ -1072,14 +1073,6 @@ let
       EOF
               exit 0
               ;;
-            verified-with-exception)
-              audit_log notice "AUDIT_LOG_VERIFY_COMPLETED: Journal integrity verified with recorded exception [$FSS_VERDICT_TAGS]"
-              fss_log pass "Journal integrity verification: VERIFIED WITH EXCEPTION ($FSS_VERDICT_REASON)"
-              if [ "$VERIFY_EXIT" -ne 0 ]; then
-                fss_log info "Note: journalctl --verify returned exit $VERIFY_EXIT without critical errors [$FSS_VERDICT_TAGS]"
-              fi
-              exit 0
-              ;;
             verified)
               audit_log info "AUDIT_LOG_VERIFY_COMPLETED: Journal integrity verification passed"
               fss_log pass "Journal integrity verification: VERIFIED"
@@ -1126,10 +1119,10 @@ in
           before that point are treated as collected but not FSS-trusted.
 
           Entries written before activation land in archives that are recorded as
-          content-bound lifecycle receipts (see activation.maxReceipts) and pass
-          verification as "verified-with-exception" for the current boot. An
-          earlier-boot receipt is downgraded to "warning"; a content mismatch
-          fails closed.
+          content-bound lifecycle receipts (see activation.maxReceipts) and
+          surface as "warning" during verification, whether the matching
+          receipt is from the current boot or an earlier one; a content
+          mismatch fails closed.
 
           Security note: enabling this trades a per-boot window of unsealed logs
           (between journald start and activation) for resilience against the

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -88,6 +88,7 @@
 let
   inherit (lib)
     mkIf
+    mkMerge
     mkOption
     types
     getExe
@@ -193,44 +194,6 @@ let
         receipt_file_has_path "$PRE_ACTIVATION_RECEIPTS_FILE" "$needle"
       }
 
-      record_lifecycle_receipt() {
-        local receipt_file="$1"
-        local archive_path="$2"
-        local reason="$3"
-        local log_level="$4"
-        local log_message="$5"
-        local inode size mtime sha boot event
-
-        [ -n "$archive_path" ] && [ -f "$archive_path" ] || return 0
-
-        inode=$(stat -c %i "$archive_path" 2>/dev/null || true)
-        size=$(stat -c %s "$archive_path" 2>/dev/null || true)
-        mtime=$(stat -c %Y "$archive_path" 2>/dev/null || true)
-        sha=$(sha256sum "$archive_path" 2>/dev/null | cut -d' ' -f1 || true)
-        boot=$(current_boot_id)
-        event="''${INVOCATION_ID:-$boot}"
-
-        if [ -z "$inode" ] || [ -z "$size" ] || [ -z "$mtime" ] || ! fss_valid_sha256 "$sha"; then
-          fss_log warn "Could not record lifecycle receipt for $archive_path: missing stat or sha256 evidence"
-          return 0
-        fi
-
-        # Dedupe on the physical archive identity (path + inode + size).
-        if [ -f "$receipt_file" ] \
-          && awk -F '\t' -v p="$archive_path" -v i="$inode" -v s="$size" \
-            '$2 == p && $3 == i && $4 == s { found = 1 } END { exit found ? 0 : 1 }' \
-            "$receipt_file"; then
-          return 0
-        fi
-
-        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-          "$FSS_RECEIPT_SCHEMA_VERSION" "$archive_path" "$inode" "$size" \
-          "$boot" "$mtime" "$sha" "$reason" "$event" \
-          >> "$receipt_file"
-        chmod 0644 "$receipt_file"
-        fss_log "$log_level" "$log_message: $archive_path"
-      }
-
       record_recovery_receipt() {
         local archive_path="$1"
         local reason="''${2:-clock-jump-recovery}"
@@ -244,7 +207,7 @@ let
           return 0
         fi
 
-        record_lifecycle_receipt \
+        fss_write_receipt \
           "$RECOVERY_RECEIPTS_FILE" \
           "$archive_path" \
           "$reason" \
@@ -259,7 +222,7 @@ let
       record_pre_activation_receipt() {
         local archive_path="$1"
         local reason="''${2:-pre-activation-rotation}"
-        record_lifecycle_receipt \
+        fss_write_receipt \
           "$PRE_ACTIVATION_RECEIPTS_FILE" \
           "$archive_path" \
           "$reason" \
@@ -271,12 +234,12 @@ let
       # "corrupted or uncleanly shut down" in the current boot's log and renamed to
       # <path>~. That message is journald's own attestation of a prior unclean kill
       # (host crash, power loss, stop-timeout SIGKILL) — the unpreventable residual.
-      # The verifier treats a content-matched unclean receipt as
-      # verified-with-exception; an unmatched .journal~ or the live system.journal
-      # still fails closed. See fss-verify-classifier.sh policy.
+      # The verifier treats a content-matched unclean receipt as a warning; an
+      # unmatched .journal~ or the live system.journal still fails closed. See
+      # fss-verify-classifier.sh policy.
       record_unclean_shutdown_receipt() {
         local archive_path="$1"
-        record_lifecycle_receipt \
+        fss_write_receipt \
           "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" \
           "$archive_path" \
           "unclean-shutdown" \
@@ -307,59 +270,16 @@ let
         done < <(unclean_shutdown_named_paths)
       }
 
-      # Bound the receipt store by capping to the newest PRE_ACTIVATION_MAX_RECEIPTS
-      # records (the file is append-ordered oldest-first). Receipts are NOT dropped
-      # merely because an archive is currently absent: a receipt for a vanished
-      # archive is harmless (the verifier's fss_filter_valid_receipts ignores it,
-      # and a deleted archive never appears as a verify failure), and dropping on
-      # transient absence would lose coverage for an archive that returns. The cap
-      # is the growth backstop; content substitution is caught at verify time.
       prune_pre_activation_receipts() {
-        local tmp total excess
-
-        [ -f "$PRE_ACTIVATION_RECEIPTS_FILE" ] || return 0
-
-        total=$(wc -l < "$PRE_ACTIVATION_RECEIPTS_FILE" 2>/dev/null || echo 0)
-        [ "$total" -gt "$PRE_ACTIVATION_MAX_RECEIPTS" ] || return 0
-
-        excess=$((total - PRE_ACTIVATION_MAX_RECEIPTS))
-        tmp=$(mktemp)
-        tail -n "$PRE_ACTIVATION_MAX_RECEIPTS" "$PRE_ACTIVATION_RECEIPTS_FILE" > "$tmp"
-        mv "$tmp" "$PRE_ACTIVATION_RECEIPTS_FILE"
-        chmod 0644 "$PRE_ACTIVATION_RECEIPTS_FILE"
-        fss_log warn "Pre-activation receipts exceeded $PRE_ACTIVATION_MAX_RECEIPTS; evicted $excess oldest record(s)"
+        fss_prune_receipt_file "$PRE_ACTIVATION_RECEIPTS_FILE" "$PRE_ACTIVATION_MAX_RECEIPTS" "Pre-activation"
       }
 
       prune_recovery_receipts() {
-        local tmp total excess
-
-        [ -f "$RECOVERY_RECEIPTS_FILE" ] || return 0
-
-        total=$(wc -l < "$RECOVERY_RECEIPTS_FILE" 2>/dev/null || echo 0)
-        [ "$total" -gt "$RECOVERY_MAX_RECEIPTS" ] || return 0
-
-        excess=$((total - RECOVERY_MAX_RECEIPTS))
-        tmp=$(mktemp)
-        tail -n "$RECOVERY_MAX_RECEIPTS" "$RECOVERY_RECEIPTS_FILE" > "$tmp"
-        mv "$tmp" "$RECOVERY_RECEIPTS_FILE"
-        chmod 0644 "$RECOVERY_RECEIPTS_FILE"
-        fss_log warn "Recovery receipts exceeded $RECOVERY_MAX_RECEIPTS; evicted $excess oldest record(s)"
+        fss_prune_receipt_file "$RECOVERY_RECEIPTS_FILE" "$RECOVERY_MAX_RECEIPTS" "Recovery"
       }
 
       prune_unclean_shutdown_receipts() {
-        local tmp total excess
-
-        [ -f "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" ] || return 0
-
-        total=$(wc -l < "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" 2>/dev/null || echo 0)
-        [ "$total" -gt "$UNCLEAN_SHUTDOWN_MAX_RECEIPTS" ] || return 0
-
-        excess=$((total - UNCLEAN_SHUTDOWN_MAX_RECEIPTS))
-        tmp=$(mktemp)
-        tail -n "$UNCLEAN_SHUTDOWN_MAX_RECEIPTS" "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" > "$tmp"
-        mv "$tmp" "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE"
-        chmod 0644 "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE"
-        fss_log warn "Unclean-shutdown receipts exceeded $UNCLEAN_SHUTDOWN_MAX_RECEIPTS; evicted $excess oldest record(s)"
+        fss_prune_receipt_file "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE" "$UNCLEAN_SHUTDOWN_MAX_RECEIPTS" "Unclean-shutdown"
       }
 
       record_fss_archive_metadata() {
@@ -389,22 +309,18 @@ let
         find "$journal_dir" -maxdepth 1 -type f -name 'system@*.journal' -print 2>/dev/null | sort
       }
 
-      current_boot_id() {
-        cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot
-      }
-
       boot_start_epoch() {
         awk -v now="$(date +%s)" '{printf "%d\n", now - $1}' /proc/uptime
       }
 
       write_boot_baseline_record() {
-        printf '%s\n' "$(current_boot_id)" > "$FSS_BOOT_BASELINE_FILE"
+        printf '%s\n' "$(fss_current_boot_id)" > "$FSS_BOOT_BASELINE_FILE"
         chmod 0644 "$FSS_BOOT_BASELINE_FILE"
       }
 
       boot_baseline_current() {
         [ -s "$FSS_BOOT_BASELINE_FILE" ] || return 1
-        [ "$(tr -d '[:space:]' < "$FSS_BOOT_BASELINE_FILE")" = "$(current_boot_id)" ]
+        [ "$(tr -d '[:space:]' < "$FSS_BOOT_BASELINE_FILE")" = "$(fss_current_boot_id)" ]
       }
 
       current_boot_time_jump_epochs() {
@@ -680,7 +596,7 @@ let
       }
 
       write_activation_state() {
-        printf '%s\t%s\n' "$1" "$(current_boot_id)" > "$ACTIVATION_STATE_FILE"
+        printf '%s\t%s\n' "$1" "$(fss_current_boot_id)" > "$ACTIVATION_STATE_FILE"
         chmod 0644 "$ACTIVATION_STATE_FILE"
       }
 
@@ -701,7 +617,7 @@ let
 
       activation_state_record_current_boot() {
         [ "$(activation_state_value)" = "active" ] \
-          && [ "$(activation_state_boot_id)" = "$(current_boot_id)" ]
+          && [ "$(activation_state_boot_id)" = "$(fss_current_boot_id)" ]
       }
 
       activation_boundary_complete_current_boot() {
@@ -726,27 +642,7 @@ let
         runtime_fss_activation_config_present \
           && activation_state_record_current_boot \
           && rotation_marker_present \
-          && sealing_active_in_config
-      }
-
-      sealing_active_in_config() {
-        local effective_seal
-
-        effective_seal=$(
-          systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
-            | awk -F= '
-              /^[[:space:]]*[#;]/ { next }
-              /^[[:space:]]*Seal[[:space:]]*=/ {
-                value = $2
-                sub(/^[[:space:]]*/, "", value)
-                sub(/[[:space:]]*[#;].*$/, "", value)
-                sub(/[[:space:]]*$/, "", value)
-                seal = tolower(value)
-              }
-              END { print seal }
-            '
-        )
-        [ "$effective_seal" = "yes" ]
+          && fss_sealing_active_in_config
       }
 
       # Restart journald so it loads the FSS sealing key, and (when activation is
@@ -786,7 +682,7 @@ let
           return 0
         fi
 
-        if [ "$restart_ok" = 1 ] && sealing_active_in_config; then
+        if [ "$restart_ok" = 1 ] && fss_sealing_active_in_config; then
           ACTIVATION_RESTARTED_THIS_RUN=1
           write_activation_state active
           fss_log info "Confirmed journald sealing is active after restart"
@@ -806,7 +702,7 @@ let
         [ "$ACTIVATION_FAILED" = 0 ] || return 1
         [ -s "$VERIFY_KEY_FILE" ] && [ -r "$VERIFY_KEY_FILE" ] || return 0
 
-        marker="FSS activation live sealing probe $(current_boot_id) $$"
+        marker="FSS activation live sealing probe $(fss_current_boot_id) $$"
         logger -t journal-fss "$marker" 2>/dev/null || true
         journalctl --sync 2>/dev/null || true
 
@@ -1047,25 +943,6 @@ let
               printf '%s\n' "$2" | systemd-cat -t journal-fss -p "$1"
             }
 
-            journald_effective_seal() {
-              systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
-                | awk -F= '
-                  /^[[:space:]]*[#;]/ { next }
-                  /^[[:space:]]*Seal[[:space:]]*=/ {
-                    value = $2
-                    sub(/^[[:space:]]*/, "", value)
-                    sub(/[[:space:]]*[#;].*$/, "", value)
-                    sub(/[[:space:]]*$/, "", value)
-                    seal = tolower(value)
-                  }
-                  END { print seal }
-                '
-            }
-
-            sealing_active_in_config() {
-              [ "$(journald_effective_seal)" = "yes" ]
-            }
-
             fss_log info "Verifying journal integrity with Forward Secure Sealing..."
 
             if ! journalctl --list-boots >/dev/null 2>&1; then
@@ -1087,7 +964,7 @@ let
             UNCLEAN_SHUTDOWN_RECEIPTS_FILE="/var/log/journal/$MACHINE_ID/fss-unclean-shutdown-receipts"
             ACTIVATION_STATE_FILE="/var/log/journal/$MACHINE_ID/fss-activation-state"
             FSS_BOOT_BASELINE_FILE="/var/log/journal/$MACHINE_ID/fss-baseline-boot"
-            CURRENT_BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot)
+            CURRENT_BOOT_ID=$(fss_current_boot_id)
             ACTIVATION_ENABLED="${if activationEnabled then "1" else "0"}"
             VERIFY_KEY=$(tr -d '[:space:]' < "$VERIFY_KEY_FILE")
 
@@ -1117,7 +994,7 @@ let
                 exit 1
               fi
 
-              if ! sealing_active_in_config; then
+              if ! fss_sealing_active_in_config; then
                 audit_log crit "AUDIT_LOG_INTEGRITY_FAIL: FSS activation failed; effective journald Seal setting is not yes [ACTIVATION_FAILED]"
                 fss_log fail "Journal integrity verification: FAILED (effective journald Seal setting is not yes)"
                 exit 1
@@ -1436,219 +1313,223 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = hasPersistentJournalStorage;
-        message = "FSS on VMs requires ghaf.storagevm.enable so /var/log/journal and the journald sealing key are persisted.";
-      }
-    ];
-
-    # Enable audit subsystem for FSS monitoring
-    # This provides auditctl and enables the audit rules defined below
-    # FSS requires audit to be enabled, so we use mkForce to ensure it's on
-    # regardless of profile settings (audit is fundamental to FSS functionality)
-    ghaf.security.audit.enable = lib.mkForce true;
-
-    environment.systemPackages = [
-      fssTriagePackage
-    ];
+  config = mkMerge [
 
     # Single on-disk copy of the verification/receipt classifier, sourced at
-    # runtime by journal-fss-setup, journal-fss-verify, fss-triage, and
-    # fss-test instead of each embedding its own build-time inlined copy.
-    environment.etc."fss-verify-classifier.sh".source = ./fss-verify-classifier.sh;
+    # runtime by journal-fss-setup, journal-fss-verify, fss-triage, fss-test,
+    # and common.nix's clock-jump recovery -- unconditional (not gated by
+    # cfg.enable) since that last consumer runs even when FSS itself is off.
+    { environment.etc."fss-verify-classifier.sh".source = ./fss-verify-classifier.sh; }
 
-    # FSS is only meaningful for persistent journals. The journald sealing key
-    # lives beside the journal files and is advanced by journald over time.
-    services.journald.extraConfig = lib.mkAfter ''
-      Storage=persistent
-      Seal=${if cfg.staticSealEnabled then "yes" else "no"}
-    '';
-
-    ghaf.storagevm.preserveLogs = mkIf (config.ghaf.type != "host") true;
-
-    # Create key directory and journal directory via tmpfiles
-    # Note: In VMs, ${cfg.keyPath} is a virtiofs mount point, so we only create it on host
-    systemd = {
-      tmpfiles.rules =
-        lib.optionals (config.ghaf.type == "host") [
-          "d /persist/common/journal-fss 0755 root root - -"
-          "d ${cfg.keyPath} 0700 root root - -"
-          "d /persist/var 0755 root root - -"
-          "d /persist/var/log 0755 root root - -"
-          "d ${hostPersistentJournalPath} 2755 root systemd-journal - -"
-        ]
-        ++ [
-          "d /var/log/journal 2755 root systemd-journal - -"
-        ];
-
-      mounts = lib.optionals (config.ghaf.type == "host") [
+    (mkIf cfg.enable {
+      assertions = [
         {
-          what = hostPersistentJournalPath;
-          where = "/var/log/journal";
-          type = "none";
-          options = "bind";
-          wantedBy = [ "local-fs.target" ];
-          requiredBy = [ "journal-fss-setup.service" ];
-          requires = [ "journal-fss-prepare-persistent-journal.service" ];
-          after = [
-            "journal-fss-prepare-persistent-journal.service"
-            "persist.mount"
-          ];
-          before = [
-            "systemd-journal-flush.service"
-            "journal-fss-setup.service"
-          ];
-          unitConfig.DefaultDependencies = false;
+          assertion = hasPersistentJournalStorage;
+          message = "FSS on VMs requires ghaf.storagevm.enable so /var/log/journal and the journald sealing key are persisted.";
         }
       ];
 
-      services = {
-        journal-fss-prepare-persistent-journal = mkIf (config.ghaf.type == "host") {
-          description = "Prepare persistent journal storage for FSS";
+      # Enable audit subsystem for FSS monitoring
+      # This provides auditctl and enables the audit rules defined below
+      # FSS requires audit to be enabled, so we use mkForce to ensure it's on
+      # regardless of profile settings (audit is fundamental to FSS functionality)
+      ghaf.security.audit.enable = lib.mkForce true;
 
-          after = [
-            "local-fs-pre.target"
-            "persist.mount"
-          ];
-          before = [
-            "var-log-journal.mount"
-            "systemd-journal-flush.service"
-            "journal-fss-setup.service"
+      environment.systemPackages = [
+        fssTriagePackage
+      ];
+
+      # FSS is only meaningful for persistent journals. The journald sealing key
+      # lives beside the journal files and is advanced by journald over time.
+      services.journald.extraConfig = lib.mkAfter ''
+        Storage=persistent
+        Seal=${if cfg.staticSealEnabled then "yes" else "no"}
+      '';
+
+      ghaf.storagevm.preserveLogs = mkIf (config.ghaf.type != "host") true;
+
+      # Create key directory and journal directory via tmpfiles
+      # Note: In VMs, ${cfg.keyPath} is a virtiofs mount point, so we only create it on host
+      systemd = {
+        tmpfiles.rules =
+          lib.optionals (config.ghaf.type == "host") [
+            "d /persist/common/journal-fss 0755 root root - -"
+            "d ${cfg.keyPath} 0700 root root - -"
+            "d /persist/var 0755 root root - -"
+            "d /persist/var/log 0755 root root - -"
+            "d ${hostPersistentJournalPath} 2755 root systemd-journal - -"
+          ]
+          ++ [
+            "d /var/log/journal 2755 root systemd-journal - -"
           ];
 
-          unitConfig = {
-            DefaultDependencies = false;
-            RequiresMountsFor = [ "/persist" ];
+        mounts = lib.optionals (config.ghaf.type == "host") [
+          {
+            what = hostPersistentJournalPath;
+            where = "/var/log/journal";
+            type = "none";
+            options = "bind";
+            wantedBy = [ "local-fs.target" ];
+            requiredBy = [ "journal-fss-setup.service" ];
+            requires = [ "journal-fss-prepare-persistent-journal.service" ];
+            after = [
+              "journal-fss-prepare-persistent-journal.service"
+              "persist.mount"
+            ];
+            before = [
+              "systemd-journal-flush.service"
+              "journal-fss-setup.service"
+            ];
+            unitConfig.DefaultDependencies = false;
+          }
+        ];
+
+        services = {
+          journal-fss-prepare-persistent-journal = mkIf (config.ghaf.type == "host") {
+            description = "Prepare persistent journal storage for FSS";
+
+            after = [
+              "local-fs-pre.target"
+              "persist.mount"
+            ];
+            before = [
+              "var-log-journal.mount"
+              "systemd-journal-flush.service"
+              "journal-fss-setup.service"
+            ];
+
+            unitConfig = {
+              DefaultDependencies = false;
+              RequiresMountsFor = [ "/persist" ];
+            };
+
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = getExe preparePersistentJournalScript;
+            };
           };
 
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            ExecStart = getExe preparePersistentJournalScript;
+          # One-shot service to generate FSS keys on first boot
+          # Runs after journald is ready, then restarts journald to enable sealing
+          journal-fss-setup = {
+            description = "Setup Forward Secure Sealing keys for systemd journal";
+            documentation = [ "man:journalctl(1)" ];
+
+            wantedBy = [ "multi-user.target" ];
+            after = [
+              "systemd-journald.service"
+              "systemd-journal-flush.service"
+            ]
+            ++ lib.optionals clockReadyEnabled [
+              "ghaf-clock-ready.service"
+              # Wait for the time-sync barrier (after networking) before activating
+              # sealing, without making the early journal flush wait on it.
+              "ghaf-clock-sync.service"
+            ]
+            ++ lib.optionals (config.ghaf.type == "host") [
+              "var-log-journal.mount"
+            ];
+            wants = [
+              "systemd-journald.service"
+              "systemd-journal-flush.service"
+            ]
+            ++ lib.optionals clockReadyEnabled [
+              "ghaf-clock-ready.service"
+              "ghaf-clock-sync.service"
+            ];
+            requires = lib.optionals clockReadyEnabled [
+              "ghaf-clock-ready.service"
+            ];
+
+            unitConfig = {
+              RequiresMountsFor = [
+                cfg.keyPath
+                "/var/log/journal"
+              ];
+              StartLimitIntervalSec = "0";
+            };
+
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = getExe setupScript;
+            };
+          };
+
+          # Service to verify journal integrity
+          journal-fss-verify = {
+            description = "Verify systemd journal integrity using Forward Secure Sealing";
+            documentation = [ "man:journalctl(1)" ];
+
+            after = [
+              "systemd-journald.service"
+              "journal-fss-setup.service"
+            ]
+            ++ lib.optionals clockReadyEnabled [
+              "ghaf-clock-ready.service"
+            ];
+            wants = [
+              "systemd-journald.service"
+              "journal-fss-setup.service"
+            ]
+            ++ lib.optionals clockReadyEnabled [
+              "ghaf-clock-ready.service"
+            ];
+            requires = lib.optionals clockReadyEnabled [
+              "ghaf-clock-ready.service"
+            ];
+
+            unitConfig = {
+              # Only run if FSS setup has completed successfully
+              ConditionPathExists = "${cfg.keyPath}/initialized";
+              StartLimitIntervalSec = "0";
+            };
+
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = getExe verifyScript;
+              WorkingDirectory = "/";
+
+              # File system access required for journal verification
+              # journalctl --verify needs write access to create verification metadata
+              # Also needs read access to verification key for sealed journal validation
+              ReadWritePaths = [
+                "/var/log/journal"
+                "/run/log/journal"
+                cfg.keyPath
+              ];
+            };
           };
         };
 
-        # One-shot service to generate FSS keys on first boot
-        # Runs after journald is ready, then restarts journald to enable sealing
-        journal-fss-setup = {
-          description = "Setup Forward Secure Sealing keys for systemd journal";
+        # Timer for periodic verification
+        timers.journal-fss-verify = {
+          description = "Timer for periodic journal integrity verification";
           documentation = [ "man:journalctl(1)" ];
 
-          wantedBy = [ "multi-user.target" ];
-          after = [
-            "systemd-journald.service"
-            "systemd-journal-flush.service"
-          ]
-          ++ lib.optionals clockReadyEnabled [
-            "ghaf-clock-ready.service"
-            # Wait for the time-sync barrier (after networking) before activating
-            # sealing, without making the early journal flush wait on it.
-            "ghaf-clock-sync.service"
-          ]
-          ++ lib.optionals (config.ghaf.type == "host") [
-            "var-log-journal.mount"
-          ];
-          wants = [
-            "systemd-journald.service"
-            "systemd-journal-flush.service"
-          ]
-          ++ lib.optionals clockReadyEnabled [
-            "ghaf-clock-ready.service"
-            "ghaf-clock-sync.service"
-          ];
-          requires = lib.optionals clockReadyEnabled [
-            "ghaf-clock-ready.service"
-          ];
+          wantedBy = [ "timers.target" ];
 
-          unitConfig = {
-            RequiresMountsFor = [
-              cfg.keyPath
-              "/var/log/journal"
-            ];
-            StartLimitIntervalSec = "0";
-          };
-
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            ExecStart = getExe setupScript;
-          };
-        };
-
-        # Service to verify journal integrity
-        journal-fss-verify = {
-          description = "Verify systemd journal integrity using Forward Secure Sealing";
-          documentation = [ "man:journalctl(1)" ];
-
-          after = [
-            "systemd-journald.service"
-            "journal-fss-setup.service"
-          ]
-          ++ lib.optionals clockReadyEnabled [
-            "ghaf-clock-ready.service"
-          ];
-          wants = [
-            "systemd-journald.service"
-            "journal-fss-setup.service"
-          ]
-          ++ lib.optionals clockReadyEnabled [
-            "ghaf-clock-ready.service"
-          ];
-          requires = lib.optionals clockReadyEnabled [
-            "ghaf-clock-ready.service"
-          ];
-
-          unitConfig = {
-            # Only run if FSS setup has completed successfully
-            ConditionPathExists = "${cfg.keyPath}/initialized";
-            StartLimitIntervalSec = "0";
-          };
-
-          serviceConfig = {
-            Type = "oneshot";
-            ExecStart = getExe verifyScript;
-            WorkingDirectory = "/";
-
-            # File system access required for journal verification
-            # journalctl --verify needs write access to create verification metadata
-            # Also needs read access to verification key for sealed journal validation
-            ReadWritePaths = [
-              "/var/log/journal"
-              "/run/log/journal"
-              cfg.keyPath
-            ];
+          timerConfig = {
+            OnCalendar = cfg.verifySchedule;
+            Persistent = true;
+            RandomizedDelaySec = "5min";
+          }
+          // optionalAttrs cfg.verifyOnBoot {
+            OnBootSec = "10min";
           };
         };
       };
 
-      # Timer for periodic verification
-      timers.journal-fss-verify = {
-        description = "Timer for periodic journal integrity verification";
-        documentation = [ "man:journalctl(1)" ];
-
-        wantedBy = [ "timers.target" ];
-
-        timerConfig = {
-          OnCalendar = cfg.verifySchedule;
-          Persistent = true;
-          RandomizedDelaySec = "5min";
-        }
-        // optionalAttrs cfg.verifyOnBoot {
-          OnBootSec = "10min";
-        };
-      };
-    };
-
-    # Audit rules to monitor FSS key and journal access
-    ghaf.security.audit.extraRules = [
-      # Monitor shared FSS key tree.
-      "-w ${fssBasePath} -p wa -k journal_fss_keys"
-      # Monitor sealed journal logs for tampering attempts
-      "-w /var/log/journal -p wa -k journal_sealed_logs"
-      # Monitor machine-id reads (critical for journal path resolution)
-      "-w /etc/machine-id -p r -k machine_id_read"
-    ];
-  };
+      # Audit rules to monitor FSS key and journal access
+      ghaf.security.audit.extraRules = [
+        # Monitor shared FSS key tree.
+        "-w ${fssBasePath} -p wa -k journal_fss_keys"
+        # Monitor sealed journal logs for tampering attempts
+        "-w /var/log/journal -p wa -k journal_sealed_logs"
+        # Monitor machine-id reads (critical for journal path resolution)
+        "-w /etc/machine-id -p r -k machine_id_read"
+      ];
+    })
+  ];
 }

--- a/modules/common/logging/journal-client.nix
+++ b/modules/common/logging/journal-client.nix
@@ -75,10 +75,11 @@ in
       extraConfig = mkIf config.ghaf.logging.journalRetention.enable ''
         MaxRetentionSec=${config.ghaf.logging.journalRetention.maxRetention}
         MaxFileSec=${config.ghaf.logging.journalRetention.MaxFileSec}
+        SyncIntervalSec=${config.ghaf.logging.journalRetention.syncInterval}
         SystemMaxUse=${config.ghaf.logging.journalRetention.maxDiskUsage}
         SystemMaxFileSize=100M
         Storage=persistent
-        ${optionalString config.ghaf.logging.fss.enable ''
+        ${optionalString config.ghaf.logging.fss.staticSealEnabled ''
           Seal=yes
         ''}
       '';

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -84,13 +84,33 @@ let
     ) config.microvm.vms
   );
 
-  gracefulShutdownVms = lib.attrNames (
+  # VMs that relay power events instead of acting on an ACPI power button (the
+  # GUI VM, which sets HandlePowerKey="ignore" under the gui power-manager
+  # profile). These must be powered off via givc, not a QMP/ACPI button.
+  givcShutdownVms = lib.attrNames (
     filterAttrs (
       _: vm:
       let
         vmConfig = lib.ghaf.vm.getConfig vm;
       in
-      vmConfig != null && vmConfig.ghaf.gracefulShutdown
+      vmConfig != null
+      && vmConfig.ghaf.services.power-manager.enable
+      && vmConfig.ghaf.services.power-manager.gui.enable
+    ) config.microvm.vms
+  );
+
+  # Every other VM accepts an ACPI power button, so the host shuts it down via
+  # QEMU QMP system_powerdown: the guest runs its own unprivileged systemd
+  # poweroff (flushing+sealing journald) before QEMU exits. This grants the guest
+  # no new privilege and does not depend on the givc admin coordinator.
+  qmpShutdownVms = lib.attrNames (
+    filterAttrs (
+      _: vm:
+      let
+        vmConfig = lib.ghaf.vm.getConfig vm;
+      in
+      vmConfig != null
+      && !(vmConfig.ghaf.services.power-manager.enable && vmConfig.ghaf.services.power-manager.gui.enable)
     ) config.microvm.vms
   );
 
@@ -260,7 +280,7 @@ let
     ];
     text = ''
       restart_logind() {
-        systemctl restart systemd-logind
+        systemctl restart systemd-logind || echo "Failed to restart systemd-logind; continuing resume fallback"
         sleep 0.3
         local job_ids
         job_ids=$(systemctl list-jobs --no-legend \
@@ -273,11 +293,15 @@ let
 
       is_lid_open() {
         local state
+        # busctl exits non-zero when logind is crashed or unreachable (exactly the
+        # case wait_for_lid_open recovers from). Tolerate that here instead of
+        # letting errexit/pipefail abort the whole resume helper before the
+        # restart_logind fallback runs; an unknown state is treated as not-open.
         state=$(busctl get-property "org.freedesktop.login1" "/org/freedesktop/login1" \
-          "org.freedesktop.login1.Manager" "LidClosed" | \
-              awk 'NR == 1 { print $2 == "true" ? "closed" : "open" }')
-        echo "Lid state: $state"
-        [ "$state" == "open" ]
+          "org.freedesktop.login1.Manager" "LidClosed" 2>/dev/null | \
+              awk 'NR == 1 { print $2 == "true" ? "closed" : "open" }') || true
+        echo "Lid state: ''${state:-unknown}"
+        [ "$state" = "open" ]
       }
 
       wait_for_lid_open() {
@@ -991,12 +1015,12 @@ in
           # from stdio, which is /dev/null under systemd. As a result, the command returns
           # immediately, systemd sees the process as still active, and kills it with SIGTERM.
           #
-          # For system VMs, we replace ExecStop with custom logic:
-          #   1. Request a graceful shutdown by starting 'poweroff.target' inside the guest.
-          #   2. Wait until the associated QEMU process ($MAINPID) exits.
-          #
-          # We also shorten TimeoutStopSec from the microvm default (150s) to 30s,
-          # since system VMs are expected to power off quickly.
+          # We replace ExecStop with custom logic, by VM class, then wait for the
+          # QEMU process ($MAINPID) to exit:
+          #   - GUI VM (ignores ACPI, relays power events): start poweroff.target via givc.
+          #   - every other VM: send QMP system_powerdown so the guest runs its own
+          #     ACPI poweroff and flushes/seals journald before QEMU exits.
+          # We also shorten TimeoutStopSec from the microvm default (150s) to 30s.
           (mkIf useGivc (
             lib.listToAttrs (
               map (
@@ -1007,14 +1031,15 @@ in
                     ExecStop =
                       let
                         sysvm-stop = pkgs.writeShellScript "sysvm-stop" ''
-                          # Check if this stop is part of a real shutdown or suspend.
-                          # During a nixos-rebuild switch, affected services (system vms) are restarted
-                          # which causes their ExecStop actions to be executed
-                          # If no real reboot/suspend job is queued, we can assume the VM should be
-                          # restarted without requesting the host itself to reboot
+                          # During ghaf-rebuild switch activation, affected system
+                          # VMs may be restarted as part of host service changes.
+                          # That path runs inside a named detached activation unit;
+                          # only skip guest poweroff for that narrow case. Ordinary
+                          # manual stops/restarts must still use graceful shutdown.
                           jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
-                          if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start'; then
-                            echo "No shutdown/suspend in progress, skipping graceful shutdown for '${vmName}' (likely a rebuild)"
+                          if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
+                            && ${getExe' pkgs.systemd "systemctl"} is-active --quiet ghaf-rebuild-switch.service; then
+                            echo "ghaf-rebuild switch activation in progress, skipping guest poweroff for '${vmName}'"
                             kill -15 $MAINPID 2>/dev/null
                             while kill -0 $MAINPID 2>/dev/null; do
                               sleep 1
@@ -1022,8 +1047,11 @@ in
                             exit 0
                           fi
 
+                          # GUI VM ignores the ACPI power button (HandlePowerKey=ignore) and
+                          # relays power events via its interceptor, so it cannot be powered off
+                          # with a QMP/ACPI button; deliver poweroff.target through givc instead.
+                          # The admin coordinator is alive here because admin-vm is shutdownLast.
                           echo "Starting poweroff target for system VM '${vmName}'"
-                          vm=''${${vmName}/-vm/}
                           ${givc-cli} start service --vm '${vmName}' poweroff.target &
 
                           echo "Waiting for system VM '${vmName}' with QEMU PID=$MAINPID to stop"
@@ -1041,51 +1069,72 @@ in
                       ];
                   };
                 }
-              ) gracefulShutdownVms
+              ) givcShutdownVms
             )
           ))
-          # Handle app-vms shutdown
+          # All ACPI-capable VMs: host-side QMP system_powerdown. The guest runs its
+          # own unprivileged systemd poweroff (journald flush+seal) before QEMU
+          # exits — no SIGTERM-mid-write corruption, no new guest privilege, no
+          # admin coordinator dependency.
           (lib.listToAttrs (
-            map
-              (
-                vmName:
-                nameValuePair "microvm@${vmName}" {
-                  serviceConfig = {
-                    TimeoutStopSec = "30";
-                    ExecStop =
-                      let
-                        ghaf-vm-stop = pkgs.writeShellScript "ghaf-vm-stop" ''
-                          echo "Sending SIGTERM to VM '${vmName}'"
+            map (
+              vmName:
+              nameValuePair "microvm@${vmName}" {
+                serviceConfig = {
+                  TimeoutStopSec = lib.mkDefault "30";
+                  ExecStop =
+                    let
+                      vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${vmName};
+                      qmpSocket =
+                        if vmConfig != null && (vmConfig.microvm.socket or null) != null then
+                          "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
+                        else
+                          "";
+                      qmp-stop = pkgs.writeShellScript "qmp-stop" ''
+                        # ghaf-rebuild switch activation restarts (not shuts down) the VM as
+                        # part of host service changes; skip the graceful poweroff only for
+                        # that narrow case and SIGTERM for a fast restart.
+                        jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
+                        if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
+                          && ${getExe' pkgs.systemd "systemctl"} is-active --quiet ghaf-rebuild-switch.service; then
+                          echo "ghaf-rebuild switch activation in progress, SIGTERM '${vmName}'"
                           kill -15 $MAINPID 2>/dev/null
-
-                          echo "Waiting for VM '${vmName}' with QEMU PID=$MAINPID to stop"
                           while kill -0 $MAINPID 2>/dev/null; do
                             sleep 1
                           done
+                          exit 0
+                        fi
 
-                          echo "VM '${vmName}' with QEMU PID=$MAINPID stopped"
-                        '';
-                      in
-                      [
-                        # Clear previous microvm ExecStop logic
-                        ""
-                        # '+' allows the ghaf-vm-stop script to be executed with full privileges
-                        "+${ghaf-vm-stop}"
-                      ];
-                  };
-                }
-              )
-              (
-                lib.attrNames (
-                  filterAttrs (
-                    _: vm:
-                    let
-                      vmConfig = lib.ghaf.vm.getConfig vm;
+                        socket='${qmpSocket}'
+                        if [ -n "$socket" ] && [ -S "$socket" ]; then
+                          # ACPI poweroff via QEMU QMP: the guest does its own clean systemd
+                          # shutdown (journald flush+seal) before QEMU exits. A bounded socat
+                          # (-t1) avoids microvm's trailing-`cat` /dev/null stdio trap.
+                          echo "QMP system_powerdown -> '${vmName}' ($socket)"
+                          printf '{"execute":"qmp_capabilities"}\n{"execute":"system_powerdown"}\n' \
+                            | ${pkgs.socat}/bin/socat -t1 - "UNIX-CONNECT:$socket" \
+                            || echo "WARN: QMP system_powerdown to '${vmName}' failed; relying on stop timeout" >&2
+                        else
+                          echo "WARN: no QMP socket for '${vmName}' ('$socket'); SIGTERM fallback" >&2
+                          kill -15 $MAINPID 2>/dev/null
+                        fi
+
+                        echo "Waiting for VM '${vmName}' with QEMU PID=$MAINPID to stop"
+                        while kill -0 $MAINPID 2>/dev/null; do
+                          sleep 1
+                        done
+                        echo "VM '${vmName}' with QEMU PID=$MAINPID stopped"
+                      '';
                     in
-                    vmConfig != null && vmConfig.ghaf.type != "system-vm"
-                  ) config.microvm.vms
-                )
-              )
+                    [
+                      # Clear previous microvm ExecStop logic
+                      ""
+                      # '+' runs the qmp-stop script with full privileges
+                      "+${qmp-stop}"
+                    ];
+                };
+              }
+            ) qmpShutdownVms
           ))
           # Handle VMs with shutdownLast enabled
           (lib.listToAttrs (
@@ -1096,6 +1145,10 @@ in
                   before = map (n: "microvm@${n}.service") (
                     lib.filter (n: n != vmName) (lib.attrNames config.microvm.vms)
                   );
+                  # The shutdown-last VM is the log aggregator (admin-vm): it stops
+                  # after every other VM and has the most journal to flush+seal, so
+                  # give it more time before the stop timeout SIGKILLs QEMU.
+                  serviceConfig.TimeoutStopSec = "60";
                 }
               )
               (

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -1031,15 +1031,20 @@ in
                     ExecStop =
                       let
                         sysvm-stop = pkgs.writeShellScript "sysvm-stop" ''
-                          # During ghaf-rebuild switch activation, affected system
-                          # VMs may be restarted as part of host service changes.
-                          # That path runs inside a named detached activation unit;
-                          # only skip guest poweroff for that narrow case. Ordinary
-                          # manual stops/restarts must still use graceful shutdown.
+                          # During switch-to-configuration activation (local nixos-rebuild
+                          # switch or the remote ghaf-build-helper path), affected system VMs
+                          # may be restarted as part of host service changes. switch-to-
+                          # configuration restarts changed units synchronously, one at a time,
+                          # so its process is guaranteed to still be alive on this host for the
+                          # entire time this ExecStop script blocks that restart -- regardless
+                          # of how activation was invoked. Detect that directly instead of
+                          # keying off one hardcoded remote-only unit name. Ordinary manual
+                          # stops/restarts (no activation in progress) still use graceful
+                          # shutdown.
                           jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
                           if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
-                            && ${getExe' pkgs.systemd "systemctl"} is-active --quiet ghaf-rebuild-switch.service; then
-                            echo "ghaf-rebuild switch activation in progress, skipping guest poweroff for '${vmName}'"
+                            && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
+                            echo "switch-to-configuration activation in progress, skipping guest poweroff for '${vmName}'"
                             kill -15 $MAINPID 2>/dev/null
                             while kill -0 $MAINPID 2>/dev/null; do
                               sleep 1
@@ -1090,14 +1095,17 @@ in
                           "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
                         else
                           "";
+                      # Half of TimeoutStopSec: how long to wait for the guest to respond to
+                      # ACPI before logging that it hasn't, so an eventual SIGKILL from
+                      # systemd's stop timeout isn't a silent surprise in the unit's journal.
+                      qmpAcpiGraceSec = 15;
                       qmp-stop = pkgs.writeShellScript "qmp-stop" ''
-                        # ghaf-rebuild switch activation restarts (not shuts down) the VM as
-                        # part of host service changes; skip the graceful poweroff only for
-                        # that narrow case and SIGTERM for a fast restart.
+                        # See sysvm-stop for why this checks for a live switch-to-configuration
+                        # process instead of one hardcoded remote-only unit name.
                         jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
                         if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
-                          && ${getExe' pkgs.systemd "systemctl"} is-active --quiet ghaf-rebuild-switch.service; then
-                          echo "ghaf-rebuild switch activation in progress, SIGTERM '${vmName}'"
+                          && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
+                          echo "switch-to-configuration activation in progress, SIGTERM '${vmName}'"
                           kill -15 $MAINPID 2>/dev/null
                           while kill -0 $MAINPID 2>/dev/null; do
                             sleep 1
@@ -1120,8 +1128,15 @@ in
                         fi
 
                         echo "Waiting for VM '${vmName}' with QEMU PID=$MAINPID to stop"
+                        waited=0
+                        acpi_timeout_logged=0
                         while kill -0 $MAINPID 2>/dev/null; do
                           sleep 1
+                          waited=$((waited + 1))
+                          if [ "$acpi_timeout_logged" = 0 ] && [ "$waited" -ge ${toString qmpAcpiGraceSec} ]; then
+                            acpi_timeout_logged=1
+                            echo "WARN: guest '${vmName}' has not responded to ACPI poweroff after ''${waited}s; will be forced by stop timeout if it does not exit" >&2
+                          fi
                         done
                         echo "VM '${vmName}' with QEMU PID=$MAINPID stopped"
                       '';

--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -9,6 +9,7 @@
 let
   # Ghaf systemd config
   cfg = config.ghaf.systemd;
+  localeDirectory = "/run/current-system/sw/lib/locale";
 
   inherit (lib)
     mkEnableOption
@@ -333,13 +334,14 @@ in
       coredump.enable = cfg.withDebug || cfg.withMachines;
       managerEnvironment.SYSTEMD_LOG_LEVEL = cfg.logLevel;
       globalEnvironment.SYSTEMD_LOG_LEVEL = cfg.logLevel;
+      globalEnvironment.SYSTEMD_LOCALE_DIRECTORY = localeDirectory;
 
       # Service startup optimization
       services.systemd-networkd-wait-online.enable = mkForce false;
     };
 
     # TODO: Remove after https://github.com/NixOS/nixpkgs/pull/445146 is available
-    environment.variables.SYSTEMD_LOCALE_DIRECTORY = "/run/current-system/sw/lib/locale";
+    environment.variables.SYSTEMD_LOCALE_DIRECTORY = localeDirectory;
 
     # Suppress systemd-tmp.conf to avoid %b specifier errors
     # (ProtectProc=noaccess prevents reading /proc/sys/kernel/random/boot_id)

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -12,6 +12,7 @@
     flash-script = final.callPackage ./pkgs-by-name/flash-script/package.nix { };
     fleet-desktop = final.callPackage ./pkgs-by-name/fleet-desktop/package.nix { };
     fleet-orbit = final.callPackage ./pkgs-by-name/fleet-orbit/package.nix { };
+    fss-triage = final.callPackage ./pkgs-by-name/fss-triage/package.nix { };
     gala = final.callPackage ./pkgs-by-name/gala/package.nix { };
     ghaf-build-helper = final.callPackage ./pkgs-by-name/ghaf-build-helper/package.nix { };
     ghaf-installer = final.callPackage ./pkgs-by-name/ghaf-installer/package.nix { };

--- a/packages/pkgs-by-name/fss-triage/package.nix
+++ b/packages/pkgs-by-name/fss-triage/package.nix
@@ -16,9 +16,6 @@
   systemd,
   util-linux,
 }:
-let
-  verifyClassifierLib = builtins.readFile ../../../modules/common/logging/fss-verify-classifier.sh;
-in
 writeShellApplication {
   name = "fss-triage";
   runtimeInputs = [
@@ -30,8 +27,11 @@ writeShellApplication {
     systemd
     util-linux
   ];
+  # /etc/fss-verify-classifier.sh is populated at runtime by fss.nix; shellcheck
+  # cannot follow it statically.
+  excludeShellChecks = [ "SC1091" ];
   text = ''
-    ${verifyClassifierLib}
+    source /etc/fss-verify-classifier.sh
 
     usage() {
       cat <<'EOF'

--- a/packages/pkgs-by-name/fss-triage/package.nix
+++ b/packages/pkgs-by-name/fss-triage/package.nix
@@ -104,10 +104,12 @@ writeShellApplication {
     COMMAND_LOG="$OUTPUT_DIR/commands.tsv"
     SUMMARY="$OUTPUT_DIR/summary.txt"
     VERIFY_SUMMARY="$OUTPUT_DIR/verify/summary.tsv"
+    RECEIPT_SUMMARY="$OUTPUT_DIR/receipt-summary.tsv"
     CRITICAL_FAILURE=0
 
     printf 'name\texit_code\tcommand\n' > "$COMMAND_LOG"
     printf 'name\texit_code\tverdict\ttags\treason\n' > "$VERIFY_SUMMARY"
+    printf 'class\ttotal\tvalid\tcurrent\tstale\tmissing\tmismatched\n' > "$RECEIPT_SUMMARY"
 
     info() { fss_log info "$1"; }
     warn() { fss_log warn "$1"; }
@@ -296,6 +298,73 @@ writeShellApplication {
       UNCLEAN_RECEIPTS="$(fss_filter_valid_receipts "$RAW_UNCLEAN_RECEIPTS")"
     }
 
+    fss_receipt_missing_paths() {
+      local records="$1"
+      local rec ver path rest missing=""
+
+      while IFS= read -r rec || [ -n "$rec" ]; do
+        [ -n "$rec" ] || continue
+        # shellcheck disable=SC2034  # ver/rest are positional placeholders
+        IFS=$'\t' read -r ver path rest <<<"$rec"
+        [ -n "$path" ] || continue
+        [ -e "$path" ] && continue
+        missing=$(fss_append_unique_line "$missing" "$path")
+      done <<<"$records"
+
+      printf '%s' "$missing"
+    }
+
+    fss_receipt_count_for_boot() {
+      local records="$1"
+      local wanted_boot="$2"
+      local mode="$3"
+      local rec ver path inode size boot rest
+      local count=0
+
+      [ -n "$wanted_boot" ] || { printf '0'; return 0; }
+      while IFS= read -r rec || [ -n "$rec" ]; do
+        [ -n "$rec" ] || continue
+        # shellcheck disable=SC2034  # ver/path/inode/size/rest are positional placeholders
+        IFS=$'\t' read -r ver path inode size boot rest <<<"$rec"
+        case "$mode" in
+        current)
+          [ "$boot" = "$wanted_boot" ] && count=$((count + 1))
+          ;;
+        stale)
+          [ -n "$boot" ] && [ "$boot" != "$wanted_boot" ] && count=$((count + 1))
+          ;;
+        esac
+      done <<<"$records"
+
+      printf '%s' "$count"
+    }
+
+    write_receipt_summary() {
+      local class="$1"
+      local raw="$2"
+      local valid="$3"
+      local mismatches="$4"
+      local missing
+
+      missing="$(fss_receipt_missing_paths "$raw")"
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$class" \
+        "$(fss_count_nonempty_lines "$raw")" \
+        "$(fss_count_nonempty_lines "$valid")" \
+        "$(fss_receipt_count_for_boot "$valid" "$CURRENT_BOOT_ID" current)" \
+        "$(fss_receipt_count_for_boot "$valid" "$CURRENT_BOOT_ID" stale)" \
+        "$(fss_count_nonempty_lines "$missing")" \
+        "$(fss_count_nonempty_lines "$mismatches")" \
+        >> "$RECEIPT_SUMMARY"
+    }
+
+    refresh_receipt_summary() {
+      printf 'class\ttotal\tvalid\tcurrent\tstale\tmissing\tmismatched\n' > "$RECEIPT_SUMMARY"
+      write_receipt_summary "recovery" "$RAW_RECOVERY_RECEIPTS" "$RECOVERY_RECEIPTS" "$RECOVERY_RECEIPT_MISMATCHES"
+      write_receipt_summary "pre-activation" "$RAW_PRE_ACTIVATION_RECEIPTS" "$PRE_ACTIVATION_RECEIPTS" "$PRE_ACTIVATION_RECEIPT_MISMATCHES"
+      write_receipt_summary "unclean-shutdown" "$RAW_UNCLEAN_RECEIPTS" "$UNCLEAN_RECEIPTS" "$UNCLEAN_RECEIPT_MISMATCHES"
+    }
+
     classify_verify_file() {
       local name="$1"
       local output_file="$2"
@@ -429,6 +498,7 @@ writeShellApplication {
     fi
 
     refresh_fss_allowlists
+    refresh_receipt_summary
 
     info "Writing FSS triage data to $OUTPUT_DIR"
 
@@ -446,6 +516,8 @@ writeShellApplication {
       printf 'recovery_receipt_mismatches_count=%s\n' "$(fss_count_nonempty_lines "$RECOVERY_RECEIPT_MISMATCHES")"
       printf 'pre_activation_receipts_count=%s\n' "$(fss_count_nonempty_lines "$PRE_ACTIVATION_RECEIPTS")"
       printf 'pre_activation_receipt_mismatches_count=%s\n' "$(fss_count_nonempty_lines "$PRE_ACTIVATION_RECEIPT_MISMATCHES")"
+      printf 'unclean_shutdown_receipts_count=%s\n' "$(fss_count_nonempty_lines "$UNCLEAN_RECEIPTS")"
+      printf 'unclean_shutdown_receipt_mismatches_count=%s\n' "$(fss_count_nonempty_lines "$UNCLEAN_RECEIPT_MISMATCHES")"
       printf 'current_boot_id=%s\n' "$CURRENT_BOOT_ID"
       if activation_mode_enabled; then
         printf 'activation_mode=enabled\n'
@@ -560,12 +632,16 @@ writeShellApplication {
     fi
 
     {
+      refresh_receipt_summary
       echo "FSS triage summary"
       echo
       cat "$OUTPUT_DIR/context.env"
       echo
       echo "Verification summary:"
       column -t -s $'\t' "$VERIFY_SUMMARY" 2>/dev/null || cat "$VERIFY_SUMMARY"
+      echo
+      echo "Receipt summary:"
+      column -t -s $'\t' "$RECEIPT_SUMMARY" 2>/dev/null || cat "$RECEIPT_SUMMARY"
       echo
       echo "Command log:"
       column -t -s $'\t' "$COMMAND_LOG" 2>/dev/null || cat "$COMMAND_LOG"

--- a/packages/pkgs-by-name/fss-triage/package.nix
+++ b/packages/pkgs-by-name/fss-triage/package.nix
@@ -167,7 +167,8 @@ writeShellApplication {
     run_shell_capture() {
       local name="$1"
       local script="$2"
-      run_capture "$name" "$BASH" -lc "$script"
+      shift 2
+      run_capture "$name" "$BASH" -lc "$script" bash "$@"
     }
 
     read_file_if_present() {
@@ -552,9 +553,18 @@ writeShellApplication {
     run_shell_capture "journald-cat-config" "systemd-analyze cat-config systemd/journald.conf"
     run_shell_capture "journald-config-snippets" "for d in /etc/systemd/journald.conf.d /run/systemd/journald.conf.d /usr/lib/systemd/journald.conf.d; do [ -d \"\$d\" ] && find \"\$d\" -maxdepth 1 -type f -print -exec sed -n '1,120p' {} \\;; done"
     run_shell_capture "clocksource" "for p in /sys/devices/system/clocksource/clocksource0/current_clocksource /sys/devices/system/clocksource/clocksource0/available_clocksource; do [ -r \"\$p\" ] && printf '%s: %s\\n' \"\$p\" \"\$(cat \"\$p\")\"; done"
-    run_shell_capture "journal-files-stat" "for d in '$STATE_DIR' '$RUNTIME_STATE_DIR'; do [ -d \"\$d\" ] || continue; find \"\$d\" -maxdepth 1 -type f -printf '%p\\t%i\\t%s\\t%TY-%Tm-%TdT%TH:%TM:%TS%TZ\\t%m\\t%u\\t%g\\n' | sort; done"
-    run_shell_capture "fss-state-files" "for p in '$STATE_DIR/fss' '$RUNTIME_STATE_DIR/fss' '$STATE_DIR/fss-rotated' '$STATE_DIR/fss-baseline-boot' '$STATE_DIR/fss-pre-fss-archive' '$STATE_DIR/fss-recovery-archives' '$STATE_DIR/fss-recovery-receipts' '$STATE_DIR/fss-pre-activation-receipts' '$STATE_DIR/fss-unclean-shutdown-receipts' '$STATE_DIR/fss-activation-state' '$FSS_CONFIG' '$KEY_DIR/initialized' '$VERIFY_KEY_PATH' /run/ghaf-clock-ready /run/ghaf-clock-ready-state /run/ghaf-clock-synced /run/ghaf-clock-sync-state /var/lib/ghaf/clock-ready/last-good-realtime; do [ -n \"\$p\" ] && [ -e \"\$p\" ] && stat -c '%n\\t%i\\t%s\\t%Y\\t%F\\t%m\\t%U\\t%G\\t%A' \"\$p\"; done"
-    run_shell_capture "fss-state-content" "for p in '$STATE_DIR/fss-pre-fss-archive' '$STATE_DIR/fss-recovery-archives' '$STATE_DIR/fss-recovery-receipts' '$STATE_DIR/fss-pre-activation-receipts' '$STATE_DIR/fss-unclean-shutdown-receipts' '$STATE_DIR/fss-activation-state' /run/ghaf-clock-ready-state /run/ghaf-clock-sync-state /var/lib/ghaf/clock-ready/last-good-realtime; do [ -r \"\$p\" ] && { printf '===== %s =====\\n' \"\$p\"; sed -n '1,200p' \"\$p\"; }; done"
+    # shellcheck disable=SC2016  # single-quoted: expands in the run_shell_capture subshell, not here
+    run_shell_capture "journal-files-stat" \
+      'for d in "$@"; do [ -d "$d" ] || continue; find "$d" -maxdepth 1 -type f -printf "%p\t%i\t%s\t%TY-%Tm-%TdT%TH:%TM:%TS%TZ\t%m\t%u\t%g\n" | sort; done' \
+      "$STATE_DIR" "$RUNTIME_STATE_DIR"
+    # shellcheck disable=SC2016  # single-quoted: expands in the run_shell_capture subshell, not here
+    run_shell_capture "fss-state-files" \
+      'for p in "$@" /run/ghaf-clock-ready /run/ghaf-clock-ready-state /run/ghaf-clock-synced /run/ghaf-clock-sync-state /var/lib/ghaf/clock-ready/last-good-realtime; do [ -n "$p" ] && [ -e "$p" ] && stat -c "%n\t%i\t%s\t%Y\t%F\t%m\t%U\t%G\t%A" "$p"; done' \
+      "$STATE_DIR/fss" "$RUNTIME_STATE_DIR/fss" "$STATE_DIR/fss-rotated" "$STATE_DIR/fss-baseline-boot" "$STATE_DIR/fss-pre-fss-archive" "$STATE_DIR/fss-recovery-archives" "$STATE_DIR/fss-recovery-receipts" "$STATE_DIR/fss-pre-activation-receipts" "$STATE_DIR/fss-unclean-shutdown-receipts" "$STATE_DIR/fss-activation-state" "$FSS_CONFIG" "$KEY_DIR/initialized" "$VERIFY_KEY_PATH"
+    # shellcheck disable=SC2016  # single-quoted: expands in the run_shell_capture subshell, not here
+    run_shell_capture "fss-state-content" \
+      'for p in "$@" /run/ghaf-clock-ready-state /run/ghaf-clock-sync-state /var/lib/ghaf/clock-ready/last-good-realtime; do [ -r "$p" ] && { printf "===== %s =====\n" "$p"; sed -n "1,200p" "$p"; }; done' \
+      "$STATE_DIR/fss-pre-fss-archive" "$STATE_DIR/fss-recovery-archives" "$STATE_DIR/fss-recovery-receipts" "$STATE_DIR/fss-pre-activation-receipts" "$STATE_DIR/fss-unclean-shutdown-receipts" "$STATE_DIR/fss-activation-state"
 
     capture_boot_logs() {
       local label="$1"

--- a/packages/pkgs-by-name/fss-triage/package.nix
+++ b/packages/pkgs-by-name/fss-triage/package.nix
@@ -1,0 +1,587 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Manual FSS triage script.
+#
+# This is intentionally separate from fss-test. It collects diagnostics and
+# runs targeted verification probes for investigating intermittent FSS/journald
+# failures on deployed systems.
+{
+  writeShellApplication,
+  coreutils,
+  findutils,
+  gawk,
+  gnugrep,
+  gnused,
+  systemd,
+  util-linux,
+}:
+let
+  verifyClassifierLib = builtins.readFile ../../../modules/common/logging/fss-verify-classifier.sh;
+in
+writeShellApplication {
+  name = "fss-triage";
+  runtimeInputs = [
+    coreutils
+    findutils
+    gawk
+    gnugrep
+    gnused
+    systemd
+    util-linux
+  ];
+  text = ''
+    ${verifyClassifierLib}
+
+    usage() {
+      cat <<'EOF'
+    Usage: fss-triage [options]
+
+    Collect FSS/journald diagnostics and run manual verification probes.
+
+    Options:
+      --output-dir DIR          Write diagnostics under DIR.
+      --no-sync                 Do not run journalctl --sync before the main verify pass.
+      --recovery-probe          Start ghaf-journal-alloy-recover.service after baseline capture and verify again.
+      --journald-restart-probe  Restart systemd-journald.service twice after baseline capture and verify again.
+      --strict-exit             Exit non-zero when a critical verification verdict is observed.
+      -h, --help                Show this help.
+
+    Default behavior is evidence-preserving: no service restarts are performed.
+    EOF
+    }
+
+    OUTPUT_DIR=""
+    DO_SYNC=1
+    DO_RECOVERY_PROBE=0
+    DO_JOURNALD_RESTART_PROBE=0
+    STRICT_EXIT=0
+
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+      --output-dir)
+        [ "$#" -ge 2 ] || { echo "--output-dir requires a value" >&2; exit 2; }
+        OUTPUT_DIR="$2"
+        shift 2
+        ;;
+      --no-sync)
+        DO_SYNC=0
+        shift
+        ;;
+      --recovery-probe)
+        DO_RECOVERY_PROBE=1
+        shift
+        ;;
+      --journald-restart-probe)
+        DO_JOURNALD_RESTART_PROBE=1
+        shift
+        ;;
+      --strict-exit)
+        STRICT_EXIT=1
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown option: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+      esac
+    done
+
+    HOSTNAME="$(cat /proc/sys/kernel/hostname 2>/dev/null || echo unknown-host)"
+    TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+    umask 077
+    if [ -z "$OUTPUT_DIR" ]; then
+      SAFE_HOSTNAME="$(printf '%s' "$HOSTNAME" | tr -c 'A-Za-z0-9_.-' '_')"
+      OUTPUT_DIR="$(mktemp -d "''${TMPDIR:-/tmp}/fss-triage-$SAFE_HOSTNAME-$TIMESTAMP-XXXXXX")"
+    fi
+    mkdir -p "$OUTPUT_DIR"/verify "$OUTPUT_DIR"/units
+
+    COMMAND_LOG="$OUTPUT_DIR/commands.tsv"
+    SUMMARY="$OUTPUT_DIR/summary.txt"
+    VERIFY_SUMMARY="$OUTPUT_DIR/verify/summary.tsv"
+    CRITICAL_FAILURE=0
+
+    printf 'name\texit_code\tcommand\n' > "$COMMAND_LOG"
+    printf 'name\texit_code\tverdict\ttags\treason\n' > "$VERIFY_SUMMARY"
+
+    info() { fss_log info "$1"; }
+    warn() { fss_log warn "$1"; }
+    pass() { fss_log pass "$1"; }
+
+    append_command_log() {
+      local name="$1"
+      local rc="$2"
+      local arg
+      local redact_next=0
+      shift 2
+
+      {
+        printf '%s\t%s\t' "$name" "$rc"
+        for arg in "$@"; do
+          if [ "$redact_next" -eq 1 ]; then
+            printf '%q ' "<redacted>"
+            redact_next=0
+            continue
+          fi
+
+          case "$arg" in
+          --verify-key=*) printf '%q ' "--verify-key=<redacted>" ;;
+          --verify-key)
+            printf '%q ' "$arg"
+            redact_next=1
+            ;;
+          *) printf '%q ' "$arg" ;;
+          esac
+        done
+        printf '\n'
+      } >> "$COMMAND_LOG"
+    }
+
+    run_capture() {
+      local name="$1"
+      shift
+      local output="$OUTPUT_DIR/$name.txt"
+      local rc
+
+      set +e
+      {
+        printf '$'
+        printf ' %q' "$@"
+        printf '\n\n'
+        "$@"
+      } >"$output" 2>&1
+      rc=$?
+      set -e
+
+      append_command_log "$name" "$rc" "$@"
+      return 0
+    }
+
+    run_shell_capture() {
+      local name="$1"
+      local script="$2"
+      run_capture "$name" "$BASH" -lc "$script"
+    }
+
+    read_file_if_present() {
+      local path="$1"
+      if [ -r "$path" ]; then
+        cat "$path"
+      fi
+    }
+
+    journald_effective_seal() {
+      systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
+        | awk -F= '
+          /^[[:space:]]*[#;]/ { next }
+          /^[[:space:]]*Seal[[:space:]]*=/ {
+            value = $2
+            sub(/^[[:space:]]*/, "", value)
+            sub(/[[:space:]]*[#;].*$/, "", value)
+            sub(/[[:space:]]*$/, "", value)
+            seal = tolower(value)
+          }
+          END { print seal }
+        '
+    }
+
+    journald_config_has_seal_no() {
+      systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
+        | awk -F= '
+          /^[[:space:]]*[#;]/ { next }
+          /^[[:space:]]*Seal[[:space:]]*=/ {
+            value = $2
+            sub(/^[[:space:]]*/, "", value)
+            sub(/[[:space:]]*[#;].*$/, "", value)
+            sub(/[[:space:]]*$/, "", value)
+            if (tolower(value) == "no") found = 1
+          }
+          END { exit found ? 0 : 1 }
+        '
+    }
+
+    sealing_active_in_config() {
+      [ "$(journald_effective_seal)" = "yes" ]
+    }
+
+    activation_state_value() {
+      [ -r "$ACTIVATION_STATE_FILE" ] || return 0
+      awk -F '\t' 'NR == 1 { print $1 }' "$ACTIVATION_STATE_FILE"
+    }
+
+    activation_state_boot_id() {
+      [ -r "$ACTIVATION_STATE_FILE" ] || return 0
+      awk -F '\t' 'NR == 1 { print $2 }' "$ACTIVATION_STATE_FILE"
+    }
+
+    activation_baseline_boot_id() {
+      [ -r "$FSS_BOOT_BASELINE_FILE" ] || return 0
+      tr -d '[:space:]' < "$FSS_BOOT_BASELINE_FILE"
+    }
+
+    activation_mode_enabled() {
+      local state
+
+      state="$(activation_state_value)"
+      [ "$state" = "disabled" ] && return 1
+      [ -n "$state" ] && return 0
+      if journald_config_has_seal_no || [ -f /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf ]; then
+        return 0
+      fi
+      return 1
+    }
+
+    run_activation_preflight() {
+      local activation_state=""
+      local activation_boot_id=""
+      local baseline_boot_id=""
+      local exit_code=0
+
+      FSS_VERDICT=verified
+      FSS_VERDICT_TAGS="ACTIVATION_DISABLED"
+      FSS_VERDICT_REASON="activation mode disabled"
+
+      if activation_mode_enabled; then
+        activation_state="$(activation_state_value)"
+        activation_boot_id="$(activation_state_boot_id)"
+        baseline_boot_id="$(activation_baseline_boot_id)"
+        FSS_VERDICT_TAGS="ACTIVATION_ACTIVE"
+        FSS_VERDICT_REASON="activation active for current boot"
+
+        if [ "$activation_state" = "failed" ]; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS="ACTIVATION_FAILED"
+          FSS_VERDICT_REASON="FSS sealing was not activated"
+          exit_code=1
+        elif [ "$activation_state" != "active" ] \
+          || [ "$activation_boot_id" != "$CURRENT_BOOT_ID" ] \
+          || [ "$baseline_boot_id" != "$CURRENT_BOOT_ID" ]; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS="ACTIVATION_STALE"
+          FSS_VERDICT_REASON="FSS activation state is not active for current boot"
+          exit_code=1
+        elif ! sealing_active_in_config; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS="ACTIVATION_FAILED"
+          FSS_VERDICT_REASON="effective journald Seal setting is not yes"
+          exit_code=1
+        fi
+      fi
+
+      printf '%s\t%s\t%s\t%s\t%s\n' \
+        "activation-preflight" "$exit_code" "$FSS_VERDICT" "$FSS_VERDICT_TAGS" "$FSS_VERDICT_REASON" \
+        >> "$VERIFY_SUMMARY"
+
+      if [ "$FSS_VERDICT" = "fail" ]; then
+        CRITICAL_FAILURE=1
+      fi
+    }
+
+    refresh_fss_allowlists() {
+      PRE_FSS_ARCHIVE="$(read_file_if_present "$STATE_DIR/fss-pre-fss-archive" | tr -d '[:space:]')"
+      RECOVERY_ARCHIVES="$(fss_read_recorded_archive_list "$STATE_DIR/fss-recovery-archives")"
+      RAW_RECOVERY_RECEIPTS="$(fss_read_receipts "$STATE_DIR/fss-recovery-receipts")"
+      RECOVERY_RECEIPT_MISMATCHES="$(fss_receipt_mismatches "$RAW_RECOVERY_RECEIPTS")"
+      RECOVERY_RECEIPTS="$(fss_filter_valid_receipts "$RAW_RECOVERY_RECEIPTS")"
+      RAW_PRE_ACTIVATION_RECEIPTS="$(fss_read_pre_activation_receipts "$STATE_DIR/fss-pre-activation-receipts")"
+      PRE_ACTIVATION_RECEIPT_MISMATCHES="$(fss_pre_activation_receipt_mismatches "$RAW_PRE_ACTIVATION_RECEIPTS")"
+      PRE_ACTIVATION_RECEIPTS="$(fss_filter_valid_receipts "$RAW_PRE_ACTIVATION_RECEIPTS")"
+      RAW_UNCLEAN_RECEIPTS="$(fss_read_unclean_shutdown_receipts "$STATE_DIR/fss-unclean-shutdown-receipts")"
+      UNCLEAN_RECEIPT_MISMATCHES="$(fss_unclean_shutdown_receipt_mismatches "$RAW_UNCLEAN_RECEIPTS")"
+      UNCLEAN_RECEIPTS="$(fss_filter_valid_receipts "$RAW_UNCLEAN_RECEIPTS")"
+    }
+
+    classify_verify_file() {
+      local name="$1"
+      local output_file="$2"
+      local exit_code="$3"
+      local expected_pre="$4"
+      local recovery_receipts="$5"
+      local pre_activation_receipts="$6"
+      local current_boot="$7"
+      local unclean_receipts="$8"
+
+      local verify_output
+      verify_output="$(cat "$output_file")"
+      fss_classify_verify_output "$verify_output"
+      fss_verify_policy_decision "$expected_pre" "$recovery_receipts" "$pre_activation_receipts" "$current_boot" "$exit_code" "$unclean_receipts"
+      if [ -n "$RECOVERY_RECEIPT_MISMATCHES" ]; then
+        FSS_VERDICT=fail
+        FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "RECOVERY_RECEIPT_MISMATCH")
+        FSS_VERDICT_REASON="recovery receipt content mismatch"
+      elif [ -n "$PRE_ACTIVATION_RECEIPT_MISMATCHES" ]; then
+        FSS_VERDICT=fail
+        FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_RECEIPT_MISMATCH")
+        FSS_VERDICT_REASON="pre-activation receipt content mismatch"
+      elif [ -n "$UNCLEAN_RECEIPT_MISMATCHES" ]; then
+        FSS_VERDICT=fail
+        FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN_RECEIPT_MISMATCH")
+        FSS_VERDICT_REASON="unclean-shutdown receipt content mismatch"
+      fi
+
+      printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$name" "$exit_code" "$FSS_VERDICT" "$FSS_VERDICT_TAGS" "$FSS_VERDICT_REASON" \
+        >> "$VERIFY_SUMMARY"
+
+      if [ "$FSS_VERDICT" = "fail" ]; then
+        CRITICAL_FAILURE=1
+      fi
+    }
+
+    run_verify_capture() {
+      local name="$1"
+      shift
+      local output="$OUTPUT_DIR/verify/$name.txt"
+      local rc
+
+      set +e
+      "$@" >"$output" 2>&1
+      rc=$?
+      set -e
+
+      append_command_log "verify/$name" "$rc" "$@"
+      refresh_fss_allowlists
+      classify_verify_file "$name" "$output" "$rc" "$PRE_FSS_ARCHIVE" "$RECOVERY_RECEIPTS" "$PRE_ACTIVATION_RECEIPTS" "$CURRENT_BOOT_ID" "$UNCLEAN_RECEIPTS"
+      return 0
+    }
+
+    run_per_file_verify() {
+      local label="$1"
+      local journal_path="$2"
+      local output="$OUTPUT_DIR/verify/per-file-$label.tsv"
+      local file safe_name rc verify_output_file
+
+      printf 'path\texit_code\tverdict\ttags\treason\n' > "$output"
+
+      while IFS= read -r file || [ -n "$file" ]; do
+        [ -n "$file" ] || continue
+        safe_name="$(printf '%s' "$file" | sed 's#[^A-Za-z0-9._-]#_#g')"
+        verify_output_file="$OUTPUT_DIR/verify/per-file-$label-$safe_name.txt"
+
+        set +e
+        if [ -n "$VERIFY_KEY" ]; then
+          journalctl --file="$file" --verify --verify-key="$VERIFY_KEY" >"$verify_output_file" 2>&1
+        else
+          journalctl --file="$file" --verify >"$verify_output_file" 2>&1
+        fi
+        rc=$?
+        set -e
+
+        fss_classify_verify_output "$(cat "$verify_output_file")"
+        fss_verify_policy_decision "$PRE_FSS_ARCHIVE" "$RECOVERY_RECEIPTS" "$PRE_ACTIVATION_RECEIPTS" "$CURRENT_BOOT_ID" "$rc" "$UNCLEAN_RECEIPTS"
+        if [ -n "$RECOVERY_RECEIPT_MISMATCHES" ]; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "RECOVERY_RECEIPT_MISMATCH")
+          FSS_VERDICT_REASON="recovery receipt content mismatch"
+        elif [ -n "$PRE_ACTIVATION_RECEIPT_MISMATCHES" ]; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "PRE_ACTIVATION_RECEIPT_MISMATCH")
+          FSS_VERDICT_REASON="pre-activation receipt content mismatch"
+        elif [ -n "$UNCLEAN_RECEIPT_MISMATCHES" ]; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS=$(fss_append_tag "$FSS_VERDICT_TAGS" "UNCLEAN_SHUTDOWN_RECEIPT_MISMATCH")
+          FSS_VERDICT_REASON="unclean-shutdown receipt content mismatch"
+        fi
+        printf '%s\t%s\t%s\t%s\t%s\n' \
+          "$file" "$rc" "$FSS_VERDICT" "$FSS_VERDICT_TAGS" "$FSS_VERDICT_REASON" \
+          >> "$output"
+
+        if [ "$FSS_VERDICT" = "fail" ]; then
+          CRITICAL_FAILURE=1
+        fi
+      done < <(find "$journal_path" -maxdepth 1 -type f \( -name '*.journal' -o -name '*.journal~' \) -print 2>/dev/null | sort)
+    }
+
+    MACHINE_ID="$(cat /etc/machine-id 2>/dev/null || true)"
+    if [ -z "$MACHINE_ID" ]; then
+      warn "Cannot read /etc/machine-id"
+      MACHINE_ID="unknown-machine-id"
+    fi
+    CURRENT_BOOT_ID="$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot)"
+
+    STATE_DIR="/var/log/journal/$MACHINE_ID"
+    RUNTIME_STATE_DIR="/run/log/journal/$MACHINE_ID"
+    FSS_CONFIG="$STATE_DIR/fss-config"
+    FSS_BOOT_BASELINE_FILE="$STATE_DIR/fss-baseline-boot"
+    ACTIVATION_STATE_FILE="$STATE_DIR/fss-activation-state"
+    KEY_DIR=""
+    if [ -s "$FSS_CONFIG" ]; then
+      KEY_DIR="$(cat "$FSS_CONFIG")"
+    else
+      for candidate in "/persist/common/journal-fss/$HOSTNAME" "/etc/common/journal-fss/$HOSTNAME"; do
+        if [ -d "$candidate" ]; then
+          KEY_DIR="$candidate"
+          break
+        fi
+      done
+    fi
+
+    VERIFY_KEY_PATH=""
+    VERIFY_KEY=""
+    if [ -n "$KEY_DIR" ] && [ -r "$KEY_DIR/verification-key" ] && [ -s "$KEY_DIR/verification-key" ]; then
+      VERIFY_KEY_PATH="$KEY_DIR/verification-key"
+      VERIFY_KEY="$(cat "$VERIFY_KEY_PATH")"
+    fi
+
+    refresh_fss_allowlists
+
+    info "Writing FSS triage data to $OUTPUT_DIR"
+
+    {
+      printf 'timestamp_utc=%s\n' "$TIMESTAMP"
+      printf 'hostname=%s\n' "$HOSTNAME"
+      printf 'machine_id=%s\n' "$MACHINE_ID"
+      printf 'state_dir=%s\n' "$STATE_DIR"
+      printf 'runtime_state_dir=%s\n' "$RUNTIME_STATE_DIR"
+      printf 'key_dir=%s\n' "''${KEY_DIR:-unknown}"
+      printf 'verification_key_path=%s\n' "''${VERIFY_KEY_PATH:-missing}"
+      printf 'pre_fss_archive=%s\n' "''${PRE_FSS_ARCHIVE:-none}"
+      printf 'recovery_archives_count=%s\n' "$(fss_count_nonempty_lines "$RECOVERY_ARCHIVES")"
+      printf 'recovery_receipts_count=%s\n' "$(fss_count_nonempty_lines "$RECOVERY_RECEIPTS")"
+      printf 'recovery_receipt_mismatches_count=%s\n' "$(fss_count_nonempty_lines "$RECOVERY_RECEIPT_MISMATCHES")"
+      printf 'pre_activation_receipts_count=%s\n' "$(fss_count_nonempty_lines "$PRE_ACTIVATION_RECEIPTS")"
+      printf 'pre_activation_receipt_mismatches_count=%s\n' "$(fss_count_nonempty_lines "$PRE_ACTIVATION_RECEIPT_MISMATCHES")"
+      printf 'current_boot_id=%s\n' "$CURRENT_BOOT_ID"
+      if activation_mode_enabled; then
+        printf 'activation_mode=enabled\n'
+      else
+        printf 'activation_mode=disabled\n'
+      fi
+      printf 'journald_effective_seal=%s\n' "$(journald_effective_seal)"
+      activation_state_raw="$(read_file_if_present "$ACTIVATION_STATE_FILE")"
+      printf 'activation_state=%s\n' "$(printf '%s\n' "$activation_state_raw" | awk -F '\t' 'NR == 1 { print $1 }')"
+      printf 'activation_boot_id=%s\n' "$(printf '%s\n' "$activation_state_raw" | awk -F '\t' 'NR == 1 { print $2 }')"
+      printf 'activation_baseline_boot_id=%s\n' "$(activation_baseline_boot_id)"
+      printf 'activation_state_raw=%s\n' "$activation_state_raw"
+      printf 'sync_before_verify=%s\n' "$DO_SYNC"
+      printf 'recovery_probe=%s\n' "$DO_RECOVERY_PROBE"
+      printf 'journald_restart_probe=%s\n' "$DO_JOURNALD_RESTART_PROBE"
+    } > "$OUTPUT_DIR/context.env"
+
+    run_activation_preflight
+
+    run_capture "date-utc" date -u
+    run_capture "hostnamectl" hostnamectl
+    run_capture "uname" uname -a
+    run_capture "uptime" uptime
+    run_capture "journalctl-version" journalctl --version
+    run_capture "journalctl-list-boots" journalctl --list-boots
+    run_capture "journalctl-disk-usage" journalctl --disk-usage
+    run_capture "timedatectl-status" timedatectl status
+    run_capture "timedatectl-sync-state" timedatectl show -p NTPSynchronized
+    run_capture "findmnt" findmnt
+    run_capture "df-journal" df -h /var/log/journal /run/log/journal
+
+    run_shell_capture "journald-cat-config" "systemd-analyze cat-config systemd/journald.conf"
+    run_shell_capture "journald-config-snippets" "for d in /etc/systemd/journald.conf.d /run/systemd/journald.conf.d /usr/lib/systemd/journald.conf.d; do [ -d \"\$d\" ] && find \"\$d\" -maxdepth 1 -type f -print -exec sed -n '1,120p' {} \\;; done"
+    run_shell_capture "clocksource" "for p in /sys/devices/system/clocksource/clocksource0/current_clocksource /sys/devices/system/clocksource/clocksource0/available_clocksource; do [ -r \"\$p\" ] && printf '%s: %s\\n' \"\$p\" \"\$(cat \"\$p\")\"; done"
+    run_shell_capture "journal-files-stat" "for d in '$STATE_DIR' '$RUNTIME_STATE_DIR'; do [ -d \"\$d\" ] || continue; find \"\$d\" -maxdepth 1 -type f -printf '%p\\t%i\\t%s\\t%TY-%Tm-%TdT%TH:%TM:%TS%TZ\\t%m\\t%u\\t%g\\n' | sort; done"
+    run_shell_capture "fss-state-files" "for p in '$STATE_DIR/fss' '$RUNTIME_STATE_DIR/fss' '$STATE_DIR/fss-rotated' '$STATE_DIR/fss-baseline-boot' '$STATE_DIR/fss-pre-fss-archive' '$STATE_DIR/fss-recovery-archives' '$STATE_DIR/fss-recovery-receipts' '$STATE_DIR/fss-pre-activation-receipts' '$STATE_DIR/fss-unclean-shutdown-receipts' '$STATE_DIR/fss-activation-state' '$FSS_CONFIG' '$KEY_DIR/initialized' '$VERIFY_KEY_PATH' /run/ghaf-clock-ready /run/ghaf-clock-ready-state /run/ghaf-clock-synced /run/ghaf-clock-sync-state /var/lib/ghaf/clock-ready/last-good-realtime; do [ -n \"\$p\" ] && [ -e \"\$p\" ] && stat -c '%n\\t%i\\t%s\\t%Y\\t%F\\t%m\\t%U\\t%G\\t%A' \"\$p\"; done"
+    run_shell_capture "fss-state-content" "for p in '$STATE_DIR/fss-pre-fss-archive' '$STATE_DIR/fss-recovery-archives' '$STATE_DIR/fss-recovery-receipts' '$STATE_DIR/fss-pre-activation-receipts' '$STATE_DIR/fss-unclean-shutdown-receipts' '$STATE_DIR/fss-activation-state' /run/ghaf-clock-ready-state /run/ghaf-clock-sync-state /var/lib/ghaf/clock-ready/last-good-realtime; do [ -r \"\$p\" ] && { printf '===== %s =====\\n' \"\$p\"; sed -n '1,200p' \"\$p\"; }; done"
+
+    capture_boot_logs() {
+      local label="$1"
+      local boot="$2"
+
+      run_shell_capture "fss-unit-logs-$label" "journalctl -u systemd-journald.service -u systemd-journal-flush.service -u ghaf-clock-ready.service -u ghaf-clock-sync.service -u journal-fss-setup.service -u journal-fss-verify.service -u ghaf-clock-jump-watcher.service -u ghaf-journal-alloy-recover.service -u alloy.service -b $boot --no-pager"
+      run_shell_capture "journal-errors-$label" "journalctl -p warning..alert -b $boot --no-pager"
+      run_shell_capture "audit-fss-events-$label" "journalctl -g 'journal_fss_keys|journal_sealed_logs|AUDIT_LOG_INTEGRITY_FAIL|AUDIT_LOG_VERIFY_COMPLETED' -b $boot --no-pager"
+    }
+
+    for unit in \
+      systemd-journald.service \
+      systemd-journal-flush.service \
+      ghaf-clock-ready.service \
+      journal-fss-setup.service \
+      journal-fss-verify.service \
+      journal-fss-verify.timer \
+      ghaf-clock-jump-watcher.service \
+      ghaf-journal-alloy-recover.service \
+      alloy.service; do
+      safe_unit="$(printf '%s' "$unit" | sed 's#[^A-Za-z0-9._-]#_#g')"
+      run_shell_capture "units/$safe_unit-show" "systemctl show '$unit' --no-pager"
+      run_shell_capture "units/$safe_unit-status" "systemctl status '$unit' --no-pager -l"
+      run_shell_capture "units/$safe_unit-cat" "systemctl cat '$unit' --no-pager"
+    done
+
+    capture_boot_logs "previous" "-1"
+    capture_boot_logs "current" "0"
+
+    if [ -z "$VERIFY_KEY" ]; then
+      warn "Verification key is unavailable; FSS authenticity verification will be skipped."
+      run_verify_capture "default-no-key-before-sync" journalctl --verify
+    else
+      run_verify_capture "default-with-key-before-sync" journalctl --verify --verify-key="$VERIFY_KEY"
+    fi
+
+    if [ "$DO_SYNC" -eq 1 ]; then
+      run_capture "journalctl-sync" journalctl --sync
+      if [ -n "$VERIFY_KEY" ]; then
+        run_verify_capture "default-with-key-after-sync" journalctl --verify --verify-key="$VERIFY_KEY"
+      else
+        run_verify_capture "default-no-key-after-sync" journalctl --verify
+      fi
+    fi
+
+    if [ -d "$STATE_DIR" ]; then
+      run_per_file_verify "persistent" "$STATE_DIR"
+    fi
+    if [ -d "$RUNTIME_STATE_DIR" ]; then
+      run_per_file_verify "runtime" "$RUNTIME_STATE_DIR"
+    fi
+
+    if [ "$DO_RECOVERY_PROBE" -eq 1 ]; then
+      warn "Running recovery probe: starting ghaf-journal-alloy-recover.service"
+      run_capture "probe-recovery-start" systemctl start ghaf-journal-alloy-recover.service
+      run_capture "probe-recovery-sync" journalctl --sync
+      if [ -n "$VERIFY_KEY" ]; then
+        run_verify_capture "probe-recovery-with-key-after-sync" journalctl --verify --verify-key="$VERIFY_KEY"
+      else
+        run_verify_capture "probe-recovery-no-key-after-sync" journalctl --verify
+      fi
+    fi
+
+    if [ "$DO_JOURNALD_RESTART_PROBE" -eq 1 ]; then
+      warn "Running journald restart probe: restarting systemd-journald.service twice"
+      run_capture "probe-journald-restart-1" systemctl restart systemd-journald.service
+      sleep 2
+      run_capture "probe-journald-restart-2" systemctl restart systemd-journald.service
+      run_capture "probe-journald-sync" journalctl --sync
+      if [ -n "$VERIFY_KEY" ]; then
+        run_verify_capture "probe-journald-restart-with-key-after-sync" journalctl --verify --verify-key="$VERIFY_KEY"
+      else
+        run_verify_capture "probe-journald-restart-no-key-after-sync" journalctl --verify
+      fi
+    fi
+
+    {
+      echo "FSS triage summary"
+      echo
+      cat "$OUTPUT_DIR/context.env"
+      echo
+      echo "Verification summary:"
+      column -t -s $'\t' "$VERIFY_SUMMARY" 2>/dev/null || cat "$VERIFY_SUMMARY"
+      echo
+      echo "Command log:"
+      column -t -s $'\t' "$COMMAND_LOG" 2>/dev/null || cat "$COMMAND_LOG"
+      echo
+      echo "Diagnostics directory: $OUTPUT_DIR"
+    } > "$SUMMARY"
+
+    cat "$SUMMARY"
+
+    if [ "$CRITICAL_FAILURE" -eq 1 ]; then
+      warn "Critical verification failures were observed. See $VERIFY_SUMMARY and $OUTPUT_DIR/verify/."
+      if [ "$STRICT_EXIT" -eq 1 ]; then
+        exit 1
+      fi
+    else
+      pass "No critical verification verdicts observed by the triage script."
+    fi
+  '';
+}

--- a/packages/pkgs-by-name/fss-triage/package.nix
+++ b/packages/pkgs-by-name/fss-triage/package.nix
@@ -178,38 +178,8 @@ writeShellApplication {
       fi
     }
 
-    journald_effective_seal() {
-      systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
-        | awk -F= '
-          /^[[:space:]]*[#;]/ { next }
-          /^[[:space:]]*Seal[[:space:]]*=/ {
-            value = $2
-            sub(/^[[:space:]]*/, "", value)
-            sub(/[[:space:]]*[#;].*$/, "", value)
-            sub(/[[:space:]]*$/, "", value)
-            seal = tolower(value)
-          }
-          END { print seal }
-        '
-    }
-
     journald_config_has_seal_no() {
-      systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
-        | awk -F= '
-          /^[[:space:]]*[#;]/ { next }
-          /^[[:space:]]*Seal[[:space:]]*=/ {
-            value = $2
-            sub(/^[[:space:]]*/, "", value)
-            sub(/[[:space:]]*[#;].*$/, "", value)
-            sub(/[[:space:]]*$/, "", value)
-            if (tolower(value) == "no") found = 1
-          }
-          END { exit found ? 0 : 1 }
-        '
-    }
-
-    sealing_active_in_config() {
-      [ "$(journald_effective_seal)" = "yes" ]
+      [ "$(fss_journald_effective_seal)" = "no" ]
     }
 
     activation_state_value() {
@@ -268,7 +238,7 @@ writeShellApplication {
           FSS_VERDICT_TAGS="ACTIVATION_STALE"
           FSS_VERDICT_REASON="FSS activation state is not active for current boot"
           exit_code=1
-        elif ! sealing_active_in_config; then
+        elif ! fss_sealing_active_in_config; then
           FSS_VERDICT=fail
           FSS_VERDICT_TAGS="ACTIVATION_FAILED"
           FSS_VERDICT_REASON="effective journald Seal setting is not yes"
@@ -472,7 +442,7 @@ writeShellApplication {
       warn "Cannot read /etc/machine-id"
       MACHINE_ID="unknown-machine-id"
     fi
-    CURRENT_BOOT_ID="$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot)"
+    CURRENT_BOOT_ID="$(fss_current_boot_id)"
 
     STATE_DIR="/var/log/journal/$MACHINE_ID"
     RUNTIME_STATE_DIR="/run/log/journal/$MACHINE_ID"
@@ -525,7 +495,7 @@ writeShellApplication {
       else
         printf 'activation_mode=disabled\n'
       fi
-      printf 'journald_effective_seal=%s\n' "$(journald_effective_seal)"
+      printf 'journald_effective_seal=%s\n' "$(fss_journald_effective_seal)"
       activation_state_raw="$(read_file_if_present "$ACTIVATION_STATE_FILE")"
       printf 'activation_state=%s\n' "$(printf '%s\n' "$activation_state_raw" | awk -F '\t' 'NR == 1 { print $1 }')"
       printf 'activation_boot_id=%s\n' "$(printf '%s\n' "$activation_state_raw" | awk -F '\t' 'NR == 1 { print $2 }')"

--- a/packages/pkgs-by-name/ghaf-build-helper/package.nix
+++ b/packages/pkgs-by-name/ghaf-build-helper/package.nix
@@ -149,14 +149,22 @@ writeShellApplication {
           # shellcheck disable=SC2086
           new_system=$(ssh $NIX_SSHOPTS root@ghaf-host readlink -f /nix/var/nix/profiles/system 2>/dev/null || true)
           show_nvd_diff "$old_system" "$new_system"
+          if [ -z "$new_system" ]; then
+            echo "Unable to resolve uploaded system profile on target; refusing to queue switch activation" >&2
+            exit 1
+          fi
 
           # Activate via systemd-run --no-block so the unit is detached from the
           # SSH session.  The connection may drop once network services restart
           echo ""
           echo "Activating new system (connection may drop)..."
           # shellcheck disable=SC2086,SC2029
-          ssh $NIX_SSHOPTS root@ghaf-host \
-            "systemd-run --no-block -- $new_system/bin/switch-to-configuration switch" || true
+          if ! ssh $NIX_SSHOPTS root@ghaf-host \
+            "systemd-run --unit=ghaf-rebuild-switch --description='Ghaf rebuild switch activation' --collect --no-block -- $new_system/bin/switch-to-configuration switch"; then
+            echo "Failed to queue remote switch activation on target" >&2
+            exit 1
+          fi
+          echo "Remote switch activation queued as ghaf-rebuild-switch.service"
         else
           nixos-rebuild --flake "$build_target" --target-host root@ghaf-host --no-reexec "''${upload_args[@]}"
 

--- a/tests/flake-module.nix
+++ b/tests/flake-module.nix
@@ -17,6 +17,7 @@
           # firewall = pkgs.callPackage ./firewall { inherit self; };
           logging-fss = pkgs.callPackage ./logging { inherit self; };
           fss-test = pkgs.callPackage ./logging/test_scripts/fss-test.nix { };
+          fss-triage = pkgs.callPackage ./logging/test_scripts/fss-triage.nix { };
         };
     };
 }

--- a/tests/logging/default.nix
+++ b/tests/logging/default.nix
@@ -65,6 +65,11 @@ pkgs.testers.nixosTest {
           enable = true;
           sealInterval = "1min";
           verifyOnBoot = true;
+          activation.syncWaitSeconds = 1;
+        };
+        ghaf.logging.recovery.clockReady = {
+          stableSeconds = 1;
+          maxWaitSeconds = 5;
         };
 
         networking.hostName = "test-host";
@@ -83,6 +88,63 @@ pkgs.testers.nixosTest {
           coreutils
           gnugrep
           util-linux
+          (callPackage ./test_scripts/fss-test.nix { })
+        ];
+      };
+    };
+
+  nodes.fssOnly =
+    { config, ... }:
+    {
+      imports = [
+        ../../modules/common/logging/common.nix
+        ../../modules/common/logging/fss.nix
+        ../../modules/common/storage-persistence.nix
+      ];
+
+      options.ghaf = {
+        type = lib.mkOption {
+          type = lib.types.str;
+          default = "host";
+        };
+
+        security.audit = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+          };
+          extraRules = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+          };
+        };
+      };
+
+      config = {
+        ghaf.logging.enable = false;
+        ghaf.logging.fss = {
+          enable = true;
+          sealInterval = "1min";
+          verifyOnBoot = false;
+          activation = {
+            enable = false;
+            syncWaitSeconds = 1;
+          };
+        };
+        ghaf.logging.recovery.clockReady = {
+          stableSeconds = 1;
+          maxWaitSeconds = 5;
+        };
+        ghaf.storagevm.enable = true;
+
+        networking.hostName = "fss-only";
+
+        environment.etc."storagevm-directories".text =
+          lib.concatStringsSep "\n" config.ghaf.storagevm.directories;
+
+        systemd.tmpfiles.rules = [
+          "d /persist/common/journal-fss 0755 root root - -"
+          "d /persist/common/journal-fss/fss-only 0700 root root - -"
         ];
       };
     };
@@ -124,17 +186,152 @@ pkgs.testers.nixosTest {
 
   testScript = _: ''
     machine = fss
+    fss_only = fssOnly
     stateless_vm = statelessVm
-    machine.start()
+    machine.start(allow_reboot=True)
+    fss_only.start()
     stateless_vm.start()
     machine.wait_for_unit("multi-user.target")
+    fss_only.wait_for_unit("multi-user.target")
     stateless_vm.wait_for_unit("multi-user.target")
 
     with subtest("FSS stays disabled for stateless VMs"):
         stateless_vm.succeed("test ! -e /etc/systemd/system/journal-fss-setup.service")
         stateless_vm.succeed("test ! -e /etc/systemd/system/journal-fss-verify.service")
+        stateless_vm.succeed("test ! -e /etc/systemd/system/ghaf-clock-ready.service")
+        stateless_vm.succeed("""
+          bash -lc '
+            set -euo pipefail
+            ! systemctl show systemd-journal-flush.service --property=After --property=Requires --property=Wants |
+              grep -F "ghaf-clock-ready.service"
+          '
+        """)
+
+    with subtest("FSS-only configs still emit and require clock readiness"):
+        fss_only.wait_for_unit("ghaf-clock-ready.service")
+        fss_only.succeed("test -e /etc/systemd/system/ghaf-clock-ready.service")
+        fss_only.succeed("""
+          bash -lc '
+            set -euo pipefail
+            systemctl show journal-fss-setup.service --property=After --property=Requires --property=Wants |
+              grep -F "ghaf-clock-ready.service"
+            systemctl cat ghaf-clock-ready.service |
+              grep -F "RequiresMountsFor=/var/lib/ghaf/clock-ready"
+            grep -Fx "/var/lib/ghaf/clock-ready" /etc/storagevm-directories
+          '
+        """)
+
+    with subtest("Static FSS preserves marker/key rotation skip"):
+        fss_only.wait_until_succeeds("""
+          bash -lc '
+            systemctl is-active --quiet journal-fss-setup.service ||
+            systemctl is-failed --quiet journal-fss-setup.service ||
+            [ "$(systemctl show journal-fss-setup.service --property=ConditionResult --value)" = "no" ]
+          '
+        """)
+        fss_only.succeed("""
+          bash -lc '
+            set -euo pipefail
+            MID=$(cat /etc/machine-id)
+            DIR="/var/log/journal/$MID"
+            KEY="$DIR/fss"
+            [ -f "$KEY" ] || KEY="/run/log/journal/$MID/fss"
+            MARKER="$DIR/fss-rotated"
+            BASE="$DIR/fss-baseline-boot"
+
+            test -f "$KEY"
+            test -f "$MARKER"
+            systemd-analyze cat-config systemd/journald.conf |
+              grep -E "^[[:space:]]*Seal[[:space:]]*=[[:space:]]*yes"
+            test ! -e /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf
+
+            printf "previous-boot\n" > "$BASE"
+            chmod 0644 "$BASE"
+            touch -d "@1000000000" "$KEY"
+            touch -d "@1000000010" "$MARKER"
+            old_marker_mtime="$(stat -c %Y "$MARKER")"
+
+            systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-static-skip.log 2>&1
+            [ "$(stat -c %Y "$MARKER")" = "$old_marker_mtime" ]
+            ! grep -F "Rotating journal to ensure clean FSS state" /tmp/journal-fss-setup-static-skip.log
+          '
+        """)
 
     ${fssSetupTest { }}
+
+    with subtest("FSS activation survives a real reboot without system journal failures"):
+        boot1 = machine.succeed("cat /proc/sys/kernel/random/boot_id").strip()
+        machine.succeed("systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true")
+        machine.succeed("systemctl start journal-fss-verify.service")
+        machine.succeed("sync")
+        machine.reboot()
+        machine.wait_for_unit("multi-user.target")
+        machine.wait_until_succeeds("""
+          bash -lc '
+            systemctl is-active --quiet journal-fss-setup.service ||
+            systemctl is-failed --quiet journal-fss-setup.service
+          '
+        """)
+        machine.succeed(f"""
+          bash -lc '
+            set -euo pipefail
+            source /etc/fss-verify-classifier.sh
+            BOOT1="{boot1}"
+            BOOT2="$(cat /proc/sys/kernel/random/boot_id)"
+            [ "$BOOT2" != "$BOOT1" ]
+
+            MID=$(cat /etc/machine-id)
+            DIR="/var/log/journal/$MID"
+            VERIFY_KEY="$(tr -d "[:space:]" < /persist/common/journal-fss/test-host/verification-key)"
+            activation_state="$(cut -f1 "$DIR/fss-activation-state")"
+            activation_boot="$(cut -f2 "$DIR/fss-activation-state")"
+
+            [ "$activation_state" = "active" ]
+            [ "$activation_boot" = "$BOOT2" ]
+            [ "$(tr -d "[:space:]" < "$DIR/fss-baseline-boot")" = "$BOOT2" ]
+            test -f "$DIR/fss-rotated"
+
+            rotations=$(journalctl -b -u journal-fss-setup.service --no-pager |
+              grep -c "Rotating journal to ensure clean FSS state" || true)
+            [ "$rotations" -eq 1 ]
+
+            effective_seal=$(systemd-analyze cat-config systemd/journald.conf | awk -F= '"'"'
+              /^[[:space:]]*[#;]/ {{ next }}
+              /^[[:space:]]*Seal[[:space:]]*=/ {{
+                value = $2
+                sub(/^[[:space:]]*/, "", value)
+                sub(/[[:space:]]*[#;].*$/, "", value)
+                sub(/[[:space:]]*$/, "", value)
+                seal = tolower(value)
+              }}
+              END {{ print seal }}
+            '"'"')
+            [ "$effective_seal" = yes ]
+
+            VERIFY_EXIT=0
+            VERIFY_OUTPUT=$(journalctl --verify --verify-key="$VERIFY_KEY" 2>&1) || VERIFY_EXIT=$?
+            fss_classify_verify_output "$VERIFY_OUTPUT"
+            if [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ]; then
+              printf "%s\n" "$VERIFY_OUTPUT"
+              exit 1
+            fi
+            fss_verify_policy_decision \
+              "$(fss_read_recorded_pre_fss_archive "$DIR/fss-pre-fss-archive")" \
+              "$(fss_filter_valid_receipts "$(fss_read_receipts "$DIR/fss-recovery-receipts")")" \
+              "$(fss_filter_valid_receipts "$(fss_read_pre_activation_receipts "$DIR/fss-pre-activation-receipts")")" \
+              "$BOOT2" \
+              "$VERIFY_EXIT"
+            if [ "$FSS_VERDICT" = "fail" ]; then
+              printf "verdict=%s tags=%s reason=%s\n%s\n" \
+                "$FSS_VERDICT" "$FSS_VERDICT_TAGS" "$FSS_VERDICT_REASON" "$VERIFY_OUTPUT"
+              exit 1
+            fi
+            if [ -n "$FSS_ARCHIVED_SYSTEM_FAILURES" ]; then
+              printf "%s" "$FSS_VERDICT_TAGS" | grep -E "PRE_ACTIVATION_ARCHIVE|RECOVERY_ARCHIVE|PRE_FSS_ARCHIVE"
+            fi
+          '
+        """)
+
     ${fssVerificationTest { }}
 
     print("All FSS tests completed successfully")

--- a/tests/logging/default.nix
+++ b/tests/logging/default.nix
@@ -74,8 +74,7 @@ pkgs.testers.nixosTest {
 
         networking.hostName = "test-host";
 
-        environment.etc."fss-verify-classifier.sh".text =
-          builtins.readFile ../../modules/common/logging/fss-verify-classifier.sh;
+        # /etc/fss-verify-classifier.sh is provided by modules/common/logging/fss.nix.
 
         # Create required directories
         systemd.tmpfiles.rules = [

--- a/tests/logging/default.nix
+++ b/tests/logging/default.nix
@@ -89,6 +89,7 @@ pkgs.testers.nixosTest {
           gnugrep
           util-linux
           (callPackage ./test_scripts/fss-test.nix { })
+          (callPackage ../../packages/pkgs-by-name/fss-triage/package.nix { })
         ];
       };
     };

--- a/tests/logging/default.nix
+++ b/tests/logging/default.nix
@@ -184,16 +184,89 @@ pkgs.testers.nixosTest {
       };
     };
 
+  # Every other node overrides ghaf.logging.recovery.clockReady.{stableSeconds,
+  # maxWaitSeconds} down to a fast path (1s/5s) so the suite doesn't spend
+  # tens of seconds per node waiting on the barrier. This node deliberately
+  # does NOT override them, so ghaf-clock-ready runs at the real production
+  # defaults (20s/90s) at least once, closing the "untested at real defaults"
+  # gap -- the algorithm itself is unchanged, this only adds coverage.
+  nodes.clockReadyProdDefaults =
+    { ... }:
+    {
+      imports = [
+        ../../modules/common/logging/common.nix
+        ../../modules/common/logging/fss.nix
+        ../../modules/common/storage-persistence.nix
+      ];
+
+      options.ghaf = {
+        type = lib.mkOption {
+          type = lib.types.str;
+          default = "host";
+        };
+
+        security.audit = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+          };
+          extraRules = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+          };
+        };
+      };
+
+      config = {
+        ghaf.logging.enable = true;
+        ghaf.logging.fss = {
+          enable = true;
+          sealInterval = "1min";
+          verifyOnBoot = true;
+          activation.syncWaitSeconds = 1;
+        };
+
+        networking.hostName = "clock-ready-prod-defaults";
+
+        systemd.tmpfiles.rules = [
+          "d /persist/common/journal-fss 0755 root root - -"
+          "d /persist/common/journal-fss/clock-ready-prod-defaults 0700 root root - -"
+        ];
+      };
+    };
+
   testScript = _: ''
     machine = fss
     fss_only = fssOnly
     stateless_vm = statelessVm
+    clock_ready_prod = clockReadyProdDefaults
     machine.start(allow_reboot=True)
     fss_only.start()
     stateless_vm.start()
+    clock_ready_prod.start()
     machine.wait_for_unit("multi-user.target")
     fss_only.wait_for_unit("multi-user.target")
     stateless_vm.wait_for_unit("multi-user.target")
+
+    with subtest("Clock readiness completes and unblocks FSS at production defaults"):
+        # TimeoutStartSec = maxWaitSeconds (90) + 30 = 120s; the default
+        # wait_for_unit timeout comfortably covers that plus boot.
+        clock_ready_prod.wait_for_unit("ghaf-clock-ready.service")
+        clock_ready_prod.succeed("""
+          bash -lc '
+            set -euo pipefail
+            systemctl show ghaf-clock-ready.service --property=Result --value | grep -Fx success
+            # ready_established=1 means the barrier converged via genuine
+            # stability, not the maxWaitSeconds (90s) fallback -- confirms the
+            # 20s stableSeconds default is actually reachable, not just bounded.
+            grep -Fx "ready_established=1" /run/ghaf-clock-ready-state
+          '
+        """)
+        clock_ready_prod.wait_for_unit("systemd-journal-flush.service")
+        clock_ready_prod.wait_for_unit("journal-fss-setup.service")
+        clock_ready_prod.succeed(
+          "systemctl show journal-fss-setup.service --property=Result --value | grep -Fx success"
+        )
 
     with subtest("FSS stays disabled for stateless VMs"):
         stateless_vm.succeed("test ! -e /etc/systemd/system/journal-fss-setup.service")

--- a/tests/logging/test_scripts/fss-test.nix
+++ b/tests/logging/test_scripts/fss-test.nix
@@ -100,6 +100,51 @@ writeShellApplication {
       [ "$(journald_effective_seal)" = "yes" ]
     }
 
+    print_verification_warning_summary() {
+      echo "   Warning summary:"
+      if [ -n "''${FSS_ACTIVE_SYSTEM_FAILURES:-}" ]; then
+        echo "     active system journal: FAILED"
+      else
+        echo "     active system journal: OK"
+      fi
+
+      if printf '%s\n' "''${FSS_VERDICT_TAGS:-}" | grep -Fq "PRE_ACTIVATION_ARCHIVE"; then
+        if printf '%s\n' "''${FSS_VERDICT_TAGS:-}" | grep -Fq "PRE_ACTIVATION_STALE"; then
+          echo "     archived system journals: recorded stale pre-activation receipts"
+        else
+          echo "     archived system journals: recorded current-boot pre-activation receipts"
+        fi
+      elif printf '%s\n' "''${FSS_VERDICT_TAGS:-}" | grep -Fq "RECOVERY_ARCHIVE"; then
+        if printf '%s\n' "''${FSS_VERDICT_TAGS:-}" | grep -Fq "RECOVERY_STALE"; then
+          echo "     archived system journals: recorded stale recovery receipts"
+        else
+          echo "     archived system journals: recorded current-boot recovery receipts"
+        fi
+      elif printf '%s\n' "''${FSS_VERDICT_TAGS:-}" | grep -Fq "UNCLEAN_SHUTDOWN"; then
+        if printf '%s\n' "''${FSS_VERDICT_TAGS:-}" | grep -Fq "UNCLEAN_SHUTDOWN_STALE"; then
+          echo "     archived system journals: recorded stale unclean-shutdown receipts"
+        else
+          echo "     archived system journals: recorded current-boot unclean-shutdown receipts"
+        fi
+      elif [ -n "''${FSS_ARCHIVED_SYSTEM_FAILURES:-}" ]; then
+        echo "     archived system journals: unexpected archived-system failures"
+      else
+        echo "     archived system journals: OK"
+      fi
+
+      if [ -n "''${FSS_USER_FAILURES:-}" ]; then
+        echo "     user journals: verification warnings only"
+      else
+        echo "     user journals: OK"
+      fi
+
+      if [ -n "''${RECOVERY_RECEIPT_MISMATCHES:-}''${PRE_ACTIVATION_RECEIPT_MISMATCHES:-}''${UNCLEAN_RECEIPT_MISMATCHES:-}" ]; then
+        echo "     receipt mismatches: present"
+      else
+        echo "     receipt mismatches: none"
+      fi
+    }
+
     # Test 1: FSS setup service
     info "Test 1: Checking journal-fss-setup service..."
     if systemctl cat journal-fss-setup.service &>/dev/null; then
@@ -262,6 +307,7 @@ writeShellApplication {
         ;;
       warning)
         warn "Journal verification WARNING [$FSS_VERDICT_TAGS] ($FSS_VERDICT_REASON)"
+        print_verification_warning_summary
         echo "   Output: $VERIFY_OUTPUT"
         ;;
       fail)

--- a/tests/logging/test_scripts/fss-test.nix
+++ b/tests/logging/test_scripts/fss-test.nix
@@ -30,6 +30,7 @@
   coreutils,
   systemd,
   gnugrep,
+  gawk,
 }:
 let
   verifyClassifierLib = builtins.readFile ../../../modules/common/logging/fss-verify-classifier.sh;
@@ -40,7 +41,10 @@ writeShellApplication {
     coreutils
     systemd
     gnugrep
+    gawk
   ];
+  # Shared classifier library: some helper functions are unused in this consumer.
+  excludeShellChecks = [ "SC2329" ];
   text = ''
     ${verifyClassifierLib}
 
@@ -60,11 +64,41 @@ writeShellApplication {
     EOF
 
     MACHINE_ID=$(cat /etc/machine-id)
+    HOSTNAME="$(cat /proc/sys/kernel/hostname 2>/dev/null || echo unknown-host)"
     FSS_KEY="/var/log/journal/$MACHINE_ID/fss"
     FSS_KEY_VOLATILE="/run/log/journal/$MACHINE_ID/fss"
     FSS_CONFIG="/var/log/journal/$MACHINE_ID/fss-config"
     PRE_FSS_ARCHIVE_FILE="/var/log/journal/$MACHINE_ID/fss-pre-fss-archive"
-    RECOVERY_ARCHIVES_FILE="/var/log/journal/$MACHINE_ID/fss-recovery-archives"
+    RECOVERY_RECEIPTS_FILE="/var/log/journal/$MACHINE_ID/fss-recovery-receipts"
+    PRE_ACTIVATION_RECEIPTS_FILE="/var/log/journal/$MACHINE_ID/fss-pre-activation-receipts"
+    UNCLEAN_SHUTDOWN_RECEIPTS_FILE="/var/log/journal/$MACHINE_ID/fss-unclean-shutdown-receipts"
+    ACTIVATION_STATE_FILE="/var/log/journal/$MACHINE_ID/fss-activation-state"
+    FSS_BOOT_BASELINE_FILE="/var/log/journal/$MACHINE_ID/fss-baseline-boot"
+    CURRENT_BOOT_ID="$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot)"
+    ACTIVATION_MODE=0
+    if systemd-analyze cat-config systemd/journald.conf 2>/dev/null |
+      grep -iqE '^[[:space:]]*Seal[[:space:]]*=[[:space:]]*no'; then
+      ACTIVATION_MODE=1
+    fi
+
+    journald_effective_seal() {
+      systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
+        | awk -F= '
+          /^[[:space:]]*[#;]/ { next }
+          /^[[:space:]]*Seal[[:space:]]*=/ {
+            value = $2
+            sub(/^[[:space:]]*/, "", value)
+            sub(/[[:space:]]*[#;].*$/, "", value)
+            sub(/[[:space:]]*$/, "", value)
+            seal = tolower(value)
+          }
+          END { print seal }
+        '
+    }
+
+    sealing_active_in_config() {
+      [ "$(journald_effective_seal)" = "yes" ]
+    }
 
     # Test 1: FSS setup service
     info "Test 1: Checking journal-fss-setup service..."
@@ -98,7 +132,7 @@ writeShellApplication {
       KEY_DIR=$(cat "$FSS_CONFIG")
       info "Key directory (from fss-config): $KEY_DIR"
     else
-      for CANDIDATE in "/persist/common/journal-fss/$(hostname)" "/etc/common/journal-fss/$(hostname)"; do
+      for CANDIDATE in "/persist/common/journal-fss/$HOSTNAME" "/etc/common/journal-fss/$HOSTNAME"; do
         if [ -d "$CANDIDATE" ]; then
           KEY_DIR="$CANDIDATE"
           info "Key directory (from hostname fallback): $KEY_DIR"
@@ -111,7 +145,15 @@ writeShellApplication {
     info "Test 3: Checking verification key..."
     VERIFY_KEY_PATH=""
     VERIFY_KEY=""
-    if [ -n "$KEY_DIR" ] && [ -e "$KEY_DIR/verification-key" ]; then
+    KEY_DIR_INACCESSIBLE=0
+    if [ -n "$KEY_DIR" ] && [ ! -x "$KEY_DIR" ]; then
+      KEY_DIR_INACCESSIBLE=1
+      if [ "$(id -u)" -eq 0 ]; then
+        fail "Key directory is not searchable at $KEY_DIR"
+      else
+        warn "Key directory is not searchable as $(id -un); rerun fss-test as root"
+      fi
+    elif [ -n "$KEY_DIR" ] && [ -e "$KEY_DIR/verification-key" ]; then
       VERIFY_KEY_PATH="$KEY_DIR/verification-key"
       if [ -s "$VERIFY_KEY_PATH" ] && [ -r "$VERIFY_KEY_PATH" ]; then
         pass "Verification key exists at $VERIFY_KEY_PATH"
@@ -129,7 +171,9 @@ writeShellApplication {
 
     # Test 4: Initialization sentinel
     info "Test 4: Checking initialization sentinel..."
-    if [ -n "$KEY_DIR" ] && [ -f "$KEY_DIR/initialized" ]; then
+    if [ "$KEY_DIR_INACCESSIBLE" = 1 ]; then
+      warn "Initialization sentinel unavailable because key directory is not searchable"
+    elif [ -n "$KEY_DIR" ] && [ -f "$KEY_DIR/initialized" ]; then
       pass "Initialization sentinel exists at $KEY_DIR/initialized"
     else
       warn "Initialization sentinel not found"
@@ -140,31 +184,98 @@ writeShellApplication {
     if [ -z "$VERIFY_KEY" ]; then
       warn "Skipping verification (verification key unavailable)"
     else
+      if ! journalctl --sync >/dev/null 2>&1; then
+        warn "journalctl --sync failed before verification"
+      fi
       VERIFY_EXIT=0
       VERIFY_OUTPUT=$(journalctl --verify --verify-key="$VERIFY_KEY" 2>&1) || VERIFY_EXIT=$?
-      fss_classify_verify_output "$VERIFY_OUTPUT"
-      fss_verify_policy_decision \
-        "$(fss_read_recorded_pre_fss_archive "$PRE_FSS_ARCHIVE_FILE")" \
-        "$(fss_read_recorded_archive_list "$RECOVERY_ARCHIVES_FILE")"
+      FSS_VERDICT=""
+      FSS_VERDICT_TAGS=""
+      FSS_VERDICT_REASON=""
+      RAW_PRE_ACTIVATION_RECEIPTS=$(fss_read_pre_activation_receipts "$PRE_ACTIVATION_RECEIPTS_FILE")
+      RAW_RECOVERY_RECEIPTS=$(fss_read_receipts "$RECOVERY_RECEIPTS_FILE")
+      RAW_UNCLEAN_RECEIPTS=$(fss_read_unclean_shutdown_receipts "$UNCLEAN_SHUTDOWN_RECEIPTS_FILE")
+      RECOVERY_RECEIPT_MISMATCHES=$(fss_receipt_mismatches "$RAW_RECOVERY_RECEIPTS")
+      PRE_ACTIVATION_RECEIPT_MISMATCHES=$(fss_pre_activation_receipt_mismatches "$RAW_PRE_ACTIVATION_RECEIPTS")
+      UNCLEAN_RECEIPT_MISMATCHES=$(fss_unclean_shutdown_receipt_mismatches "$RAW_UNCLEAN_RECEIPTS")
+      if [ "$ACTIVATION_MODE" = 1 ]; then
+        ACTIVATION_STATE=""
+        ACTIVATION_BOOT_ID=""
+        ACTIVATION_BASELINE_BOOT_ID=""
+        if [ -r "$ACTIVATION_STATE_FILE" ]; then
+          ACTIVATION_STATE=$(awk -F '\t' 'NR == 1 { print $1 }' "$ACTIVATION_STATE_FILE")
+          ACTIVATION_BOOT_ID=$(awk -F '\t' 'NR == 1 { print $2 }' "$ACTIVATION_STATE_FILE")
+        fi
+        if [ -r "$FSS_BOOT_BASELINE_FILE" ]; then
+          ACTIVATION_BASELINE_BOOT_ID=$(tr -d '[:space:]' < "$FSS_BOOT_BASELINE_FILE")
+        fi
+        if [ "$ACTIVATION_STATE" = "failed" ]; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS="ACTIVATION_FAILED"
+          FSS_VERDICT_REASON="FSS sealing was not activated"
+        elif [ "$ACTIVATION_STATE" != "active" ] \
+          || [ "$ACTIVATION_BOOT_ID" != "$CURRENT_BOOT_ID" ] \
+          || [ "$ACTIVATION_BASELINE_BOOT_ID" != "$CURRENT_BOOT_ID" ]; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS="ACTIVATION_STALE"
+          FSS_VERDICT_REASON="FSS activation state is not active for current boot"
+        elif ! sealing_active_in_config; then
+          FSS_VERDICT=fail
+          FSS_VERDICT_TAGS="ACTIVATION_FAILED"
+          FSS_VERDICT_REASON="effective journald Seal setting is not yes"
+        fi
+      fi
+
+      if [ -z "$FSS_VERDICT" ] && [ -n "$RECOVERY_RECEIPT_MISMATCHES" ]; then
+        FSS_VERDICT=fail
+        FSS_VERDICT_TAGS="RECOVERY_RECEIPT_MISMATCH"
+        FSS_VERDICT_REASON="recovery receipt content mismatch"
+      elif [ -z "$FSS_VERDICT" ] && [ -n "$PRE_ACTIVATION_RECEIPT_MISMATCHES" ]; then
+        FSS_VERDICT=fail
+        FSS_VERDICT_TAGS="PRE_ACTIVATION_RECEIPT_MISMATCH"
+        FSS_VERDICT_REASON="pre-activation receipt content mismatch"
+      elif [ -z "$FSS_VERDICT" ] && [ -n "$UNCLEAN_RECEIPT_MISMATCHES" ]; then
+        FSS_VERDICT=fail
+        FSS_VERDICT_TAGS="UNCLEAN_SHUTDOWN_RECEIPT_MISMATCH"
+        FSS_VERDICT_REASON="unclean-shutdown receipt content mismatch"
+      elif [ -z "$FSS_VERDICT" ]; then
+        fss_classify_verify_output "$VERIFY_OUTPUT"
+        fss_verify_policy_decision \
+          "$(fss_read_recorded_pre_fss_archive "$PRE_FSS_ARCHIVE_FILE")" \
+          "$(fss_filter_valid_receipts "$RAW_RECOVERY_RECEIPTS")" \
+          "$(fss_filter_valid_receipts "$RAW_PRE_ACTIVATION_RECEIPTS")" \
+          "$CURRENT_BOOT_ID" \
+          "$VERIFY_EXIT" \
+          "$(fss_filter_valid_receipts "$RAW_UNCLEAN_RECEIPTS")"
+      fi
 
       case "$FSS_VERDICT" in
-      pass)
+      verified)
         if [ -n "$FSS_VERDICT_REASON" ]; then
-          pass "Journal verification passed ($FSS_VERDICT_REASON)"
+          pass "Journal verification verified ($FSS_VERDICT_REASON)"
         else
-          pass "Journal verification passed"
+          pass "Journal verification verified"
         fi
         ;;
-      partial)
-        warn "Journal verification PARTIAL [$FSS_VERDICT_TAGS] ($FSS_VERDICT_REASON)"
+      verified-with-exception)
+        pass "Journal verification verified with recorded exception [$FSS_VERDICT_TAGS] ($FSS_VERDICT_REASON)"
+        ;;
+      warning)
+        warn "Journal verification WARNING [$FSS_VERDICT_TAGS] ($FSS_VERDICT_REASON)"
         echo "   Output: $VERIFY_OUTPUT"
         ;;
       fail)
         fail "Journal verification FAILED [$FSS_VERDICT_TAGS] ($FSS_VERDICT_REASON)"
+        [ -n "''${RECOVERY_RECEIPT_MISMATCHES:-}" ] &&
+          echo "   Mismatched recovery receipts: $RECOVERY_RECEIPT_MISMATCHES"
+        [ -n "''${PRE_ACTIVATION_RECEIPT_MISMATCHES:-}" ] &&
+          echo "   Mismatched pre-activation receipts: $PRE_ACTIVATION_RECEIPT_MISMATCHES"
+        [ -n "''${UNCLEAN_RECEIPT_MISMATCHES:-}" ] &&
+          echo "   Mismatched unclean-shutdown receipts: $UNCLEAN_RECEIPT_MISMATCHES"
         echo "   Output: $VERIFY_OUTPUT"
         ;;
       esac
-      [ "$VERIFY_EXIT" -ne 0 ] && [ "$FSS_VERDICT" = "pass" ] &&
+      [ "$VERIFY_EXIT" -ne 0 ] && [ "$FSS_VERDICT" != "fail" ] &&
         info "journalctl --verify returned exit $VERIFY_EXIT with no critical errors"
     fi
 
@@ -185,12 +296,22 @@ writeShellApplication {
     # Test 7: Audit rules
     info "Test 7: Checking audit rules..."
     if command -v auditctl &>/dev/null; then
-      RULES=$(auditctl -l 2>/dev/null || echo "no rules")
-      if echo "$RULES" | grep -q "journal_fss_keys\|journal_sealed_logs"; then
-        pass "FSS audit rules are configured"
-      elif echo "$RULES" | grep -q "No rules"; then
-        warn "No audit rules configured (auditd may not be enabled)"
+      AUDITCTL_OUTPUT=""
+      if AUDITCTL_OUTPUT=$(auditctl -l 2>&1); then
+        RULES="$AUDITCTL_OUTPUT"
+      elif [ "$(id -u)" -ne 0 ]; then
+        warn "Audit rules unreadable as $(id -un); rerun fss-test as root"
+        RULES=""
       else
+        warn "Could not list audit rules: $AUDITCTL_OUTPUT"
+        RULES=""
+      fi
+
+      if [ -n "$RULES" ] && echo "$RULES" | grep -q "journal_fss_keys\|journal_sealed_logs"; then
+        pass "FSS audit rules are configured"
+      elif [ -n "$RULES" ] && echo "$RULES" | grep -q "No rules"; then
+        warn "No audit rules configured (auditd may not be enabled)"
+      elif [ -n "$RULES" ]; then
         warn "FSS-specific audit rules not found"
       fi
     else

--- a/tests/logging/test_scripts/fss-test.nix
+++ b/tests/logging/test_scripts/fss-test.nix
@@ -32,9 +32,6 @@
   gnugrep,
   gawk,
 }:
-let
-  verifyClassifierLib = builtins.readFile ../../../modules/common/logging/fss-verify-classifier.sh;
-in
 writeShellApplication {
   name = "fss-test";
   runtimeInputs = [
@@ -43,10 +40,11 @@ writeShellApplication {
     gnugrep
     gawk
   ];
-  # Shared classifier library: some helper functions are unused in this consumer.
-  excludeShellChecks = [ "SC2329" ];
+  # /etc/fss-verify-classifier.sh is populated at runtime by fss.nix; shellcheck
+  # cannot follow it statically.
+  excludeShellChecks = [ "SC1091" ];
   text = ''
-    ${verifyClassifierLib}
+    source /etc/fss-verify-classifier.sh
 
     PASSED=0
     FAILED=0

--- a/tests/logging/test_scripts/fss-test.nix
+++ b/tests/logging/test_scripts/fss-test.nix
@@ -72,31 +72,12 @@ writeShellApplication {
     UNCLEAN_SHUTDOWN_RECEIPTS_FILE="/var/log/journal/$MACHINE_ID/fss-unclean-shutdown-receipts"
     ACTIVATION_STATE_FILE="/var/log/journal/$MACHINE_ID/fss-activation-state"
     FSS_BOOT_BASELINE_FILE="/var/log/journal/$MACHINE_ID/fss-baseline-boot"
-    CURRENT_BOOT_ID="$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown-boot)"
+    CURRENT_BOOT_ID="$(fss_current_boot_id)"
     ACTIVATION_MODE=0
     if systemd-analyze cat-config systemd/journald.conf 2>/dev/null |
       grep -iqE '^[[:space:]]*Seal[[:space:]]*=[[:space:]]*no'; then
       ACTIVATION_MODE=1
     fi
-
-    journald_effective_seal() {
-      systemd-analyze cat-config systemd/journald.conf 2>/dev/null \
-        | awk -F= '
-          /^[[:space:]]*[#;]/ { next }
-          /^[[:space:]]*Seal[[:space:]]*=/ {
-            value = $2
-            sub(/^[[:space:]]*/, "", value)
-            sub(/[[:space:]]*[#;].*$/, "", value)
-            sub(/[[:space:]]*$/, "", value)
-            seal = tolower(value)
-          }
-          END { print seal }
-        '
-    }
-
-    sealing_active_in_config() {
-      [ "$(journald_effective_seal)" = "yes" ]
-    }
 
     print_verification_warning_summary() {
       echo "   Warning summary:"
@@ -262,7 +243,7 @@ writeShellApplication {
           FSS_VERDICT=fail
           FSS_VERDICT_TAGS="ACTIVATION_STALE"
           FSS_VERDICT_REASON="FSS activation state is not active for current boot"
-        elif ! sealing_active_in_config; then
+        elif ! fss_sealing_active_in_config; then
           FSS_VERDICT=fail
           FSS_VERDICT_TAGS="ACTIVATION_FAILED"
           FSS_VERDICT_REASON="effective journald Seal setting is not yes"

--- a/tests/logging/test_scripts/fss-test.nix
+++ b/tests/logging/test_scripts/fss-test.nix
@@ -281,9 +281,6 @@ writeShellApplication {
           pass "Journal verification verified"
         fi
         ;;
-      verified-with-exception)
-        pass "Journal verification verified with recorded exception [$FSS_VERDICT_TAGS] ($FSS_VERDICT_REASON)"
-        ;;
       warning)
         warn "Journal verification WARNING [$FSS_VERDICT_TAGS] ($FSS_VERDICT_REASON)"
         print_verification_warning_summary

--- a/tests/logging/test_scripts/fss-triage.nix
+++ b/tests/logging/test_scripts/fss-triage.nix
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+import ../../../packages/pkgs-by-name/fss-triage/package.nix

--- a/tests/logging/test_scripts/fss_setup.nix
+++ b/tests/logging/test_scripts/fss_setup.nix
@@ -36,10 +36,12 @@ _: ''
       exit_code, _ = machine.execute(f"test -f /var/log/journal/{mid}/fss")
       if exit_code == 0:
           print(f"FSS sealing key exists at /var/log/journal/{mid}/fss")
+          machine.succeed(f"test \"$(stat -c '%U:%G %a' /var/log/journal/{mid}/fss)\" = 'root:root 600'")
       else:
           exit_code2, _ = machine.execute(f"test -f /run/log/journal/{mid}/fss")
           if exit_code2 == 0:
               print("FSS sealing key exists in volatile storage")
+              machine.succeed(f"test \"$(stat -c '%U:%G %a' /run/log/journal/{mid}/fss)\" = 'root:root 600'")
           else:
               print("FSS sealing key not found - service conditions may not have been met")
 
@@ -63,6 +65,32 @@ _: ''
               print("Verification key exists and is non-empty")
           else:
               print("Skipping verification key assertion because setup did not complete successfully")
+
+  with subtest("Runtime FSS activation config is written"):
+      if setup_succeeded:
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              test -f /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf
+              grep -Fx "[Journal]" /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf
+              grep -Fx "Seal=yes" /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf
+              systemd-analyze cat-config systemd/journald.conf | grep -E "^[[:space:]]*Seal[[:space:]]*=[[:space:]]*no"
+              effective_seal=$(systemd-analyze cat-config systemd/journald.conf | awk -F= '"'"'
+                /^[[:space:]]*[#;]/ { next }
+                /^[[:space:]]*Seal[[:space:]]*=/ {
+                  value = $2
+                  sub(/^[[:space:]]*/, "", value)
+                  sub(/[[:space:]]*[#;].*$/, "", value)
+                  sub(/[[:space:]]*$/, "", value)
+                  seal = tolower(value)
+                }
+                END { print seal }
+              '"'"')
+              [ "$effective_seal" = yes ]
+            '
+          """)
+      else:
+          print("Skipping runtime activation assertion because setup did not complete successfully")
 
   with subtest("Initialized sentinel exists"):
       if setup_succeeded:

--- a/tests/logging/test_scripts/fss_verification.nix
+++ b/tests/logging/test_scripts/fss_verification.nix
@@ -32,11 +32,28 @@ _: ''
               set -euo pipefail
               source /etc/fss-verify-classifier.sh
               MID=$(cat /etc/machine-id)
-              VERIFY_OUTPUT=$(journalctl --verify --verify-key="$(cat {verify_key_path})" 2>&1 || true)
+              journalctl --sync
+              VERIFY_EXIT=0
+              VERIFY_OUTPUT=$(journalctl --verify --verify-key="$(cat {verify_key_path})" 2>&1) || VERIFY_EXIT=$?
+              RAW_RECOVERY_RECEIPTS=$(fss_read_receipts "/var/log/journal/$MID/fss-recovery-receipts")
+              RAW_PRE_ACTIVATION_RECEIPTS=$(fss_read_pre_activation_receipts "/var/log/journal/$MID/fss-pre-activation-receipts")
+              RAW_UNCLEAN_RECEIPTS=$(fss_read_unclean_shutdown_receipts "/var/log/journal/$MID/fss-unclean-shutdown-receipts")
+              RECOVERY_RECEIPT_MISMATCHES=$(fss_receipt_mismatches "$RAW_RECOVERY_RECEIPTS")
+              PRE_ACTIVATION_RECEIPT_MISMATCHES=$(fss_pre_activation_receipt_mismatches "$RAW_PRE_ACTIVATION_RECEIPTS")
+              UNCLEAN_RECEIPT_MISMATCHES=$(fss_unclean_shutdown_receipt_mismatches "$RAW_UNCLEAN_RECEIPTS")
+              if [ -n "$RECOVERY_RECEIPT_MISMATCHES$PRE_ACTIVATION_RECEIPT_MISMATCHES$UNCLEAN_RECEIPT_MISMATCHES" ]; then
+                printf "receipt mismatch: recovery=%s pre_activation=%s unclean=%s\n" \
+                  "$RECOVERY_RECEIPT_MISMATCHES" "$PRE_ACTIVATION_RECEIPT_MISMATCHES" "$UNCLEAN_RECEIPT_MISMATCHES"
+                exit 1
+              fi
               fss_classify_verify_output "$VERIFY_OUTPUT"
               fss_verify_policy_decision \
                 "$(fss_read_recorded_pre_fss_archive "/var/log/journal/$MID/fss-pre-fss-archive")" \
-                "$(fss_read_recorded_archive_list "/var/log/journal/$MID/fss-recovery-archives")"
+                "$(fss_filter_valid_receipts "$RAW_RECOVERY_RECEIPTS")" \
+                "$(fss_filter_valid_receipts "$RAW_PRE_ACTIVATION_RECEIPTS")" \
+                "$(cat /proc/sys/kernel/random/boot_id)" \
+                "$VERIFY_EXIT" \
+                "$(fss_filter_valid_receipts "$RAW_UNCLEAN_RECEIPTS")"
               if [ "$FSS_VERDICT" = "fail" ]; then
                 printf "%s\\n%s\\n" "$FSS_VERDICT_TAGS" "$VERIFY_OUTPUT"
                 exit 1
@@ -53,69 +70,222 @@ _: ''
           set -euo pipefail
           source /etc/fss-verify-classifier.sh
 
-          # Assert that classifying $sample and running policy with $pre/$recov yields $want.
-          # Usage: assert_verdict <want> <sample> [expected_pre] [expected_recovery]
+          # Assert that classifying $sample and running policy yields $want.
+          # Usage: assert_verdict <want> <sample> [pre] [recovery_receipts] [pre_activation_receipts] [boot] [verify_exit]
           assert_verdict() {
-            local want="$1" sample="$2" pre="''${3:-}" recov="''${4:-}"
+            local want="$1" sample="$2" pre="''${3:-}" recov="''${4:-}" receipts="''${5:-}" boot="''${6:-}" verify_exit="''${7:-0}" unclean="''${8:-}"
             fss_classify_verify_output "$sample"
-            fss_verify_policy_decision "$pre" "$recov"
+            fss_verify_policy_decision "$pre" "$recov" "$receipts" "$boot" "$verify_exit" "$unclean"
             if [ "$FSS_VERDICT" != "$want" ]; then
-              printf "verdict mismatch: want=%s got=%s reason=%s sample=%s\n" \
-                "$want" "$FSS_VERDICT" "$FSS_VERDICT_REASON" "$sample" >&2
+              printf "verdict mismatch: want=%s got=%s reason=%s tags=%s sample=%s\n" \
+                "$want" "$FSS_VERDICT" "$FSS_VERDICT_REASON" "$FSS_VERDICT_TAGS" "$sample" >&2
               return 1
             fi
           }
 
+          # Build a synthetic pre-activation receipt record for path and boot id.
+          mkreceipt() {
+            printf "v1\t%s\t111\t2048\t%s\t1700000000\tdeadbeef\tpre-activation-rotation\tevt" "$1" "$2"
+          }
+
+          mkuncleanreceipt() {
+            printf "v1\t%s\t111\t2048\t%s\t1700000000\tdeadbeef\tunclean-shutdown\tevt" "$1" "$2"
+          }
+
+          CURBOOT="boot-current"
           ACTIVE="/var/log/journal/mid/system.journal"
           ALLOWED_ARCHIVE="/var/log/journal/mid/system@0000000000000001-0000000000000002.journal"
           RECOVERY_ARCHIVE="/var/log/journal/mid/system@0000000000000005-0000000000000006.journal"
+          STALE_RECOVERY_ARCHIVE="/var/log/journal/mid/system@0000000000000011-0000000000000012.journal"
+          PRE_ACTIVATION_ARCHIVE="/var/log/journal/mid/system@0000000000000007-0000000000000008.journal"
+          STALE_PRE_ACTIVATION_ARCHIVE="/var/log/journal/mid/system@0000000000000009-0000000000000010.journal"
           UNEXPECTED_ARCHIVE="/var/log/journal/mid/system@0000000000000003-0000000000000004.journal"
           USER_JOURNAL="/var/log/journal/mid/user-1000@0000000000000001-0000000000000002.journal"
-          TEMP_JOURNAL="/var/log/journal/mid/system@0000000000000001-0000000000000002.journal~"
+          TEMP_JOURNAL="/var/log/journal/mid/custom.journal~"
+          ACTIVE_TEMP_JOURNAL="/var/log/journal/mid/system.journal~"
+          ARCHIVED_TEMP_JOURNAL="/var/log/journal/mid/system@0000000000000001-0000000000000002.journal~"
           OTHER="/var/log/journal/mid/custom.journal"
 
           # Active system failure → fail
           assert_verdict fail "FAIL: $ACTIVE (Bad message)"
           [ "$FSS_REASON_TAGS" = "BAD_MESSAGE" ]
 
-          # Allowed archive only → partial (matches pre-FSS allowlist)
-          assert_verdict partial \
+          # Clean output → verified
+          assert_verdict verified "PASS: $ACTIVE"
+
+          # Clean output with current-boot pre-activation receipt still means
+          # verified-with-exception: those entries were structurally readable but
+          # not FSS-trusted.
+          assert_verdict verified-with-exception \
+            "PASS: $ACTIVE" \
+            "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "$CURBOOT")" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "recorded insecure boot logs (current boot)" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "PRE_ACTIVATION_ARCHIVE"
+
+          # Clean output with only an EARLIER-boot pre-activation receipt → warning:
+          # old unsealed boot logs lingering on disk must not report as fully verified.
+          assert_verdict warning \
+            "PASS: $ACTIVE" \
+            "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "boot-earlier")" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "insecure boot logs from an earlier boot" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "PRE_ACTIVATION_STALE"
+
+          # Clean output with both current and earlier-boot receipts → warning:
+          # stale retained evidence must not be hidden by a new current-boot receipt.
+          MIXED_PRE_ACTIVATION_RECEIPTS="$(printf "%s\n%s" \
+            "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "$CURBOOT")" \
+            "$(mkreceipt "$STALE_PRE_ACTIVATION_ARCHIVE" "boot-earlier")")"
+          assert_verdict warning \
+            "PASS: $ACTIVE" \
+            "" "" "$MIXED_PRE_ACTIVATION_RECEIPTS" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "insecure boot logs from an earlier boot" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "PRE_ACTIVATION_STALE"
+
+          # Allowed archive only → verified-with-exception (matches pre-FSS allowlist)
+          assert_verdict verified-with-exception \
             "$(printf "FAIL: %s (Input/output error)\nPASS: %s" "$ALLOWED_ARCHIVE" "$ACTIVE")" \
             "$ALLOWED_ARCHIVE"
           [ "$FSS_REASON_TAGS" = "INPUT_OUTPUT_ERROR" ]
+          [ "$FSS_VERDICT_REASON" = "recorded archived-system exceptions only" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "PRE_FSS_ARCHIVE"
           fss_matches_only_expected_archived_system_failure "$ALLOWED_ARCHIVE"
 
-          # Recovery archive (duplicate in list, to test dedup) → partial
-          assert_verdict partial \
+          # Legacy path-only recovery archive → fail (no longer trusted)
+          assert_verdict fail \
             "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$RECOVERY_ARCHIVE" "$ACTIVE")" \
             "" "$(printf "%s\n%s" "$RECOVERY_ARCHIVE" "$RECOVERY_ARCHIVE")"
+
+          # Current-boot recovery receipt → verified-with-exception
+          assert_verdict verified-with-exception \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$RECOVERY_ARCHIVE" "$ACTIVE")" \
+            "" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "recorded recovery archive (current boot)" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "RECOVERY_ARCHIVE"
+
+          # Earlier-boot recovery receipt → warning
+          assert_verdict warning \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$STALE_RECOVERY_ARCHIVE" "$ACTIVE")" \
+            "" "$(mkreceipt "$STALE_RECOVERY_ARCHIVE" "boot-earlier")" "" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "recovery archive from an earlier boot" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "RECOVERY_STALE"
+
+          # Current-boot pre-activation receipt → verified-with-exception
+          assert_verdict verified-with-exception \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$PRE_ACTIVATION_ARCHIVE" "$ACTIVE")" \
+            "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "$CURBOOT")" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "recorded insecure boot logs (current boot)" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "PRE_ACTIVATION_ARCHIVE"
+          ! printf "%s" "$FSS_VERDICT_TAGS" | grep -F "PRE_ACTIVATION_STALE"
+
+          # Earlier-boot pre-activation receipt → warning (evidenced but stale)
+          assert_verdict warning \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$PRE_ACTIVATION_ARCHIVE" "$ACTIVE")" \
+            "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "boot-earlier")" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "insecure boot logs from an earlier boot" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "PRE_ACTIVATION_STALE"
+
+          # Archived failure with no matching receipt → fail (unrecorded/substituted)
+          assert_verdict fail \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$PRE_ACTIVATION_ARCHIVE" "$ACTIVE")" \
+            "" "" "" "$CURBOOT"
 
           # Unexpected archive → fail
           assert_verdict fail \
             "$(printf "FAIL: %s (Input/output error)\nPASS: %s" "$UNEXPECTED_ARCHIVE" "$ACTIVE")" \
-            "$ALLOWED_ARCHIVE" "$(printf "%s" "$RECOVERY_ARCHIVE")"
+            "$ALLOWED_ARCHIVE" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
 
-          # Allowed + recovery archives together → partial
-          assert_verdict partial \
+          # Allowed + recovery archives together → verified-with-exception
+          assert_verdict verified-with-exception \
             "$(printf "FAIL: %s (Bad message)\nFAIL: %s (Bad message)" "$ALLOWED_ARCHIVE" "$RECOVERY_ARCHIVE")" \
-            "$ALLOWED_ARCHIVE" "$(printf "%s" "$RECOVERY_ARCHIVE")"
+            "$ALLOWED_ARCHIVE" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
 
           # Allowed + unexpected archive → fail (allowlist miss on one path)
           assert_verdict fail \
             "$(printf "FAIL: %s (Bad message)\nFAIL: %s (Bad message)" "$ALLOWED_ARCHIVE" "$UNEXPECTED_ARCHIVE")" \
-            "$ALLOWED_ARCHIVE" "$(printf "%s" "$RECOVERY_ARCHIVE")"
+            "$ALLOWED_ARCHIVE" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
 
-          # User journal failure alone → partial (non-fatal)
-          assert_verdict partial "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$USER_JOURNAL" "$ACTIVE")"
+          # Filesystem restrictions make otherwise allowlisted verifies a warning
+          assert_verdict warning "Failed to open journal file: Read-only file system"
+          [ "$FSS_VERDICT_REASON" = "filesystem restrictions encountered" ]
+
+          assert_verdict warning \
+            "$(printf "Failed to open journal file: Read-only file system\nFAIL: %s (Bad message)" "$ALLOWED_ARCHIVE")" \
+            "$ALLOWED_ARCHIVE"
+          [ "$FSS_VERDICT_REASON" = "filesystem restrictions encountered" ]
+
+          assert_verdict warning \
+            "$(printf "Failed to open journal file: Permission denied\nFAIL: %s (Bad message)" "$RECOVERY_ARCHIVE")" \
+            "" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "filesystem restrictions encountered" ]
+
+          assert_verdict fail \
+            "$(printf "Failed to open journal file: Read-only file system\nFAIL: %s (Bad message)" "$UNEXPECTED_ARCHIVE")" \
+            "$ALLOWED_ARCHIVE" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
+
+          # User journal failure alone → warning (non-fatal)
+          assert_verdict warning "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$USER_JOURNAL" "$ACTIVE")"
           [ -n "$FSS_USER_FAILURES" ]
           [ -z "$FSS_ACTIVE_SYSTEM_FAILURES" ]
 
-          # User journal with corruption diagnostics → partial
-          assert_verdict partial "$(printf "2cb2e0: Tag failed verification\nFile corruption detected at %s:2929376 (of 8388608 bytes, 34%%).\nFAIL: %s (Bad message)\nPASS: %s" "$USER_JOURNAL" "$USER_JOURNAL" "$ACTIVE")"
+          # Localized journalctl reason text still classifies by failed path.
+          assert_verdict warning "$(printf "FAIL: %s (Virheellinen viesti)\nPASS: %s" "$USER_JOURNAL" "$ACTIVE")"
+          [ -n "$FSS_USER_FAILURES" ]
+          [ -z "$FSS_ACTIVE_SYSTEM_FAILURES" ]
+          ! printf "%s" "$FSS_REASON_TAGS" | grep -F "BAD_MESSAGE"
 
-          # Temp journal failure → pass (ignored)
-          assert_verdict pass "FAIL: $TEMP_JOURNAL (Bad message)"
+          assert_verdict fail "FAIL: $ACTIVE (Virheellinen viesti)"
+          [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ]
+          [ -z "$FSS_REASON_TAGS" ]
+
+          # User journal with corruption diagnostics → warning
+          assert_verdict warning "$(printf "2cb2e0: Tag failed verification\nFile corruption detected at %s:2929376 (of 8388608 bytes, 34%%).\nFAIL: %s (Bad message)\nPASS: %s" "$USER_JOURNAL" "$USER_JOURNAL" "$ACTIVE")"
+
+          # Temp journal failure → warning (ignored leftover)
+          assert_verdict warning "FAIL: $TEMP_JOURNAL (Bad message)"
           [ -n "$FSS_TEMP_FAILURES" ]
+
+          # Critical system journals renamed with ~ retain their base severity.
+          assert_verdict fail "FAIL: $ACTIVE_TEMP_JOURNAL (Bad message)"
+          [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ]
+          assert_verdict fail "FAIL: $ARCHIVED_TEMP_JOURNAL (Bad message)"
+          [ -n "$FSS_ARCHIVED_SYSTEM_FAILURES" ]
+
+          # Unclean-shutdown receipting (journald-attested, content-bound). An
+          # archived .journal~ corpse with a current-boot unclean receipt is an
+          # expected exception, not a hard fail.
+          assert_verdict verified-with-exception \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$ARCHIVED_TEMP_JOURNAL" "$ACTIVE")" \
+            "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "$CURBOOT")"
+          [ "$FSS_VERDICT_REASON" = "recorded unclean-shutdown journal (current boot)" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "UNCLEAN_SHUTDOWN"
+
+          # The active system.journal~ corpse is carved out of the fatal active-system
+          # set only with a matching content-bound receipt.
+          assert_verdict verified-with-exception \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$ACTIVE_TEMP_JOURNAL" "$ACTIVE")" \
+            "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ACTIVE_TEMP_JOURNAL" "$CURBOOT")"
+
+          # The LIVE system.journal (no ~) is NEVER exempted, even with an unclean
+          # receipt present for some other path.
+          assert_verdict fail \
+            "FAIL: $ACTIVE (Bad message)" \
+            "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "$CURBOOT")"
+
+          # An unmatched system@*.journal~ (no receipt) still fails closed.
+          assert_verdict fail \
+            "FAIL: $ARCHIVED_TEMP_JOURNAL (Bad message)" \
+            "" "" "" "$CURBOOT" 1 ""
+
+          # Earlier-boot unclean receipt → warning (stale must not pass forever).
+          assert_verdict warning \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$ARCHIVED_TEMP_JOURNAL" "$ACTIVE")" \
+            "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "boot-earlier")"
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "UNCLEAN_SHUTDOWN_STALE"
+
+          # Clean output + current-boot unclean receipt → verified-with-exception.
+          assert_verdict verified-with-exception \
+            "PASS: $ACTIVE" \
+            "" "" "" "$CURBOOT" 0 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "$CURBOOT")"
 
           # Other/unclassified journal → fail
           assert_verdict fail "FAIL: $OTHER (Bad message)"
@@ -127,10 +297,34 @@ _: ''
           [ "$FSS_KEY_REQUIRED_ERROR" -eq 1 ]
           [ "$FSS_REASON_TAGS" = "KEY_PARSE_ERROR,KEY_MISSING" ]
 
-          # Empty input → pass (no findings)
-          assert_verdict pass ""
+          # Empty input → verified (no findings)
+          assert_verdict verified ""
           [ -z "$FSS_REASON_TAGS" ]
           [ -z "$FSS_FAIL_LINES" ]
+
+          # Nonzero verify exit with no classified exception → fail
+          assert_verdict fail "" "" "" "" "$CURBOOT" 42
+          [ "$FSS_VERDICT_REASON" = "journalctl verify exited nonzero without a classified exception" ]
+          printf "%s" "$FSS_VERDICT_TAGS" | grep -F "VERIFY_EXIT_UNCLASSIFIED"
+
+          # Content-bound receipt filtering against the live filesystem.
+          real=$(mktemp)
+          printf "original" > "$real"
+          rino=$(stat -c %i "$real"); rsz=$(stat -c %s "$real"); rsha=$(sha256sum "$real" | cut -d" " -f1)
+          good=$(printf "v1\t%s\t%s\t%s\t%s\t1\t%s\tpre-activation-rotation\tevt" "$real" "$rino" "$rsz" "$CURBOOT" "$rsha")
+          [ "$(fss_filter_valid_receipts "$good")" = "$good" ]
+          [ -z "$(fss_pre_activation_receipt_mismatches "$good")" ]
+          weak=$(printf "v1\t%s\t%s\t%s\t%s\t1\t-\tpre-activation-rotation\tevt" "$real" "$rino" "$rsz" "$CURBOOT")
+          [ -z "$(fss_filter_valid_receipts "$weak")" ]
+          [ -z "$(fss_pre_activation_receipt_mismatches "$weak")" ]
+          # Substituted content (size + hash change) → receipt dropped
+          printf "tampered-and-longer" > "$real"
+          [ "$(fss_pre_activation_receipt_mismatches "$good")" = "$real" ]
+          [ -z "$(fss_filter_valid_receipts "$good")" ]
+          # Missing file → receipt dropped
+          rm -f "$real"
+          [ -z "$(fss_pre_activation_receipt_mismatches "$good")" ]
+          [ -z "$(fss_filter_valid_receipts "$good")" ]
 
           # Bucket classification and dedup of unique fail paths
           MIXED=$(printf "FAIL: %s (Bad message)\nFAIL: %s (Bad message)\nFAIL: %s (Bad message)\nFAIL: %s (Bad message)\nFAIL: %s (Bad message)\nFAIL: %s (Bad message)" \
@@ -140,6 +334,8 @@ _: ''
           [ "$(fss_failure_bucket_for_path "$ALLOWED_ARCHIVE")" = "archived-system" ]
           [ "$(fss_failure_bucket_for_path "$USER_JOURNAL")" = "user-journal" ]
           [ "$(fss_failure_bucket_for_path "$TEMP_JOURNAL")" = "temp" ]
+          [ "$(fss_failure_bucket_for_path "$ACTIVE_TEMP_JOURNAL")" = "active-system" ]
+          [ "$(fss_failure_bucket_for_path "$ARCHIVED_TEMP_JOURNAL")" = "archived-system" ]
           [ "$(fss_failure_bucket_for_path "$OTHER")" = "other" ]
 
           # Log format: level names are case-insensitive; output has no color when stdout is piped.
@@ -166,12 +362,85 @@ _: ''
       """)
 
   with subtest("Clock-jump recovery defaults are enabled"):
+      machine.succeed("systemctl list-unit-files ghaf-clock-ready.service")
       machine.succeed("systemctl list-unit-files ghaf-clock-jump-watcher.service")
       machine.succeed("systemctl list-unit-files ghaf-journal-alloy-recover.service")
+      machine.wait_for_unit("ghaf-clock-ready.service")
       machine.wait_for_unit("ghaf-clock-jump-watcher.service")
       status = machine.succeed("systemctl show ghaf-clock-jump-watcher.service --property=ActiveState,UnitFileState")
       if "ActiveState=active" not in status or "UnitFileState=enabled" not in status:
           raise Exception(f"Clock-jump watcher not enabled: {status}")
+
+  with subtest("Clock readiness gates persistent FSS logging"):
+      machine.wait_for_unit("ghaf-clock-sync.service")
+      machine.succeed("""
+        bash -lc '
+          set -euo pipefail
+          test -e /run/ghaf-clock-ready
+          test -s /run/ghaf-clock-ready-state
+          test -s /var/lib/ghaf/clock-ready/last-good-realtime
+          # The early barrier defers the NTP wait so it cannot stall journal flush.
+          grep -F "sync_result=deferred" /run/ghaf-clock-ready-state
+          systemctl cat ghaf-clock-ready.service | grep -F "TimeoutStartSec=35s"
+
+          # The NTP wait happens in the separate sync unit, after networking.
+          test -s /run/ghaf-clock-sync-state
+          grep -E "sync_result=(synchronized|timeout|disabled|timedatectl-unavailable)" /run/ghaf-clock-sync-state
+
+          # The early journal flush only waits on the fast barrier, never the NTP unit.
+          for unit in systemd-journal-flush.service journal-fss-setup.service journal-fss-verify.service; do
+            systemctl show "$unit" --property=After --property=Requires --property=Wants |
+              grep -F "ghaf-clock-ready.service"
+          done
+          flush_after="$(systemctl show systemd-journal-flush.service --property=After)"
+          if printf "%s" "$flush_after" | grep -F "ghaf-clock-sync.service"; then
+            echo "journal flush must not order after the NTP sync unit" >&2
+            exit 1
+          fi
+          # FSS activation, however, must wait for the sync unit.
+          systemctl show journal-fss-setup.service --property=After | grep -F "ghaf-clock-sync.service"
+
+          # Clock-jump recovery must not run in the activation Seal=no window.
+          for unit in ghaf-clock-jump-watcher.service ghaf-journal-alloy-recover.service; do
+            systemctl show "$unit" --property=After --property=Wants |
+              grep -F "journal-fss-setup.service"
+          done
+        '
+      """)
+
+  with subtest("Clock readiness does not downgrade last-good anchor on fallback"):
+      machine.succeed("""
+        bash -lc '
+          set -euo pipefail
+          anchor="/var/lib/ghaf/clock-ready/last-good-realtime"
+          future="$(( $(date +%s) + 3600 ))"
+          printf "%s\n" "$future" > "$anchor"
+          chmod 0644 "$anchor"
+          rm -f /run/ghaf-clock-ready
+          systemctl reset-failed ghaf-clock-ready.service >/dev/null 2>&1 || true
+          systemctl restart ghaf-clock-ready.service
+          [ "$(cat "$anchor")" = "$future" ]
+          test -e /run/ghaf-clock-ready
+        '
+      """)
+
+  with subtest("Clock readiness self-heals future-poisoned anchors"):
+      machine.succeed("""
+        bash -lc '
+          set -euo pipefail
+          anchor="/var/lib/ghaf/clock-ready/last-good-realtime"
+          poison=2524608001
+          printf "%s\n" "$poison" > "$anchor"
+          chmod 0644 "$anchor"
+          rm -f /run/ghaf-clock-ready
+          systemctl reset-failed ghaf-clock-ready.service >/dev/null 2>&1 || true
+          systemctl restart ghaf-clock-ready.service
+          [ "$(cat "$anchor")" -lt "$poison" ]
+          grep -F "max_allowed=2524608000" /run/ghaf-clock-ready-state
+          grep -F "anchor_status=ignored-future" /run/ghaf-clock-ready-state
+          test -e /run/ghaf-clock-ready
+        '
+      """)
 
   with subtest("Clock-jump recovery tolerates missing alloy service"):
       exit_code, output = machine.execute("systemctl start ghaf-journal-alloy-recover.service 2>&1")
@@ -204,6 +473,257 @@ _: ''
       machine.succeed("systemctl list-unit-files journal-fss-verify.service")
       machine.execute("systemctl start journal-fss-verify.service 2>&1")
 
+  with subtest("Deployed fss-test operator tool runs"):
+      if not skip_if_setup_failed("fss-test"):
+          machine.succeed("fss-test >/tmp/fss-test-operator.log 2>&1 || { cat /tmp/fss-test-operator.log; exit 1; }")
+
+  with subtest("Setup records activation state and a content-bound receipt store"):
+      if not skip_if_setup_failed("activation state + receipts"):
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              MID=$(cat /etc/machine-id)
+              DIR="/var/log/journal/$MID"
+              # Activation is enabled by default in the test config; setup must
+              # have confirmed sealing and written the runtime drop-in.
+              [ "$(awk -F "\t" "NR == 1 { print \\$1 }" "$DIR/fss-activation-state")" = "active" ]
+              [ "$(awk -F "\t" "NR == 1 { print \\$2 }" "$DIR/fss-activation-state")" = "$(cat /proc/sys/kernel/random/boot_id)" ]
+              test -f /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf
+              systemd-analyze cat-config systemd/journald.conf | grep -E "^[[:space:]]*Seal[[:space:]]*=[[:space:]]*no"
+              effective_seal=$(systemd-analyze cat-config systemd/journald.conf | awk -F= '"'"'
+                /^[[:space:]]*[#;]/ { next }
+                /^[[:space:]]*Seal[[:space:]]*=/ {
+                  value = $2
+                  sub(/^[[:space:]]*/, "", value)
+                  sub(/[[:space:]]*[#;].*$/, "", value)
+                  sub(/[[:space:]]*$/, "", value)
+                  seal = tolower(value)
+                }
+                END { print seal }
+              '"'"')
+              [ "$effective_seal" = yes ]
+              # If a pre-activation receipt was recorded, it must be schema v1 and
+              # tagged with this boot id.
+              if [ -s "$DIR/fss-pre-activation-receipts" ]; then
+                while IFS="$(printf "\t")" read -r ver path inode size rboot rest; do
+                  [ -n "$ver" ] || continue
+                  [ "$ver" = "v1" ]
+                  [ -n "$rboot" ]
+                done < "$DIR/fss-pre-activation-receipts"
+              fi
+            '
+          """)
+
+  with subtest("Setup restart does not receipt post-activation archives"):
+      if not skip_if_setup_failed("post-activation receipt guard"):
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              MID=$(cat /etc/machine-id)
+              DIR="/var/log/journal/$MID"
+              RECEIPTS="$DIR/fss-pre-activation-receipts"
+              POST="$DIR/system@ffffffffffffffff-ffffffffffffffff.journal"
+
+              cleanup() {
+                rm -f "$POST"
+                systemctl reset-failed journal-fss-setup.service >/dev/null 2>&1 || true
+              }
+              trap cleanup EXIT
+
+              [ "$(awk -F "\t" "NR == 1 { print \\$1 }" "$DIR/fss-activation-state")" = "active" ]
+              test -f /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf
+              : > "$POST"
+              systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-post-activation-receipt.log 2>&1
+              if [ -f "$RECEIPTS" ]; then
+                ! grep -F "$POST" "$RECEIPTS"
+              fi
+            '
+          """)
+
+  with subtest("Setup rotates on the first activation of each boot"):
+      if not skip_if_setup_failed("per-boot activation rotation"):
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              MID=$(cat /etc/machine-id)
+              DIR="/var/log/journal/$MID"
+              STATE="$DIR/fss-activation-state"
+              BASE="$DIR/fss-baseline-boot"
+              MARKER="$DIR/fss-rotated"
+              BOOT="$(cat /proc/sys/kernel/random/boot_id)"
+
+              test -f "$MARKER"
+              old_marker_mtime="$(stat -c %Y "$MARKER")"
+              printf "active\tprevious-boot\n" > "$STATE"; chmod 0644 "$STATE"
+              printf "previous-boot\n" > "$BASE"; chmod 0644 "$BASE"
+              sleep 1
+              systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-first-activation-rotation.log 2>&1
+
+              [ "$(awk -F "\t" "NR == 1 { print \\$1 }" "$STATE")" = "active" ]
+              [ "$(awk -F "\t" "NR == 1 { print \\$2 }" "$STATE")" = "$BOOT" ]
+              [ "$(tr -d "[:space:]" < "$BASE")" = "$BOOT" ]
+              [ "$(stat -c %Y "$MARKER")" -gt "$old_marker_mtime" ]
+              journalctl -u journal-fss-setup.service -n 40 --no-pager |
+                grep -F "Rotating journal to ensure clean FSS state"
+            '
+          """)
+
+  with subtest("Verify fails closed when activation could not be confirmed"):
+      if not skip_if_setup_failed("activation fail-closed"):
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              MID=$(cat /etc/machine-id)
+              STATE="/var/log/journal/$MID/fss-activation-state"
+              BASE="/var/log/journal/$MID/fss-baseline-boot"
+              BOOT="$(cat /proc/sys/kernel/random/boot_id)"
+              ORIG=""
+              ORIG_BASE=""
+              [ -f "$STATE" ] && ORIG="$(cat "$STATE")"
+              [ -f "$BASE" ] && ORIG_BASE="$(cat "$BASE")"
+              restore() {
+                if [ -n "$ORIG" ]; then printf "%s\n" "$ORIG" > "$STATE"; else rm -f "$STATE"; fi
+                if [ -n "$ORIG_BASE" ]; then printf "%s\n" "$ORIG_BASE" > "$BASE"; else rm -f "$BASE"; fi
+                systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true
+              }
+              trap restore EXIT
+
+              printf "failed\n" > "$STATE"; chmod 0644 "$STATE"
+              systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true
+              if systemctl start journal-fss-verify.service >/tmp/fss-verify-activation-failed.log 2>&1; then
+                echo "verify unexpectedly passed with activation=failed" >&2; exit 1
+              fi
+              journalctl -u journal-fss-verify.service -n 20 --no-pager | grep -F "ACTIVATION_FAILED"
+
+              RECOV="/var/log/journal/$MID/fss-recovery-receipts"
+              old_recov="$(cat "$RECOV" 2>/dev/null || true)"
+              rm -f /run/ghaf-journal-alloy-recover.stamp
+              systemctl reset-failed ghaf-journal-alloy-recover.service >/dev/null 2>&1 || true
+              systemctl start ghaf-journal-alloy-recover.service >/tmp/ghaf-journal-alloy-recover-activation-failed.log 2>&1
+              [ ! -e /run/ghaf-journal-alloy-recover.stamp ]
+              [ "$(cat "$RECOV" 2>/dev/null || true)" = "$old_recov" ]
+
+              rm -rf /tmp/fss-triage-activation-failed
+              if fss-triage --strict-exit --no-sync --output-dir /tmp/fss-triage-activation-failed >/tmp/fss-triage-activation-failed.log 2>&1; then
+                echo "triage unexpectedly passed with activation=failed" >&2; exit 1
+              fi
+              grep -F "activation-preflight" /tmp/fss-triage-activation-failed/verify/summary.tsv
+              grep -F "ACTIVATION_FAILED" /tmp/fss-triage-activation-failed/verify/summary.tsv
+
+              printf "active\tstale-boot\n" > "$STATE"; chmod 0644 "$STATE"
+              systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true
+              if systemctl start journal-fss-verify.service >/tmp/fss-verify-activation-stale.log 2>&1; then
+                echo "verify unexpectedly passed with stale activation state" >&2; exit 1
+              fi
+              journalctl -u journal-fss-verify.service -n 20 --no-pager | grep -F "ACTIVATION_STALE"
+
+              rm -f "$STATE"
+              systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true
+              if systemctl start journal-fss-verify.service >/tmp/fss-verify-activation-missing.log 2>&1; then
+                echo "verify unexpectedly passed with missing activation state" >&2; exit 1
+              fi
+              journalctl -u journal-fss-verify.service -n 20 --no-pager | grep -F "ACTIVATION_STALE"
+
+              printf "active\t%s\n" "$BOOT" > "$STATE"; chmod 0644 "$STATE"
+              rm -f "$BASE"
+              systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true
+              if systemctl start journal-fss-verify.service >/tmp/fss-verify-activation-missing-baseline.log 2>&1; then
+                echo "verify unexpectedly passed with missing activation baseline" >&2; exit 1
+              fi
+              journalctl -u journal-fss-verify.service -n 20 --no-pager | grep -F "ACTIVATION_STALE"
+            '
+          """)
+
+  with subtest("Setup fails closed when effective journald Seal is overridden"):
+      if not skip_if_setup_failed("effective Seal override"):
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              MID=$(cat /etc/machine-id)
+              DIR="/var/log/journal/$MID"
+              STATE="$DIR/fss-activation-state"
+              OVERRIDE="/etc/systemd/journald.conf.d/99-fss-test-seal-no.conf"
+              BOOT="$(cat /proc/sys/kernel/random/boot_id)"
+
+              effective_seal() {
+                systemd-analyze cat-config systemd/journald.conf | awk -F= '"'"'
+                  /^[[:space:]]*[#;]/ { next }
+                  /^[[:space:]]*Seal[[:space:]]*=/ {
+                    value = $2
+                    sub(/^[[:space:]]*/, "", value)
+                    sub(/[[:space:]]*[#;].*$/, "", value)
+                    sub(/[[:space:]]*$/, "", value)
+                    seal = tolower(value)
+                  }
+                  END { print seal }
+                '"'"'
+              }
+
+              cleanup() {
+                rm -f "$OVERRIDE"
+                systemctl reset-failed journal-fss-setup.service journal-fss-verify.service >/dev/null 2>&1 || true
+                systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-seal-override-cleanup.log 2>&1 || true
+              }
+              trap cleanup EXIT
+
+              mkdir -p "$(dirname "$OVERRIDE")"
+              printf "[Journal]\nSeal=no\n" > "$OVERRIDE"
+              [ "$(effective_seal)" = no ]
+
+              if systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-seal-override.log 2>&1; then
+                echo "setup unexpectedly succeeded with effective Seal=no" >&2; exit 1
+              fi
+              [ "$(awk -F "\t" "NR == 1 { print \\$1 }" "$STATE")" = "failed" ]
+              journalctl -u journal-fss-setup.service -n 60 --no-pager |
+                grep -F "Journald sealing could not be confirmed after restart"
+              journalctl -u journal-fss-setup.service -n 60 --no-pager |
+                grep -F "Skipping FSS cleanup rotation because sealing activation failed"
+
+              systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true
+              if systemctl start journal-fss-verify.service >/tmp/fss-verify-seal-override.log 2>&1; then
+                echo "verify unexpectedly passed with effective Seal=no" >&2; exit 1
+              fi
+              journalctl -u journal-fss-verify.service -n 30 --no-pager | grep -F "ACTIVATION_FAILED"
+
+              rm -f "$OVERRIDE"
+              systemctl reset-failed journal-fss-setup.service journal-fss-verify.service >/dev/null 2>&1 || true
+              systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-seal-override-recovery.log 2>&1
+              [ "$(awk -F "\t" "NR == 1 { print \\$1 }" "$STATE")" = "active" ]
+              [ "$(awk -F "\t" "NR == 1 { print \\$2 }" "$STATE")" = "$BOOT" ]
+              [ "$(effective_seal)" = yes ]
+            '
+          """)
+
+  with subtest("Setup repairs a missing same-boot baseline without rotating"):
+      if not skip_if_setup_failed("per-boot baseline"):
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              MID=$(cat /etc/machine-id)
+              DIR="/var/log/journal/$MID"
+              PRE="$DIR/fss-pre-fss-archive"
+              RECOV="$DIR/fss-recovery-receipts"
+              BASE="$DIR/fss-baseline-boot"
+              MARKER="$DIR/fss-rotated"
+
+              test -s "$PRE"
+              old_pre="$(tr -d "[:space:]" < "$PRE")"
+              old_recov="$(cat "$RECOV" 2>/dev/null || true)"
+              old_marker_mtime="$(stat -c %Y "$MARKER")"
+              rm -f "$BASE"
+              sleep 1
+              systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-per-boot-baseline.log 2>&1
+
+              test -s "$BASE"
+              [ "$(tr -d "[:space:]" < "$BASE")" = "$(cat /proc/sys/kernel/random/boot_id)" ]
+              [ "$(tr -d "[:space:]" < "$PRE")" = "$old_pre" ]
+              [ "$(cat "$RECOV" 2>/dev/null || true)" = "$old_recov" ]
+              [ "$(stat -c %Y "$MARKER")" = "$old_marker_mtime" ]
+              journalctl -u journal-fss-setup.service -n 20 --no-pager |
+                grep -F "Restoring current boot FSS baseline without post-activation rotation"
+            '
+          """)
+
   with subtest("Setup backfills only the archive created at the original FSS rotation"):
       if not skip_if_setup_failed("archive backfill check"):
           machine.succeed("""
@@ -212,13 +732,23 @@ _: ''
               MID=$(cat /etc/machine-id)
               DIR="/var/log/journal/$MID"
               PRE="$DIR/fss-pre-fss-archive"
-              MARKER_MTIME=$(stat -c %Y "$DIR/fss-rotated")
+              RECOV="$DIR/fss-recovery-receipts"
+              BASE="$DIR/fss-baseline-boot"
+              MARKER="$DIR/fss-rotated"
+              MARKER_MTIME=$(stat -c %Y "$MARKER")
+              ORIGINAL_PRE="$(tr -d "[:space:]" < "$PRE" 2>/dev/null || true)"
+              OLD_RECOV="$(cat "$RECOV" 2>/dev/null || true)"
               BACKUP=$(mktemp -d)
               CANDIDATE="$DIR/system@0000000000000001-0000000000000001.journal"
               LATER="$DIR/system@0000000000000002-0000000000000002.journal"
 
               cleanup() {
+                find "$DIR" -maxdepth 1 -type f -name "system@*.journal" -delete
                 rm -f "$PRE" "$CANDIDATE" "$LATER"
+                if [ -n "$ORIGINAL_PRE" ]; then
+                  printf "%s\n" "$ORIGINAL_PRE" > "$PRE"
+                  chmod 0644 "$PRE"
+                fi
                 find "$BACKUP" -maxdepth 1 -type f -name "system@*.journal" -exec mv {} "$DIR"/ \;
                 rmdir "$BACKUP"
               }
@@ -228,11 +758,15 @@ _: ''
               : > "$CANDIDATE"; : > "$LATER"
               touch -d "@$MARKER_MTIME" "$CANDIDATE"
               touch -d "@$((MARKER_MTIME + 30))" "$LATER"
-              rm -f "$PRE"
+              rm -f "$PRE" "$BASE"
+              sleep 1
               systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-backfill.log 2>&1
 
               test -f "$PRE"
               [ "$(tr -d "[:space:]" < "$PRE")" = "$CANDIDATE" ]
+              [ "$(cat "$RECOV" 2>/dev/null || true)" = "$OLD_RECOV" ]
+              [ "$(stat -c %Y "$MARKER")" = "$MARKER_MTIME" ]
+              [ "$(tr -d "[:space:]" < "$BASE")" = "$(cat /proc/sys/kernel/random/boot_id)" ]
             '
           """)
 
@@ -244,12 +778,22 @@ _: ''
               MID=$(cat /etc/machine-id)
               DIR="/var/log/journal/$MID"
               PRE="$DIR/fss-pre-fss-archive"
-              MARKER_MTIME=$(stat -c %Y "$DIR/fss-rotated")
+              RECOV="$DIR/fss-recovery-receipts"
+              BASE="$DIR/fss-baseline-boot"
+              MARKER="$DIR/fss-rotated"
+              MARKER_MTIME=$(stat -c %Y "$MARKER")
+              ORIGINAL_PRE="$(tr -d "[:space:]" < "$PRE" 2>/dev/null || true)"
+              OLD_RECOV="$(cat "$RECOV" 2>/dev/null || true)"
               BACKUP=$(mktemp -d)
               LATER="$DIR/system@0000000000000002-0000000000000002.journal"
 
               cleanup() {
+                find "$DIR" -maxdepth 1 -type f -name "system@*.journal" -delete
                 rm -f "$PRE" "$LATER"
+                if [ -n "$ORIGINAL_PRE" ]; then
+                  printf "%s\n" "$ORIGINAL_PRE" > "$PRE"
+                  chmod 0644 "$PRE"
+                fi
                 find "$BACKUP" -maxdepth 1 -type f -name "system@*.journal" -exec mv {} "$DIR"/ \;
                 rmdir "$BACKUP"
               }
@@ -258,10 +802,14 @@ _: ''
               find "$DIR" -maxdepth 1 -type f -name "system@*.journal" -exec mv {} "$BACKUP"/ \;
               : > "$LATER"
               touch -d "@$((MARKER_MTIME + 30))" "$LATER"
-              rm -f "$PRE"
+              rm -f "$PRE" "$BASE"
+              sleep 1
               systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-no-backfill.log 2>&1
 
               [ ! -e "$PRE" ]
+              [ "$(cat "$RECOV" 2>/dev/null || true)" = "$OLD_RECOV" ]
+              [ "$(stat -c %Y "$MARKER")" = "$MARKER_MTIME" ]
+              [ "$(tr -d "[:space:]" < "$BASE")" = "$(cat /proc/sys/kernel/random/boot_id)" ]
             '
           """)
 
@@ -289,14 +837,14 @@ _: ''
 
               cp "{verify_key_path}" "$BACKUP"
               test -f "$INIT" && test -f "$MARKER"
-              rm -f "$VKEY" "$MARKER"
-              before=$(systemctl show systemd-journald.service -p InvocationID --value)
+              rm -f "$VKEY"
 
               if systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-missing-key.log 2>&1; then
                 echo "setup unexpectedly succeeded with missing key" >&2; exit 1
               fi
-              test -f "$INIT" && [ ! -e "$MARKER" ] && test -f "$DIR/fss-config"
-              [ "$(systemctl show systemd-journald.service -p InvocationID --value)" = "$before" ]
+              test -f "$INIT" && test -f "$MARKER" && test -f "$DIR/fss-config"
+              test -f /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf
+              grep -Fx "Seal=yes" /run/systemd/journald.conf.d/90-ghaf-fss-activation.conf
 
               systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true
               if systemctl start journal-fss-verify.service >/tmp/journal-fss-verify-missing-key.log 2>&1; then
@@ -307,12 +855,14 @@ _: ''
               journalctl -u journal-fss-verify.service -n 20 --no-pager | grep -F "KEY_MISSING"
 
               cp "$BACKUP" "$VKEY"; chmod 0400 "$VKEY"
-              before_recovery=$(systemctl show systemd-journald.service -p InvocationID --value)
               systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-recovery.log 2>&1
               [ -f "$MARKER" ]
-              [ "$(systemctl show systemd-journald.service -p InvocationID --value)" != "$before_recovery" ]
               systemctl reset-failed journal-fss-verify.service >/dev/null 2>&1 || true
-              systemctl start journal-fss-verify.service >/tmp/journal-fss-verify-recovery.log 2>&1
+              systemctl start journal-fss-verify.service >/tmp/journal-fss-verify-recovery.log 2>&1 || {{
+                cat /tmp/journal-fss-verify-recovery.log
+                journalctl -u journal-fss-verify.service -n 80 --no-pager
+                exit 1
+              }}
             '
           """)
 
@@ -334,6 +884,35 @@ _: ''
               systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-regeneration.log 2>&1
               test -f "$FSS_KEY" && test -f "$PRE"
               [ "$(stat -c %Y "$MARKER")" -gt "$old" ]
+            '
+          """)
+
+  with subtest("Setup does not rotate only because active sealing key mtime advances"):
+      if not skip_if_setup_failed("same-boot active key mtime"):
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              MID=$(cat /etc/machine-id)
+              DIR="/var/log/journal/$MID"
+              MARKER="$DIR/fss-rotated"
+              BASE="$DIR/fss-baseline-boot"
+              RECOV="$DIR/fss-recovery-receipts"
+              FSS_KEY="$DIR/fss"
+              [ -f "$FSS_KEY" ] || FSS_KEY="/run/log/journal/$MID/fss"
+
+              test -f "$FSS_KEY" && test -f "$MARKER" && test -f "$BASE"
+              [ "$(tr -d "[:space:]" < "$BASE")" = "$(cat /proc/sys/kernel/random/boot_id)" ]
+              old_marker_mtime="$(stat -c %Y "$MARKER")"
+              old_recov="$(cat "$RECOV" 2>/dev/null || true)"
+              sleep 1
+              touch "$FSS_KEY"
+              [ "$(stat -c %Y "$FSS_KEY")" -gt "$old_marker_mtime" ]
+              systemctl restart journal-fss-setup.service >/tmp/journal-fss-setup-same-boot-key-replacement.log 2>&1
+              [ "$(stat -c %Y "$MARKER")" = "$old_marker_mtime" ]
+              [ "$(tr -d "[:space:]" < "$BASE")" = "$(cat /proc/sys/kernel/random/boot_id)" ]
+              [ "$(cat "$RECOV" 2>/dev/null || true)" = "$old_recov" ]
+              journalctl -u journal-fss-setup.service -n 20 --no-pager |
+                grep -F "Journald FSS activation is already active for this boot; skipping restart"
             '
           """)
 

--- a/tests/logging/test_scripts/fss_verification.nix
+++ b/tests/logging/test_scripts/fss_verification.nix
@@ -106,6 +106,46 @@ _: ''
           ARCHIVED_TEMP_JOURNAL="/var/log/journal/mid/system@0000000000000001-0000000000000002.journal~"
           OTHER="/var/log/journal/mid/custom.journal"
 
+          # Trust transition matrix: these cases are the compact executable
+          # specification for FSS verification policy.
+          assert_verdict verified "PASS: $ACTIVE"
+
+          assert_verdict fail "FAIL: $ACTIVE (Bad message)"
+          [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ]
+
+          assert_verdict verified-with-exception \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$PRE_ACTIVATION_ARCHIVE" "$ACTIVE")" \
+            "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "$CURBOOT")" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "recorded insecure boot logs (current boot)" ]
+
+          assert_verdict warning \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$PRE_ACTIVATION_ARCHIVE" "$ACTIVE")" \
+            "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "boot-earlier")" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "insecure boot logs from an earlier boot" ]
+
+          assert_verdict fail \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$PRE_ACTIVATION_ARCHIVE" "$ACTIVE")" \
+            "" "" "" "$CURBOOT"
+          [ "$FSS_VERDICT_REASON" = "archived system journal failures outside allowlist" ]
+
+          assert_verdict warning "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$USER_JOURNAL" "$ACTIVE")"
+          [ -n "$FSS_USER_FAILURES" ]
+          [ -z "$FSS_ACTIVE_SYSTEM_FAILURES" ]
+
+          assert_verdict verified-with-exception \
+            "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$ARCHIVED_TEMP_JOURNAL" "$ACTIVE")" \
+            "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "$CURBOOT")"
+          [ "$FSS_VERDICT_REASON" = "recorded unclean-shutdown journal (current boot)" ]
+
+          assert_verdict fail \
+            "FAIL: $ACTIVE (Bad message)" \
+            "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "$CURBOOT")"
+          [ "$FSS_VERDICT_REASON" = "active system journal verification failed" ]
+
+          assert_verdict warning "$(printf "FAIL: %s (Virheellinen viesti)\nPASS: %s" "$USER_JOURNAL" "$ACTIVE")"
+          [ -n "$FSS_USER_FAILURES" ]
+          ! printf "%s" "$FSS_REASON_TAGS" | grep -F "BAD_MESSAGE"
+
           # Active system failure → fail
           assert_verdict fail "FAIL: $ACTIVE (Bad message)"
           [ "$FSS_REASON_TAGS" = "BAD_MESSAGE" ]
@@ -476,6 +516,24 @@ _: ''
   with subtest("Deployed fss-test operator tool runs"):
       if not skip_if_setup_failed("fss-test"):
           machine.succeed("fss-test >/tmp/fss-test-operator.log 2>&1 || { cat /tmp/fss-test-operator.log; exit 1; }")
+
+  with subtest("Deployed fss-triage reports receipt summary"):
+      if not skip_if_setup_failed("fss-triage"):
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              OUT=$(mktemp -d)
+              fss-triage --output-dir "$OUT" >/tmp/fss-triage-operator.log 2>&1 || {
+                cat /tmp/fss-triage-operator.log
+                exit 1
+              }
+              grep -F "Receipt summary:" "$OUT/summary.txt"
+              grep -E "^class[[:space:]]+total[[:space:]]+valid[[:space:]]+current[[:space:]]+stale[[:space:]]+missing[[:space:]]+mismatched" "$OUT/summary.txt"
+              grep -E "^pre-activation[[:space:]]+" "$OUT/summary.txt"
+              grep -E "^recovery[[:space:]]+" "$OUT/summary.txt"
+              grep -E "^unclean-shutdown[[:space:]]+" "$OUT/summary.txt"
+            '
+          """)
 
   with subtest("Setup records activation state and a content-bound receipt store"):
       if not skip_if_setup_failed("activation state + receipts"):

--- a/tests/logging/test_scripts/fss_verification.nix
+++ b/tests/logging/test_scripts/fss_verification.nix
@@ -113,7 +113,7 @@ _: ''
           assert_verdict fail "FAIL: $ACTIVE (Bad message)"
           [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ]
 
-          assert_verdict verified-with-exception \
+          assert_verdict warning \
             "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$PRE_ACTIVATION_ARCHIVE" "$ACTIVE")" \
             "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "$CURBOOT")" "$CURBOOT"
           [ "$FSS_VERDICT_REASON" = "recorded insecure boot logs (current boot)" ]
@@ -132,7 +132,7 @@ _: ''
           [ -n "$FSS_USER_FAILURES" ]
           [ -z "$FSS_ACTIVE_SYSTEM_FAILURES" ]
 
-          assert_verdict verified-with-exception \
+          assert_verdict warning \
             "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$ARCHIVED_TEMP_JOURNAL" "$ACTIVE")" \
             "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "$CURBOOT")"
           [ "$FSS_VERDICT_REASON" = "recorded unclean-shutdown journal (current boot)" ]
@@ -153,10 +153,10 @@ _: ''
           # Clean output → verified
           assert_verdict verified "PASS: $ACTIVE"
 
-          # Clean output with current-boot pre-activation receipt still means
-          # verified-with-exception: those entries were structurally readable but
-          # not FSS-trusted.
-          assert_verdict verified-with-exception \
+          # Clean output with a current-boot pre-activation receipt still means
+          # warning: those entries were structurally readable but not FSS-trusted,
+          # and the receipt backing the exception is itself unauthenticated.
+          assert_verdict warning \
             "PASS: $ACTIVE" \
             "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "$CURBOOT")" "$CURBOOT"
           [ "$FSS_VERDICT_REASON" = "recorded insecure boot logs (current boot)" ]
@@ -181,8 +181,8 @@ _: ''
           [ "$FSS_VERDICT_REASON" = "insecure boot logs from an earlier boot" ]
           printf "%s" "$FSS_VERDICT_TAGS" | grep -F "PRE_ACTIVATION_STALE"
 
-          # Allowed archive only → verified-with-exception (matches pre-FSS allowlist)
-          assert_verdict verified-with-exception \
+          # Allowed archive only → warning (matches pre-FSS allowlist)
+          assert_verdict warning \
             "$(printf "FAIL: %s (Input/output error)\nPASS: %s" "$ALLOWED_ARCHIVE" "$ACTIVE")" \
             "$ALLOWED_ARCHIVE"
           [ "$FSS_REASON_TAGS" = "INPUT_OUTPUT_ERROR" ]
@@ -195,8 +195,8 @@ _: ''
             "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$RECOVERY_ARCHIVE" "$ACTIVE")" \
             "" "$(printf "%s\n%s" "$RECOVERY_ARCHIVE" "$RECOVERY_ARCHIVE")"
 
-          # Current-boot recovery receipt → verified-with-exception
-          assert_verdict verified-with-exception \
+          # Current-boot recovery receipt → warning
+          assert_verdict warning \
             "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$RECOVERY_ARCHIVE" "$ACTIVE")" \
             "" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
           [ "$FSS_VERDICT_REASON" = "recorded recovery archive (current boot)" ]
@@ -209,8 +209,8 @@ _: ''
           [ "$FSS_VERDICT_REASON" = "recovery archive from an earlier boot" ]
           printf "%s" "$FSS_VERDICT_TAGS" | grep -F "RECOVERY_STALE"
 
-          # Current-boot pre-activation receipt → verified-with-exception
-          assert_verdict verified-with-exception \
+          # Current-boot pre-activation receipt → warning
+          assert_verdict warning \
             "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$PRE_ACTIVATION_ARCHIVE" "$ACTIVE")" \
             "" "" "$(mkreceipt "$PRE_ACTIVATION_ARCHIVE" "$CURBOOT")" "$CURBOOT"
           [ "$FSS_VERDICT_REASON" = "recorded insecure boot logs (current boot)" ]
@@ -234,8 +234,8 @@ _: ''
             "$(printf "FAIL: %s (Input/output error)\nPASS: %s" "$UNEXPECTED_ARCHIVE" "$ACTIVE")" \
             "$ALLOWED_ARCHIVE" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
 
-          # Allowed + recovery archives together → verified-with-exception
-          assert_verdict verified-with-exception \
+          # Allowed + recovery archives together → warning
+          assert_verdict warning \
             "$(printf "FAIL: %s (Bad message)\nFAIL: %s (Bad message)" "$ALLOWED_ARCHIVE" "$RECOVERY_ARCHIVE")" \
             "$ALLOWED_ARCHIVE" "$(mkreceipt "$RECOVERY_ARCHIVE" "$CURBOOT")" "" "$CURBOOT"
 
@@ -293,7 +293,7 @@ _: ''
           # Unclean-shutdown receipting (journald-attested, content-bound). An
           # archived .journal~ corpse with a current-boot unclean receipt is an
           # expected exception, not a hard fail.
-          assert_verdict verified-with-exception \
+          assert_verdict warning \
             "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$ARCHIVED_TEMP_JOURNAL" "$ACTIVE")" \
             "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "$CURBOOT")"
           [ "$FSS_VERDICT_REASON" = "recorded unclean-shutdown journal (current boot)" ]
@@ -301,7 +301,7 @@ _: ''
 
           # The active system.journal~ corpse is carved out of the fatal active-system
           # set only with a matching content-bound receipt.
-          assert_verdict verified-with-exception \
+          assert_verdict warning \
             "$(printf "FAIL: %s (Bad message)\nPASS: %s" "$ACTIVE_TEMP_JOURNAL" "$ACTIVE")" \
             "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ACTIVE_TEMP_JOURNAL" "$CURBOOT")"
 
@@ -322,8 +322,8 @@ _: ''
             "" "" "" "$CURBOOT" 1 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "boot-earlier")"
           printf "%s" "$FSS_VERDICT_TAGS" | grep -F "UNCLEAN_SHUTDOWN_STALE"
 
-          # Clean output + current-boot unclean receipt → verified-with-exception.
-          assert_verdict verified-with-exception \
+          # Clean output + current-boot unclean receipt → warning.
+          assert_verdict warning \
             "PASS: $ACTIVE" \
             "" "" "" "$CURBOOT" 0 "$(mkuncleanreceipt "$ARCHIVED_TEMP_JOURNAL" "$CURBOOT")"
 


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This PR improves Forward Secure Sealing (FSS) reliability around boot-time clock instability and journald recovery.

The changes add a clock-readiness barrier before persistent sealed logging starts, so journal flush, FSS setup, verification, recovery, and Alloy are ordered after the realtime clock has either stabilized or reached a bounded fallback. FSS setup now records per-boot baseline state and expected bootstrap/recovery archives, allowing verification to distinguish known clock-induced journal rotations from active system journal corruption.

The PR also adds packaged FSS triage tooling for deployed systems. The `fss-triage` helper collects journald/FSS state, unit status, current and previous boot logs, verification summaries, and relevant clock-readiness state while redacting verification keys from command logs.

Additional hardening ensures sealing keys are owned by `root:root` with `0600` permissions, avoids unnecessary empty rotations, preserves verification behavior across recovery rotations, and extends the FSS test coverage for these paths.

### Type of Change
- [X] New Feature
- [X] Bug Fix
- [X] Improvement / Refactor

## Related Issues / Tickets

None linked.

## Checklist

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [X] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `make-checks` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [x] Author has added reviewers and removed PR draft status

`make-checks` and GitHub Actions are left unchecked until they have been run for this branch.

## Testing Instructions

### Applicable Targets
- [X] Orin AGX `aarch64`
- [X] Orin NX `aarch64`
- [X] Lenovo X1 `x86_64`
- [X] Dell Latitude `x86_64`
- [X] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Build the FSS NixOS test:

   ```bash
   nix build .#checks.x86_64-linux.logging-fss
   ```

2. Build the manual FSS test and triage helpers:

   ```bash
   nix build .#checks.x86_64-linux.fss-test
   nix build .#checks.x86_64-linux.fss-triage
   ```

3. Deploy a system with FSS enabled using the updated closure, for example with `nixos-rebuild ... switch`.

4. After boot, verify that clock readiness completed and the dependent logging services are ordered after it:

   ```bash
   systemctl status ghaf-clock-ready.service
   systemctl show systemd-journal-flush.service journal-fss-setup.service journal-fss-verify.service \
     --property=After --property=Requires --property=Wants
   ```

5. Verify that FSS setup completed and the sealing key has restricted permissions:

   ```bash
   systemctl status journal-fss-setup.service
   stat -c '%U:%G %a' /var/log/journal/$(cat /etc/machine-id)/fss
   ```

   Expected permission output is:

   ```text
   root:root 600
   ```

6. Run the deployed FSS test helper as root:

   ```bash
   fss-test
   ```

7. Collect triage diagnostics and inspect the generated summary:

   ```bash
   fss-triage
   ```

8. Confirm that active system journal verification does not report critical failures:

   ```bash
   journalctl -u journal-fss-verify.service --no-pager
   journalctl -g 'AUDIT_LOG_INTEGRITY_FAIL|AUDIT_LOG_VERIFY_COMPLETED' --no-pager
   ```
