### PR TITLE
feat(ota-update):  OCI/ORAS update artifacts delivery

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -358,11 +358,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781776737,
-        "narHash": "sha256-mNEFUFVWwxIafNRIRUbCYS7LcoUPmQTKvmPCQDJJKqg=",
+        "lastModified": 1782209550,
+        "narHash": "sha256-pvTS0tthEVPiIMRQkgbLD1Zk9vTIHPtU0CWq6anRyPc=",
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "417ecd24b7375c3d377988d7e23bd0def55dab58",
+        "rev": "683deff4d32f06819b3413fe396869167135ced9",
         "type": "github"
       },
       "original": {

--- a/modules/givc/netvm.nix
+++ b/modules/givc/netvm.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -26,6 +27,10 @@ in
   };
 
   config = mkIf (cfg.enable && config.ghaf.givc.enable) {
+    environment.systemPackages = [
+      pkgs.ota-update
+    ];
+
     assertions = [
       {
         assertion = !config.ghaf.givc.policyAdmin.enable;

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -32,6 +32,7 @@
                 nix-output-monitor
                 nix-tree
                 nixVersions.latest
+                oras
                 prefetch-npm-deps
                 reuse
                 self'.legacyPackages.flash-script

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -6,5 +6,6 @@
     ./devshell.nix
     ./nixpkgs.nix
     ./treefmt.nix
+    ./oras-push.nix
   ];
 }

--- a/nix/oras-push.nix
+++ b/nix/oras-push.nix
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ inputs, ... }:
+{
+  perSystem = { system, ... }: {
+    apps.ota-oras-push = inputs.givc.apps.${system}.ota-oras-push;
+  };
+}


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Include bumped version of `ota-update` with implemented OCI pull, also oras tool added to devshell, and `ota-update` to net-vm to perform updates pull.
Also re-export `ota-oras-push` app from GIVC for `nix run .#ota-oras-push ...` and perform uploads by CI/CD team
(that done to use bound version of GIVC to perform uploads)

Open question -- worth to move `...-sysupdate` output from `carbox-x1-gen11` target to generic intel laptop in this PR, or make own for that change.

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

https://github.com/tiiuae/ghaf-givc/pull/430 (actual code changes is here)

## Checklist

- [x] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other:
  Build `...-sysupdate` target, deliver it by scp, and apply using `ota-update image install` on host
(both reinstall and sysupdate should have same effect)

### Test Steps To Verify:


1. On net-vm: run following command: `time ota-update registry pull registry.vedenemo.dev/ghaf-ota-update-test/ghaf:26.07.1.1`  (time prefix not nessesary, but I curious how much time download take in unikie office)
2 On host: run `sudo ota-update image install --manifest /persist/sysupdate/ghaf-ota-update-test/ghaf/26.07.1.1/manifest.json`
NOTE: you may need remove unused update slot first
NOTE: in comments I add my own transcript of testing session
