### PR TITLE
feat(spire): support named agent instances and upstream integration

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -248,11 +248,7 @@ in
       }
     );
 
-    spireNodeAttestationMode = lib.types.enum [
-      "join_token"
-      "x509pop"
-      "tpm_devid"
-    ];
+    spireNodeAttestationMode = lib.types.enum [ "x509pop" ];
 
   };
 

--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -65,7 +65,7 @@ in
               options = {
                 nodeAttestationMode = mkOption {
                   type = types.spireNodeAttestationMode;
-                  default = "join_token";
+                  default = "x509pop";
                   description = "Spire node attestation mode";
                 };
                 workloads = mkOption {

--- a/modules/common/security/spire/agent.nix
+++ b/modules/common/security/spire/agent.nix
@@ -8,183 +8,309 @@
 }:
 with lib;
 let
-  cfg = config.ghaf.security.spire.agent;
-  runtimeDataDir = "/run/spire-agent";
-  dataDir = "${runtimeDataDir}";
-  credSourceDir = "/etc/givc";
-
   spire-package = config.ghaf.common.spire.package;
-  healthCheckPort = toString config.ghaf.common.spire.server.healthCheckPort;
 
-  joinTokenConf = optionalString (cfg.nodeAttestationMode == "join_token") ''
-    join_token_file = "${cfg.settings.join_token.token}"
-  '';
-  joinTokenPlugin = optionalString (cfg.nodeAttestationMode == "join_token") ''
-    NodeAttestor "join_token" {
-      plugin_data {}
+  serviceName = name: if name == "downstream" then "spire-agent" else "spire-agent-${name}";
+  runtimeDir = name: "/run/${serviceName name}";
+
+  agentType = types.submodule (
+    { name, ... }:
+    {
+      options = {
+        enable = mkEnableOption "SPIRE agent ${name}";
+
+        serverAddress = mkOption {
+          type = types.str;
+          default = config.ghaf.common.spire.server.address;
+          description = "SPIRE server address.";
+        };
+
+        serverPort = mkOption {
+          type = types.port;
+          default = config.ghaf.common.spire.server.port;
+          description = "SPIRE server agent port.";
+        };
+
+        serverHealthCheck = {
+          enable = mkOption {
+            type = types.bool;
+            default = name == "downstream";
+            description = "Wait for the SPIRE server readiness endpoint before starting.";
+          };
+
+          port = mkOption {
+            type = types.port;
+            default = config.ghaf.common.spire.server.healthCheckPort;
+            description = "SPIRE server readiness endpoint port.";
+          };
+        };
+
+        trustDomain = mkOption {
+          type = types.str;
+          default = config.ghaf.common.spire.server.trustDomain;
+          description = "SPIFFE trust domain.";
+        };
+
+        nodeAttestationMode = mkOption {
+          type = types.enum [
+            "join_token"
+            "x509pop"
+          ];
+          default = "x509pop";
+          description = "Node attestation mode.";
+        };
+
+        workloads = mkOption {
+          type = types.spireWorkloads;
+          default = [ ];
+          description = "List of workloads for this SPIRE agent.";
+        };
+
+        trustBundlePath = mkOption {
+          type = types.str;
+          default = "/etc/common/spire/bundle.pem";
+          description = "Path to the SPIRE bootstrap trust bundle.";
+        };
+
+        dataDir = mkOption {
+          type = types.str;
+          default = runtimeDir name;
+          description = "SPIRE agent data directory.";
+        };
+
+        socketPath = mkOption {
+          type = types.str;
+          default = "${runtimeDir name}/agent.sock";
+          description = "SPIFFE Workload API socket path.";
+        };
+
+        logLevel = mkOption {
+          type = types.str;
+          default = "INFO";
+          description = "SPIRE agent log level.";
+        };
+
+        settings = {
+          join_token.token = mkOption {
+            type = types.str;
+            default = "/etc/common/spire/tokens/${config.networking.hostName}.token";
+            description = "Path to the server-generated join token.";
+          };
+
+          x509pop = {
+            privateKeyPath = mkOption {
+              type = types.str;
+              default = "/etc/givc/key.pem";
+              description = "Path to the X.509 node-attestation private key.";
+            };
+
+            certificatePath = mkOption {
+              type = types.str;
+              default = "/etc/givc/cert.pem";
+              description = "Path to the X.509 node-attestation certificate.";
+            };
+          };
+        };
+      };
     }
-  '';
-  x509popPlugin = optionalString (cfg.nodeAttestationMode == "x509pop") ''
-    NodeAttestor "x509pop" {
-      plugin_data {
-        private_key_path = "$CREDENTIALS_DIRECTORY/key.pem"
-        certificate_path = "$CREDENTIALS_DIRECTORY/cert.pem"
+  );
+
+  enabledAgents = filterAttrs (_: agent: agent.enable) config.ghaf.security.spire.agents;
+  isJoinToken = agent: agent.nodeAttestationMode == "join_token";
+
+  credentials =
+    agent:
+    if isJoinToken agent then
+      [ "join-token:${agent.settings.join_token.token}" ]
+    else
+      [
+        "key.pem:${agent.settings.x509pop.privateKeyPath}"
+        "cert.pem:${agent.settings.x509pop.certificatePath}"
+      ];
+
+  credentialPaths =
+    agent:
+    if isJoinToken agent then
+      [ agent.settings.join_token.token ]
+    else
+      [
+        agent.settings.x509pop.privateKeyPath
+        agent.settings.x509pop.certificatePath
+      ];
+
+  agentConf =
+    agent:
+    let
+      nodeAttestor =
+        if isJoinToken agent then
+          ''
+            NodeAttestor "join_token" {
+              plugin_data {}
+            }
+          ''
+        else
+          ''
+            NodeAttestor "x509pop" {
+              plugin_data {
+                private_key_path = "$CREDENTIALS_DIRECTORY/key.pem"
+                certificate_path = "$CREDENTIALS_DIRECTORY/cert.pem"
+              }
+            }
+          '';
+    in
+    ''
+      agent {
+        data_dir = "${agent.dataDir}"
+        log_level = "${agent.logLevel}"
+        server_address = "${agent.serverAddress}"
+        server_port = ${toString agent.serverPort}
+        trust_domain = "${agent.trustDomain}"
+        trust_bundle_path = "${agent.trustBundlePath}"
+        socket_path = "${agent.socketPath}"
+        ${optionalString (isJoinToken agent) ''join_token_file = "$CREDENTIALS_DIRECTORY/join-token"''}
       }
-    }
-  '';
-  agentConf = ''
-    agent {
-      data_dir = "${dataDir}"
-      log_level = "${cfg.logLevel}"
-      server_address = "${config.ghaf.common.spire.server.address}"
-      server_port = ${toString config.ghaf.common.spire.server.port}
-      trust_domain = "${config.ghaf.common.spire.server.trustDomain}"
-      trust_bundle_path = "${cfg.trustBundlePath}"
-      socket_path = "${runtimeDataDir}/agent.sock"
-      ${joinTokenConf}
-    }
 
-    plugins {
-      ${joinTokenPlugin}
-      ${x509popPlugin}
+      plugins {
+        ${nodeAttestor}
 
-      WorkloadAttestor "unix" {
-        plugin_data {}
+        WorkloadAttestor "unix" {
+          plugin_data {}
+        }
+        KeyManager "memory" {
+          plugin_data {}
+        }
       }
-      KeyManager "memory" {
-        plugin_data {}
-      }
-    }
-  '';
+    '';
 
-  server-health = pkgs.writeShellApplication {
-    name = "spire-server-healthcheck";
+  configFiles = mapAttrs (
+    name: agent: pkgs.writeText "${serviceName name}.conf" (agentConf agent)
+  ) enabledAgents;
 
-    runtimeInputs = [
-      pkgs.curl
-    ];
+  waitForAgent =
+    name: agent:
+    pkgs.writeShellApplication {
+      name = "wait-for-${serviceName name}";
+      runtimeInputs = optionals agent.serverHealthCheck.enable [ pkgs.curl ];
+      text = ''
+        ${optionalString agent.serverHealthCheck.enable ''
+          server_url="http://${agent.serverAddress}:${toString agent.serverHealthCheck.port}/ready"
+          until curl --fail --silent --connect-timeout 1 --max-time 2 "$server_url" >/dev/null 2>&1; do
+            echo "Waiting for SPIRE server at $server_url"
+            sleep 1
+          done
+        ''}
 
-    text = ''
-      SERVER_URL="http://${config.ghaf.common.spire.server.address}:${healthCheckPort}/ready"
-      MODE="${cfg.nodeAttestationMode}"
-
-      echo "Checking SPIRE Server readiness at $SERVER_URL..."
-
-      # Short per-attempt timeouts: without them, curl defaults to ~30s on
-      # silently-dropped SYNs (rpfilter / netfilter not yet up on admin-vm),
-      # so a single hung TCP burns the whole 90s ExecStartPre budget.
-      until curl --fail --silent --connect-timeout 1 --max-time 2 "$SERVER_URL" > /dev/null 2>&1; do
-        echo "SPIRE Server is not ready yet. Retrying in 1 second..."
-        sleep 1
-      done
-
-      echo "SPIRE Server is ready! Starting SPIRE Agent..."
-
-      while [ ! -e "${cfg.trustBundlePath}" ]; do
-        echo "Waiting for trust bundle..."
-        sleep 1
-      done
-
-      if [ "$MODE" == "join_token" ]; then
-        while [ ! -e "${cfg.settings.join_token.token}" ]; do
-          echo "Waiting for server token..."
+        until [ -e ${escapeShellArg agent.trustBundlePath} ]; do
+          echo "Waiting for SPIRE trust bundle ${agent.trustBundlePath}"
           sleep 1
         done
-      fi
 
-    '';
-  };
+        ${optionalString (isJoinToken agent) ''
+          until [ -e ${escapeShellArg agent.settings.join_token.token} ]; do
+            echo "Waiting for SPIRE join token ${agent.settings.join_token.token}"
+            sleep 1
+          done
+        ''}
+      '';
+    };
+
+  agentServices = mapAttrs' (
+    name: agent:
+    let
+      unitName = serviceName name;
+    in
+    nameValuePair unitName {
+      description = "SPIRE agent ${name}";
+      wantedBy = [ "multi-user.target" ];
+      requires = [
+        "network-online.target"
+        "local-fs.target"
+      ];
+      after = [
+        "network-online.target"
+        "local-fs.target"
+      ]
+      ++ optional (!isJoinToken agent) "givc-key-setup.service";
+
+      unitConfig.RequiresMountsFor = [
+        agent.trustBundlePath
+      ]
+      ++ credentialPaths agent
+      ++ optional (!hasPrefix "/run/" agent.dataDir) agent.dataDir;
+
+      serviceConfig = {
+        ExecStartPre = [
+          (getExe (waitForAgent name agent))
+          (pkgs.writeShellScript "validate-${unitName}" ''
+            exec ${getExe' spire-package "spire-agent"} validate \
+              -expandEnv \
+              -config ${escapeShellArg configFiles.${name}}
+          '')
+        ];
+        ExecStart = "${getExe' spire-package "spire-agent"} run -expandEnv -config ${configFiles.${name}}";
+        LoadCredential = credentials agent;
+        User = unitName;
+        Group = unitName;
+        RuntimeDirectory = unitName;
+        RuntimeDirectoryMode = "0755";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        UMask = "0027";
+
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = unique [
+          agent.dataDir
+          (runtimeDir name)
+        ];
+      };
+    }
+  ) enabledAgents;
 in
 {
   _file = ./agent.nix;
 
-  options.ghaf.security.spire.agent = {
-    enable = mkEnableOption "SPIRE agent";
-    nodeAttestationMode = mkOption {
-      type = types.spireNodeAttestationMode;
-      default = "x509pop";
-      description = "Node attestation mode";
-    };
-    workloads = mkOption {
-      type = types.spireWorkloads;
-      default = [ ];
-      description = "List of workloads for this spire agent";
-    };
-    trustBundlePath = mkOption {
-      type = types.path;
-      default = "/etc/common/spire/bundle.pem";
-      description = "Path to the SPIRE trust bundle PEM file (used to verify the server during bootstrap)";
-    };
-    logLevel = mkOption {
-      type = types.str;
-      default = "INFO";
-      description = "SPIRE server log level";
-    };
-    settings = {
-      join_token = {
-        token = mkOption {
-          type = types.path;
-          default = "/etc/common/spire/tokens/${config.networking.hostName}.token";
-          description = "SPIRE server log level";
-        };
-      };
-    };
+  options.ghaf.security.spire.agents = mkOption {
+    type = types.attrsOf agentType;
+    default = { };
+    description = "Named SPIRE agent instances.";
   };
 
-  config = mkIf cfg.enable {
-    environment.etc."spire/agent.conf".text = agentConf;
-    services.spire.agent = {
-      enable = true;
-      package = spire-package;
-      configFile = "/etc/spire/agent.conf";
-    };
+  config = mkIf (enabledAgents != { }) {
+    assertions = [
+      {
+        assertion =
+          builtins.length (unique (map (agent: agent.socketPath) (builtins.attrValues enabledAgents)))
+          == builtins.length (builtins.attrValues enabledAgents);
+        message = "SPIRE agents must use unique socket paths.";
+      }
+    ];
 
     environment.systemPackages = [ spire-package ];
+
+    users = {
+      groups = mapAttrs' (name: _: nameValuePair (serviceName name) { }) enabledAgents;
+      users = mapAttrs' (
+        name: _:
+        nameValuePair (serviceName name) {
+          isSystemUser = true;
+          group = serviceName name;
+        }
+      ) enabledAgents;
+    };
+
     systemd = {
-      services = {
-        spire-agent = {
-          requires = [
-            "network-online.target"
-            "local-fs.target"
-          ];
-          # givc-key-setup writes /etc/givc/{key,cert,ca-cert}.pem that
-          # LoadCredential below depends on. Without explicit After=, the
-          # agent races the cert generator and the early ExecStartPre
-          # restarts on CREDENTIALS failure before settling.
-          after = [
-            "network-online.target"
-            "local-fs.target"
-            "givc-key-setup.service"
-          ];
-
-          unitConfig = {
-            RequiresMountsFor = [ "/etc/common" ];
-          };
-
-          serviceConfig = {
-            RuntimeDirectory = mkForce "spire-agent";
-            StateDirectory = mkForce "spire-agent";
-            ExecStartPre = getExe server-health;
-            NoNewPrivileges = true;
-            PrivateTmp = true;
-            ProtectSystem = "strict";
-            ProtectHome = true;
-            ReadWritePaths = [
-              "${dataDir}"
-              "${runtimeDataDir}"
-            ];
-          }
-          // optionalAttrs (cfg.nodeAttestationMode == "x509pop") {
-            LoadCredential = [
-              "key.pem:${credSourceDir}/key.pem"
-              "cert.pem:${credSourceDir}/cert.pem"
-            ];
-          };
-        };
-      };
-      tmpfiles.rules = [
-        "d ${runtimeDataDir} 0755 spire-agent spire-agent - -"
-      ];
+      services = agentServices;
+      tmpfiles.rules = filter (rule: rule != "") (
+        mapAttrsToList (
+          name: agent:
+          optionalString (
+            !hasPrefix "/run/" agent.dataDir
+          ) "d ${agent.dataDir} 0700 ${serviceName name} ${serviceName name} - -"
+        ) enabledAgents
+      );
     };
   };
 }

--- a/modules/common/security/spire/agent.nix
+++ b/modules/common/security/spire/agent.nix
@@ -52,10 +52,7 @@ let
         };
 
         nodeAttestationMode = mkOption {
-          type = types.enum [
-            "join_token"
-            "x509pop"
-          ];
+          type = types.enum [ "x509pop" ];
           default = "x509pop";
           description = "Node attestation mode.";
         };
@@ -91,12 +88,6 @@ let
         };
 
         settings = {
-          join_token.token = mkOption {
-            type = types.str;
-            default = "/etc/common/spire/tokens/${config.networking.hostName}.token";
-            description = "Path to the server-generated join token.";
-          };
-
           x509pop = {
             privateKeyPath = mkOption {
               type = types.str;
@@ -116,71 +107,44 @@ let
   );
 
   enabledAgents = filterAttrs (_: agent: agent.enable) config.ghaf.security.spire.agents;
-  isJoinToken = agent: agent.nodeAttestationMode == "join_token";
 
-  credentials =
-    agent:
-    if isJoinToken agent then
-      [ "join-token:${agent.settings.join_token.token}" ]
-    else
-      [
-        "key.pem:${agent.settings.x509pop.privateKeyPath}"
-        "cert.pem:${agent.settings.x509pop.certificatePath}"
-      ];
+  credentials = agent: [
+    "key.pem:${agent.settings.x509pop.privateKeyPath}"
+    "cert.pem:${agent.settings.x509pop.certificatePath}"
+  ];
 
-  credentialPaths =
-    agent:
-    if isJoinToken agent then
-      [ agent.settings.join_token.token ]
-    else
-      [
-        agent.settings.x509pop.privateKeyPath
-        agent.settings.x509pop.certificatePath
-      ];
+  credentialPaths = agent: [
+    agent.settings.x509pop.privateKeyPath
+    agent.settings.x509pop.certificatePath
+  ];
 
-  agentConf =
-    agent:
-    let
-      nodeAttestor =
-        if isJoinToken agent then
-          ''
-            NodeAttestor "join_token" {
-              plugin_data {}
-            }
-          ''
-        else
-          ''
-            NodeAttestor "x509pop" {
-              plugin_data {
-                private_key_path = "$CREDENTIALS_DIRECTORY/key.pem"
-                certificate_path = "$CREDENTIALS_DIRECTORY/cert.pem"
-              }
-            }
-          '';
-    in
-    ''
-      agent {
-        data_dir = "${agent.dataDir}"
-        log_level = "${agent.logLevel}"
-        server_address = "${agent.serverAddress}"
-        server_port = ${toString agent.serverPort}
-        trust_domain = "${agent.trustDomain}"
-        trust_bundle_path = "${agent.trustBundlePath}"
-        socket_path = "${agent.socketPath}"
-        ${optionalString (isJoinToken agent) ''join_token_file = "$CREDENTIALS_DIRECTORY/join-token"''}
-      }
+  agentConf = agent: ''
+    agent {
+      data_dir = "${agent.dataDir}"
+      log_level = "${agent.logLevel}"
+      server_address = "${agent.serverAddress}"
+      server_port = ${toString agent.serverPort}
+      trust_domain = "${agent.trustDomain}"
+      trust_bundle_path = "${agent.trustBundlePath}"
+      socket_path = "${agent.socketPath}"
+    }
 
-      plugins {
-        ${nodeAttestor}
-
-        WorkloadAttestor "unix" {
-          plugin_data {}
-        }
-        KeyManager "memory" {
-          plugin_data {}
+    plugins {
+      NodeAttestor "x509pop" {
+        plugin_data {
+          private_key_path = "$CREDENTIALS_DIRECTORY/key.pem"
+          certificate_path = "$CREDENTIALS_DIRECTORY/cert.pem"
         }
       }
-    '';
+
+      WorkloadAttestor "unix" {
+        plugin_data {}
+      }
+      KeyManager "memory" {
+        plugin_data {}
+      }
+    }
+  '';
 
   configFiles = mapAttrs (
     name: agent: pkgs.writeText "${serviceName name}.conf" (agentConf agent)
@@ -204,13 +168,6 @@ let
           echo "Waiting for SPIRE trust bundle ${agent.trustBundlePath}"
           sleep 1
         done
-
-        ${optionalString (isJoinToken agent) ''
-          until [ -e ${escapeShellArg agent.settings.join_token.token} ]; do
-            echo "Waiting for SPIRE join token ${agent.settings.join_token.token}"
-            sleep 1
-          done
-        ''}
       '';
     };
 
@@ -229,8 +186,8 @@ let
       after = [
         "network-online.target"
         "local-fs.target"
-      ]
-      ++ optional (!isJoinToken agent) "givc-key-setup.service";
+        "givc-key-setup.service"
+      ];
 
       unitConfig.RequiresMountsFor = [
         agent.trustBundlePath

--- a/modules/common/security/spire/agent.nix
+++ b/modules/common/security/spire/agent.nix
@@ -15,19 +15,22 @@ let
 
   agentType = types.submodule (
     { name, ... }:
+    let
+      localServerDefault = value: if name == "downstream" then value else null;
+    in
     {
       options = {
         enable = mkEnableOption "SPIRE agent ${name}";
 
         serverAddress = mkOption {
-          type = types.str;
-          default = config.ghaf.common.spire.server.address;
+          type = types.nullOr types.str;
+          default = localServerDefault config.ghaf.common.spire.server.address;
           description = "SPIRE server address.";
         };
 
         serverPort = mkOption {
-          type = types.port;
-          default = config.ghaf.common.spire.server.port;
+          type = types.nullOr types.port;
+          default = localServerDefault config.ghaf.common.spire.server.port;
           description = "SPIRE server agent port.";
         };
 
@@ -46,13 +49,13 @@ let
         };
 
         trustDomain = mkOption {
-          type = types.str;
-          default = config.ghaf.common.spire.server.trustDomain;
+          type = types.nullOr types.str;
+          default = localServerDefault config.ghaf.common.spire.server.trustDomain;
           description = "SPIFFE trust domain.";
         };
 
         nodeAttestationMode = mkOption {
-          type = types.enum [ "x509pop" ];
+          type = types.spireNodeAttestationMode;
           default = "x509pop";
           description = "Node attestation mode.";
         };
@@ -64,9 +67,18 @@ let
         };
 
         trustBundlePath = mkOption {
-          type = types.str;
-          default = "/etc/common/spire/bundle.pem";
+          type = types.nullOr types.str;
+          default = localServerDefault "/etc/common/spire/bundle.pem";
           description = "Path to the SPIRE bootstrap trust bundle.";
+        };
+
+        trustBundleUrl = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            HTTPS URL for the SPIRE bootstrap trust bundle, validated against the system CA store.
+            Prefer trustBundlePath when an out-of-band pinned bundle is available.
+          '';
         };
 
         dataDir = mkOption {
@@ -107,6 +119,16 @@ let
   );
 
   enabledAgents = filterAttrs (_: agent: agent.enable) config.ghaf.security.spire.agents;
+  hasValue = value: value != null && value != "";
+  connectionConfigured =
+    agent:
+    hasValue agent.serverAddress
+    && agent.serverPort != null
+    && hasValue agent.trustDomain
+    && (hasValue agent.trustBundleUrl || hasValue agent.trustBundlePath);
+  trustBundleUrlIsSecure =
+    agent: agent.trustBundleUrl == null || hasPrefix "https://" agent.trustBundleUrl;
+  configuredAgents = filterAttrs (_: connectionConfigured) enabledAgents;
 
   credentials = agent: [
     "key.pem:${agent.settings.x509pop.privateKeyPath}"
@@ -118,6 +140,13 @@ let
     agent.settings.x509pop.certificatePath
   ];
 
+  trustBundleConfig =
+    agent:
+    if agent.trustBundleUrl != null then
+      ''trust_bundle_url = "${agent.trustBundleUrl}"''
+    else
+      ''trust_bundle_path = "${agent.trustBundlePath}"'';
+
   agentConf = agent: ''
     agent {
       data_dir = "${agent.dataDir}"
@@ -125,7 +154,7 @@ let
       server_address = "${agent.serverAddress}"
       server_port = ${toString agent.serverPort}
       trust_domain = "${agent.trustDomain}"
-      trust_bundle_path = "${agent.trustBundlePath}"
+      ${trustBundleConfig agent}
       socket_path = "${agent.socketPath}"
     }
 
@@ -140,6 +169,9 @@ let
       WorkloadAttestor "unix" {
         plugin_data {}
       }
+      WorkloadAttestor "systemd" {
+        plugin_data {}
+      }
       KeyManager "memory" {
         plugin_data {}
       }
@@ -148,13 +180,15 @@ let
 
   configFiles = mapAttrs (
     name: agent: pkgs.writeText "${serviceName name}.conf" (agentConf agent)
-  ) enabledAgents;
+  ) configuredAgents;
 
   waitForAgent =
     name: agent:
     pkgs.writeShellApplication {
       name = "wait-for-${serviceName name}";
-      runtimeInputs = optionals agent.serverHealthCheck.enable [ pkgs.curl ];
+      runtimeInputs = optionals (agent.serverHealthCheck.enable || agent.trustBundleUrl != null) [
+        pkgs.curl
+      ];
       text = ''
         ${optionalString agent.serverHealthCheck.enable ''
           server_url="http://${agent.serverAddress}:${toString agent.serverHealthCheck.port}/ready"
@@ -164,10 +198,20 @@ let
           done
         ''}
 
-        until [ -e ${escapeShellArg agent.trustBundlePath} ]; do
-          echo "Waiting for SPIRE trust bundle ${agent.trustBundlePath}"
-          sleep 1
-        done
+        ${optionalString (agent.trustBundleUrl != null) ''
+          trust_bundle_url=${escapeShellArg agent.trustBundleUrl}
+          until curl --fail --silent --location --connect-timeout 2 --max-time 5 --output /dev/null "$trust_bundle_url"; do
+            echo "Waiting for SPIRE trust bundle URL $trust_bundle_url"
+            sleep 1
+          done
+        ''}
+
+        ${optionalString (agent.trustBundleUrl == null) ''
+          until [ -e ${escapeShellArg agent.trustBundlePath} ]; do
+            echo "Waiting for SPIRE trust bundle ${agent.trustBundlePath}"
+            sleep 1
+          done
+        ''}
       '';
     };
 
@@ -189,11 +233,10 @@ let
         "givc-key-setup.service"
       ];
 
-      unitConfig.RequiresMountsFor = [
-        agent.trustBundlePath
-      ]
-      ++ credentialPaths agent
-      ++ optional (!hasPrefix "/run/" agent.dataDir) agent.dataDir;
+      unitConfig.RequiresMountsFor =
+        optional (agent.trustBundleUrl == null) agent.trustBundlePath
+        ++ credentialPaths agent
+        ++ optional (!hasPrefix "/run/" agent.dataDir) agent.dataDir;
 
       serviceConfig = {
         ExecStartPre = [
@@ -209,7 +252,7 @@ let
         User = unitName;
         Group = unitName;
         RuntimeDirectory = unitName;
-        RuntimeDirectoryMode = "0755";
+        RuntimeDirectoryMode = if name == "downstream" then "0755" else "0750";
         Restart = "on-failure";
         RestartSec = "5s";
         UMask = "0027";
@@ -224,7 +267,7 @@ let
         ];
       };
     }
-  ) enabledAgents;
+  ) configuredAgents;
 in
 {
   _file = ./agent.nix;
@@ -236,26 +279,38 @@ in
   };
 
   config = mkIf (enabledAgents != { }) {
-    assertions = [
-      {
-        assertion =
-          builtins.length (unique (map (agent: agent.socketPath) (builtins.attrValues enabledAgents)))
-          == builtins.length (builtins.attrValues enabledAgents);
-        message = "SPIRE agents must use unique socket paths.";
-      }
-    ];
+    assertions =
+      mapAttrsToList (name: agent: {
+        assertion = connectionConfigured agent;
+        message = ''
+          Enabled SPIRE agent "${name}" must configure serverAddress, serverPort,
+          trustDomain, and either trustBundleUrl or trustBundlePath.
+        '';
+      }) enabledAgents
+      ++ mapAttrsToList (name: agent: {
+        assertion = trustBundleUrlIsSecure agent;
+        message = "SPIRE agent \"${name}\" trustBundleUrl must use HTTPS.";
+      }) enabledAgents
+      ++ [
+        {
+          assertion =
+            builtins.length (unique (map (agent: agent.socketPath) (builtins.attrValues enabledAgents)))
+            == builtins.length (builtins.attrValues enabledAgents);
+          message = "SPIRE agents must use unique socket paths.";
+        }
+      ];
 
     environment.systemPackages = [ spire-package ];
 
     users = {
-      groups = mapAttrs' (name: _: nameValuePair (serviceName name) { }) enabledAgents;
+      groups = mapAttrs' (name: _: nameValuePair (serviceName name) { }) configuredAgents;
       users = mapAttrs' (
         name: _:
         nameValuePair (serviceName name) {
           isSystemUser = true;
           group = serviceName name;
         }
-      ) enabledAgents;
+      ) configuredAgents;
     };
 
     systemd = {
@@ -266,7 +321,7 @@ in
           optionalString (
             !hasPrefix "/run/" agent.dataDir
           ) "d ${agent.dataDir} 0700 ${serviceName name} ${serviceName name} - -"
-        ) enabledAgents
+        ) configuredAgents
       );
     };
   };

