### PR TITLE
fix(flash): pass image to bmaptool in prebuilt-bmap path

### DIFF
--- a/packages/pkgs-by-name/flash-script/flash.sh
+++ b/packages/pkgs-by-name/flash-script/flash.sh
@@ -227,7 +227,7 @@ flash_zst_with_bmap() {
   PREBUILT_BMAP="${FILENAME%%.*}.bmap"
   if [ -f "$PREBUILT_BMAP" ]; then
     echo "Flashing with sparse-aware copy..."
-    if ! bmaptool_copy_retry bmaptool copy --bmap "$PREBUILT_BMAP" "$DEVICE"; then
+    if ! bmaptool_copy_retry bmaptool copy --bmap "$PREBUILT_BMAP" "$FILENAME" "$DEVICE"; then
       warn "Sparse-aware flashing failed, likely because the device is still busy."
       return 1
     fi


### PR DESCRIPTION
`bmaptool copy` is `copy [--bmap BMAP] IMAGE DEST`, but `flash_zst_with_bmap` calls it with `--bmap BMAP DEVICE` — no image. It always errors, retries 3x, then silently falls back to a full stream decompress, so the prebuilt `.bmap` is never used.

Add `$FILENAME` (a `.raw.zst`, which bmaptool reads directly), matching the sibling call below. Introduced in #2012.