### PR TITLE
refactor(features/logging): refactor global features, add logging features

### DIFF
--- a/docs/src/content/docs/ghaf/dev/guides/adding-features.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/adding-features.mdx
@@ -15,9 +15,12 @@ This guide covers how to add new hardware features to the Ghaf Framework using t
 The features system (`globalConfig.features`) provides:
 
 - **Centralized management** - All feature assignments in one place
-- **Flexible VM assignment** - Features can run in any VM
+- **Two-tier enablement** - `isEnabled` for host/appvms, `isEnabledFor` for sysvms
+- **Flexible VM assignment** - Features can run in any sysvm via `targetVms`
 - **Multi-VM support** - Same feature in multiple VMs
 - **Downstream customization** - Easy to override assignments
+
+When a feature is enabled (`feature.enable = true`), it is active on the **host** and all **appvms** unconditionally. The `targetVms` list additionally gates which **sysvms** receive it. Use `lib.ghaf.features.isEnabled` in host and appvm modules, and `lib.ghaf.features.isEnabledFor` in sysvm base modules.
 
 ## Adding a New Feature
 
@@ -45,9 +48,22 @@ features = {
 };
 ```
 
-### Step 2: Create the Feature Module
+### Step 2: Wire up the host and/or appvm (if applicable)
 
-Create `modules/microvm/guivm-features/my-feature.nix`:
+If the feature should also apply to the host or appvms, add an `isEnabled` check in `modules/microvm/host/microvm-host.nix` or `modules/microvm/sysvms/appvm-base.nix`, respectively:
+
+```nix
+let
+  myFeatureEnabled = lib.ghaf.features.isEnabled globalConfig "myFeature";
+in
+{
+  ghaf.services.myFeature.enable = myFeatureEnabled;
+}
+```
+
+### Step 3: Create the Sysvm Feature Module
+
+Create `modules/microvm/guivm-features/my-feature.nix`. Use `isEnabledFor` since this is a sysvm:
 
 ```nix
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
@@ -88,7 +104,7 @@ in
 }
 ```
 
-### Step 3: Include in VM Base
+### Step 4: Include in VM Base
 
 Add to the appropriate VM base module. In `modules/microvm/sysvms/guivm-base.nix`:
 
@@ -108,7 +124,7 @@ imports = [
   ../guivm-features/my-feature.nix;
 ```
 
-### Step 4: Add Hardware Passthrough (if needed)
+### Step 5: Add Hardware Passthrough (if needed)
 
 If the feature requires hardware passthrough, update the hardware definition:
 
@@ -376,7 +392,7 @@ Example documentation block:
 
 - [ ] Add feature schema to `lib/global-config.nix`
 - [ ] Create feature module with `_file` declaration
-- [ ] Use `lib.ghaf.features.isEnabledFor` for conditional config
+- [ ] Use `lib.ghaf.features.isEnabledFor` or `lib.ghaf.features.isEnabled` for conditional config
 - [ ] Add to appropriate VM base module imports
 - [ ] Configure hardware passthrough if needed
 - [ ] Add udev rules if needed

--- a/docs/src/content/docs/ghaf/dev/library/features-api.mdx
+++ b/docs/src/content/docs/ghaf/dev/library/features-api.mdx
@@ -8,16 +8,37 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Features API
 
-The `lib.ghaf.features` namespace provides utilities for managing hardware feature assignments across VMs in the Ghaf framework.
+The `lib.ghaf.features` namespace provides utilities for managing feature assignments across the host and VMs in the Ghaf framework.
 
 ## Overview
 
-The features system allows centralized management of hardware capabilities (fingerprint, YubiKey, WiFi, audio, etc.) with flexible VM assignment. Instead of hardcoding which VM owns a feature, this is now configurable.
+The features system allows centralized management of capabilities (fingerprint, YubiKey, WiFi, audio, timezone, etc.) with configurable VM assignment. Two helpers cover the two distinct contexts where features are checked:
 
 ```nix
 lib.ghaf.features = {
-  isEnabledFor    # Check if a feature is enabled for a specific VM
+  isEnabled     # Check if a feature is enabled system-wide
+  isEnabledFor  # Check if a feature is enabled for a specific VM
 };
+```
+
+### Two-Tier Enablement Model
+
+A feature's `enable` flag and its `targetVms` list serve different roles:
+
+| Context                                         | Helper         | Condition                                             |
+| ----------------------------------------------- | -------------- | ----------------------------------------------------- |
+| **Host**                                        | `isEnabled`    | `feature.enable == true`                              |
+| **AppVMs**                                      | `isEnabled`    | `feature.enable == true`                              |
+| **SysVMs** (net-vm, gui-vm, audio-vm, admin-vm) | `isEnabledFor` | `feature.enable == true` **and** VM is in `targetVms` |
+
+In other words: enabling a feature means it is active on the host and on all app VMs. The `targetVms` list controls which system VMs additionally receive it.
+
+```
+feature.enable = true
+        │
+        ├─ host              ← always enabled (via isEnabled)
+        ├─ all appvms        ← always enabled (via isEnabled)
+        └─ VMs in targetVms  ← enabled only if listed (via isEnabledFor)
 ```
 
 ## Configuration Schema
@@ -34,21 +55,9 @@ ghaf.global-config.features = {
     enable = true;
     targetVms = [ "gui-vm" ];
   };
