### PR TITLE
feat: implement remote and local wiping

### DIFF
--- a/docs/src/content/docs/ghaf/dev/ref/fleet.mdx
+++ b/docs/src/content/docs/ghaf/dev/ref/fleet.mdx
@@ -21,30 +21,30 @@ Fleet Orbit runs in the GUI VM and reports to a central Fleet server using a dyn
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                        Host VM                               │
+│                        Ghaf Host                            │
 │  ┌─────────────────────────────────────────────────────┐    │
-│  │  ghaf-dynamic-hostname service                       │    │
-│  │  └─► /persist/common/ghaf/hostname                   │    │
+│  │  ghaf-dynamic-hostname service                      │    │
+│  │  └─► /persist/common/ghaf/hostname                  │    │
 │  └─────────────────────────────────────────────────────┘    │
-│                           │ (virtiofs)                       │
+│                           │ (virtiofs)                      │
 └───────────────────────────┼─────────────────────────────────┘
                             │
 ┌───────────────────────────┼─────────────────────────────────┐
-│                        GUI VM                                │
-│                           ▼                                  │
+│                        GUI VM                               │
+│                           ▼                                 │
 │  ┌─────────────────────────────────────────────────────┐    │
-│  │  /etc/common/ghaf/hostname                           │    │
+│  │  /etc/common/ghaf/hostname                          │    │
 │  └──────────────────────┬──────────────────────────────┘    │
-│                         │                                    │
+│                         │                                   │
 │  ┌──────────────────────▼──────────────────────────────┐    │
-│  │  orbit.service                                       │    │
-│  │  └─► ORBIT_HOSTNAME_FILE=/etc/common/ghaf/hostname   │    │
-│  │  └─► Reports to Fleet Server                         │    │
+│  │  orbit.service                                      │    │
+│  │  └─► ORBIT_HOSTNAME_FILE=/etc/common/ghaf/hostname  │    │
+│  │  └─► Reports to Fleet Server                        │    │
 │  └─────────────────────────────────────────────────────┘    │
-│                                                              │
+│                                                             │
 │  ┌─────────────────────────────────────────────────────┐    │