--- a/modules/common/security/spire/create-workload-entries.nix
+++ b/modules/common/security/spire/create-workload-entries.nix
@@ -15,8 +15,7 @@ pkgs.writeShellApplication {
   name = "spire-create-workload-entries";
   runtimeInputs = [
     pkgs.coreutils
-    pkgs.gawk
-    pkgs.gnugrep
+    pkgs.jq
     spire-package
   ];
   text = ''
@@ -40,7 +39,15 @@ pkgs.writeShellApplication {
       shift 3
       local selectors=("$@")
 
-      if spire-server entry show -socketPath "$SOCKET" -spiffeID "$spiffeID" >/dev/null 2>&1; then
+      local entry_count
+      entry_count="$(
+        spire-server entry count \
+          -socketPath "$SOCKET" \
+          -spiffeID "$spiffeID" \
+          -output json | jq -er '.count'
+      )"
+
+      if [ "$entry_count" -gt 0 ]; then
         echo "Entry exists: $spiffeID"
         return
       fi

--- a/modules/common/security/spire/create-workload-entries.nix
+++ b/modules/common/security/spire/create-workload-entries.nix
@@ -67,13 +67,9 @@ pkgs.writeShellApplication {
         agentCfg = config.ghaf.common.spire.agents.${vmName};
         agentSpiffeID = "spiffe://${config.ghaf.common.spire.server.trustDomain}/${vmName}";
 
-        nodeEntryCmd =
-          if (agentCfg.nodeAttestationMode == "x509pop") then
-            ''
-              create_entry "" ${escapeShellArg agentSpiffeID} "true" "x509pop:subject:cn:${escapeShellArg vmName}"
-            ''
-          else
-            "";
+        nodeEntryCmd = ''
+          create_entry "" ${escapeShellArg agentSpiffeID} "true" "x509pop:subject:cn:${escapeShellArg vmName}"
+        '';
 
         workloadCmds = concatMapStringsSep "\n" (
           workload:

--- a/modules/common/security/spire/server.nix
+++ b/modules/common/security/spire/server.nix
@@ -19,6 +19,8 @@ let
   inherit (config.ghaf.common.spire.server) healthCheckPort;
   inherit (config.ghaf.common.spire.server) trustDomain;
   spireAgentVMs = builtins.attrNames spireAgents;
+  upstreamAgent = config.ghaf.security.spire.agents.upstream or { enable = false; };
+  upstreamAgentServiceName = "spire-agent-upstream";
   getVMsByAttestation =
     mode: builtins.attrNames (filterAttrs (_vm: cfg: (cfg.nodeAttestationMode == mode)) spireAgents);
 
@@ -108,6 +110,37 @@ let
       spireAgentVMs
       ;
   };
+
+  spireServerUpstreamWorkloadApp = pkgs.writeShellApplication {
+    name = "spire-server-upstream-workload";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = ''
+      socket=${escapeShellArg upstreamAgent.socketPath}
+      retry_interval=30
+
+      probe_upstream_svid() {
+        echo "Waiting to verify upstream SPIRE workload SVID issuance"
+
+        while true; do
+          # This is a one-shot probe for the initial upstream agent integration.
+          # SVID persistence and renewal await the final backend requirements.
+          if [ -S "$socket" ] && ${getExe' spire-package "spire-agent"} api fetch x509 \
+            -silent \
+            -socketPath "$socket" \
+            -timeout 5s >/dev/null 2>&1; then
+            echo "Fetched upstream SPIRE workload SVID for spire-server.service"
+            return 0
+          fi
+
+          sleep "$retry_interval"
+        done
+      }
+
+      # Keep retries asynchronous so the optional upstream path cannot delay
+      # the independent local SPIRE server.
+      probe_upstream_svid &
+    '';
+  };
 in
 {
   _file = ./server.nix;
@@ -179,6 +212,10 @@ in
               "${dataDir}"
               "${runtimeDataDir}"
             ];
+          }
+          // optionalAttrs upstreamAgent.enable {
+            ExecStartPost = getExe spireServerUpstreamWorkloadApp;
+            SupplementaryGroups = [ upstreamAgentServiceName ];
           }
           // optionalAttrs (builtins.length x509popVMs > 0) {
             LoadCredential = [

--- a/modules/common/security/spire/server.nix
+++ b/modules/common/security/spire/server.nix
@@ -10,7 +10,6 @@ with lib;
 let
   cfg = config.ghaf.security.spire.server;
   runtimeDataDir = "/run/spire-server";
-  tokenDir = "/etc/common/spire/tokens";
   credSourceDir = "/etc/givc";
   socketPath = "${runtimeDataDir}/api.sock";
   dataDir = "${runtimeDataDir}";
@@ -23,14 +22,8 @@ let
   getVMsByAttestation =
     mode: builtins.attrNames (filterAttrs (_vm: cfg: (cfg.nodeAttestationMode == mode)) spireAgents);
 
-  joinTokenVMs = getVMsByAttestation "join_token";
   x509popVMs = getVMsByAttestation "x509pop";
 
-  joinTokenPlugin = optionalString (builtins.length joinTokenVMs > 0) ''
-    NodeAttestor "join_token" {
-      plugin_data {}
-    }
-  '';
   x509popPlugin = optionalString (builtins.length x509popVMs > 0) ''
     NodeAttestor "x509pop" {
       plugin_data {
@@ -65,55 +58,9 @@ let
       KeyManager "memory" {
         plugin_data {}
       }
-      ${joinTokenPlugin}
       ${x509popPlugin}
     }
   '';
-
-  spireGenerateJoinTokensApp = pkgs.writeShellApplication {
-    name = "spire-generate-join-tokens";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.gawk
-      spire-package
-    ];
-    text = ''
-      mkdir -p "${tokenDir}"
-      chmod 755 "${tokenDir}"
-
-      # Wait until the server is up
-      for i in $(seq 1 60); do
-        if spire-server healthcheck -socketPath ${socketPath} >/dev/null 2>&1; then
-          echo "SPIRE server is ready"
-          break
-        fi
-        echo "Waiting for SPIRE server... ($i/60)"
-        sleep 1
-      done
-
-      ${concatMapStringsSep "\n" (vm: ''
-        tokenFile="${tokenDir}/${vm}.token"
-
-        # Check if agent is already registered
-        if spire-server agent list -socketPath ${socketPath} 2>/dev/null | grep -q "spiffe://${trustDomain}/agent/${vm}"; then
-          echo "Agent ${vm} already registered, skipping token generation"
-        else
-          echo "Generating new token for ${vm}"
-          # Capture output and check success in one go
-          if ! output=$(spire-server token generate -socketPath "${socketPath}" -spiffeID "spiffe://${trustDomain}/${vm}"); then
-              echo "Error: SPIRE token generation failed!" >&2
-              exit 1
-          fi
-
-          token=$(echo "$output" | awk '/^Token:/ {print $2}')
-
-          printf '%s\n' "$token" > "$tokenFile"
-          chmod 0644 "$tokenFile"
-          echo "Token written to $tokenFile"
-        fi
-      '') joinTokenVMs}
-    '';
-  };
 
   spirePublishBundleApp = pkgs.writeShellApplication {
     name = "spire-publish-bundle";
@@ -194,7 +141,6 @@ in
     systemd = {
       tmpfiles.rules = [
         "d ${runtimeDataDir} 0755 root root - -"
-        "d ${tokenDir} 0755 root root - -"
       ];
 
       services = {
@@ -241,23 +187,6 @@ in
           };
         };
 
-        spire-generate-join-tokens = mkIf (builtins.length joinTokenVMs > 0) {
-          description = "Generate SPIRE join tokens for Ghaf VMs (PoC)";
-          wantedBy = [ "multi-user.target" ];
-          after = [
-            "spire-server.service"
-            "network-online.target"
-          ];
-          wants = [
-            "spire-server.service"
-            "network-online.target"
-          ];
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-            ExecStart = getExe spireGenerateJoinTokensApp;
-          };
-        };
         spire-publish-bundle = {
           description = "Publish SPIRE trust bundle (PoC)";
           wantedBy = [ "multi-user.target" ];
@@ -272,10 +201,7 @@ in
         spire-create-workload-entries = {
           description = "Create SPIRE workload entries";
           wantedBy = [ "multi-user.target" ];
-          after = [
-            "spire-server.service"
-          ]
-          ++ optionals (builtins.length joinTokenVMs > 0) [ "spire-generate-join-tokens.service" ];
+          after = [ "spire-server.service" ];
           wants = [ "spire-server.service" ];
 
           serviceConfig = {

--- a/modules/microvm/appvm.nix
+++ b/modules/microvm/appvm.nix
@@ -311,9 +311,9 @@ in
         lib.mapAttrsToList (
           name: vm:
           let
-            spireAgent = vm.evaluatedConfig.config.ghaf.security.spire.agent;
+            spireAgent = vm.evaluatedConfig.config.ghaf.security.spire.agents.downstream or null;
           in
-          if spireAgent.enable then
+          if spireAgent != null && spireAgent.enable then
             {
               "${name}-vm" = {
                 inherit (spireAgent) nodeAttestationMode workloads;

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -148,14 +148,14 @@ in
           policies = lib.mkIf config.ghaf.givc.policyClient.enable {
             ghaf-host = config.ghaf.givc.policyClient.policies;
           };
-          spire.agents = lib.mkIf config.ghaf.security.spire.agent.enable {
+          spire.agents = lib.mkIf config.ghaf.security.spire.agents.downstream.enable {
             ghaf-host = {
-              inherit (config.ghaf.security.spire.agent) nodeAttestationMode workloads;
+              inherit (config.ghaf.security.spire.agents.downstream) nodeAttestationMode workloads;
             };
           };
         };
 
-        security.spire.agent = {
+        security.spire.agents.downstream = {
           inherit (config.ghaf.global-config.spire) enable;
           logLevel = if config.ghaf.global-config.spire.debug then "DEBUG" else "INFO";
           nodeAttestationMode = if config.ghaf.global-config.givc.enable then "x509pop" else "join_token";

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -158,7 +158,6 @@ in
         security.spire.agents.downstream = {
           inherit (config.ghaf.global-config.spire) enable;
           logLevel = if config.ghaf.global-config.spire.debug then "DEBUG" else "INFO";
-          nodeAttestationMode = "x509pop";
           trustBundlePath = "/persist/common/spire/bundle.pem";
         };
       };

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -158,8 +158,7 @@ in
         security.spire.agents.downstream = {
           inherit (config.ghaf.global-config.spire) enable;
           logLevel = if config.ghaf.global-config.spire.debug then "DEBUG" else "INFO";
-          nodeAttestationMode = if config.ghaf.global-config.givc.enable then "x509pop" else "join_token";
-          settings.join_token.token = "/persist/common/spire/tokens/${config.networking.hostName}.token";
+          nodeAttestationMode = "x509pop";
           trustBundlePath = "/persist/common/spire/bundle.pem";
         };
       };

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -165,10 +165,27 @@ in
           enable = globalConfig.spire.enable or false;
           logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
         };
-        agent = {
+        agents.downstream = {
           enable = globalConfig.spire.enable or false;
           logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
           nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+        };
+
+        # Disabled by default. Placeholders for when connecting admin-vm to an external SPIRE backend.
+        agents.upstream = {
+          enable = false;
+
+          # Server Info
+          # serverAddress = "<external-spire-server-address>";
+          # serverPort = 8081;
+          # trustDomain = "<external-trust-domain>";
+          # trustBundlePath = "/etc/common/spire/external/bundle.pem";
+          # logLevel = if config.ghaf.global-config.spire.debug then "DEBUG" else "INFO";
+
+          # Attestation
+          # nodeAttestationMode = "x509pop";
+          # settings.x509pop.privateKeyPath = "/etc/common/spire/external/key.pem";
+          # settings.x509pop.certificatePath = "/etc/common/spire/external/cert.pem";
         };
       };
     };

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -168,7 +168,7 @@ in
         agents.downstream = {
           enable = globalConfig.spire.enable or false;
           logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-          nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+          nodeAttestationMode = "x509pop";
         };
 
         # Disabled by default. Placeholders for when connecting admin-vm to an external SPIRE backend.

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -168,24 +168,23 @@ in
         agents.downstream = {
           enable = globalConfig.spire.enable or false;
           logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-          nodeAttestationMode = "x509pop";
         };
 
-        # Disabled by default. Placeholders for when connecting admin-vm to an external SPIRE backend.
+        # Disabled by default. Enable for the external SPIRE backend.
         agents.upstream = {
-          enable = false;
+          enable = lib.mkDefault false;
 
           # Server Info
           # serverAddress = "<external-spire-server-address>";
           # serverPort = 8081;
           # trustDomain = "<external-trust-domain>";
-          # trustBundlePath = "/etc/common/spire/external/bundle.pem";
+          # trustBundleUrl = "https://<external-spire-server>/bundle.pem";
           # logLevel = if config.ghaf.global-config.spire.debug then "DEBUG" else "INFO";
 
           # Attestation
           # nodeAttestationMode = "x509pop";
-          # settings.x509pop.privateKeyPath = "/etc/common/spire/external/key.pem";
-          # settings.x509pop.certificatePath = "/etc/common/spire/external/cert.pem";
+          # settings.x509pop.privateKeyPath = "<path-to-key.pem>";
+          # settings.x509pop.certificatePath = "<path-to-cert.pem>";
         };
       };
     };

--- a/modules/microvm/sysvms/adminvm.nix
+++ b/modules/microvm/sysvms/adminvm.nix
@@ -67,9 +67,12 @@ in
       ghaf.common = {
         extraNetworking.hosts.${vmName} = cfg.extraNetworking;
         spire = {
-          agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agent.enable {
+          agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream.enable {
             "${vmName}" = {
-              inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agent) nodeAttestationMode workloads;
+              inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream)
+                nodeAttestationMode
+                workloads
+                ;
             };
           };
           server.address =

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -265,7 +265,7 @@ in
         # Security
         security = {
           fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
-          spire.agent = {
+          spire.agents.downstream = {
             enable = globalConfig.spire.enable or false;
             logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
             nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -268,7 +268,7 @@ in
           spire.agents.downstream = {
             enable = globalConfig.spire.enable or false;
             logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-            nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+            nodeAttestationMode = "x509pop";
           };
         };
       };

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -268,7 +268,6 @@ in
           spire.agents.downstream = {
             enable = globalConfig.spire.enable or false;
             logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-            nodeAttestationMode = "x509pop";
           };
         };
       };

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -156,7 +156,7 @@ in
 
     security = {
       fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
-      spire.agent = {
+      spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
         nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -159,7 +159,6 @@ in
       spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = "x509pop";
       };
     };
 

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -159,7 +159,7 @@ in
       spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+        nodeAttestationMode = "x509pop";
       };
     };
 

--- a/modules/microvm/sysvms/audiovm.nix
+++ b/modules/microvm/sysvms/audiovm.nix
@@ -69,9 +69,12 @@ in
         policies = lib.mkIf cfg.evaluatedConfig.config.ghaf.givc.policyClient.enable {
           "${vmName}" = cfg.evaluatedConfig.config.ghaf.givc.policyClient.policies;
         };
-        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agent.enable {
+        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream.enable {
           "${vmName}" = {
-            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agent) nodeAttestationMode workloads;
+            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream)
+              nodeAttestationMode
+              workloads
+              ;
           };
         };
       };

