### PR TITLE
fix(ci): unblock fork PRs after actions/checkout and codeql-action bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
           persist-credentials: false
+          # Checking out fork code in a 'pull_request_target' workflow is the
+          # "pwn request" pattern, so actions/checkout v7 refuses it unless we
+          # opt in. The 'authorize' job above gates this one on the PR author
+          # being a tiiuae org member, and runs from the base version of
+          # authorize.yml, so untrusted code never reaches a runner unreviewed.
+          allow-unsafe-pr-checkout: true
       - name: Rebase
         if: ${{ github.base_ref != '' }}
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.


### PR DESCRIPTION
Every fork PR currently fails all ten `build` jobs and both `Analyze` jobs. Both causes are dependabot bumps on `main`, not the PRs. No contributor branch can work around either: `build.yml` runs on `pull_request_target`, and `pull_request` workflows are evaluated from the merge commit.

 `build` — dies in Checkout, before Nix

`actions/checkout` v6.0.3 → v7.0.0 (76ea1d9a) added a hard refusal:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow.
... set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

 `Analyze` — version skew

`autobuild` and `analyze` went to v4.36.3 (677d9477, 10ca6cea) while `init` stayed on v4.36.2:

```
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