-│  │  fleet-desktop.service (user)                        │    │
-│  │  └─► Tray icon for device status                     │    │
+│  │  fleet-desktop.service (user)                       │    │
+│  │  └─► Tray icon for device status                    │    │
 │  └─────────────────────────────────────────────────────┘    │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -65,18 +65,18 @@ services.orbit = {
 
 ### Configuration Options
 
-| Option | Environment Variable | Description |
-|--------|---------------------|-------------|
-| `enable` | — | Enable Fleet Orbit systemd service |
-| `fleetUrl` | `ORBIT_FLEET_URL` | Base URL of the Fleet server |
-| `enrollSecret` | `ORBIT_ENROLL_SECRET` | Enroll secret for Fleet server |
+| Option             | Environment Variable       | Description                                             |
+| ------------------ | -------------------------- | ------------------------------------------------------- |
+| `enable`           | —                          | Enable Fleet Orbit systemd service                      |
+| `fleetUrl`         | `ORBIT_FLEET_URL`          | Base URL of the Fleet server                            |
+| `enrollSecret`     | `ORBIT_ENROLL_SECRET`      | Enroll secret for Fleet server                          |
 | `enrollSecretPath` | `ORBIT_ENROLL_SECRET_PATH` | Path to enroll secret file (recommended for production) |
-| `fleetCertificate` | `ORBIT_FLEET_CERTIFICATE` | Path to Fleet server certificate chain |
-| `hostnameFile` | `ORBIT_HOSTNAME_FILE` | Path to file containing hostname (Ghaf-specific) |
-| `hostIdentifier` | `ORBIT_HOST_IDENTIFIER` | Host identifier mode: `uuid` or `instance` |
-| `enableScripts` | `ORBIT_ENABLE_SCRIPTS` | Enable remote script execution |
-| `debug` | `ORBIT_DEBUG` | Enable debug logging |
-| `insecure` | `ORBIT_INSECURE` | Disable TLS certificate verification |
+| `fleetCertificate` | `ORBIT_FLEET_CERTIFICATE`  | Path to Fleet server certificate chain                  |
+| `hostnameFile`     | `ORBIT_HOSTNAME_FILE`      | Path to file containing hostname (Ghaf-specific)        |
+| `hostIdentifier`   | `ORBIT_HOST_IDENTIFIER`    | Host identifier mode: `uuid` or `instance`              |
+| `enableScripts`    | `ORBIT_ENABLE_SCRIPTS`     | Enable remote script execution                          |
+| `debug`            | `ORBIT_DEBUG`              | Enable debug logging                                    |
+| `insecure`         | `ORBIT_INSECURE`           | Disable TLS certificate verification                    |
 
 ### Secret Management
 
@@ -118,6 +118,7 @@ Two systemd services are created:
 ## Logs
 
 Orbit logs are written to:
+
 - `/var/log/orbit/orbit.log` — Main Orbit log
 - `/var/log/orbit/osquery/` — osquery result and status logs
 - `journalctl -u orbit` — Systemd journal
@@ -136,16 +137,19 @@ The Ghaf Fleet integration includes patches for NixOS compatibility:
 ### Orbit not starting
 
 Check if the hostname file exists:
+
 ```bash
 ls -la /etc/common/ghaf/hostname
 ```
 
 If you use `enrollSecretPath`, also verify the secret file is present:
+
 ```bash
 ls -la /etc/common/ghaf/fleet/enroll
 ```
 
 Check service status:
+
 ```bash
 systemctl status orbit
 journalctl -u orbit -f
@@ -154,6 +158,7 @@ journalctl -u orbit -f
 ### Connection issues
 
 Enable debug logging:
+
 ```nix
 services.orbit = {
   debug = true;
@@ -165,6 +170,7 @@ services.orbit = {
 ### Script execution failures
 
 Verify scripts are enabled and check logs:
+
 ```bash
 cat /var/log/orbit/orbit.log | grep -i script
 ```

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -87,6 +87,11 @@ rec {
         debug = mkEnableOption "SPIRE debug logs";
       };
 
+      orbit = {
+        enable = mkEnableOption "Orbit Fleet MDM globally";
+        debug = mkEnableOption "Orbing Fleet MDM debug logs";
+      };
+
       storage = {
         encryption.enable = mkEnableOption "storage encryption globally";
         storeOnDisk = {
@@ -374,6 +379,11 @@ rec {
         debug = false;
       };
 
+      orbit = {
+        enable = true;
+        debug = true;
+      };
+
       spire = {
         enable = true;
         debug = true;
@@ -475,6 +485,11 @@ rec {
         debug = false;
       };
 
+      orbit = {
+        enable = false;
+        debug = false;
+      };
+
       storage = {
         encryption.enable = true;
         storeOnDisk.enable = false;
@@ -565,6 +580,11 @@ rec {
 
       spire = {
         enable = true;
+        debug = false;
+      };
+
+      orbit = {
+        enable = false;
         debug = false;
       };
 

--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -296,8 +296,10 @@ in
       "/share/iso-codes"
     ];
 
-    i18n.defaultLocale = "en_US.UTF-8";
-
-    i18n.extraLocales = "all";
+    i18n = {
+      defaultLocale = "en_US.UTF-8";
+      imperativeLocale = true;
+      extraLocales = "all";
+    };
   };
 }

--- a/modules/common/security/fleet/default.nix
+++ b/modules/common/security/fleet/default.nix
@@ -7,7 +7,11 @@
   ...
 }:
 let
-  cfg = config.services.orbit;
+  cfg = config.ghaf.services.orbit;
+
+  givc-cli = "${lib.getExe' pkgs.givc-cli "givc-cli"} ${
+    lib.replaceString "/run" "/etc" config.ghaf.givc.cliArgs
+  }";
 
   nullOrBoolToString = v: if v == null then null else lib.boolToString v;
 
@@ -31,19 +35,101 @@ let
     '';
   };
 
+  ghafWipe = pkgs.writeShellApplication {
+    name = "ghaf-wipe";
+    runtimeInputs =
+      with pkgs;
+      [
+        coreutils
+        cryptsetup
+        systemd
+        util-linux
+      ]
+      ++ lib.optionals (
+        config.ghaf.storage.encryption.enable && config.ghaf.storage.encryption.backendType == "tpm2"
+      ) [ config.ghaf.security.tpm2.tools ];
+    text = ''
+      # Ignore stop signals for the duration of the wipe - once started
+      # this must complete. A SIGKILL from root can still terminate us,
+      # but that requires deliberate action and gives us a window to
+      # finish the critical LUKS erase before poweroff.
+      trap ''' TERM INT HUP QUIT PIPE
+
+      echo "[1/3] Stopping virtual machines..."
+      systemctl mask --runtime 'microvm@*.service' 2>/dev/null || true
+      systemctl kill --kill-whom=all --signal=SIGKILL 'microvm@*.service' 2>/dev/null || true
+
+      echo "      Done."
+
+      echo "[2/3] Wiping..."
+      ${lib.optionalString config.ghaf.storage.encryption.enable ''
+        P_DEVPATH=$(readlink -f ${config.ghaf.storage.encryption.partitionDevice})
+
+        if cryptsetup -q isLuks "$P_DEVPATH"; then
+          echo "      Erasing all LUKS keyslots - data is unrecoverable beyond this point..."
+          cryptsetup luksErase -q "$P_DEVPATH"
+          ${lib.optionalString (config.ghaf.storage.encryption.backendType == "tpm2") ''
+            echo "      Clearing TPM - sealed blobs in any header backup are now invalid..."
+            tpm2_clear || true
+          ''}
+          echo "      Done."
+          echo "[3/3] Powering off..."
+          systemctl poweroff -ff
+        fi
+      ''}
+
+      echo "      Not a LUKS device - overwriting persist with zeroes..."
+      PERSIST_DEV=$(findmnt -n -o SOURCE /persist)
+      # Discard first, so even if power is cut, at least the blocks are discarded
+      blkdiscard -f "$PERSIST_DEV" 2>/dev/null || true
+      shred -n 0 -z "$PERSIST_DEV" || true
+      echo "      Done."
+
+      echo "[3/3] Powering off..."
+      systemctl poweroff -ff
+    '';
+  };
+
+  ghafWipeRequest = pkgs.writeShellApplication {
+    name = "ghaf-wipe-request";
+    runtimeInputs = with pkgs; [
+      givc-cli
+      libnotify
+      systemd
+      gawk
+    ];
+    text = ''
+      trap ''' TERM INT HUP QUIT PIPE
+      # Terminate all active sessions immediately
+      loginctl list-sessions --no-legend | awk '{print $1}' | xargs -r loginctl terminate-session || true
+      # Trigger host-side wipe (host takes it from here)
+      systemd-run --no-block \
+        -p DefaultDependencies=no -p TimeoutSec=5 \
+        -- ${givc-cli} start service --vm "ghaf-host" ${cfg.host.wipeService}.service
+    '';
+  };
+
   # Validation: require one of enrollSecret or enrollSecretPath
 in
 {
   _file = ./default.nix;
 
-  options.services.orbit = {
+  options.ghaf.services.orbit = {
     enable = lib.mkEnableOption "Fleet Orbit systemd service";
 
-    orbitPackage = lib.mkPackageOption pkgs "fleet-orbit" { };
+    debug = lib.mkEnableOption "debug logging";
 
-    osqueryPackage = lib.mkPackageOption pkgs "osquery" { };
+    gui.enable = lib.mkEnableOption "Fleet Orbit GUI tools and config";
 
-    fleetDesktopPackage = lib.mkPackageOption pkgs "fleet-desktop" { };
+    host = {
+      enable = lib.mkEnableOption "Fleet Orbit config for the host";
+      wipeService = lib.mkOption {
+        type = lib.types.str;
+        description = "Ghaf wipe service name";
+        readOnly = true;
+        default = "ghaf-wipe";
+      };
+    };
 
     # NOTE: We only expose the options for the flags from orbit that make sense
     # when you assume that update and fleet desktop are off. Other flags that
@@ -51,10 +137,24 @@ in
     # https://github.com/fleetdm/fleet/blob/main/orbit/cmd/orbit/orbit.go
     # for the possible flags that could be exposed.
 
-    fleetUrl = lib.mkOption {
-      type = lib.types.nonEmptyStr;
-      example = "https://your-fleet.example.com";
-      description = "The base URL of the Fleet server.";
+    desktopApp.enable = lib.mkEnableOption "Orbit fleet-desktop desktop app";
+
+    devMode = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Enable development mode.";
+    };
+
+    enableScripts = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Enable script execution.";
+    };
+
+    endUserEmail = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "End user email (experimental).";
     };
 
     enrollSecret = lib.mkOption {
@@ -75,34 +175,24 @@ in
       description = "Path to the Fleet server certificate chain. Defaults to system CA bundle.";
     };
 
-    debug = lib.mkOption {
-      type = lib.types.nullOr lib.types.bool;
-      default = null;
-      description = "Enable debug logging.";
-    };
-
-    devMode = lib.mkOption {
-      type = lib.types.nullOr lib.types.bool;
-      default = null;
-      description = "Enable development mode.";
-    };
-
-    hostIdentifier = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "Host identifier mode (e.g. 'uuid').";
-    };
-
-    enableScripts = lib.mkOption {
-      type = lib.types.nullOr lib.types.bool;
-      default = null;
-      description = "Enable script execution.";
-    };
-
     fleetDesktopAlternativeBrowserHost = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
       description = "Alternative browser host for Fleet Desktop.";
+    };
+
+    fleetDesktopPackage = lib.mkPackageOption pkgs "fleet-desktop" { };
+
+    fleetDesktopTLSClientCertificate = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to TLS client certificate for Fleet Desktop to authenticate to the Fleet server.";
+    };
+
+    fleetDesktopTLSClientKey = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Path to TLS client key for Fleet Desktop to authenticate to the Fleet server.";
     };
 
     fleetManagedHostIdentityCertificate = lib.mkOption {
@@ -111,16 +201,17 @@ in
       description = "Use TPM-backed key for Fleet EE (requires license).";
     };
 
