### PR TITLE
bump: bump all inputs 2026-07-08

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781770515,
-        "narHash": "sha256-S7tkUI9UeyLNVpivfFsjbELx0CjRdPPd114usOEDoiM=",
+        "lastModified": 1783427032,
+        "narHash": "sha256-70+74ivTehh1gmSHKZqDtzBdwbR2ekBdyE1E9J8QtYs=",
         "owner": "tiiuae",
         "repo": "ci-test-automation",
-        "rev": "505e707fabf469e86ea7a0e4919861710ca182c8",
+        "rev": "2a67484d67b59c48ff31cf6a2fc9c3ba560dbe3f",
         "type": "github"
       },
       "original": {
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -292,43 +292,21 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -358,11 +336,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782209550,
-        "narHash": "sha256-pvTS0tthEVPiIMRQkgbLD1Zk9vTIHPtU0CWq6anRyPc=",
+        "lastModified": 1782814855,
+        "narHash": "sha256-oVVhQ/D9AR+D0O7p+YmqlWmyrfX73U85N2dL/HpjwJE=",
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "683deff4d32f06819b3413fe396869167135ced9",
+        "rev": "4c6296533278250e80a0c42309e657b75b4e2d3d",
         "type": "github"
       },
       "original": {
@@ -395,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780380869,
-        "narHash": "sha256-S8TBmNb+LGVXR1JSykKCBcETYJRWW3eGQUTd6iPlVzU=",
+        "lastModified": 1782133039,
+        "narHash": "sha256-C86PDzGAaKWgZVevRfq7oZsj+As36dEzG9vCrkPIDKQ=",
         "owner": "brianmcgillion",
         "repo": "gp-gui",
-        "rev": "a827a380a40527af59ac0ac3c1cfa31db52c03cd",
+        "rev": "219b60339e6ecce9788c121406abeba28a576cb2",
         "type": "github"
       },
       "original": {
@@ -438,11 +416,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1781738058,
-        "narHash": "sha256-wgKY6pbZbFpBXae+8bjvJtW1Z9qekZergGly44n2qZw=",
+        "lastModified": 1783451207,
+        "narHash": "sha256-6+I67Kj47Ljwj8JGi8P3fSTxCBR+L0AauZTTmrrwLTs=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "225b35c204e29efb5bbe9b55b1a38b07b3fca2af",
+        "rev": "c5a04bcc9d1f5a6ccafdcdf607bf49f70d5f7f20",
         "type": "github"
       },
       "original": {
@@ -511,11 +489,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781622756,
-        "narHash": "sha256-JrPh4M6S7aPsEE9tOENuZrxC6o2szSLlK+t4+nLke9s=",
+        "lastModified": 1783370751,
+        "narHash": "sha256-E+3MIMvKuo9k+K+qLQ9YXzsBzkgHuyVLnsEbN2DFfuc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "08018c72174a4df5657f8d94178ac69fb9c243e5",
+        "rev": "662bd6e312d2c8b212e32cb377abaee190749320",
         "type": "github"
       },
       "original": {
@@ -526,11 +504,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -667,11 +645,10 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1778940603,
-        "narHash": "sha256-voSM8dZNlaOWN3kbYFky+FNY6fFQOEw0xF+ZMpZKkCQ=",
-        "ref": "refs/heads/main",
-        "rev": "367dd227f539267eae2b62770b4c17b88ac8c1f1",
-        "revCount": 1265,
+        "lastModified": 1783423582,
+        "narHash": "sha256-4z10q9MX1irpGhLe+uYC6k7evEnyhb/z1eNeIf71B+g=",
+        "rev": "0adfbcb6c12f35b33b8f47dc527587d4d20eeb93",
+        "revCount": 1400,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },
@@ -687,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781754174,
-        "narHash": "sha256-Q5hp6+DYj23gMAvhLXBYNan9EwY9C+oxyU+M1TJDwgo=",
+        "lastModified": 1782959762,
+        "narHash": "sha256-foGp7WLUoX50QN1VzBDkdDOkxkRGGPoXQdgMbEFqBYs=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "18ae1c654f60fb8dafb40c48fe25eb09f1aaddb2",
+        "rev": "9228f1ec58f3af7cb7cb09aaa7db138c96d7e97e",
         "type": "github"
       },
       "original": {
@@ -748,11 +725,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777319010,
-        "narHash": "sha256-8NVTCQmY93KfnJDL+r7WpfXr3zqyl98YpJiVuQyqx78=",
+        "lastModified": 1783074608,
+        "narHash": "sha256-NpYOpMfIivSSawdK+naoPPYZsT2iLYzO5AoceGF3gWw=",
         "owner": "tiiuae",
         "repo": "vhotplug",
-        "rev": "c3474a98f251f6e7cdff4ba5030a755d4dd8c35c",
+        "rev": "c3b4521aac9f41aaddd9c1c91d99dee42a7c4c4a",
         "type": "github"
       },
       "original": {

--- a/modules/common/logging/journal-server.nix
+++ b/modules/common/logging/journal-server.nix
@@ -73,7 +73,6 @@ in
 
     services.journald.remote = {
       enable = true;
-      listen = "http";
       port = cfg.tls.terminator.backendPort;
       output = "/var/log/journal/remote/";
       settings.Remote = {

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -293,6 +293,8 @@ in
       systemPackages =
         with pkgs;
         [
+          # TODO: Remove when https://github.com/NixOS/nixpkgs/pull/539917 is available
+          cosmic-monitor
           papirus-icon-theme-grey
           adwaita-icon-theme
           ghaf-wallpapers
@@ -361,7 +363,7 @@ in
           Type = "simple";
           Restart = "on-failure";
           RestartSec = "5";
-          Path = [
+          ExecSearchPath = [
             "${pkgs.ghaf-usb-applet}/bin"
           ];
           ExecStart = ''
@@ -455,7 +457,7 @@ in
     hardware.bluetooth.enable = graphicsProfileCfg.bluetooth.enable;
     networking.networkmanager.enable = graphicsProfileCfg.networkManager.enable;
 
-    services.gvfs.enable = lib.mkForce false;
+    # TODO: Revisit below when https://github.com/NixOS/nixpkgs/pull/539810 is available
     services.gnome.gnome-keyring.enable = lib.mkForce false;
     services.power-profiles-daemon.enable = lib.mkForce false;
     # Fails to build in cross-compilation for Orins

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -59,9 +59,9 @@
               category = "linters";
             }
             {
-              help = "Generate changelog";
+              help = "Generate Ghaf changelog since last ghaf-xx.xx tag";
               name = "ghaf-changelog";
-              command = "git cliff --unreleased --config .github/cliff.toml $@";
+              command = "git-cliff --offline -l --unreleased --config .github/cliff.toml $@";
               category = "changelog";
             }
             {

--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -14,58 +14,6 @@
       ) [ final.buildPackages.pkg-config ];
   });
 
-  # Fix for efitools cross-compilation.
-  # The Make.rules uses `uname -m` to detect ARCH, which returns the build machine
-  # architecture instead of the target architecture during cross-compilation.
-  # This causes x86_64-specific compiler flags (like -mno-red-zone) to be used
-  # when building for aarch64, and wrong include paths to be used.
-  # Also, the Makefile uses hardcoded `ar`, `nm`, and `objcopy` instead of the
-  # cross-toolchain versions.
-  # Additionally, the default `all` target generates certificates and signed EFI
-  # files by running freshly-built tools (cert-to-efi-sig-list, sign-efi-sig-list).
-  # These are cross-compiled for the target and cannot execute on the build host.
-  # We build only the CLI binaries and EFI files, skipping cert generation.
-  efitools = prev.efitools.overrideAttrs (oldAttrs: {
-    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
-      final.buildPackages.openssl
-      final.buildPackages.sbsigntool
-    ];
-    postPatch = (oldAttrs.postPatch or "") + ''
-      # Fix ar to use $(AR) variable
-      substituteInPlace Make.rules --replace-warn 'ar rcv' '$(AR) rcv'
-      # Fix nm to use $(NM) variable
-      substituteInPlace Make.rules --replace-warn 'nm -D' '$(NM) -D'
-      # Fix objcopy to use the cross-toolchain version
-      substituteInPlace Make.rules --replace-warn 'OBJCOPY		= objcopy' 'OBJCOPY		= ${final.stdenv.cc.targetPrefix}objcopy'
-    '';
-    makeFlags = (oldAttrs.makeFlags or [ ]) ++ [
-      "ARCH=${final.stdenv.hostPlatform.parsed.cpu.name}"
-      "AR=${final.stdenv.cc.targetPrefix}ar"
-      "NM=${final.stdenv.cc.targetPrefix}nm"
-    ];
-    # Only build the CLI binaries and EFI files — skip cert/auth generation
-    # and EFI signing which require executing cross-compiled binaries on the
-    # build host.
-    buildFlags = [
-      "cert-to-efi-sig-list"
-      "sig-list-to-certs"
-      "sign-efi-sig-list"
-      "hash-to-efi-sig-list"
-      "efi-readvar"
-      "efi-updatevar"
-      "cert-to-efi-hash-list"
-      "flash-var"
-    ];
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/bin
-      install -m 755 cert-to-efi-sig-list sig-list-to-certs sign-efi-sig-list \
-        hash-to-efi-sig-list efi-readvar efi-updatevar cert-to-efi-hash-list \
-        flash-var $out/bin
-      runHook postInstall
-    '';
-  });
-
   # Remove gfortran from FFTW to avoid cross-compiling the entire Fortran
   # toolchain. FFTW is pulled in by PipeWire for audio processing. The Fortran
   # wrapper generation is only needed when building docs (--disable-doc already
@@ -74,14 +22,6 @@
     nativeBuildInputs = builtins.filter (d: !(final.lib.hasPrefix "gfortran" (d.pname or ""))) (
       oldAttrs.nativeBuildInputs or [ ]
     );
-  });
-
-  # git 2.54+ includes a Rust component (gitcore) whose build script runs on
-  # the build machine but can't find `cc` in the cross-compilation stdenv.
-  git = prev.git.overrideAttrs (oldAttrs: {
-    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
-      final.buildPackages.stdenv.cc
-    ];
   });
 
   # Fix for libqmi cross-compilation.
