### PR TITLE
feat(waypipe): socket-activate xwayland-satellite

### DIFF
--- a/modules/microvm/common/waypipe.nix
+++ b/modules/microvm/common/waypipe.nix
@@ -50,6 +50,13 @@ let
     --display ${cfg.persistentWaypipeServer.display} \
     server -- ${pkgs.coreutils}/bin/sleep infinity
   '';
+
+  xwaylandSatelliteSocket =
+    xDisplay:
+    let
+      displayNumber = builtins.head (strings.splitString "." (strings.removePrefix ":" xDisplay));
+    in
+    "/tmp/.X11-unix/X${displayNumber}";
 in
 {
   _file = ./waypipe.nix;
@@ -234,23 +241,45 @@ in
               '';
             };
           };
-
+        }
+        // lib.optionalAttrs (cfg.persistentWaypipeServer.xDisplay != null) {
           # XWayland Satellite allows X11 apps to run in the AppVM and display through the persistent Waypipe server
           xwayland-satellite = {
-            enable = cfg.persistentWaypipeServer.xDisplay != null;
             description = "XWayland Satellite";
-            wantedBy = [ "waypipe-server.service" ];
+            requires = [
+              "xwayland-satellite.socket"
+              "waypipe-server.service"
+            ];
             after = [ "waypipe-server.service" ];
             unitConfig = {
               ConditionUser = config.ghaf.users.appUser.name;
             };
             serviceConfig = {
               Type = "notify";
+              Environment = [
+                "WAYLAND_DISPLAY=${cfg.persistentWaypipeServer.display}"
+              ];
               ExecStart = ''
-                ${lib.getExe pkgs.xwayland-satellite} ${cfg.persistentWaypipeServer.xDisplay}
+                ${getExe pkgs.xwayland-satellite} ${cfg.persistentWaypipeServer.xDisplay} -listenfd 3
               '';
-              Restart = "on-failure";
-              RestartSec = "5s";
+            };
+          };
+        };
+
+        systemd.user.sockets = lib.optionalAttrs (cfg.persistentWaypipeServer.xDisplay != null) {
+          xwayland-satellite = {
+            description = "XWayland Satellite socket";
+            wantedBy = [ "sockets.target" ];
+            unitConfig = {
+              ConditionUser = config.ghaf.users.appUser.name;
+            };
+            listenStreams = [ (xwaylandSatelliteSocket cfg.persistentWaypipeServer.xDisplay) ];
+            socketConfig = {
+              DirectoryMode = "1777";
+              FlushPending = true;
+              RemoveOnStop = true;
+              Service = "xwayland-satellite.service";
+              SocketMode = "0600";
             };
           };
         };


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Currently, xwayland-satellite is running all the time. When the user is logged out, it is unable to connect to the Wayland compositor, producing a large number of error messages in the logs. This patch enables socket activation for xwayland-satellite so it only runs when an X11 application is active.

The host logs also contain some unnecessary diagnostic messages from vsockproxy. These will be removed once this PR is merged: https://github.com/tiiuae/ghafpkgs/pull/303

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-8428
https://jira.tii.ae/browse/SSRCSP-8430

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Check the logs when the user is logged out and verify that there are no recurring error messages related to xwayland-satellite or vsockproxy.
2. Try running an X11 application to ensure it works correctly and that there are no regressions.