-    endUserEmail = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "End user email (experimental).";
+    fleetUrl = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      default = "https://";
+      example = "https://your-fleet.example.com";
+      description = "The base URL of the Fleet server.";
     };
 
-    insecure = lib.mkOption {
-      type = lib.types.nullOr lib.types.bool;
+    hostIdentifier = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
-      description = "Disable TLS certificate verification.";
+      description = "Host identifier mode (e.g. 'uuid').";
     };
 
     hostnameFile = lib.mkOption {
@@ -129,10 +220,10 @@ in
       description = "Path to a file containing the hostname to use instead of system hostname. Useful for dynamic hostname environments.";
     };
 
-    rootDir = lib.mkOption {
-      type = lib.types.str;
-      default = "/var/lib/orbit";
-      description = "Orbit runtime directory (node key, osquery db, sockets). Set to a persistent path to avoid re-enrollment.";
+    insecure = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Disable TLS certificate verification.";
     };
 
     logDir = lib.mkOption {
@@ -140,111 +231,171 @@ in
       default = "/var/log/orbit";
       description = "Orbit log directory.";
     };
+
+    orbitPackage = lib.mkPackageOption pkgs "fleet-orbit" { };
+
+    osqueryPackage = lib.mkPackageOption pkgs "osquery" { };
+
+    rootDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/orbit";
+      description = "Orbit runtime directory (node key, osquery db, sockets). Set to a persistent path to avoid re-enrollment.";
+    };
   };
 
