### PR TITLE
fix(audit): stop full backlog stalling auditd startup

### DIFF
--- a/modules/common/security/audit/default.nix
+++ b/modules/common/security/audit/default.nix
@@ -104,6 +104,11 @@ in
 
     boot.kernelParams = [
       "audit_backlog_limit=${toString config.security.audit.backlogLimit}"
+      # A full backlog blocks audit-triggering syscalls for wait_time (kernel
+      # default 60s). A heavy first boot refills even 32k before auditd drains
+      # it, so auditd's own startup syscalls block and its start job times out.
+      # 0 = drop events instead of stalling; the large backlog keeps drops rare.
+      "audit_backlog_wait_time=0"
     ];
 
     systemd = {


### PR DESCRIPTION
## Description of Changes

Orin AGX sometimes hangs at boot on the `Security Audit Logging Service`
(`auditd.service`) start job until it times out (~90s), stalling the boot test.

Root cause: a saturated kernel audit backlog blocks every audit-triggering
syscall for `audit_backlog_wait_time` (kernel default 60s). The backlog limit was
raised to 32k earlier to dodge this, but that only delays the fill — a heavy first
boot (microvm bring-up plus the recent mgbe0/bpmp passthrough churn) refills even
32k before auditd drains it. auditd's own startup syscalls then block and its start
job times out, intermittently wedging boot.

Fix: set `audit_backlog_wait_time=0` so a full backlog drops events instead of
stalling syscalls. auditd starts, drains, and boot proceeds. The large backlog
limit keeps drops rare.

### Type of Change

- [x] Bug fix

## Related Issues / Tickets

Regression first observed after commit aa546fa2 (mgbe0 net-vm passthrough), which
added boot weight rather than audit config. Related earlier stall work: SSRCSP-8701.

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation

### Test Steps To Verify:

1. Boot Orin AGX from SSD (native or cross-compiled image), repeatedly.
2. Confirm boot reaches serial login and no longer stalls on
   `A start job is running for Security Audit Logging Service`.
3. On the running device, confirm the setting took effect:
   - `cat /proc/cmdline` shows `audit_backlog_wait_time=0`
   - `auditctl -s` reports `backlog_wait_time 0`
4. Optional pre-fix confirmation on an affected boot:
   `dmesg | grep -i 'audit.*backlog'` shows `backlog limit exceeded`.