@@ -96,89 +36,6 @@
     nativeBuildInputs = builtins.filter (d: (d.pname or "") != "gi-docgen") (
       oldAttrs.nativeBuildInputs or [ ]
     );
-  });
-
-  # Fix for setuptools-rust cross-compilation hook mismatch.
-  # When building Python packages natively (host == target), the setuptools-rust
-  # hook was incorrectly setting PYO3_CROSS_LIB_DIR to pythonOnTargetForTarget
-  # (which points to cross-compiled Python) while CARGO_BUILD_TARGET was set to
-  # the native platform. This caused PyO3 to fail finding sysconfigdata.
-  # This fix backports https://github.com/NixOS/nixpkgs/pull/480005
-  # which adds a condition to skip the setup hook when host == target.
-  pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
-    (_python-final: python-prev: {
-      setuptools-rust =
-        if final.lib.systems.equals final.stdenv.hostPlatform final.stdenv.targetPlatform then
-          # When host == target (native build), remove the setup hook entirely
-          # to avoid the cross-compilation environment variables being set incorrectly
-          python-prev.setuptools-rust.overrideAttrs (oldAttrs: {
-            postFixup = (oldAttrs.postFixup or "") + ''
-              # Remove the problematic cross-compilation setup hook for native builds
-              rm -f $out/nix-support/setup-hook
-            '';
-          })
-        else
-          python-prev.setuptools-rust;
-    })
-  ];
-
-  # Fix for sbsigntool cross-compilation.
-  # Multiple issues need to be addressed:
-  # 1. The create-ccan-tree script uses getopt which is not available in nativeBuildInputs.
-  # 2. The configure script uses `uname -m` to detect EFI_ARCH, which returns the build
-  #    machine architecture instead of the target architecture during cross-compilation.
-  # 3. The lib/ccan Makefile uses hardcoded `ar` instead of the autoconf-detected AR.
-  # 4. The create-ccan-tree script runs `make tools/ccan_depends` which compiles and
-  #    executes the CCAN configurator. During cross-compilation, the configurator is
-  #    compiled for the target architecture and cannot execute on the build host.
-  #    We pre-build it with the native compiler before create-ccan-tree runs.
-  # This fix adds util-linux for getopt, patches configure.ac to use the correct
-  # target architecture, sets AR/RANLIB for make, and handles CCAN configurator
-  # cross-compilation.
-  sbsigntool = prev.sbsigntool.overrideAttrs (oldAttrs: {
-    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
-      final.buildPackages.util-linux
-    ];
-    makeFlags = (oldAttrs.makeFlags or [ ]) ++ [
-      "AR=${final.stdenv.cc.targetPrefix}ar"
-      "RANLIB=${final.stdenv.cc.targetPrefix}ranlib"
-    ];
-    configurePhase = ''
-      runHook preConfigure
-
-      substituteInPlace configure.ac --replace-warn "@@NIX_GNUEFI@@" "${final.gnu-efi}"
-
-      # Fix EFI_ARCH to use target architecture instead of build machine's uname -m
-      substituteInPlace configure.ac \
-        --replace-warn 'EFI_ARCH=$(uname -m | sed' 'EFI_ARCH=$(echo ${final.stdenv.hostPlatform.parsed.cpu.name} | sed'
-
-      # Pre-build CCAN configurator and ccan_depends with the native compiler.
-      # create-ccan-tree runs `make tools/ccan_depends` which first compiles the
-      # CCAN configurator to generate config.h, then compiles ccan_depends itself.
-      # Both are build-time tools that must execute on the build host, but the
-      # Makefile uses $(CC) which points to the cross-compiler during cross-builds.
-      # Override CC for the entire create-ccan-tree invocation so all build-time
-      # tools are compiled natively.
-      CC=${final.buildPackages.buildPackages.stdenv.cc}/bin/cc \
-        lib/ccan.git/tools/create-ccan-tree --build-type=automake lib/ccan \
-        "talloc read_write_all build_assert array_size endian"
-      touch AUTHORS
-      touch ChangeLog
-
-      # Exclude docs: help2man cannot run cross-compiled binaries to generate man pages
-      echo "SUBDIRS = lib/ccan src" >> Makefile.am
-
-      aclocal
-      autoheader
-      autoconf
-      automake --add-missing -Wno-portability
-
-      ./configure --prefix=$out \
-        --host=${final.stdenv.hostPlatform.config} \
-        --build=${final.stdenv.buildPlatform.config}
-
-      runHook postConfigure
-    '';
   });
 
 })