-  config = lib.mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = lib.hasPrefix "https://" cfg.fleetUrl;
-        message = "services.orbit.fleetUrl must start with https://.";
-      }
-    ];
-
-    systemd = {
-      services.orbit = {
-        description = "Orbit OSQuery";
-        wantedBy = [ "multi-user.target" ];
-
-        after = [
-          "network.service"
-          "syslog.service"
-        ];
-
-        unitConfig = lib.mkIf (cfg.hostnameFile != null || cfg.enrollSecretPath != null) {
-          ConditionPathExists =
-            lib.optionals (cfg.hostnameFile != null) [ cfg.hostnameFile ]
-            ++ lib.optionals (cfg.enrollSecretPath != null) [ cfg.enrollSecretPath ];
-        };
-
-        environment = lib.mkMerge [
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      # GUI fleet MDM config
+      (lib.mkIf cfg.gui.enable {
+        assertions = [
           {
-            # Required config:
-            ORBIT_FLEET_URL = cfg.fleetUrl;
-            ORBIT_ENROLL_SECRET = cfg.enrollSecret;
-            ORBIT_ENROLL_SECRET_PATH = cfg.enrollSecretPath;
-
-            # Optional config:
-            ORBIT_DEBUG = nullOrBoolToString cfg.debug;
-            ORBIT_DEV_MODE = nullOrBoolToString cfg.devMode;
-            ORBIT_ENABLE_SCRIPTS = nullOrBoolToString cfg.enableScripts;
-            ORBIT_END_USER_EMAIL = cfg.endUserEmail;
-            ORBIT_FLEET_CERTIFICATE = cfg.fleetCertificate;
-            ORBIT_FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST = cfg.fleetDesktopAlternativeBrowserHost;
-            ORBIT_FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE = nullOrBoolToString cfg.fleetManagedHostIdentityCertificate;
-            ORBIT_INSECURE = nullOrBoolToString cfg.insecure;
-
-            # Hardcoded variables to ensure we play nice with nix.
-            ORBIT_DISABLE_KEYSTORE = "true";
-            ORBIT_DISABLE_UPDATES = "true";
-            ORBIT_FLEET_DESKTOP = "false";
-            ORBIT_LOG_FILE = "${cfg.logDir}/orbit.log";
-            ORBIT_OSQUERY_DB = "${cfg.rootDir}/osquery.db";
-            ORBIT_ROOT_DIR = cfg.rootDir;
-            NIX_ORBIT_OSQUERYD_PATH = "${cfg.osqueryPackage}/bin/osqueryd";
-            NIX_ORBIT_OSQUERY_LOG_PATH = "${cfg.logDir}/osquery/";
+            assertion = lib.hasPrefix "https://" cfg.fleetUrl;
+            message = "services.orbit.fleetUrl must start with https://.";
           }
-          (lib.optionalAttrs (cfg.hostnameFile != null) {
-            ORBIT_HOSTNAME_FILE = cfg.hostnameFile;
-            OSQUERY_HOSTNAME_FILE = cfg.hostnameFile;
-            OSQUERY_UUID_FILE = "/etc/common/ghaf/uuid";
-          })
-          (lib.optionalAttrs (cfg.hostIdentifier != null) {
-            ORBIT_HOST_IDENTIFIER = cfg.hostIdentifier;
-          })
         ];
+        systemd = {
+          services = {
+            orbit = {
+              description = "Orbit OSQuery";
+              wantedBy = [ "multi-user.target" ];
 
-        preStart = lib.mkIf (cfg.hostIdentifier == "specified") (lib.getExe orbitSpecifiedPreStart);
+              after = [
+                "network.service"
+                "syslog.service"
+              ];
 
-        serviceConfig = {
-          ExecStart = lib.getExe cfg.orbitPackage;
-          TimeoutStartSec = 0;
-          Restart = "always";
-          RestartSec = 60;
+              unitConfig = lib.mkIf (cfg.hostnameFile != null || cfg.enrollSecretPath != null) {
+                ConditionPathExists =
+                  lib.optionals (cfg.hostnameFile != null) [ cfg.hostnameFile ]
+                  ++ lib.optionals (cfg.enrollSecretPath != null) [ cfg.enrollSecretPath ];
+              };
+
+              environment = lib.mkMerge [
+                {
+                  # Required config:
+                  ORBIT_FLEET_URL = cfg.fleetUrl;
+                  ORBIT_ENROLL_SECRET = cfg.enrollSecret;
+                  ORBIT_ENROLL_SECRET_PATH = cfg.enrollSecretPath;
+
+                  # Optional config:
+                  ORBIT_DEBUG = nullOrBoolToString cfg.debug;
+                  ORBIT_DEV_MODE = nullOrBoolToString cfg.devMode;
+                  ORBIT_ENABLE_SCRIPTS = nullOrBoolToString cfg.enableScripts;
+                  ORBIT_END_USER_EMAIL = cfg.endUserEmail;
+                  ORBIT_FLEET_CERTIFICATE = cfg.fleetCertificate;
+                  ORBIT_FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST = cfg.fleetDesktopAlternativeBrowserHost;
+                  ORBIT_FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE = nullOrBoolToString cfg.fleetManagedHostIdentityCertificate;
+                  ORBIT_INSECURE = nullOrBoolToString cfg.insecure;
+
+                  # Hardcoded variables to ensure we play nice with nix.
+                  ORBIT_DISABLE_KEYSTORE = "true";
+                  ORBIT_DISABLE_UPDATES = "true";
+                  ORBIT_FLEET_DESKTOP = "false";
+                  ORBIT_LOG_FILE = "${cfg.logDir}/orbit.log";
+                  ORBIT_OSQUERY_DB = "${cfg.rootDir}/osquery.db";
+                  ORBIT_ROOT_DIR = cfg.rootDir;
+                  NIX_ORBIT_OSQUERYD_PATH = "${cfg.osqueryPackage}/bin/osqueryd";
+                  NIX_ORBIT_OSQUERY_LOG_PATH = "${cfg.logDir}/osquery/";
+                }
+                (lib.optionalAttrs (cfg.hostnameFile != null) {
+                  ORBIT_HOSTNAME_FILE = cfg.hostnameFile;
+                  OSQUERY_HOSTNAME_FILE = cfg.hostnameFile;
+                  OSQUERY_UUID_FILE = "/etc/common/ghaf/uuid";
+                })
+                (lib.optionalAttrs (cfg.hostIdentifier != null) {
+                  ORBIT_HOST_IDENTIFIER = cfg.hostIdentifier;
+                })
+              ];
+
+              preStart = lib.mkIf (cfg.hostIdentifier == "specified") (lib.getExe orbitSpecifiedPreStart);
+
+              serviceConfig = {
+                ExecStart = lib.getExe cfg.orbitPackage;
+                TimeoutStartSec = 0;
+                Restart = "always";
+                RestartSec = 60;
+              };
+            };
+            ghaf-wipe-request = {
+              description = "Orbit Remote Wipe Request";
+
+              after = [
+                "network.service"
+              ];
+
+              serviceConfig = {
+                ExecStart = lib.getExe ghafWipeRequest;
+              };
+            };
+          };
+
+          tmpfiles.rules = [
+            "d ${cfg.rootDir} 0755 root root -"
+            "d ${cfg.logDir} 0755 root root -"
+          ];
+
+          # This service replaces the built in orbit logic for detecting running
+          # sessions and starting the fleet-desktop.
+          user.services.fleet-desktop = {
+            inherit (cfg.desktopApp) enable;
+            description = "Fleet Desktop GUI";
+            after = [
+              "graphical-session.target"
+              "orbit.service"
+            ];
+            wantedBy = [ "graphical-session.target" ];
+
+            environment = lib.mkMerge [
+              {
+                FLEET_DESKTOP_DEVICE_IDENTIFIER_PATH = "${cfg.rootDir}/identifier";
+                FLEET_DESKTOP_FLEET_URL = cfg.fleetUrl;
+              }
+              (lib.optionalAttrs (cfg.fleetDesktopAlternativeBrowserHost != null) {
+                FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST = cfg.fleetDesktopAlternativeBrowserHost;
+              })
+              (lib.optionalAttrs (cfg.fleetDesktopTLSClientCertificate != null) {
+                FLEET_DESKTOP_FLEET_TLS_CLIENT_CERTIFICATE = cfg.fleetDesktopTLSClientCertificate;
+              })
+              (lib.optionalAttrs (cfg.fleetDesktopTLSClientKey != null) {
+                FLEET_DESKTOP_FLEET_TLS_CLIENT_KEY = cfg.fleetDesktopTLSClientKey;
+              })
+            ];
+
+            serviceConfig = {
+              ExecStart = lib.getExe' cfg.fleetDesktopPackage "fleet-desktop";
+              Restart = "on-failure";
+              RestartSec = 10;
+            };
+          };
         };
-      };
 
-      tmpfiles.rules = [
-        "d ${cfg.rootDir} 0755 root root -"
-        "d ${cfg.logDir} 0755 root root -"
-      ];
+        environment.systemPackages = [ pkgs.xdg-utils ] ++ lib.optionals cfg.debug [ pkgs.fleetctl ];
 
-      # This service replaces the built in orbit logic for detecting running
-      # sessions and starting the fleet-desktop.
-      user.services."fleet-desktop" = {
-        description = "Fleet Desktop GUI";
-        after = [
-          "graphical-session.target"
-          "orbit.service"
-        ];
-        wantedBy = [ "graphical-session.target" ];
-
-        environment = {
-          FLEET_DESKTOP_DEVICE_IDENTIFIER_PATH = "${cfg.rootDir}/identifier";
-          FLEET_DESKTOP_FLEET_URL = cfg.fleetUrl;
+        environment.sessionVariables = {
+          PATH = lib.mkAfter "$PATH:${pkgs.xdg-utils}/bin";
         };
+      })
 
-        serviceConfig = {
-          ExecStart = "${cfg.fleetDesktopPackage}/bin/fleet-desktop";
-          Restart = "on-failure";
-          RestartSec = 10;
+      # Host fleet MDM config
+      (lib.mkIf cfg.host.enable {
+        systemd.services."${cfg.host.wipeService}" = {
+          description = "Ghaf Wipe";
+
+          unitConfig = {
+            DefaultDependencies = false;
+          };
+
+          serviceConfig = {
+            Type = "oneshot";
+            Restart = "no";
+
+            StandardOutput = "journal";
+            StandardError = "journal";
+
+            ExecStart = lib.getExe ghafWipe;
+          };
         };
-      };
-    };
-
-    environment.systemPackages = [ pkgs.xdg-utils ];
-
-    environment.sessionVariables = {
-      PATH = lib.mkAfter "$PATH:${pkgs.xdg-utils}/bin";
-    };
-  };
+      })
+    ]
+  );
 }

