### PR TITLE
fix(partitioning): don't call GUM before Plymouth releases the console

### DIFF
--- a/modules/partitioning/deferred-disk-encryption.nix
+++ b/modules/partitioning/deferred-disk-encryption.nix
@@ -100,24 +100,30 @@ let
         done
 
         if [ -z "$ESP_DEVICE" ]; then
-          show_warning "ESP partition not found - cannot check for installer marker. Skipping deferred encryption."
+          echo "ESP partition not found - cannot check for installer marker. Skipping deferred encryption."
           exit 0
         fi
 
         mkdir -p /mnt/esp
         if ! mount "$ESP_DEVICE" /mnt/esp; then
-          show_warning "Failed to mount ESP - skipping deferred encryption."
+          echo "Failed to mount ESP - skipping deferred encryption."
           exit 0
         fi
 
         if [ ! -f "/mnt/esp/.ghaf-installer-encrypt" ]; then
-          show_info "Installer marker not found on ESP - skipping deferred encryption."
+          echo "Installer marker not found on ESP - skipping deferred encryption."
           umount /mnt/esp
           exit 0
         fi
 
         # ---------------------------------------------------------------------------
         # Stop Plymouth so GUM can own the framebuffer TTY
+        #
+        # This is the boundary: GUM is only safe to call below this block. Above it
+        # plymouthd still owns the console, and GUM renders through a terminal
+        # library that expects to own the TTY. The two deadlock, and since this
+        # service is ordered Before=sysroot.mount, the boot hangs on the splash
+        # forever. Use plain echo above this point.
         # ---------------------------------------------------------------------------
         if command -v plymouth >/dev/null 2>&1; then
           plymouth quit || true


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Raw-flashed `intel-laptop-debug` images have hung at the Ghaf splash since 2026-07-07. Intermittent, no serial output, no journal from the failed boot. The Plymouth throbber keeps animating, so the kernel is alive — the boot is blocked on an initrd job.

`first-boot-encrypt.service` takes `/dev/console` (`StandardInput=tty-force`) and is ordered `Before=sysroot.mount`. 2aa297e9 swapped its three early-exit `echo` calls for `show_warning`/`show_info`, which are `gum style`. All three run *before* `plymouth quit`. GUM wants the TTY, `plymouthd` still holds it, they deadlock, `sysroot.mount` never runs.

Only raw images hit it: `.ghaf-installer-encrypt` is written solely by the installer, so a `dd`'d image always takes the "marker not found" path. Installed images short-circuit at the LUKS fast-path; ISOs don't ship the service.

Fix: plain `echo` on the three skip paths. They print one line and `exit 0` — they never needed styling. Every remaining GUM call is downstream of `plymouth quit`, where the console is free.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

Regression from 2aa297e9. No issue filed; reported internally against the lab X1 fleet.

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- No docs: restores prior behaviour of an internal initrd service, no user-facing surface. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [x] Other: reproducing needs a raw flash — an affected system never reaches a login prompt.

### Test Steps To Verify:

1. Flash an `intel-laptop-debug` raw image from this branch to a Lenovo X1 and boot it 20 times, no extra kernel parameters. Expect 20 clean boots with the splash enabled.
2. Install from the installer ISO and confirm the first-boot encryption TUI still prompts for a passphrase. That path runs after `plymouth quit` and must be unchanged.

On an unpatched image, either `rd.systemd.mask=first-boot-encrypt.service` or `plymouth.enable=0` boots reliably — each removes one half of the deadlock.

