### PR TITLE
fix(net-vm): ax88179 power management quirks

### DIFF
--- a/modules/hardware/passthrough/usb-quirks.nix
+++ b/modules/hardware/passthrough/usb-quirks.nix
@@ -14,7 +14,8 @@ let
   # https://github.com/eihqnh/.nixconfig/blob/a685389652c3df60b1ece49125f3e2db993aeebf/common.nix#L102
   # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/7.7_release_notes/kernel_parameters_changes
   quirks = [
-    "2357:0601:k" # TP-Link’s USB 3.0 Ethernet adapters (AX88179 chipset)
+    "2357:0601:k" # TP-Link’s USB 3.0 Ethernet adapters (Realtek chipset)
+    "0b95:1790:k" # TP-Link's ASIX chipset USB 3.x ethernet adapters(AX88179 chipset)
     "0bda:8153:k" # Realtek Semiconductor Corp. RTL8153 Gigabit Ethernet Adapter
   ];
 


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

The power management of several USB ethernet devices caused the arp layer failed in net-vm after a passthrough. Due to this arp layer failure the ssh service of net-vm failed from time to time.  There is a workaround for it to add device id to the usbquirks as a kernel parameter. This solves the ethernet device power management issues. This was due to the AX88179 Black Tp-link usb gbe adapter. 
Bus 002 Device 003: ID 0b95:1790 ASIX Elec. Corp. AX88179. Ensure to test with this device. 

### Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->
https://jira.tii.ae/projects/SSRCSP/issues/SSRCSP-8585?filter=allopenissues

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [X] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Download or build ghaf mainline Orin NX image
2. Flash on USB SSD
3. Boot with TP-Link USB-eth adapter connected to network and Serial cable connected
4. Login via Serial and check the IP on net-vm
5. Try to ssh to the IP from the network: ssh ghaf@IP
6. Check if ssh connection works for at least 10 reboots.