--- a/modules/microvm/sysvms/gpuvm-base.nix
+++ b/modules/microvm/sysvms/gpuvm-base.nix
@@ -115,10 +115,9 @@ in
       fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
       audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
 
-      spire.agent = {
+      spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
       };
     };
 

--- a/modules/microvm/sysvms/gpuvm.nix
+++ b/modules/microvm/sysvms/gpuvm.nix
@@ -71,9 +71,12 @@ in
         policies = lib.mkIf cfg.evaluatedConfig.config.ghaf.givc.policyClient.enable {
           "${vmName}" = cfg.evaluatedConfig.config.ghaf.givc.policyClient.policies;
         };
-        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agent.enable {
+        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream.enable {
           "${vmName}" = {
-            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agent) nodeAttestationMode workloads;
+            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream)
+              nodeAttestationMode
+              workloads
+              ;
           };
         };
       };

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -281,7 +281,7 @@ in
       audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
       fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
 
-      spire.agent = {
+      spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
         nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -284,7 +284,7 @@ in
       spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+        nodeAttestationMode = "x509pop";
       };
     };
   };

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -284,7 +284,6 @@ in
       spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = "x509pop";
       };
     };
   };

--- a/modules/microvm/sysvms/guivm.nix
+++ b/modules/microvm/sysvms/guivm.nix
@@ -80,9 +80,12 @@ in
         policies = lib.mkIf cfg.evaluatedConfig.config.ghaf.givc.policyClient.enable {
           "${vmName}" = cfg.evaluatedConfig.config.ghaf.givc.policyClient.policies;
         };
