### PR TITLE
fix(logging): reduce alloy stop timeout

### DIFF
--- a/modules/common/logging/alloy-server.nix
+++ b/modules/common/logging/alloy-server.nix
@@ -275,7 +275,7 @@ in
         # If there is no internet connection , shutdown/reboot will take around 100sec
         # So, to fix that problem we need to add stop timeout
         # https://github.com/grafana/loki/issues/6533
-        TimeoutStopSec = 25;
+        TimeoutStopSec = 5;
 
         # Copy certs/keys (and optional remote CA) into /run/credentials/alloy.service/…
         LoadCredential = [


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Lower alloy.service TimeoutStopSec from 25s to 10s to reduce shutdown delay when Alloy is blocked during stop.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets
https://jira.tii.ae/browse/SSRCSP-8613
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
Please see the instructions at https://jira.tii.ae/browse/SSRCSP-8613
1. Boot and login
2. Shutdown from power menu
3. Measure the shutdown time. In automated tests we look for serial log "System Power Off" to determine when the laptop is off. This pretty closely matches the time when the fans stop and the LEDs turn off.