-  brightness = {
-    enable = true;
-    targetVms = [ "gui-vm" ];
-  };
   wifi = {
     enable = true;
     targetVms = [ "net-vm" ];
-  };
-  audio = {
-    enable = true;
-    targetVms = [ "audio-vm" ];
-  };
-  bluetooth = {
-    enable = true;
-    targetVms = [ "audio-vm" ];
   };
 };
 ```
@@ -57,29 +66,84 @@ ghaf.global-config.features = {
 
 Each feature has the same structure:
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enable` | bool | `true` | Whether the feature is enabled globally |
-| `targetVms` | list of str | varies | VMs that should have this feature |
+| Option      | Type        | Description                                                            |
+| ----------- | ----------- | ---------------------------------------------------------------------- |
+| `enable`    | bool        | Whether the feature is enabled system-wide (host + appvms + targetVms) |
+| `targetVms` | list of str | SysVMs that should additionally have this feature                      |
 
 ### Default Assignments
 
-| Feature | Default VMs | Description |
-|---------|-------------|-------------|
-| `fprint` | `[ "gui-vm" ]` | Fingerprint reader support |
-| `yubikey` | `[ "gui-vm" ]` | YubiKey/smart card support |
-| `brightness` | `[ "gui-vm" ]` | Screen brightness control |
-| `wifi` | `[ "net-vm" ]` | WiFi network management |
-| `audio` | `[ "audio-vm" ]` | Audio playback/recording |
-| `bluetooth` | `[ "audio-vm" ]` | Bluetooth connectivity |
+| Feature         | Default `targetVms` | Description                              |
+| --------------- | ------------------- | ---------------------------------------- |
+| `audio`         | `[ "audio-vm" ]`    | Audio playback and recording             |
+| `bluetooth`     | `[ "audio-vm" ]`    | Bluetooth connectivity                   |
+| `brightness`    | `[ "gui-vm" ]`      | Screen brightness control via VirtIO     |
+| `fprint`        | `[ "gui-vm" ]`      | Fingerprint reader support               |
+| `locale`        | `[ ]`               | Runtime locale management                |
+| `log-upload`    | `[ ]`               | Log forwarding to central logging server |
+| `performance`   | `[ ]`               | Performance and PPD profiles             |
+| `power-manager` | `[ ]`               | Power management                         |
+| `timezone`      | `[ ]`               | Runtime timezone management              |
+| `wifi`          | `[ "net-vm" ]`      | WiFi network management                  |
+| `yubikey`       | `[ "gui-vm" ]`      | YubiKey / smart card support             |
 
 ---
 
 ## Function Reference
 
+### isEnabled
+
+Checks if a feature is enabled system-wide. Returns `true` if `feature.enable` is set. Used by the **host** and **appvms**, which receive a feature whenever it is enabled regardless of `targetVms`.
+
+**Signature:**
+
+```nix
+isEnabled :: AttrSet -> String -> Bool
+isEnabled globalConfig featureName
+```
+
+**Parameters:**
+
+| Name           | Type    | Description                                            |
+| -------------- | ------- | ------------------------------------------------------ |
+| `globalConfig` | AttrSet | The global configuration (`config.ghaf.global-config`) |
+| `featureName`  | String  | Feature name (e.g., `"wifi"`, `"timezone"`)            |
+
+**Returns:** `true` if `feature.enable` is `true`, `false` otherwise.
+
+**Example - host module:**
+
+```nix
+# In microvm-host.nix
+let
+  globalConfig = config.ghaf.global-config;
+  timezoneEnabled = lib.ghaf.features.isEnabled globalConfig "timezone";
+  powerEnabled    = lib.ghaf.features.isEnabled globalConfig "power-manager";
+in
+{
+  ghaf.services.timezone.enable    = lib.mkDefault timezoneEnabled;
+  ghaf.services.power-manager.enable = lib.mkDefault powerEnabled;
+}
+```
+
+**Example - appvm base module:**
+
+```nix
+# In appvm-base.nix
+{ globalConfig, lib, ... }:
+let
+  timezoneEnabled = lib.ghaf.features.isEnabled globalConfig "timezone";
+in
+{
+  ghaf.services.timezone.enable = lib.mkDefault timezoneEnabled;
+}
+```
+
+---
+
 ### isEnabledFor
 
-Checks if a specific feature is enabled for a specific VM.
+Checks if a feature is enabled for a specific VM. Returns `true` only if both `feature.enable` is set **and** the VM is listed in `targetVms`. Used by **VM base modules** (gui-vm, net-vm, audio-vm, admin-vm).
 
 **Signature:**
 
@@ -90,30 +154,26 @@ isEnabledFor globalConfig featureName vmName
 
 **Parameters:**
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name           | Type    | Description                                            |
+| -------------- | ------- | ------------------------------------------------------ |
 | `globalConfig` | AttrSet | The global configuration (`config.ghaf.global-config`) |
-| `featureName` | String | Feature name (e.g., "fprint", "wifi") |
-| `vmName` | String | VM name (e.g., "gui-vm", "net-vm") |
+| `featureName`  | String  | Feature name (e.g., `"fprint"`, `"wifi"`)              |
+| `vmName`       | String  | Sysvm name (e.g., `"gui-vm"`, `"net-vm"`)              |
 
-**Returns:** `true` if the feature is enabled AND the VM is in `targetVms`, `false` otherwise.
+**Returns:** `true` if `feature.enable` is `true` AND `vmName` is in `feature.targetVms`, `false` otherwise.
 
 **Example:**
 
 ```nix
+# In guivm-base.nix
 { globalConfig, lib, ... }:
+let
+  fprintEnabled  = lib.ghaf.features.isEnabledFor globalConfig "fprint"  "gui-vm";
+  yubikeyEnabled = lib.ghaf.features.isEnabledFor globalConfig "yubikey" "gui-vm";
+in
 {
-  config = lib.mkMerge [
-    # Only enable fprintd if fprint feature assigned to this VM
-    (lib.mkIf (lib.ghaf.features.isEnabledFor globalConfig "fprint" "gui-vm") {
-      services.fprintd.enable = true;
-    })
-
-    # Only enable WiFi services if wifi feature assigned
-    (lib.mkIf (lib.ghaf.features.isEnabledFor globalConfig "wifi" "net-vm") {
-      networking.wireless.enable = true;
-    })
-  ];
+  services.fprintd.enable = lib.mkDefault fprintEnabled;
+  services.pcscd.enable   = lib.mkDefault yubikeyEnabled;
 }
 ```
 