-        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agent.enable {
+        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream.enable {
           "${vmName}" = {
-            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agent) nodeAttestationMode workloads;
+            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream)
+              nodeAttestationMode
+              workloads
+              ;
           };
         };
       };

--- a/modules/microvm/sysvms/idsvm/idsvm.nix
+++ b/modules/microvm/sysvms/idsvm/idsvm.nix
@@ -73,11 +73,15 @@ in
         policies = lib.mkIf cfg.evaluatedConfig.config.ghaf.givc.policyClient.enable {
           "${vmName}" = cfg.evaluatedConfig.config.ghaf.givc.policyClient.policies;
         };
-        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agent.enable {
-          "${vmName}" = {
-            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agent) nodeAttestationMode workloads;
+        spire.agents =
+          let
+            localAgent = cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream or null;
+          in
+          lib.mkIf (localAgent != null && localAgent.enable) {
+            "${vmName}" = {
+              inherit (localAgent) nodeAttestationMode workloads;
+            };
           };
-        };
       };
 
       microvm.vms."${vmName}" = {

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -175,7 +175,7 @@ in
       # Audit - from globalConfig
       audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
 
-      spire.agent = {
+      spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
         nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -178,7 +178,7 @@ in
       spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+        nodeAttestationMode = "x509pop";
       };
     };
 

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -178,7 +178,6 @@ in
       spire.agents.downstream = {
         enable = globalConfig.spire.enable or false;
         logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
-        nodeAttestationMode = "x509pop";
       };
     };
 