--- a/modules/givc/host.nix
+++ b/modules/givc/host.nix
@@ -57,6 +57,9 @@ in
           "host-powersave-battery.service"
           "host-balanced-battery.service"
           "host-performance-battery.service"
+        ]
+        ++ optionals config.ghaf.services.orbit.host.enable [
+          "${config.ghaf.services.orbit.host.wipeService}.service"
         ];
         vmServices = {
           adminVm = optionalString (

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -109,6 +109,11 @@ in
           renderer = "simpledrm"; # Force simpledrm framebuffer for graphical boot on host
         };
         services = {
+          orbit = {
+            inherit (config.ghaf.global-config.orbit) enable debug;
+            host.enable = config.ghaf.global-config.orbit.enable;
+            gui.enable = config.ghaf.profiles.graphics.enable;
+          };
           power-manager = {
             host.enable = true;
             gui.enable = config.ghaf.profiles.graphics.enable;

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -258,6 +258,20 @@ in
       };
 
       disks.enable = true;
+
+      orbit = {
+        inherit (globalConfig.orbit) enable debug;
+        gui.enable = true;
+        desktopApp.enable = false;
+        # CI/dev injects enroll secret via virtiofs to avoid baking secrets into images.
+        enrollSecretPath = "/etc/common/ghaf/fleet/enroll";
+        fleetUrl = "https://fleetdm.vedenemo.dev";
+        hostnameFile = "/etc/common/ghaf/hostname";
+        rootDir = "/etc/common/ghaf/orbit";
+        enableScripts = true;
+        hostIdentifier = "specified";
+        osqueryPackage = lib.mkForce pkgs."osquery-with-hostname";
+      };
     };
 
     xdgitems.enable = true;
@@ -280,24 +294,10 @@ in
   services = {
     # We dont enable services.blueman because it adds blueman desktop entry
     dbus.packages = [ pkgs.blueman ];
-
-    orbit = {
-      enable = true;
-      # CI/dev injects enroll secret via virtiofs to avoid baking secrets into images.
-      enrollSecretPath = "/etc/common/ghaf/fleet/enroll";
-      fleetUrl = "https://fleetdm.vedenemo.dev";
-      hostnameFile = "/etc/common/ghaf/hostname";
-      rootDir = "/etc/common/ghaf/orbit";
-      enableScripts = true;
-      hostIdentifier = "specified";
-      osqueryPackage = lib.mkForce pkgs."osquery-with-hostname";
-    };
   };
 
   systemd = {
     packages = [ pkgs.blueman ];
-    user.services."fleet-desktop".enable = false;
-
     services."waypipe-ssh-keygen" =
       let
         uid =

--- a/modules/reference/profiles/mvp-orinuser-trial.nix
+++ b/modules/reference/profiles/mvp-orinuser-trial.nix
@@ -71,6 +71,9 @@ in
       };
 
       security.audit.enable = false;
+
+      # osquery fails to build for cross-compiled targets
+      services.orbit.enable = lib.mkForce false;
     };
   };
 }


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes


