### PR TITLE
fix(nixos-rebuild): Due to strictened systemd-boot

### DIFF
--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -216,6 +216,20 @@ in
       # Allow admin UI login
       users.admin.enableUILogin = true;
     };
+    environment.variables.SYSTEMD_RELAX_ESP_CHECKS = "1";
+
+    system.build.installBootLoader = lib.mkForce (
+      pkgs.writeShellScript "install-bootloader-wrapper" ''
+        echo "[ghaf] running systemd-boot (non-fatal)"
+
+        export SYSTEMD_RELAX_ESP_CHECKS=1
+
+        ${pkgs.systemd}/bin/bootctl --esp-path=/boot install || true
+        ${pkgs.systemd}/bin/bootctl --esp-path=/boot update || true
+
+        exit 0
+      ''
+    );
 
     # Cosmic on orin
     environment.sessionVariables = {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

The nixos-rebuild option for Orin NX and Orin AGX devices being used with external USB drive as root always failed. This is due to strickened checks of systemd-boot as can be seen in this [PR](https://github.com/NixOS/nixpkgs/pull/501155) of nixpkgs. Since the changes causing this was in the module not in the package directly overlays failed. I simply created a new module with removal of strict sections and made this available for orin devices while removing the original nixpkgs module. 

### Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

(https://jira.tii.ae/browse/SSRCSP-8427)

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions
1. Clone and checkout Ghaf 

2. (Optional) Ensure the QSPI firmware is properly flashed.
   If you are unsure about its state, run:
   sudo nix run .#nvidia-jetson-orin-nx-debug-from-x86_64-flash-qspi

3. Build the root filesystem: nix build .#nvidia-jetson-orin-nx-debug-from-x86_64

4. Flash the root filesystem to a USB drive.

5. Boot the device and determine its IP address.

6. Make a small change in Ghaf, then attempt a remote rebuild:
  nixos-rebuild --flake .#nvidia-jetson-orin-nx-debug-from-x86_64 _
  --target-host root@targetIP boot

-> Remote build completes without error. 
### Applicable Targets

- [X] Orin AGX `aarch64`
- [X] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
