### PR TITLE
fix(logging): prevent offline logs from being lost on reboot

### DIFF
--- a/modules/common/logging/alloy-server.nix
+++ b/modules/common/logging/alloy-server.nix
@@ -226,6 +226,7 @@ in
 
               batch_size          = "256KiB"
               max_backoff_period  = "30s"
+              max_backoff_retries = 0
               remote_timeout      = "60s"
 
               tls_config {
@@ -274,7 +275,7 @@ in
         # If there is no internet connection , shutdown/reboot will take around 100sec
         # So, to fix that problem we need to add stop timeout
         # https://github.com/grafana/loki/issues/6533
-        TimeoutStopSec = 4;
+        TimeoutStopSec = 25;
 
         # Copy certs/keys (and optional remote CA) into /run/credentials/alloy.service/…
         LoadCredential = [

--- a/overlays/custom-packages/grafana-alloy/default.nix
+++ b/overlays/custom-packages/grafana-alloy/default.nix
@@ -8,5 +8,21 @@
 # https://github.com/grafana/alloy/blob/63ab53d8b477a0403ce24dbd759572707bd3fef2/Makefile#L131
 { prev }:
 prev.grafana-alloy.overrideAttrs (oldAttrs: {
+  patchPhase = (oldAttrs.patchPhase or "") + ''
+    substituteInPlace internal/component/common/loki/wal/watcher.go \
+      --replace-fail 'if r > index {' 'if r >= index {'
+    substituteInPlace internal/component/common/loki/wal/watcher_test.go \
+      --replace-fail \
+        'return writeTo.ReadEntries.Length() == 6 // wait for watcher to catch up with both segments' \
+        'return writeTo.ReadEntries.Length() == 7 // replay the marked segment and catch up with both later segments'
+    substituteInPlace internal/component/common/loki/client/shards.go \
+      --replace-fail \
+        'defer batch.reportAsSentData(s.markerHandler, obs)' \
+        $'batchHandled := true\n\tdefer func() {\n\t\tif batchHandled {\n\t\t\tbatch.reportAsSentData(s.markerHandler, obs)\n\t\t}\n\t}()' \
+      --replace-fail \
+        $'\tlevel.Error(s.logger).Log("msg", "final error sending batch, no retries left, dropping data"' \
+        $'\tbatchHandled = s.ctx.Err() == nil\n\n\tlevel.Error(s.logger).Log("msg", "final error sending batch, no retries left, dropping data"'
+  '';
+
   tags = builtins.filter (t: t != "gore2regex") oldAttrs.tags;
 })


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
This PR fixes log forwarding after an offline reboot.

When a VM is disconnected from the internet, logs written before reboot can remain unsent in Alloy’s WAL. Before this change, Alloy could treat shutdown-interrupted WAL batches as handled and then skip them after restart, so the logs were not reliably forwarded to Loki/Grafana once connectivity returned.

Changes included:
- Makes Alloy replay the marked WAL segment after restart, instead of starting from the next segment. This avoids skipping logs from a partially processed segment.
- Prevents Alloy from marking a batch as handled when sending is interrupted by a shutdown. 
- Increases Alloy’s shutdown timeout from 4s to 25s, giving Alloy enough time to drain/stop its WAL pipeline cleanly during reboot.
- Configures Alloy to retry Loki writes indefinitely while the endpoint is unreachable, so offline logs stay queued instead of being dropped after retry exhaustion.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets
https://jira.tii.ae/browse/SSRCSP-8525
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
Tested both on X1 and Orin AGX
Follow the steps at https://jira.tii.ae/browse/SSRCSP-8525 or:
1. Disconnect the internet
2. Create the log while offline. Example:
```
MARKER="offline-$(date -u +%Y%m%dT%H%M%SZ)"
echo "$MARKER"
logger --priority=user.info "$MARKER"
```
3. Reboot while still offline
4. After reboot, reconnect internet
5. Wait 60-90 seconds after reconnect
6. Search in Grafana for the log. Example: `offline-20260616T120313Z`
7. The log should appear on Grafana