--- a/modules/microvm/sysvms/netvm.nix
+++ b/modules/microvm/sysvms/netvm.nix
@@ -73,9 +73,12 @@ in
         policies = lib.mkIf cfg.evaluatedConfig.config.ghaf.givc.policyClient.enable {
           "${vmName}" = cfg.evaluatedConfig.config.ghaf.givc.policyClient.policies;
         };
-        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agent.enable {
+        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream.enable {
           "${vmName}" = {
-            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agent) nodeAttestationMode workloads;
+            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream)
+              nodeAttestationMode
+              workloads
+              ;
           };
         };
       };


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
This PR adds optional integration with an external SPIRE backend while keeping the local SPIRE deployment independent. It introduces three main changes:

1. **Support named SPIRE agent instances.** Refactor the SPIRE agent module to allow multiple isolated agent instances on the same VM, each with its own configuration, systemd service, runtime directory, user, group, and Workload API socket. Existing agents are migrated to the `downstream` instance, while admin-vm receives an `upstream` instance that is disabled by default and can be configured to connect to an external SPIRE server.

2. **Remove join-token attestation.** Remove join-token configuration, plugins, token generation, and related fallback logic. SPIRE agents now  use `x509pop` as the supported node attestation method by default.

3. **Integrate the local server with the optional upstream agent.** Add trust-bundle URL support and systemd workload attestation to SPIRE agents. When the upstream agent is enabled, the local `spire-server.service` can access its Workload API and fetch an X.509-SVID issued by the external SPIRE server. The external server registers this workload using the `systemd:id:spire-server.service` selector. If the upstream agent is disabled or unavailable, the upstream identity fetch is skipped and the local SPIRE server and agents continue operating independently.