@@ -121,44 +181,45 @@ isEnabledFor globalConfig featureName vmName
 
 ## Usage Patterns
 
-### Pattern 1: Conditional Service Enablement
+### Pattern 1: Host configuration (isEnabled)
 
-The most common pattern is conditionally enabling services based on feature assignment:
+Use `isEnabled` when configuring the host - `targetVms` does not apply here:
+
+```nix
+# In microvm-host.nix
+let
+  globalConfig    = config.ghaf.global-config;
+  timezoneEnabled = lib.ghaf.features.isEnabled globalConfig "timezone";
+  powerEnabled    = lib.ghaf.features.isEnabled globalConfig "power-manager";
+in
+{
+  ghaf.services.timezone.enable      = lib.mkDefault timezoneEnabled;
+  ghaf.services.power-manager.enable = lib.mkDefault powerEnabled;
+}
+```
+
+### Pattern 2: Sysvm conditional service enablement (isEnabledFor)
+
+Use `isEnabledFor` in VM base modules - the feature only applies if this VM is in `targetVms`:
 
 ```nix
 # In guivm-base.nix
 { globalConfig, lib, ... }:
+let
+  fprintEnabled  = lib.ghaf.features.isEnabledFor globalConfig "fprint"  "gui-vm";
+  yubikeyEnabled = lib.ghaf.features.isEnabledFor globalConfig "yubikey" "gui-vm";
+in
 {
-  config = lib.mkMerge [
-    # Fingerprint authentication
-    (lib.mkIf (lib.ghaf.features.isEnabledFor globalConfig "fprint" "gui-vm") {
-      services.fprintd.enable = true;
-      security.pam.services.login.fprintAuth = true;
-    })
-
-    # YubiKey/smart card support
-    (lib.mkIf (lib.ghaf.features.isEnabledFor globalConfig "yubikey" "gui-vm") {
-      services.pcscd.enable = true;
-      hardware.gpgSmartcards.enable = true;
-    })
-
-    # Brightness control
-    (lib.mkIf (lib.ghaf.features.isEnabledFor globalConfig "brightness" "gui-vm") {
-      programs.light.enable = true;
-      services.udev.extraRules = ''
-        ACTION=="add", SUBSYSTEM=="backlight", RUN+="${pkgs.coreutils}/bin/chmod 666 /sys/class/backlight/%k/brightness"
-      '';
-    })
-  ];
+  services.fprintd.enable = lib.mkDefault fprintEnabled;
+  services.pcscd.enable   = lib.mkDefault yubikeyEnabled;
 }
 ```
 
-### Pattern 2: Downstream Feature Reassignment
+### Pattern 3: Downstream feature reassignment
 
-Move a feature to a different VM:
+Move a feature to a different VM, or expand to multiple VMs:
 
 ```nix
-# Downstream project configuration
 {
   ghaf.global-config.features = {
     # Move fingerprint from gui-vm to admin-vm
@@ -167,39 +228,25 @@ Move a feature to a different VM:
     # Enable YubiKey in multiple VMs
     yubikey.targetVms = [ "gui-vm" "admin-vm" ];
 
-    # Disable audio entirely
+    # Disable audio entirely (host and all VMs)
     audio.enable = false;
   };
 }
 ```
 
-### Pattern 3: Checking Multiple Features
+### Pattern 4: Checking multiple features in one module
 
 ```nix
 { globalConfig, lib, ... }:
 let
-  isAudioVm = lib.ghaf.features.isEnabledFor globalConfig "audio" "audio-vm";
+  isAudioVm    = lib.ghaf.features.isEnabledFor globalConfig "audio"     "audio-vm";
   hasBluetooth = lib.ghaf.features.isEnabledFor globalConfig "bluetooth" "audio-vm";
 in
 {
   config = lib.mkIf isAudioVm {
-    # Audio configuration
     services.pipewire.enable = true;
-
-    # Bluetooth only if also assigned
     hardware.bluetooth.enable = hasBluetooth;
   };
-}
-```
-
-### Pattern 4: Feature-Based Package Installation
-
-```nix
-{ globalConfig, lib, pkgs, ... }:
-{
-  environment.systemPackages = lib.optionals
-    (lib.ghaf.features.isEnabledFor globalConfig "yubikey" "gui-vm")
-    [ pkgs.yubikey-manager pkgs.yubikey-personalization ];
 }
 ```
 
@@ -211,40 +258,59 @@ To add a new feature to the system:
 
 ### 1. Add to globalConfig Schema
 
-In `lib/global-config.nix`:
+In `lib/global-config.nix`, inside the `features` attrset (the list is keep-sorted):
 
 ```nix
-features.myFeature = {
-  enable = lib.mkEnableOption "My Feature" // { default = true; };
-  targetVms = lib.mkOption {
-    type = lib.types.listOf lib.types.str;
+myFeature = {
+  enable = mkEnableOption "my feature description";
+  targetVms = mkOption {
+    type = types.listOf types.str;
     default = [ "gui-vm" ];
-    description = "VMs where my feature should be enabled";
+    description = "SysVMs that should have my feature enabled";
   };
 };
 ```
 