--- a/overlays/custom-packages/cosmic/cosmic-applets/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-applets/default.nix
@@ -8,7 +8,4 @@ prev.cosmic-applets.overrideAttrs (oldAttrs: {
   patches = oldAttrs.patches ++ [
     ./0001-Hide-some-panel-buttons.patch
   ];
-  postInstall = oldAttrs.postInstall or "" + ''
-    sed -i 's|^Exec=.*|Exec=env PIPEWIRE_RUNTIME_DIR=/tmp cosmic-applet-audio|' $out/share/applications/com.system76.CosmicAppletAudio.desktop
-  '';
 })

--- a/overlays/custom-packages/cosmic/cosmic-player/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-player/default.nix
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-
 # Add missing plugins and path
-
+# TODO: Remove after https://github.com/NixOS/nixpkgs/pull/534694 is merged and available
 { prev }:
 (prev.cosmic-player.overrideAttrs (oldAttrs: {
   dontWrapLibcosmicApp = true;

--- a/overlays/custom-packages/cosmic/cosmic-settings-daemon/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-settings-daemon/default.nix
@@ -9,4 +9,16 @@
       --replace '.arg("--media-role")' "" \
       --replace '.arg("Notification")' ""
   '';
+
+  # Below is needed for cosmic DE and tools to query PipeWire on audio-vm
+  # rather than any local PipeWire instance on the gui-vm
+  # Ensure `config.ghaf.services.audio.client.enablePipewireControl` is enabled
+  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
+    prev.buildPackages.makeWrapper
+  ];
+
+  postInstall = oldAttrs.postInstall or "" + ''
+    wrapProgram "$out/bin/cosmic-settings-daemon" \
+      --set PIPEWIRE_RUNTIME_DIR /tmp
+  '';
 }))

