### PR TITLE
fix(netvm): assign stable NIC names

### DIFF
--- a/modules/hardware/common/devices.nix
+++ b/modules/hardware/common/devices.nix
@@ -8,9 +8,9 @@
 }:
 let
   inherit (lib)
-    concatMapStringsSep
     imap1
     getExe
+    nameValuePair
     mkOption
     types
     optionalAttrs
@@ -49,6 +49,23 @@ let
   nicPciDevices = lib.filter (
     d: d.path != "" || (d.vendorId != null && d.productId != null)
   ) config.ghaf.hardware.definition.network.pciDevices;
+  namedNicDevices = lib.filter (d: d.name != null) config.ghaf.hardware.definition.network.pciDevices;
+  nicLinkMatch =
+    d:
+    if d.vendorId != null && d.productId != null then
+      {
+        Property = "ID_VENDOR_ID=0x${d.vendorId} ID_MODEL_ID=0x${d.productId}";
+      }
+    else if d.path != "" then
+      {
+        Path = "pci-${d.path}";
+      }
+    else
+      {
+        # Generic laptop targets discover the passed-through network device at runtime
+        # So, no stable PCI identity is available in their definition.
+        Type = "wlan";
+      };
   gpuPciDevices = config.ghaf.hardware.definition.gpu.pciDevices;
   sndPciDevices = config.ghaf.hardware.definition.audio.pciDevices;
   evdevDevices = config.ghaf.hardware.definition.input.misc.evdev;
@@ -115,10 +132,18 @@ in
           };
         }) nicPciDevices;
 
-        services.udev.extraRules = concatMapStringsSep "\n" (
-          d:
-          ''SUBSYSTEM=="net", ACTION=="add", ATTRS{vendor}=="0x${d.vendorId}", ATTRS{device}=="0x${d.productId}", NAME="${d.name}"''
-        ) nicPciDevices;
+        systemd.network.links = builtins.listToAttrs (
+          imap1 (
+            i: d:
+            nameValuePair "10-ghaf-nic-${toString i}" {
+              matchConfig = nicLinkMatch d;
+              linkConfig = {
+                NamePolicy = "";
+                Name = d.name;
+              };
+            }
+          ) namedNicDevices
+        );
       };
 
       gpus.microvm.devices = imap1 (i: d: {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

This PR fixes repeated `smcroute.service` failures in the generic `intel-laptop-debug` image by assigning stable network interface names with systemd link rules. PCI identifiers are used when available, with a WLAN type fallback for dynamically detected devices. 

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets
https://jira.tii.ae/browse/SSRCSP-8582
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Boot the `intel-laptop-debug` image and SSH to `net-vm`.
2. Monitor the logs:
 ```
   journalctl -f -u smcroute.service
```
3. Verify that `wlp0s5f0: error fetching interface information: Device not found` is not repeatedly logged.
4. The following should be active: `systemctl is-active smcroute.service nw-packet-forwarder.service`