-### 2. Update VM Base Modules
+### 2. Wire up the host (if applicable)
 
-In the relevant base module (e.g., `guivm-base.nix`):
+In `modules/microvm/host/microvm-host.nix`, add an `isEnabled` check:
 
 ```nix
-{ globalConfig, lib, ... }:
+let
+  myFeatureEnabled = lib.ghaf.features.isEnabled globalConfig "myFeature";
+in
 {
-  config = lib.mkMerge [
-    # ... existing config ...
-
-    (lib.mkIf (lib.ghaf.features.isEnabledFor globalConfig "myFeature" "gui-vm") {
-      # My feature configuration
-      services.myFeature.enable = true;
-    })
-  ];
+  ghaf.services.myFeature.enable = myFeatureEnabled;
 }
 ```
 
-### 3. Document the Feature
+### 3. Wire up VM base modules
 
-Update this documentation with the new feature's default assignment and description.
+In the relevant base module (e.g., `guivm-base.nix`), add an `isEnabledFor` check:
+
+```nix
+let
+  myFeatureEnabled = lib.ghaf.features.isEnabledFor globalConfig "myFeature" "gui-vm";
+in
+{
+  ghaf.services.myFeature.enable = lib.mkDefault myFeatureEnabled;
+}
+```
+
+### 4. Update profiles
+
+Add `myFeature` to the `features` attrset in all three profiles (`debug`, `release`, `minimal`) in `lib/global-config.nix`:
+
+```nix
+myFeature = {
+  enable = true;          # or false for minimal
+  targetVms = [ "gui-vm" ];
+};
+```
+
+### 5. Document the Feature
+
+Update the Default Assignments table in this file.
 
 ---
 
@@ -252,12 +318,12 @@ Update this documentation with the new feature's default assignment and descript
 
 Features and hardware definitions serve different purposes:
 
-| Aspect | Features (`globalConfig.features`) | Hardware Definition (`hardware.definition`) |
-|--------|-----------------------------------|---------------------------------------------|
-| **Scope** | Software service assignment | Hardware passthrough configuration |
-| **Example** | "Which VM runs fprintd?" | "Pass USB device 1234:5678 to gui-vm" |
-| **Configurability** | Downstream can reassign VMs | Hardware-specific, rarely changed |
-| **Location** | `lib/global-config.nix` | `modules/hardware/definition.nix` |
+| Aspect              | Features (`globalConfig.features`) | Hardware Definition (`hardware.definition`) |
+| ------------------- | ---------------------------------- | ------------------------------------------- |
+| **Scope**           | Software service assignment        | Hardware passthrough configuration          |
+| **Example**         | "Which VM runs fprintd?"           | "Pass USB device 1234:5678 to gui-vm"       |
+| **Configurability** | Downstream can reassign VMs        | Hardware-specific, rarely changed           |
+| **Location**        | `lib/global-config.nix`            | `modules/hardware/definition.nix`           |
 
 **When to use which:**
 
@@ -268,31 +334,36 @@ Features and hardware definitions serve different purposes:
 
 ## Troubleshooting
 
-### Feature Not Enabling
+### Feature not enabling on a VM
 
-If a feature isn't activating:
+1. Check that the feature is globally enabled:
 
-1. Check if feature is globally enabled:
    ```nix
-   globalConfig.features.fprint.enable  # Should be true
+   globalConfig.features.fprint.enable  # should be true
    ```
 
-2. Check if VM is in targetVms:
+2. Check that the VM is in `targetVms`:
+
    ```nix
-   globalConfig.features.fprint.targetVms  # Should include your VM
+   globalConfig.features.fprint.targetVms  # should include your VM
    ```
 
-3. Verify the VM base module checks the feature:
+3. Verify the VM base module uses `isEnabledFor`, not `isEnabled`.
+
+### Feature not enabling on the host or an appvm
+
+1. Check that the feature is globally enabled:
+
    ```nix
-   lib.mkIf (lib.ghaf.features.isEnabledFor globalConfig "fprint" "gui-vm") { ... }
+   globalConfig.features.timezone.enable  # should be true
    ```
 
-### Feature Enabled When It Shouldn't Be
+2. Verify the host/appvm module uses `isEnabled`, not `isEnabledFor`.
 
-If a feature is active when disabled:
+### Feature enabled when it shouldn't be
 
-1. Check for hardcoded enables in the base module
-2. Ensure you're not using `lib.mkForce` to override
+1. Check for hardcoded enables in the base module.
+2. Ensure you're not using `lib.mkForce` to override.
 3. Verify the feature check is using `mkIf`, not just `=`
 
 ---

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -43,8 +43,6 @@ rec {
       };
 
       logging = {
-        enable = mkEnableOption "logging globally";
-
         listener = {
           address = mkOption {
             type = types.str;
@@ -67,8 +65,6 @@ rec {
           };
         };
       };
-
-      security.audit.enable = mkEnableOption "security auditing globally";
 
       givc = {
         enable = mkEnableOption "GIVC (Ghaf Inter-VM Communication) globally";
@@ -122,12 +118,6 @@ rec {
           default = "x86_64-linux";
           description = "Host platform system (e.g., x86_64-linux)";
         };
-
-        timeZone = mkOption {
-          type = lib.types.nullOr types.str;
-          default = null;
-          description = "System timezone";
-        };
       };
 
       # ═══════════════════════════════════════════════════════════════════════
@@ -156,6 +146,15 @@ rec {
             type = types.listOf types.str;
             default = [ "audio-vm" ];
             description = "VMs that should have audio support";
+          };
+        };
+
+        audit = {
+          enable = mkEnableOption "the Linux audit system";
+          targetVms = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = "VMs that should have the Linux audit system enabled";
           };
         };
 