--- a/overlays/custom-packages/cosmic/cosmic-settings/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-settings/default.nix
@@ -3,7 +3,7 @@
 # Disable certain settings pages in cosmic-settings
 # Ref: https://github.com/pop-os/cosmic-settings/blob/master/cosmic-settings/Cargo.toml
 { prev }:
-(prev.cosmic-settings.overrideAttrs (oldAttrs: {
+(prev.cosmic-settings.overrideAttrs (_oldAttrs: {
   cargoBuildNoDefaultFeatures = true;
   cargoBuildFeatures = [
     "cosmic-comp-config"
@@ -30,16 +30,4 @@
     "xdg-portal"
     "systemd"
   ];
-
-  # Below is needed for cosmic DE and tools to query PipeWire on audio-vm
-  # rather than any local PipeWire instance on the gui-vm
-  # Ensure `config.ghaf.services.audio.client.enablePipewireControl` is enabled
-  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
-    prev.buildPackages.makeWrapper
-  ];
-
-  postInstall = oldAttrs.postInstall or "" + ''
-    wrapProgram "$out/bin/cosmic-settings" \
-      --set PIPEWIRE_RUNTIME_DIR /tmp
-  '';
 }))


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Notable changes:
- COSMIC 1.0.16 -> 1.1.0
  Major overhaul to audio handling - now handled entirely by `cosmic-settings-daemon`
- Electron 42.4.0 -> 42.5.1
- Chrome/Chromium 149.0.7827.114 -> 150.0.7871.46
- Systemd 260.1 -> 260.2

### Fixes/adjustments:
- Removed unused attr from `modules/common/logging/journal-server.nix`
- Removed no longer needed cross-compilation workarounds from `overlays/cross-compilation/default.nix`
   - https://github.com/NixOS/nixpkgs/pull/486185
   - https://github.com/NixOS/nixpkgs/pull/526197
   - https://github.com/NixOS/nixpkgs/pull/480005 (this appears to be fixed, although this specific change was reverted)
- Adjusted COSMIC for the audio rework and other stuff:
   - Moved pipewire wrapping to `cosmic-settings-daemon`, as it's now the sole handler of `libpipewire` within COSMIC
   - Enabled gvfs (default) to reduce errors from xdg-document-portal service
   - Added `cosmic-monitor` to gui-vm. This package will be available by default next bump
   - Fixed up some random errors by enabling `gvfs` (following upstream behavior)(https://github.com/NixOS/nixpkgs/pull/539917)
- Devshell: Adjusted `ghaf-changelog` to explicitly run offline and generate changelogs only since latest available tag (follow up to #2028)

### All version changes vs mainline (07.10 intel laptop target (c6f428b6d8a94c84d9c7917823b98bd825c90f03)):
<details>
<summary>Version changes (137 lines):</summary>

```
[U.]  #001  OVMF                                  202602-fd -> 202605-fd
[U.]  #002  adminvm-systemd                       260.1 -> 260.2
[U.]  #003  appvm-systemd                         260.1 -> 260.2
[U.]  #004  at-spi2-core                          2.60.1, 2.60.1-dev -> 2.60.4, 2.60.4-dev
[U.]  #005  audiovm-systemd                       260.1 -> 260.2
[U*]  #006  audit                                 4.1.2-unstable-2025-09-06, 4.1.2-unstable-2025-09-06-bin, 4.1.2-unstable-2025-09-06-lib -> 4.1.4, 4.1.4-bin, 4.1.4-lib
[U*]  #007  bind                                  9.20.23-dnsutils x3, 9.20.23-host, 9.20.23-lib x3 -> 9.20.24-dnsutils x3, 9.20.24-host, 9.20.24-lib x3
[U.]  #008  chromium                              149.0.7827.114, 149.0.7827.114-sandbox -> 150.0.7871.46, 150.0.7871.46-sandbox
[U.]  #009  chromium-unwrapped                    149.0.7827.114, 149.0.7827.114-sandbox -> 150.0.7871.46, 150.0.7871.46-sandbox
[U.]  #010  cosmic-applets                        1.0.16 -> 1.1.0
[U.]  #011  cosmic-applibrary                     1.0.16 -> 1.1.0
[U.]  #012  cosmic-bg                             1.0.16 -> 1.1.0
[U.]  #013  cosmic-comp                           1.0.16 -> 1.1.0
[U.]  #014  cosmic-edit                           1.0.16 -> 1.1.0
[U.]  #015  cosmic-files                          1.0.16 -> 1.1.0
[U.]  #016  cosmic-greeter                        1.0.16 -> 1.1.0
[U.]  #017  cosmic-icons                          1.0.16 -> 1.1.0
[U.]  #018  cosmic-idle                           1.0.16 -> 1.1.0
[U.]  #019  cosmic-initial-setup                  1.0.16 -> 1.1.0
[U.]  #020  cosmic-launcher                       1.0.16 -> 1.1.0
[U.]  #021  cosmic-notifications                  1.0.16 -> 1.1.0
[U.]  #022  cosmic-osd                            1.0.16 -> 1.1.0
[U.]  #023  cosmic-panel                          1.0.16 -> 1.1.0
[U.]  #024  cosmic-player                         1.0.16 -> 1.1.0
[U.]  #025  cosmic-randr                          1.0.16 -> 1.1.0
[U.]  #026  cosmic-screenshot                     1.0.16 -> 1.1.0
[U.]  #027  cosmic-session                        1.0.16 -> 1.1.0
[U.]  #028  cosmic-settings                       1.0.16 -> 1.1.0
[U.]  #029  cosmic-settings-daemon                1.0.16 -> 1.1.0
[U.]  #030  cosmic-store                          1.0.16 -> 1.1.0
[U.]  #031  cosmic-term                           1.0.16 -> 1.1.0
[U.]  #032  cosmic-wallpapers                     1.0.16 -> 1.1.0
[U.]  #033  cosmic-workspaces-epoch               1.0.16 -> 1.1.0
[U*]  #034  e2fsprogs                             1.47.3, 1.47.3-bin -> 1.47.4, 1.47.4-bin
[U.]  #035  electron                              42.4.0 -> 42.5.1
[U.]  #036  electron-unwrapped                    42.4.0 -> 42.5.1
[U.]  #037  element-desktop                       1.12.21 -> 1.12.22
[U.]  #038  element-web                           1.12.21 -> 1.12.22
[U.]  #039  expat                                 2.8.0, 2.8.0-dev -> 2.8.1, 2.8.1-dev
[U.]  #040  ffmpeg                                8.1-bin, 8.1-data x2, 8.1-lib x2 -> 8.1.1-bin, 8.1.1-data x2, 8.1.1-lib x2
[U.]  #041  ffmpeg-headless                       8.1-data, 8.1-lib -> 8.1.1-data, 8.1.1-lib
[U.]  #042  fftw-double                           3.3.10 -> 3.3.11
[U.]  #043  fftw-single                           3.3.10 -> 3.3.11
[U.]  #044  flatpak                               1.16.6 -> 1.18.0
[U.]  #045  freetype                              2.14.2, 2.14.2-dev -> 2.14.3, 2.14.3-dev
[U*]  #046  getent-glibc                          2.42-61 -> 2.42-67
[U*]  #047  glibc                                 2.42-61, 2.42-61-bin, 2.42-61-dev, 2.42-61-getent -> 2.42-67, 2.42-67-bin, 2.42-67-dev, 2.42-67-getent
[U*]  #048  glibc-locales                         2.42-61 -> 2.42-67
[U.]  #049  google-chrome                         149.0.7827.114 -> 150.0.7871.46
[U.]  #050  gpauth                                2.5.4 -> 2.6.4
[U.]  #051  gpclient                              2.5.4 -> 2.6.4
[U.]  #052  gpclient-wrapper                      2.5.4 -> 2.6.4
[U.]  #053  gpu-screen-recorder                   5.13.8 -> 5.13.9
[U.]  #054  guivm-systemd                         260.1 -> 260.2
[U*]  #055  host-systemd                          260.1 -> 260.2
[C.]  #056  icu4c                                 76.1, 76.1-dev, 77.1 -> 76.1, 76.1-dev, 77.1, 78.3, 78.3-dev
[U.]  #057  initrd-linux                          7.1 x10 -> 7.1.3 x10
[U.]  #058  intel-compute-runtime                 26.18.38308.1 -> 26.22.38646.4
[U.]  #059  intel-graphics-compiler               2.34.4 -> 2.36.3
[U.]  #060  krb5                                  1.22.1, 1.22.1-lib -> 1.22.2, 1.22.2-lib
[U.]  #061  libadwaita                            1.9.0 x2 -> 1.9.1 x2
[U.]  #062  libde265                              1.0.18 -> 1.1.1
[U.]  #063  libgcrypt                             1.11.2-lib -> 1.12.2-lib
[U.]  #064  libpng-apng                           1.6.56, 1.6.56-dev -> 1.6.58, 1.6.58-dev
[U.]  #065  libxml2                               2.15.2, 2.15.2-bin, 2.15.2-dev -> 2.15.3, 2.15.3-bin, 2.15.3-dev
[U.]  #066  linux                                 7.1 x4, 7.1-modules x8 -> 7.1.3 x4, 7.1.3-modules x8
[U.]  #067  linux-firmware                        20260519-zstd -> 20260622-zstd
[U.]  #068  mdadm                                 4.4 -> 4.6
[U.]  #069  mesa                                  26.1.2 -> 26.1.4
[U*]  #070  nano                                  9.0 -> 9.1
[U.]  #071  netvm-systemd                         260.1 -> 260.2
[U.]  #072  nixos-system-admin-vm                 26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #073  nixos-system-audio-vm                 26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #074  nixos-system-business-vm              26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #075  nixos-system-chrome-vm                26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #076  nixos-system-comms-vm                 26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #077  nixos-system-flatpak-vm               26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #078  nixos-system-ghaf-host                26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #079  nixos-system-gui-vm                   26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #080  nixos-system-media-vm                 26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #081  nixos-system-net-vm                   26.11.20260616.567a49d -> 26.11.20260705.d407951
[U.]  #082  nodejs                                24.15.0 -> 24.16.0
[U.]  #083  nodejs-slim                           24.15.0, 24.15.0-corepack, 24.15.0-npm -> 24.16.0, 24.16.0-corepack, 24.16.0-npm
[U.]  #084  noto-fonts                            2026.06.01 -> 2026.07.01
[U.]  #085  nvidia-kernel-modules                 595.80-7.1 -> 595.84-7.1.3
[U.]  #086  nvidia-x11                            595.80, 595.80-bin, 595.80-firmware -> 595.84, 595.84-bin, 595.84-firmware
[U.]  #087  openapv                               0.2.1.2 -> 0.2.1.3
[U.]  #088  openexr                               3.4.10 -> 3.4.11
[U.]  #089  orca                                  50.1.2 -> 50.2
[U.]  #090  perl5.42.0-HTTP-Daemon                6.16 -> 6.17
[C.]  #091  pipewire-extra-config                 <none> x2 -> <none>
[U.]  #092  publicsuffix-list                     0-unstable-2026-03-26 -> 0-unstable-2026-05-13
[U.]  #093  qt5compat                             6.11.0 -> 6.11.1
[U.]  #094  qtbase                                6.11.0, 6.11.0-dev, 6.11.0-only-plugins-qml -> 6.11.1, 6.11.1-dev, 6.11.1-only-plugins-qml
[U.]  #095  qtdeclarative                         6.11.0 -> 6.11.1
[U.]  #096  qtshadertools                         6.11.0 -> 6.11.1
[U.]  #097  qtsvg                                 6.11.0, 6.11.0-dev -> 6.11.1, 6.11.1-dev
[U.]  #098  qttranslations                        6.11.0 -> 6.11.1
[U.]  #099  rsync                                 3.4.1 -> 3.4.4
[U.]  #100  sdl3                                  3.4.8-lib -> 3.4.10-lib
[U.]  #101  simdjson                              4.6.0 -> 4.6.4
[U.]  #102  sqlcipher                             4.14.0 -> 4.16.0
[U.]  #103  sssd                                  2.13.0 -> 2.13.1
[U.]  #104  stage1-systemd                        260.1 x2 -> 260.2 x2
[U*]  #105  strace                                7.0 -> 7.1
[U.]  #106  stunnel                               5.76 -> 5.79
[U.]  #107  system76-io-module                    1.0.4-7.1 -> 1.0.4-7.1.3
[U.]  #108  system76-module                       1.0.17-7.1 -> 1.0.17-7.1.3
[C.]  #109  systemd                               <none> x6, 260.1, 260.1-dev -> <none> x6, 260.2, 260.2-dev
[U.]  #110  systemd-minimal                       260.1 -> 260.2
[U.]  #111  systemd-minimal-libs                  260.1, 260.1-dev -> 260.2, 260.2-dev
[U.]  #112  unbound                               1.25.0-lib -> 1.25.1-lib
[C.]  #113  unit-script-suid-sgid-wrappers-start  <none> x5 -> <none> x6
[C.]  #114  unit-suid-sgid-wrappers.service       <none> x8 -> <none> x9
[U.]  #115  wireplumber                           0.5.14 -> 0.5.15
[U.]  #116  xdg-desktop-portal-cosmic             1.0.16 -> 1.1.0
Selection state changes:
[C-]  #1  fuse  2.9.9, 2.9.9-bin, 3.17.4, 3.17.4-bin
Added packages:
[A.]  #01  cosmic-monitor         1.1.0
[A.]  #02  gnome-online-accounts  3.58.1
[A.]  #03  gvfs                   1.60.1 x2
[A.]  #04  libcdio                2.3.0-lib
[A.]  #05  libcdio-paranoia       2.0.2
[A.]  #06  libgphoto2             2.5.34
[A.]  #07  libmsgraph             0.3.4
[A.]  #08  libmtp                 1.1.22
[A.]  #09  libnfs                 6.0.2
[A.]  #10  librest                0.10.2
[A.]  #11  polkitd.conf           <none>
Removed packages:
[R.]  #1  apparmor-closure-rules-security.wrappers.fusermount   <none>
[R.]  #2  apparmor-closure-rules-security.wrappers.fusermount3  <none>
[R.]  #3  nixos-security.wrappers-fusermount                    <none>
[R.]  #4  nixos-security.wrappers-fusermount3                   <none>
[R.]  #5  unit-cosmic-session.target                            <none>
Closure size: 3452 -> 3462 (3446 paths added, 3436 paths removed, delta +10, disk usage +179.7MiB).
```
</details>

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Regression tests