The local SPIRE server (i.e., `downstream`) remains its own authority, e.g. `ghaf.internal`, and the cloud SPIRE server (i.e., `upstream`) remains another authority. They exchange trust bundles. Local agents/workloads continue to get local identities even if the cloud server is down. 

The following Figure shows the SPIRE architecture when the `upstream` is enabled:
<img width="1242" height="1193" alt="image" src="https://github.com/user-attachments/assets/fe959cb9-7ad2-47e4-805f-004698ea6d18" />

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets
https://jira.tii.ae/browse/SSRCSP-8653
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Verify that the upstream agent is disabled by default:

   ```console
   systemctl status spire-agent-upstream.service
   ```

   The expected esult is:

   ```text
   Unit spire-agent-upstream.service could not be found.
   ```

2. Verify that the local SPIRE server is healthy and that the downstream agents have successfully completed `x509pop` node attestation:

   ```console
   sudo spire-server healthcheck \
     -socketPath /run/spire-server/api.sock \
     -verbose

   sudo spire-server agent list \
     -socketPath /run/spire-server/api.sock \
     -attestationType x509pop
   ```

   The health check should report:

   ```text
   Server is healthy.
   ```

   The agent list should report one attested agent for each VM:

   ```text
   Found 10 attested agents:

   SPIFFE ID        : spiffe://<LOCAL_TRUST_DOMAIN>/spire/agent/x509pop/<AGENT_FINGERPRINT>
   Attestation type : x509pop
   ```