@@ -211,6 +210,28 @@ rec {
           };
         };
 
+        log-upload = {
+          enable = mkEnableOption "log uploading to central logging infrastructure";
+          targetVms = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = ''
+              VMs that should upload their logs to the central logging server.
+              For client VMs this enables journal forwarding to admin-vm.
+              For admin-vm this enables uploading to the external Loki endpoint.
+            '';
+          };
+        };
+
+        logging = {
+          enable = mkEnableOption "log collection infrastructure";
+          targetVms = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = "VMs that should have log collection enabled";
+          };
+        };
+
         performance = {
           enable = mkEnableOption "Ghaf performance and PPD profiles";
           targetVms = mkOption {
@@ -230,14 +251,15 @@ rec {
         };
 
         timezone = {
-          enable = mkEnableOption "runtime management of timezone settings and propagation to host";
+          enable = mkEnableOption "runtime management of timezone settings";
           targetVms = mkOption {
             type = types.listOf types.str;
             default = [ ];
             description = ''
-              VMs where runtime timezone settings management should be enabled.
+              Enables runtime management of timezone settings and sets default timezone to UTC.
 
-              Propagation will only be enabled on GUI VM.
+              For gui-vm this also enables timezone propagation - any runtime changes made will be
+              forwarded to the host and all other VMs.
             '';
           };
         };
@@ -279,10 +301,7 @@ rec {
   # ═══════════════════════════════════════════════════════════════════════════
   #
   # Helper functions for checking and managing service feature assignments.
-  # These are used by VM base modules to determine which services to enable.
-  #
-  # Usage in VM base modules:
-  #   ghaf.services.fprint.enable = lib.ghaf.features.isEnabledFor globalConfig "fprint" vmName;
+  # These are used by VM base modules and host to determine which services to enable.
   #
   features = {
     # Check if a feature should be enabled for a specific VM
@@ -297,6 +316,10 @@ rec {
     #   vmName: Name of the VM to check (e.g., "gui-vm", "net-vm")
     #
     # Returns: bool
+    #
+    # Usage in VM base modules:
+    #   ghaf.services.fprint.enable = lib.ghaf.features.isEnabledFor globalConfig "fprint" vmName;
+    #
     isEnabledFor =
       globalConfig: featureName: vmName:
       let
@@ -308,6 +331,33 @@ rec {
           };
       in
       (feature.enable or false) && builtins.elem vmName (feature.targetVms or [ ]);
+    # Check if a feature is enabled system-wide
+    #
+    # Usage:
+    #   lib.ghaf.features.isEnabled globalConfig "fprint"
+    #   # Returns: true if fprint.enable
+    #
+    # This is useful for the host and appvms
+    #
+    # Parameters:
+    #   globalConfig: The ghaf.global-config attribute set (from specialArgs)
+    #   featureName: Name of the feature (e.g., "fprint", "wifi")
+    #
+    # Returns: bool
+    #
+    # Usage in host config:
+    #   ghaf.services.fprint.enable = lib.ghaf.features.isEnabled config.ghaf.global-config "fprint";
+    #
+    isEnabled =
+      globalConfig: featureName:
+      let
+        featuresAttr = globalConfig.features or { };
+        feature =
+          featuresAttr.${featureName} or {
+            enable = false;
+          };
+      in
+      feature.enable or false;
   };
 
   # Predefined global config profiles
@@ -327,11 +377,8 @@ rec {
       # Note: listener.address is auto-populated from admin-vm IP by
       # modules/common/global-config.nix (no need to set it per profile).
       logging = {
-        enable = true;
         server.endpoint = defaultLoggingEndpoint;
       };
-
-      security.audit.enable = false;
 
       givc = {
         enable = true;
@@ -402,6 +449,33 @@ rec {
             "gui-vm"
           ];
         };
+        audit = {
+          enable = true;
+          targetVms = [
+            "admin-vm"
+            "audio-vm"
+            "gui-vm"
+            "net-vm"
+          ];
+        };
+        log-upload = {
+          enable = true;
+          targetVms = [
+            "admin-vm"
+            "audio-vm"
+            "gui-vm"
+            "net-vm"
+          ];
+        };
+        logging = {
+          enable = true;
+          targetVms = [
+            "admin-vm"
+            "audio-vm"
+            "gui-vm"
+            "net-vm"
+          ];
+        };
         timezone = {
           enable = true;
           targetVms = [
@@ -425,10 +499,8 @@ rec {
       };
 
       logging = {
-        enable = true;
         server.endpoint = defaultLoggingEndpoint;
       };
-      security.audit.enable = true;
 
       givc = {
         enable = true;
@@ -498,6 +570,33 @@ rec {
             "gui-vm"
           ];
         };
+        audit = {
+          enable = true;
+          targetVms = [
+            "admin-vm"
+            "audio-vm"
+            "gui-vm"
+            "net-vm"
+          ];
+        };
+        log-upload = {
+          enable = true;
+          targetVms = [
+            "admin-vm"
+            "audio-vm"
+            "gui-vm"
+            "net-vm"
+          ];
+        };
+        logging = {
+          enable = true;
+          targetVms = [
+            "admin-vm"
+            "audio-vm"
+            "gui-vm"
+            "net-vm"
+          ];
+        };
         timezone = {
           enable = true;
           targetVms = [
@@ -519,9 +618,6 @@ rec {
         debug.tools.enable = false;
         nix-setup.enable = false;
       };
-
-      logging.enable = false;
-      security.audit.enable = false;
 
       givc = {
         enable = false;
@@ -567,11 +663,23 @@ rec {
           enable = false;
           targetVms = [ ];
         };
-        power-manager = {
+        audit = {
+          enable = false;
+          targetVms = [ ];
+        };
+        log-upload = {
+          enable = false;
+          targetVms = [ ];
+        };
+        logging = {
           enable = false;
           targetVms = [ ];
         };
         performance = {
+          enable = false;
+          targetVms = [ ];
+        };
+        power-manager = {
           enable = false;
           targetVms = [ ];
         };

--- a/modules/common/global-config.nix
+++ b/modules/common/global-config.nix
@@ -35,7 +35,6 @@
       platform = {
         buildSystem = lib.mkDefault config.nixpkgs.buildPlatform.system;
         hostSystem = lib.mkDefault config.nixpkgs.hostPlatform.system;
-        timeZone = lib.mkDefault config.time.timeZone;
       };
 
       # Propagate host storeOnDisk setting to global-config for VMs
@@ -45,7 +44,8 @@
       # The logging listener always runs on admin-vm, so derive the address
       # from hosts.nix rather than requiring each profile to set it manually.
       logging.listener.address = lib.mkIf (
-        config.ghaf.global-config.logging.enable && config.ghaf.common.adminHost != null
+        lib.ghaf.features.isEnabled config.ghaf.global-config "logging"
+        && config.ghaf.common.adminHost != null
       ) (lib.mkDefault config.ghaf.networking.hosts.admin-vm.ipv4);
     };
   };

--- a/modules/common/security/audit/default.nix
+++ b/modules/common/security/audit/default.nix
@@ -28,7 +28,7 @@ in
   _file = ./default.nix;
 
   options.ghaf.security.audit = {
-    enable = mkEnableOption "audit support";
+    enable = mkEnableOption "the Linux audit system";
     debug = mkOption {
       type = types.bool;
       default = true; # for now

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -14,6 +14,12 @@
 }:
 let
   cfg = config.ghaf.virtualization.microvm-host;
+  globalConfig = config.ghaf.global-config;
+  # System-wide features
+  auditEnabled = lib.ghaf.features.isEnabled globalConfig "audit";
+  logUploadEnabled = lib.ghaf.features.isEnabled globalConfig "log-upload";
+  loggingEnabled = lib.ghaf.features.isEnabled globalConfig "logging";
+  timezoneEnabled = lib.ghaf.features.isEnabled globalConfig "timezone";
   inherit (lib)
     mkEnableOption
     mkIf
@@ -130,13 +136,12 @@ in
           usb-serial.enable = config.ghaf.profiles.debug.enable;
         };
         logging = {
+          enable = lib.mkDefault loggingEnabled;
           listener = {
-            address = lib.mkDefault config.ghaf.global-config.logging.listener.address;
-            port = lib.mkDefault config.ghaf.global-config.logging.listener.port;
+            address = lib.mkDefault globalConfig.logging.listener.address;
+            port = lib.mkDefault globalConfig.logging.listener.port;
           };
-          journalClient = {
-            inherit (config.ghaf.logging) enable;
-          };
+          journalClient.enable = lib.mkDefault logUploadEnabled;
         };
         common = {
           extraNetworking.hosts.ghaf-host = cfg.extraNetworking;
@@ -149,13 +154,19 @@ in
             };
           };
         };
+        security = {
+          audit.enable = auditEnabled;
 
-        security.spire.agent = {
-          inherit (config.ghaf.global-config.spire) enable;
-          logLevel = if config.ghaf.global-config.spire.debug then "DEBUG" else "INFO";
-          nodeAttestationMode = if config.ghaf.global-config.givc.enable then "x509pop" else "join_token";
-          settings.join_token.token = "/persist/common/spire/tokens/${config.networking.hostName}.token";
-          trustBundlePath = "/persist/common/spire/bundle.pem";
+          spire.agent = {
+            inherit (globalConfig.spire) enable;
+            logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
+            nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+            settings.join_token.token = "/persist/common/spire/tokens/${config.networking.hostName}.token";
+            trustBundlePath = "/persist/common/spire/bundle.pem";
+          };
+        };
+        services.timezone = {
+          enable = lib.mkDefault timezoneEnabled;
         };
       };
 

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -24,7 +24,12 @@
 }:
 let
   vmName = "admin-vm";
+  # keep-sorted start
+  auditEnabled = lib.ghaf.features.isEnabledFor globalConfig "audit" vmName;
+  logUploadEnabled = lib.ghaf.features.isEnabledFor globalConfig "log-upload" vmName;
+  loggingEnabled = lib.ghaf.features.isEnabledFor globalConfig "logging" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+  # keep-sorted end
 in
 {
   _file = ./adminvm-base.nix;
@@ -79,6 +84,8 @@ in
     };
 
     givc = {
+      enable = globalConfig.givc.enable or false;
+      debug = globalConfig.givc.debug or false;
       adminvm.enable = true;
       policyAdmin = {
         enable = true;
@@ -130,15 +137,16 @@ in
       };
     };
 
-    # Logging - from globalConfig
+    # Logging - from globalConfig and features
     logging = {
-      inherit (globalConfig.logging) enable listener;
+      enable = loggingEnabled;
+      inherit (globalConfig.logging) listener;
       journalServer = {
-        inherit (globalConfig.logging) enable;
+        enable = loggingEnabled;
       };
 
       server = {
-        inherit (globalConfig.logging) enable;
+        enable = logUploadEnabled;
         endpoint = globalConfig.logging.server.endpoint or "";
 
         tls = {
@@ -149,16 +157,10 @@ in
       recovery.enable = true;
     };
 
-    # GIVC configuration - from globalConfig
-    givc = {
-      inherit (globalConfig.givc) enable;
-      inherit (globalConfig.givc) debug;
-    };
-
     # Security
     security = {
       fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
-      audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+      audit.enable = lib.mkDefault auditEnabled;
 
       spire = {
         server = {
@@ -173,16 +175,12 @@ in
       };
     };
 
-    services.timezone.enable = lib.mkDefault (
-      timezoneEnabled && globalConfig.platform.timeZone == null
-    );
+    services.timezone.enable = lib.mkDefault timezoneEnabled;
 
     # Make sure admin-vm is the last to shutdown
     # This is done to allow servicing GIVC requests until the very end
     shutdownLast = true;
   };
-
-  time.timeZone = lib.mkIf (!timezoneEnabled) (lib.mkDefault globalConfig.platform.timeZone);
 
   system.stateVersion = lib.trivial.release;
 

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -43,6 +43,11 @@ let
   # Get VM definition from hostConfig
   vm = hostConfig.appvm;
   vmName = "${vm.name}-vm";
+  # keep-sorted start
+  logUploadEnabled = lib.ghaf.features.isEnabled globalConfig "log-upload";
+  loggingEnabled = lib.ghaf.features.isEnabled globalConfig "logging";
+  timezoneEnabled = lib.ghaf.features.isEnabled globalConfig "timezone";
+  # keep-sorted end
 
   # Helper to unwrap mkDefault values for use in lib.mkIf conditions
   # Values like `lib.mkDefault true` become { _type = "override"; content = true; priority = 1000; }
@@ -254,12 +259,11 @@ in
           role = "client";
         };
 
-        # Logging - from globalConfig
+        # Logging - from globalConfig and features
         logging = {
-          inherit (globalConfig.logging) enable listener;
-          journalClient = {
-            inherit (globalConfig.logging) enable;
-          };
+          enable = loggingEnabled;
+          inherit (globalConfig.logging) listener;
+          journalClient.enable = logUploadEnabled;
         };
 
         # Security
@@ -271,6 +275,8 @@ in
             nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
           };
         };
+
+        services.timezone.enable = lib.mkDefault timezoneEnabled;
       };
 
       # Combined udev rules (yubikey + passthrough)
@@ -307,8 +313,6 @@ in
       };
 
       system.stateVersion = lib.trivial.release;
-
-      time.timeZone = lib.mkDefault globalConfig.platform.timeZone;
 
       nixpkgs = {
         buildPlatform.system = globalConfig.platform.buildSystem or "x86_64-linux";

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -26,11 +26,16 @@
 }:
 let
   vmName = "audio-vm";
+  # keep-sorted start
   audioEnabled = lib.ghaf.features.isEnabledFor globalConfig "audio" vmName;
+  auditEnabled = lib.ghaf.features.isEnabledFor globalConfig "audit" vmName;
   bluetoothEnabled = lib.ghaf.features.isEnabledFor globalConfig "bluetooth" vmName;
-  powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
+  logUploadEnabled = lib.ghaf.features.isEnabledFor globalConfig "log-upload" vmName;
+  loggingEnabled = lib.ghaf.features.isEnabledFor globalConfig "logging" vmName;
   performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
+  powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+  # keep-sorted end
 in
 {
   _file = ./audiovm-base.nix;
@@ -143,15 +148,14 @@ in
         vm.enable = true;
       };
 
-      timezone.enable = lib.mkDefault (timezoneEnabled && globalConfig.platform.timeZone == null);
+      timezone.enable = lib.mkDefault timezoneEnabled;
     };
 
-    # Logging - from globalConfig
+    # Logging - from globalConfig and features
     logging = {
-      inherit (globalConfig.logging) enable listener;
-      journalClient = {
-        inherit (globalConfig.logging) enable;
-      };
+      enable = loggingEnabled;
+      inherit (globalConfig.logging) listener;
+      journalClient.enable = logUploadEnabled;
     };
 
     security = {
@@ -182,10 +186,8 @@ in
     };
 
     # Security - from globalConfig
-    security.audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+    security.audit.enable = lib.mkDefault auditEnabled;
   };
-
-  time.timeZone = lib.mkIf (!timezoneEnabled) (lib.mkDefault globalConfig.platform.timeZone);
 
   environment = {
     systemPackages = [

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -39,13 +39,18 @@
 }:
 let
   vmName = "gui-vm";
-  fprintEnabled = lib.ghaf.features.isEnabledFor globalConfig "fprint" vmName;
-  yubikeyEnabled = lib.ghaf.features.isEnabledFor globalConfig "yubikey" vmName;
+  # keep-sorted start
+  auditEnabled = lib.ghaf.features.isEnabledFor globalConfig "audit" vmName;
   brightnessEnabled = lib.ghaf.features.isEnabledFor globalConfig "brightness" vmName;
-  powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
-  performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
+  fprintEnabled = lib.ghaf.features.isEnabledFor globalConfig "fprint" vmName;
   localeEnabled = lib.ghaf.features.isEnabledFor globalConfig "locale" vmName;
+  logUploadEnabled = lib.ghaf.features.isEnabledFor globalConfig "log-upload" vmName;
+  loggingEnabled = lib.ghaf.features.isEnabledFor globalConfig "logging" vmName;
+  performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
+  powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+  yubikeyEnabled = lib.ghaf.features.isEnabledFor globalConfig "yubikey" vmName;
+  # keep-sorted end
 
   # A list of applications from all AppVMs (accessed via hostConfig)
   enabledVms = lib.filterAttrs (_: vm: vm.enable) (hostConfig.appvms or { });
@@ -136,9 +141,9 @@ in
     givc = {
       enable = globalConfig.givc.enable or false;
       debug = globalConfig.givc.debug or false;
+      guivm.enable = true;
+      sni.enable = true;
     };
-    givc.guivm.enable = true;
-    givc.sni.enable = true;
 
     # Storage - from globalConfig
     storagevm = {
@@ -195,11 +200,12 @@ in
       };
     };
 
-    # Logging - from globalConfig
+    # Logging - from globalConfig and features
     logging = {
-      inherit (globalConfig.logging) enable listener;
+      enable = loggingEnabled;
+      inherit (globalConfig.logging) listener;
       journalClient = {
-        inherit (globalConfig.logging) enable;
+        enable = logUploadEnabled;
       };
     };
 
@@ -247,7 +253,7 @@ in
       };
 
       timezone = {
-        enable = lib.mkDefault (timezoneEnabled && globalConfig.platform.timeZone == null);
+        enable = lib.mkDefault timezoneEnabled;
         propagate = true;
       };
 
