### PR TITLE
fix(jetson-orin): Cosmic auto suspend disable

### DIFF
--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -147,6 +147,9 @@ in
           "com.system76.CosmicAppletPower"
         ];
         screenRecorder.enable = false;
+        idleManagement.screenOffTime = lib.mkForce 0;
+        idleManagement.suspendOnBattery = lib.mkForce 0;
+        idleManagement.suspendOnAC = lib.mkForce 0;
       };
 
       reference.programs.windows-launcher.enable = true;


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Default COSMIC configuration resulted in an unavoidable suspend in Orin AGX, NX devices even though performing active operation through ssh or terminal. Disabled the default Suspend in Orin devices. 
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [X] Orin AGX `aarch64`
- [X] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Flash the Orin or boot from USB or perform a nixos-rebuild boot and reboot the Orin
2. Login and wait idle for 20 minutes.
3. If Orin device is still responsive test succeeds. If is not responding and in suspend state test fails.
