### PR TITLE
fix(wipe): fix persist not being wiped when disk is encrypted

### DIFF
--- a/modules/common/security/fleet/default.nix
+++ b/modules/common/security/fleet/default.nix
@@ -72,13 +72,10 @@ let
             echo "      Clearing TPM - sealed blobs in any header backup are now invalid..."
             tpm2_clear || true
           ''}
-          echo "      Done."
-          echo "[3/3] Powering off..."
-          systemctl poweroff -ff
         fi
       ''}
 
-      echo "      Not a LUKS device - overwriting persist with zeroes..."
+      echo "      Overwriting persist with zeroes..."
       PERSIST_DEV=$(findmnt -n -o SOURCE /persist)
       # Discard first, so even if power is cut, at least the blocks are discarded
       blkdiscard -f "$PERSIST_DEV" 2>/dev/null || true


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Follow-up to https://github.com/tiiuae/ghaf/pull/2006

`ghaf-wipe` will now **always** also wipe `/persist`

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