@@ -264,7 +270,7 @@ in
 
     security = {
       # Audit - from globalConfig
-      audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+      audit.enable = lib.mkDefault auditEnabled;
       fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
 
       spire.agent = {
@@ -274,8 +280,6 @@ in
       };
     };
   };
-
-  time.timeZone = lib.mkIf (!timezoneEnabled) (lib.mkDefault globalConfig.platform.timeZone);
 
   services = {
     # We dont enable services.blueman because it adds blueman desktop entry

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -25,10 +25,15 @@
 }:
 let
   vmName = "net-vm";
-  powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
+  # keep-sorted start
+  auditEnabled = lib.ghaf.features.isEnabledFor globalConfig "audit" vmName;
+  logUploadEnabled = lib.ghaf.features.isEnabledFor globalConfig "log-upload" vmName;
+  loggingEnabled = lib.ghaf.features.isEnabledFor globalConfig "logging" vmName;
   performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
-  wifiEnabled = lib.ghaf.features.isEnabledFor globalConfig "wifi" vmName;
+  powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+  wifiEnabled = lib.ghaf.features.isEnabledFor globalConfig "wifi" vmName;
+  # keep-sorted end
 in
 {
   _file = ./netvm-base.nix;
@@ -152,15 +157,14 @@ in
         net.enable = pkgs.stdenv.hostPlatform.isx86;
       };
 
