### PR TITLE
refactor(ssh-tarpit): replacing endlessh-go with tarssh

### DIFF
--- a/modules/common/security/ssh-tarpit/default.nix
+++ b/modules/common/security/ssh-tarpit/default.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -13,6 +14,7 @@ let
     mkForce
     mkOption
     types
+    getExe
     ;
   tarpitListenPort = 2222;
   sshPort = lib.head config.services.openssh.ports;
@@ -48,18 +50,17 @@ in
         message = "Fail2ban must be enabled to activate ssh-tarpit module";
       }
     ];
-    services.endlessh-go = {
-      enable = true;
-      port = tarpitListenPort;
-      openFirewall = false;
-      inherit (cfg) listenAddress;
-      extraOptions = [ "-interval_ms 3000 -v 1" ];
-    };
-    systemd.services.endlessh-go.serviceConfig = {
-      Restart = lib.mkForce "on-failure";
-      RestartSec = "10s";
-      StartLimitBurst = 10;
-      StartLimitIntervalSec = 60;
+    systemd.services.ssh-tarpit = {
+      description = "SSH tarpit";
+      requires = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = mkForce "${getExe pkgs.tarssh} --listen ${cfg.listenAddress}:${toString tarpitListenPort} --delay 3 --max-clients 64";
+        Restart = mkForce "always";
+        RestartSec = mkForce "10s";
+        StartLimitBurst = mkForce 10;
+        StartLimitIntervalSec = mkForce 60;
+      };
     };
 
     ghaf.security.fail2ban.sshd-jail-fwmark = {

--- a/modules/common/systemd/hardened-configs/default.nix
+++ b/modules/common/systemd/hardened-configs/default.nix
@@ -31,6 +31,7 @@
     nw-packet-forwarder.serviceConfig = import ./nw-packet-forwarder.nix;
     rtkit-daemon.serviceConfig = import ./rtkit-daemon.nix;
     seatd.serviceConfig = import ./seatd.nix;
+    ssh-tarpit.serviceConfig = import ./ssh-tarpit.nix;
     systemd-journal-catalog-update.serviceConfig = import ./systemd-journal-catalog-update.nix;
     systemd-journal-flush.serviceConfig = import ./systemd-journal-flush.nix;
     systemd-networkd-wait-online.serviceConfig = import ./systemd-networkd-wait-online.nix;

--- a/modules/common/systemd/hardened-configs/ssh-tarpit.nix
+++ b/modules/common/systemd/hardened-configs/ssh-tarpit.nix
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+{
+  ##############
+  # Networking #
+  ##############
+
+  RestrictAddressFamilies = [
+    "AF_INET"
+    "AF_INET6"
+  ];
+
+  ###############
+  # File system #
+  ###############
+
+  PrivateTmp = true;
+  ProtectHome = true;
+  ProtectSystem = "strict";
+  ProtectProc = "noaccess";
+  ProcSubset = "pid";
+
+  ###################
+  # User separation #
+  ###################
+
+  PrivateUsers = true;
+  DynamicUser = true;
+  RootDirectory = "/run/ssh-tarpit";
+  BindReadOnlyPaths = [
+    builtins.storeDir
+    "-/etc/hosts"
+    "-/etc/localtime"
+    "-/etc/nsswitch.conf"
+    "-/etc/resolv.conf"
+  ];
+  InaccessiblePaths = [ "-+/run/ssh-tarpit" ];
+  RuntimeDirectory = "ssh-tarpit";
+  RuntimeDirectoryMode = "700";
+
+  ###########
+  # Devices #
+  ###########
+
+  PrivateDevices = true;
+
+  ##########
+  # Kernel #
+  ##########
+
+  ProtectKernelTunables = true;
+  ProtectKernelModules = true;
+  ProtectKernelLogs = true;
+
+  ########
+  # Misc #
+  ########
+
+  NoNewPrivileges = true;
+  UMask = "0077";
+  ProtectHostname = true;
+  ProtectClock = true;
+  ProtectControlGroups = true;
+  LockPersonality = true;
+  MemoryDenyWriteExecute = true;
+  RestrictRealtime = true;
+  RestrictSUIDSGID = true;
+  RemoveIPC = true;
+  RestrictNamespaces = true;
+  SystemCallArchitectures = "native";
+  SystemCallFilter = [
+    "@system-service"
+    "~@privileged"
+  ];
+
+  ################
+  # Capabilities #
+  ################
+
+  AmbientCapabilities = [ "" ];
+  CapabilityBoundingSet = [ "" ];
+}


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
The endlessh-go package is licensed under the GNU GPL v3.0, which is incompatible with ghaf and can be replaced by tarssh.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets
SSRCSP-8570
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Regression test for network-related services
2. Check endless-go in net-vm whether it is activated with `systemctl status ssh-tarpit`
3. Attempt to establish an SSH connection, but enter the password incorrectly more than the SSH threshold limit.
4. Check the blacklist on the net-vm by using the command `ipset list f2b-blacklist.` You should see the attacker's IP address listed in the members section.
5. Try to make an SSH connection again from the attacker's device. The connection should hang.
