### PR TITLE
fix(cosmic): Orin devices COSMIC display working again

### DIFF
--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -132,7 +132,7 @@ in
       graphics.cosmic = {
         # Crucial for Orin devices to use the correct render device
         # Also needs 'mesa' to be in hardware.graphics.extraPackages
-        renderDevice = "/dev/dri/renderD129";
+        renderDevice = lib.mkDefault "/dev/dri/renderD128";
         # Keep only essential applets for Orin devices
         topPanelApplets.right = [
           "com.system76.CosmicAppletInputSources"
@@ -217,8 +217,19 @@ in
       users.admin.enableUILogin = true;
     };
 
+    # Cosmic on orin
+    environment.sessionVariables = {
+      GBM_BACKEND = "dri";
+      __EGL_VENDOR_LIBRARY_FILENAMES = "/run/opengl-driver/share/glvnd/egl_vendor.d/50_mesa.json";
+    };
+
+    # Cosmic on orin
     hardware.graphics.extraPackages = lib.mkAfter [
       pkgs.mesa
     ];
+
+    # Cosmic on orin
+    users.users.ghaf.extraGroups = [ "video" ];
+
   };
 }

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -91,6 +91,9 @@ let
       extraModules = commonModules;
       extraConfig = {
         reference.profiles.mvp-orinuser-trial.enable = true;
+        # Crucial for Orin devices to use the correct render device
+        # Also needs 'mesa' to be in hardware.graphics.extraPackages
+        graphics.cosmic.renderDevice = "/dev/dri/renderD128";
       };
     })
 
@@ -143,6 +146,9 @@ let
       extraModules = commonModules;
       extraConfig = {
         reference.profiles.mvp-orinuser-trial.enable = true;
+        # Crucial for Orin devices to use the correct render device
+        # Also needs 'mesa' to be in hardware.graphics.extraPackages
+        graphics.cosmic.renderDevice = "/dev/dri/renderD128";
       };
     })
   ];


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

On latest COSMIC version bump the Orin devices failed to provide a display output anymore. We added ghaf user to video group and added corresponding environment variables to system as well as defining the display port device. Now both AGX and NX devices are providing Cosmic display output. 

Known limitations: 
1- The Display Port to HDMI converters do not work. You need a display with Display Port to get screen output for Orin devices.
2- After cosmic is enabled the Orin devices start suspending after some period of time requiring user to press power button to resume which is annoying. I suggest disabling of suspend for Orin devices.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->
No Jira tickets as there were no active Orin users that used COSMIC display.
## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [X] Orin AGX `aarch64`
- [X] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Build an image and flash to USB/NVME/eEMMC or perform a nixos-rebuild boot to Orin NX or AGX device 
2. Reboot
3. Cosmic screen arrives