-      timezone.enable = lib.mkDefault (timezoneEnabled && globalConfig.platform.timeZone == null);
+      timezone.enable = lib.mkDefault timezoneEnabled;
     };
 
-    # Logging - from globalConfig (includes listener address)
+    # Logging - from globalConfig and features
     logging = {
-      inherit (globalConfig.logging) enable listener;
-      journalClient = {
-        inherit (globalConfig.logging) enable;
-      };
+      enable = loggingEnabled;
+      inherit (globalConfig.logging) listener;
+      journalClient.enable = logUploadEnabled;
     };
 
     security = {
@@ -171,8 +175,7 @@ in
         listenAddress = hostConfig.networking.thisVm.ipv4 or "192.168.100.1";
       };
 
-      # Audit - from globalConfig
-      audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+      audit.enable = lib.mkDefault auditEnabled;
 
       spire.agent = {
         enable = globalConfig.spire.enable or false;
@@ -187,8 +190,6 @@ in
     # Note: reference.services is NOT set here - it should come via extraModules
     # from hardware.definition.netvm.extraModules if needed
   };
-
-  time.timeZone = lib.mkIf (!timezoneEnabled) (lib.mkDefault globalConfig.platform.timeZone);
 
   system.stateVersion = lib.trivial.release;
 


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

