### PR TITLE
fix(cosmic-greeter): Enable fingerprint unlock

### DIFF
--- a/modules/common/services/fprint.nix
+++ b/modules/common/services/fprint.nix
@@ -22,6 +22,22 @@ in
     services.fprintd.enable = true;
     environment.systemPackages = [ pkgs.fprintd ];
 
+    ghaf.services.power-manager.suspend.extraSuspendCommands = ''
+      ${lib.getExe' pkgs.systemd "systemctl"} stop fprintd || true
+    '';
+
+    systemd.services.fprintd-resume = {
+      wantedBy = [ "post-resume.target" ];
+      after = [ "systemd-logind.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = ''
+          ${pkgs.systemd}/bin/systemctl restart fprintd
+        '';
+      };
+    };
+
     ghaf = {
       systemd.withPolkit = true;
       security.audit.extraRules = [

--- a/modules/desktop/graphics/login-manager.nix
+++ b/modules/desktop/graphics/login-manager.nix
@@ -73,10 +73,24 @@ in
     security.pam.services = {
       cosmic-greeter = {
         rules = {
+          account = {
+            # When homed auth was used, PAM_AUTHTOK holds the real password and
+            # systemd_home account succeeds → done. When fingerprint was used,
+            # PAM_AUTHTOK is unset and systemd_home fails → fall through to permit.
+            systemd_home.control = lib.mkForce "[success=done default=ignore]";
+            permit = {
+              enable = true;
+              control = "[success=done default=ignore]";
+              modulePath = "${pkgs.linux-pam}/lib/security/pam_permit.so";
+              order = 10900; # after systemd_home (10800), before unix (11000)
+            };
+          };
           auth = {
-            systemd_home.order = 11399; # Re-order to allow either password _or_ fingerprint on lockscreen
             unix.settings.use_first_pass = !config.ghaf.services.sssd.enable;
-            fprintd.args = [ "maxtries=3" ];
+            fprintd.args = [
+              "max-tries=3"
+              "timeout=-1"
+            ];
           };
         };
       };
@@ -84,9 +98,7 @@ in
         fprintAuth = false; # User needs to enter password to decrypt home on login
         rules = {
           auth = {
-            systemd_home.order = 11399; # Re-order to allow either password _or_ fingerprint on lockscreen
             unix.settings.use_first_pass = !config.ghaf.services.sssd.enable;
-            fprintd.args = [ "maxtries=3" ];
 
             # This should precede other auth rules e.g. pam_sss.so (pam module for SSSD)
             faillock_preauth = mkIf cfg.failLock.enable {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Initial login screen and lock screen separated to different logic allowing fingerprint lock screen
- Initial login accept only password

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

Login with password, remove exististing finger prints fprintd-delete
Lock screen -> only password option should appear
fprintd-enroll
Lock screen -> finger print option first and if 3 failures, password fallback appear