### PR TITLE
fix(identity): break set-dynamic-hostname ordering cycle

### DIFF
--- a/modules/common/identity/vm-hostname-setter.nix
+++ b/modules/common/identity/vm-hostname-setter.nix
@@ -48,16 +48,18 @@ in
     systemd.services.set-dynamic-hostname = {
       description = "Set hostname from hardware-based identity";
       wantedBy = [ "network-pre.target" ];
+      unitConfig.DefaultDependencies = false;
       after = [
         "sysinit.target"
         "local-fs.target"
-        "systemd-hostnamed.service"
       ];
       before = [
         "network-pre.target"
         "network.target"
         "NetworkManager.service"
+        "shutdown.target"
       ];
+      conflicts = [ "shutdown.target" ];
       serviceConfig =
         let
           setDynamicHostname = pkgs.writeShellApplication {


### PR DESCRIPTION
## Description of Changes

On some boots net-vm keeps the static hostname `net-vm` instead of the dynamic `ghaf-<id>`, because `set-dynamic-hostname.service` is skipped:

```
network-pre.target: Found ordering cycle: set-dynamic-hostname.service/start after basic.target/start after sockets.target/start after systemd-networkd-resolve-hook.socket/start after network-pre.target/start - after set-dynamic-hostname.service
network-pre.target: Job set-dynamic-hostname.service/start deleted to break ordering cycle starting with network-pre.target/start
```

**Root cause:** `set-dynamic-hostname.service` is ordered `Before=network-pre.target` but, with default dependencies, also gains an implicit `After=basic.target`. Commit 58e68c7 added `systemd-networkd-resolve-hook.socket` (pulled by `sockets.target`, ordered `After=network-pre.target`), pushing `basic.target` to land after `network-pre.target`:

```
set-dynamic-hostname -> After basic.target -> After sockets.target
  -> After systemd-networkd-resolve-hook.socket -> After network-pre.target
  -> After set-dynamic-hostname (its own Before=network-pre.target)
```

systemd breaks the cycle by non-deterministically deleting a job — sometimes `set-dynamic-hostname.service` — hence the intermittent failure that clears after a reboot. `After=systemd-hostnamed.service` is a second back-edge (hostnamed is `After=basic.target`).

**Fix:**
- `DefaultDependencies=no` — removes the implicit `After=basic.target`.
- Drop `After=systemd-hostnamed.service` — script sets the hostname via `/proc/sys/kernel/hostname` and `/etc/hostname` directly and calls `hostnamectl` best-effort (already `|| true` guarded), so no ordering dep on hostnamed is needed.
- Add `shutdown.target` conflict/ordering now that default deps are disabled.

Resulting order: `sysinit.target -> set-dynamic-hostname -> network-pre.target`, no cycle. Service runs deterministically on every boot.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!-- Regression introduced by 58e68c793aa30e92eabe09c4f2f80535ae8c045a -->

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Boot the device.
2. SSH to net-vm and run `hostname` — expect `ghaf-<id>` (e.g. `ghaf-3991574267`), not `net-vm`.
3. Check `journalctl -b -u set-dynamic-hostname.service` — service ran; no "deleted to break ordering cycle" for it in `journalctl -b | grep ordering`.
4. Reboot several times and repeat — hostname must be dynamic on every boot.

