### PR TITLE
fix(microvm): route VM DNS through net-vm

### DIFF
--- a/modules/common/users/active-directory.nix
+++ b/modules/common/users/active-directory.nix
@@ -333,6 +333,7 @@ in
     );
     systemd.network.networks."10-${interfaceName}" = {
       matchConfig.Name = interfaceName;
+      networkConfig.DNSDefaultRoute = false;
       dns = map (name: cfg.domains.${name}.dnsProvider.ipAddress) dnsDomains;
       domains = map (name: "~${name}") (lib.attrNames cfg.domains);
     };

--- a/modules/microvm/common/vm-networking.nix
+++ b/modules/microvm/common/vm-networking.nix
@@ -24,6 +24,7 @@ let
   netVmAddress = hosts."net-vm".ipv4;
   idsVmAddress = hosts."ids-vm".ipv4;
   gateway = if isIdsvmEnabled && (cfg.vmName != "ids-vm") then [ idsVmAddress ] else [ netVmAddress ];
+  useNetVmDns = cfg.vmName != "net-vm";
 in
 {
   _file = ./vm-networking.nix;
@@ -48,6 +49,7 @@ in
     networking = {
       hostName = cfg.vmName;
       enableIPv6 = false;
+      nameservers = mkIf useNetVmDns (mkDefault [ netVmAddress ]);
       useNetworkd = true;
       nat = {
         enable = cfg.isGateway;

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -29,6 +29,7 @@ let
   performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
   wifiEnabled = lib.ghaf.features.isEnabledFor globalConfig "wifi" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+  netVmAddress = hostConfig.networking.thisVm.ipv4 or "192.168.100.1";
 in
 {
   _file = ./netvm-base.nix;
@@ -168,7 +169,7 @@ in
 
       ssh-tarpit = {
         enable = globalConfig.development.ssh.daemon.enable or false;
-        listenAddress = hostConfig.networking.thisVm.ipv4 or "192.168.100.1";
+        listenAddress = netVmAddress;
       };
 
       # Audit - from globalConfig
@@ -205,6 +206,8 @@ in
       allowedTCPPorts = [ dnsPort ];
       allowedUDPPorts = [ dnsPort ];
     };
+
+  services.resolved.settings.Resolve.DNSStubListenerExtra = netVmAddress;
 
   # Disable mDNS publishing on net-vm. With two live interfaces (internal
   # ethint0 + USB/Wi-Fi uplink), systemd-resolved hears its own announcements


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Currently, VMs use the public fallback DNS servers built into systemd-resolved (such as 1.1.1.1, 8.8.8.8, etc.) instead of the DNS servers configured for the current network connection. This can cause DNS reliability issues and local resources may not be resolved correctly when the system is used on a corporate network.

This patch configures all VMs to use net-vm as their DNS resolver.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-8665

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Make sure DNS name resolution still works correctly, for example by running `resolvectl query example.com` from an AppVM or by opening a website in the browser.
2. Check what DNS server is used in AppVMs by running `resolvectl status`. Currently it may show public fallback DNS servers in the `Current DNS Server` field. With this patch, it should show 192.168.100.1(net-vm).