- Added `ghaf-wipe.service` in host for wiping
- Added `ghaf-wipe-request.service` in gui-vm for requesting a wipe
- Updated fleet module and config, added separate host config section
- Explicitly disabled fleet/orbit on Orins (was already implicitly disabled)

Wipe behavior:

1. **gui-vm** kills user sessions, tells host to start `ghaf-wipe.service`
2. **host** masks signals, SIGKILLs all VMs
3. If **LUKS**: erases all keyslots + clears TPM -> immediate poweroff
   - Uses [cryptsetup luksErase](https://man7.org/linux/man-pages/man8/cryptsetup-erase.8.html)
   - Technically can be interrupted by cutting power to the device, but not feasible in real-world - the user is given no indication when the wipe will start, besides the screen going black. The entire process takes around 4 seconds.
   - On next boot, host will fail to decrypt the drive.
     The user may be prompted to enter their recovery key but this won't decrypt the data.
4. If not **LUKS**: discards, then overwrites `/persist` with zeroes -> poweroff
   - This is _**significantly**_ slower than step 3, and _can_ be interrupted by cutting power to the device.
   - Tested on an X1 gen 11 - around 13 mins

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
#### Device enrollment in fleet:
1. From gui-vm terminal, run `sudo mkdir -p /etc/common/ghaf/fleet && sudo install -m 600 /dev/stdin /etc/common/ghaf/fleet/enroll` -> paste the enroll secret fetched from https://fleetdm.vedenemo.dev/, and hit CTRL+D
2. Run `sudo systemctl restart orbit`
3. Verify host is enrolled in Fleet MDM

#### Script (upload to fleet mdm)
<details>

<summary>wipe.sh</summary>

```sh
#!/bin/bash
set -euo pipefail
systemctl start --no-block ghaf-wipe-request.service
```

</details>

#### Scenario 1 - disk encryption enabled:
1. Install Ghaf with deferred disk encryption enabled
2. Boot into Ghaf
3. Perform the actions to enroll the device (see above)
4. In Fleet MDM upload and run wipe.sh (see above) on your enrolled host
6. Confirm the device shuts down promptly after wipe was requested
7. Try to boot after wipe - should not be possible

#### Scenario 2 - disk encryption **disabled** (questionable if needed/useful):
1. Install Ghaf with deferred disk encryption **disabled**
2. Boot into Ghaf
3. Perform the actions to enroll the device (see above)
4. In Fleet MDM upload and run wipe.sh (see above) on your enrolled host
6. Confirm the device screen goes black, session is closed, no interaction is possible, aside from HW
7. Confirm the device shuts down a few minutes after the wipe request has been issued
8. Try to boot after wipe - should not be possible