3. The configuration of the external SPIRE server is outside the scope of this PR. It will require defining the appropriate CA and certificate provisioning model, trust bundle distribution method, and workload registration policy.

    For testing purposes, with help from Pavel (thanks!), we deployed a SPIRE Server on a backend/cloud machine configured with `x509pop` node attestation. The backend server was configured to trust the CA that signed the admin-vm certificate.

   For this validation, the `upstream` agent was enabled and configured with the backend server address, port, trust domain, and trust bundle. The backend also contained a workload registration entry for `spire-server.service`, associated with the upstream agent through the `systemd:id:spire-server.service` selector.

   The following backend log confirms that the external SPIRE server issued an X.509-SVID for the local SPIRE server workload:

   ```text
   Jul 10 14:51:52 nixos spire-server[1614]:
   time="2026-07-10T14:51:52+03:00" level=debug
   msg="Signed X509 SVID"
   authorized_as=agent authorized_via=datastore
   caller_addr="<ADMIN_VM_ADDRESS>:42720"
   caller_id="spiffe://example.org/spire/agent/x509pop/<AGENT_FINGERPRINT>"
   entry_id=<ENTRY_ID>
   expiration="2026-07-10T12:51:52Z"
   method=BatchNewX509SVID
   request_id=<REQUEST_ID>
   revision_number=0
   serial_num=243259129904215621232601805090303982465
   service=svid.v1.SVID
   spiffe_id="spiffe://example.org/ghaf/admin-vm/spire-server"
   subsystem_name=api
   ```

   The following admin-vm log confirms that the local SPIRE server retrieved the workload X.509-SVID through the upstream agent:

   ```text
   Jul 10 15:57:19 admin-vm spire-server-upstream-workload[11833]: 
   Fetched upstream SPIRE workload SVID for spire-server.service
   ```