### PR TITLE
fix(sni): migrate dbus-proxy-sni to user services to fix log visibility

### DIFF
--- a/modules/microvm/common/sni.nix
+++ b/modules/microvm/common/sni.nix
@@ -33,7 +33,6 @@ let
   inherit (config.networking) hostName;
   guivmName = "gui-vm";
   appUserUid = toString config.ghaf.users.appUser.uid;
-  homedUid = toString config.ghaf.users.homedUser.uid;
 
   # Port map: built from sniCfg.vms so ports start at portBase regardless of
   # where the VM falls in the full appHosts list.
@@ -175,41 +174,29 @@ in
           inherit (src) socket;
         }) sniSources;
 
-        # Path units: activate the dbus-proxy-sni service only when the tunnel
-        # socket actually appears (i.e., the appvm has SNI enabled and is running).
-        # This prevents restart-loops for appvms that have SNI disabled.
-        systemd.paths = listToAttrs (
-          map (
-            src:
-            nameValuePair "dbus-proxy-sni-${src.vmName}" {
-              description = "Watch for SNI tunnel socket from ${src.vmName}";
-              wantedBy = [ "graphical.target" ];
-              pathConfig = {
-                PathExists = src.socket;
-                Unit = "dbus-proxy-sni-${src.vmName}.service";
-              };
-            }
-          ) sniSources
-        );
-
-        # One dbus-proxy-sni service per appvm: bridges the GIVC tunnel socket
-        # (system bus) to the user session bus so the compositor sees the tray icons.
-        # Activated on-demand by the corresponding path unit above.
-        systemd.services = listToAttrs (
+        # User services: run as the logged-in user.
+        systemd.user.services = listToAttrs (
           map (
             src:
             nameValuePair "dbus-proxy-sni-${src.vmName}" {
               description = "DBus proxy for SNI tray icons from ${src.vmName}";
-              after = [ "user-login.service" ];
+              after = [ "graphical-session.target" ];
+              wantedBy = [ "graphical-session.target" ];
+              partOf = [ "graphical-session.target" ];
+              unitConfig = {
+                ConditionUser = toString config.ghaf.users.homedUser.uid;
+              };
               serviceConfig = {
                 Type = "exec";
                 Restart = "on-failure";
-                RestartSec = "5s";
+                # Retry if the GIVC socket is not yet ready when the session starts.
+                RestartSec = "30s";
+                # Override the system bus to the GIVC tunnel socket.
+                # The session bus is available automatically in user service context.
                 Environment = [
                   "DBUS_SYSTEM_BUS_ADDRESS=unix:path=${src.socket}"
-                  "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${homedUid}/bus"
                 ];
-                User = homedUid;
+
                 ExecStart = ''
                   ${getExe pkgs.dbus-proxy} \
                     --sni-mode \


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
The previous system-scoped services ran independently of the user session,
generating continuous log noise. Migrating to `systemd.user.services` tied
to `graphical-session.target` ensures the services start when the user logs
in and stop when the user logs out, eliminating unnecessary logging outside
of active sessions.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets
SSRCSP-8429
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Check SSRCSP-8429 issue if it is still available.
2. SNI functionality should work as expected. (Follow test instructions: https://github.com/tiiuae/ghaf/pull/1907#issue-4316043219)