### **Motivation**
Originally features were introduced with two main options - `enable` and `targetVms`.
Enabling a feature was described as "Whether the feature is available system-wide". Despite this, we still had some top-level global config options like `security.audit.enable` and `logging.enable`, which were enabled system-wide but were not considered features.

As a result, the host and appvm configs never made use of features and instead relied on the top-level global config options.

This refactor attempts to change this behavior

---

### **Implementation**

`lib.ghaf.features` now includes a new helper `isEnabled`, which allows checking if a given feature is enabled system-wide.

As a result, the host (and appvms) can now make use of the Features API. Note that a feature does not activate automatically on the host or appvms - the relevant module still has to opt in by calling `isEnabled` and wiring the result to the appropriate option.

**Limitations**
Enabling a feature system-wide now implicitly enables it for all appvms and the host, as long as those modules wire it up via `isEnabled`. This is generally a good idea for our use case, but there may be situations in the future where a certain feature may be needed on a specific sysvm, but not on the host or any appvms.

---

### **Alternative implementation**

As an alternative, and mainly to address the limitation introduced by the current implementation (see above), we could introduce one or two more options to the `feature` attr to allow configuring features for the host and appvms independently of the `targetVms` config:
- `enableOnHost` or `host` - Whether the feature is enabled on the host
- `enableAppVms` - Whether the feature is enabled on appvms

These would only be needed in the unusual case where a feature should be assigned to a sysvm via `targetVms` but should explicitly not apply to the host or appvms.

---

### Other changes:

- Introduce 3 new Ghaf features, which can be enabled/disabled per-vm:
   - `logging` - whether to enable log collection
   - `log-upload` - whether to enable log upload
   - `audit` - whether to enable the Linux audit system
- Update `features-api.mdx` and `adding-features.mdx` to document `isEnabled` and the two-tier enablement model


<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `make-checks` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] System 76 `x86_64`

### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
