### PR TITLE
fix(wireguard-gui): enabling pkexec wrapper

### DIFF
--- a/modules/reference/services/wireguard-gui/wireguard-gui.nix
+++ b/modules/reference/services/wireguard-gui/wireguard-gui.nix
@@ -80,6 +80,8 @@ in
     ];
     security.polkit = {
       enable = true;
+      enablePkexecWrapper = true;
+      extraArgs = [ "--log-level=notice" ];
       extraConfig = ''
         polkit.addRule(function(action, subject) {
           polkit.log("user " +  subject.user + " is attempting action " + action.id + " from PID " + subject.pid);


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
**Root cause:** nixpkgs commit [e88efa7](https://github.com/NixOS/nixpkgs/commit/e88efa73069adf9abd9b0e78d10a1367560728d2) made the pkexec setuid wrapper opt-in via a new `security.polkit.enablePkexecWrapper` option (default false). Our pinned nixpkgs rev already includes this change, but wireguard-gui.nix only set `security.polkit.enable = true`, so `/run/wrappers/bin/pkexec` was never built with the setuid bit — pkexec had no way to gain root, hence the self-check failure.
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->
SSRCSP-8637
## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Try to launch wireguard-gui
