### PR TITLE
feat(orin): two-VM host1x ownership split (GPU compute + software display)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ CLAUDE.md
 
 # Ignore VIM backup files (hide them from reuse lint)
 *.swp
+.gcroots/

--- a/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_vm_display.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_vm_display.mdx
@@ -86,10 +86,12 @@ Four cooperating pieces:
    `tegra_dce_client_ipc_inject` — identical to native IVC delivery from the
    driver's point of view.
 2. **QEMU DCE bridge** (`nvidia_dce_guest` device in `ghaf-qemu-bpmp`) traps
-   the window. A doorbell write runs the forward round-trip synchronously:
-   packages the request and `write()`s it to `/dev/dce-host`, which returns
-   only when the real DCE has answered. A pump thread `poll()`s the same fd
-   for asynchronous events and publishes them into the reverse window.
+   the window. Bridge creation is opt-in through `GHAF_DCE_GUEST=1`; only the
+   VM that owns the display path may set it and open `/dev/dce-host`. A
+   doorbell write runs the forward round-trip synchronously: it packages the
+   request and `write()`s it to `/dev/dce-host`, which returns only when the
+   real DCE has answered. A pump thread `poll()`s the same fd for asynchronous
+   events and publishes them into the reverse window.
 3. **`dce-host-proxy.ko` (host)** registers as a tegra-dce client (`CPU_RM`
    interface) and relays each guest request to the real DCE via
    `tegra_dce_client_ipc_send_recv`. Unsolicited DCE notifications (channel
@@ -119,6 +121,10 @@ The reverse window is single-slot with a sequence/ack handshake: the bridge
 publishes one event and bumps `EVT_SEQ`; the guest consumes it and writes the
 sequence back to `EVT_ACK`; the bridge holds the next event (buffered in the
 host ring) until the ack catches up. Slow guest ⇒ delayed events, never lost.
+
+The host event ring is single-consumer. Do not enable the DCE bridge in a
+compute-only GPU VM, NetVM, or AdminVM. Multiple QEMU readers race after
+`poll()`, produce `EAGAIN`, and can consume a display event in the wrong VM.
 
 <Aside type="caution">
   Every word moved through this window is a trapping MMIO access (~µs each,
@@ -153,6 +159,10 @@ the display engine's ISO/NISO SMMU streams.
   scanout readers `NVDISPLAYR`/`NVDISPLAYR1` to ISO SID 1 through stock
   `interconnects` entries (memory-controller SID override registers).
   Boot-lifetime by design: unloading could not restore the MC SID overrides.
+- **Split display-VM CMA.** The two-VM display guest allocates display memory
+  from `0xe2000000..0xe6000000`. Both anchor domains therefore include
+  `0x7fe2000000 -> 0xe2000000` for 64 MiB. Without this mapping, SID-7 context
+  faults and host EMEM decode errors leave an active DP modeset black.
 - **39-bit ISO limit.** The display frontend truncates ISO addresses at bit
   39, so scanout surfaces must be allocated below 4GB: the guest's nvmap
   *generic* carveout (384MB at `0x98000000`) keeps EGL surface allocations
@@ -261,3 +271,18 @@ started manually to drive the modeset (no auto-modeset service yet).
 - A dark panel with a live mode usually means an address-translation problem
   (check host `smmu_iso`/`smmu_niso` faults and `EMEM address decode error`),
   not a mode-set failure: the DCE reports success while scanout reads garbage.
+
+## Two-VM ownership split (experiment)
+
+The `experiment/orin-two-vm-host1x` branch splits ownership across two VMs:
+
+| Owner | Devices |
+| --- | --- |
+| GPU VM | GA10B, physical host1x, syncpoint shim, media engines |
+| Display VM | nvdisplay, DCE proxy, display keyholes, scanout, connector |
+
+Chosen from hardware measurement: nvgpu probes without physical host1x but CUDA
+rejects it (`cuInit` 801), while the display VM drives color bars host1x-free by
+forcing NVKMS's no-syncpoint path. Both then run concurrently with disjoint VFIO
+ownership — CUDA on `sm_87` alongside a held 3440x1440 DP-1 modeset. Not yet
+validated: the GUI compositor, AppVM presentation, explicit-fence behavior.

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -468,5 +468,32 @@ in
           '';
         };
       };
+
+      dispvm = {
+        extraModules = mkOption {
+          description = ''
+            Hardware-specific NixOS modules for Disp VM configuration.
+
+            This option allows hardware definitions to provide VM-specific
+            configuration that will be merged with the base Disp VM config.
+
+            Use this ONLY for hardware-specific settings like:
+            - Display device passthrough (vfio-platform, BPMP guest proxy)
+            - Guest kernel/kernel parameters required by the passthrough
+            - Custom qemu arguments (device tree, machine args)
+
+            For resource allocation (memory, vCPUs) or profile-specific modules,
+            use ghaf.virtualization.vmConfig.sysvms.dispvm instead.
+          '';
+          type = types.listOf types.unspecified;
+          default = [ ];
+          example = literalExpression ''
+            [
+              ./disp-config.nix
+              { microvm.qemu.extraArgs = [ ... ]; }
+            ]
+          '';
+        };
+      };
     };
 }

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -13,6 +13,7 @@ _: {
       ./host/microvm-host.nix
       ./sysvms/netvm.nix
       ./sysvms/gpuvm.nix
+      ./sysvms/dispvm.nix
       ./sysvms/adminvm.nix
       ./appvm.nix
       ./sysvms/guivm.nix
@@ -90,6 +91,13 @@ _: {
     #   lib.nixosSystem { modules = [ inputs.self.nixosModules.gpuvm-base ]; ... }
     #     .extendModules { modules = [ ... ]; }
     gpuvm-base = ./sysvms/gpuvm-base.nix;
+
+    # Disp VM base module for layered composition (Orin AGX display
+    # passthrough, experiment/orin-two-vm-host1x concurrent build).
+    # Use with extendModules pattern:
+    #   lib.nixosSystem { modules = [ inputs.self.nixosModules.dispvm-base ]; ... }
+    #     .extendModules { modules = [ ... ]; }
+    dispvm-base = ./sysvms/dispvm-base.nix;
 
     # App VM base module for layered composition
     # Unlike singleton VMs, App VMs are instantiated multiple times using mkAppVm.

--- a/modules/microvm/sysvms/dispvm-base.nix
+++ b/modules/microvm/sysvms/dispvm-base.nix
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Disp VM Base Module
+#
+# Base config for the display-passthrough VM (Orin AGX,
+# experiment/orin-two-vm-host1x). Like gpuvm-base but without GPU-compute
+# (CUDA, gpu-vm-load, /dev/nvgpu): disp-vm owns only display/scanout
+# passthrough via ghaf.hardware.definition.dispvm.extraModules.
+#
+# Usage in profiles:
+#   lib.nixosSystem {
+#     modules = [ inputs.self.nixosModules.dispvm-base ];
+#     specialArgs = { inherit globalConfig hostConfig; };
+#   }
+#
+# Then extend with:
+#   base.extendModules { modules = [ ... ]; }
+#
+{
+  lib,
+  inputs,
+  globalConfig,
+  hostConfig,
+  ...
+}:
+let
+  vmName = "disp-vm";
+  timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+in
+{
+  _file = ./dispvm-base.nix;
+
+  imports = [
+    inputs.preservation.nixosModules.preservation
+    inputs.self.nixosModules.givc
+    inputs.self.nixosModules.hardware-x86_64-guest-kernel
+    inputs.self.nixosModules.vm-modules
+    inputs.self.nixosModules.profiles
+  ];
+
+  ghaf = {
+    # Profiles - from globalConfig
+    profiles.debug.enable = lib.mkDefault (globalConfig.debug.enable or false);
+
+    development = {
+      ssh.daemon.enable = lib.mkDefault (globalConfig.development.ssh.daemon.enable or false);
+      debug.tools.enable = lib.mkDefault (globalConfig.development.debug.tools.enable or false);
+      nix-setup.enable = lib.mkDefault (globalConfig.development.nix-setup.enable or false);
+    };
+
+    # Networking hosts - from hostConfig
+    # Required for vm-networking.nix to look up this VM's MAC/IP
+    networking.hosts = hostConfig.networking.hosts or { };
+
+    # Common namespace - from hostConfig
+    common = hostConfig.common or { };
+
+    # User configuration - from hostConfig
+    users = {
+      profile = hostConfig.users.profile or { };
+      admin = hostConfig.users.admin or { };
+      managed = hostConfig.users.managed or { };
+    };
+
+    # Enable dynamic hostname export for VMs
+    identity.vmHostNameExport.enable = true;
+
+    # System
+    type = "system-vm";
+
+    systemd = {
+      enable = true;
+      withName = "dispvm-systemd";
+      withLocaled = true;
+      withNss = true;
+      withResolved = true;
+      withTimesyncd = true;
+      withDebug = globalConfig.debug.enable or false;
+      withHardenedConfigs = true;
+    };
+
+    # GIVC - from globalConfig. ponytail: no dispvm givc role; enable
+    # transport only, like gpuvm-base.
+    givc = {
+      enable = globalConfig.givc.enable or false;
+      debug = globalConfig.givc.debug or false;
+    };
+
+    # Storage - from globalConfig
+    storagevm = {
+      enable = true;
+      name = vmName;
+      encryption.enable = globalConfig.storage.encryption.enable or false;
+    };
+
+    virtualization.microvm = {
+      swap.enable = true;
+
+      vm-networking = {
+        enable = true;
+        inherit vmName;
+      };
+
+      tpm.emulated = {
+        # aarch64: TPM passthrough is x86-only, so emulate when encryption on.
+        enable = globalConfig.storage.encryption.enable or false;
+        name = vmName;
+      };
+    };
+
+    # Logging - from globalConfig
+    logging = {
+      inherit (globalConfig.logging) enable listener;
+      journalClient = {
+        inherit (globalConfig.logging) enable;
+      };
+    };
+
+    security = {
+      fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+      audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+
+      spire.agents.downstream = {
+        enable = globalConfig.spire.enable or false;
+        logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
+        nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+      };
+    };
+
+    services.timezone.enable = lib.mkDefault (
+      timezoneEnabled && globalConfig.platform.timeZone == null
+    );
+  };
+
+  time.timeZone = lib.mkIf (!timezoneEnabled) (lib.mkDefault globalConfig.platform.timeZone);
+
+  system.stateVersion = lib.trivial.release;
+
+  nixpkgs = {
+    buildPlatform.system = globalConfig.platform.buildSystem or "x86_64-linux";
+    hostPlatform.system = globalConfig.platform.hostSystem or "aarch64-linux";
+  };
+
+  microvm = {
+    optimize.enable = false;
+    # ponytail: vcpu=4 matches tegra234-dispvm.dts cpus node; mem is a
+    # display-only default, smaller than GPU VM's 6000.
+    vcpu = 4;
+    mem = lib.mkDefault 4000;
+    hypervisor = "qemu";
+
+    shares = [
+      {
+        tag = "ghaf-common";
+        source = "/persist/common";
+        mountPoint = "/etc/common";
+        proto = "virtiofs";
+      }
+    ]
+    # Shared store (when not using storeOnDisk)
+    ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
+      {
+        tag = "ro-store";
+        source = "/nix/store";
+        mountPoint = "/nix/.ro-store";
+        proto = "virtiofs";
+      }
+    ];
+
+    writableStoreOverlay = lib.mkIf (
+      !(globalConfig.storage.storeOnDisk.enable or false)
+    ) "/nix/.rw-store";
+
+    qemu = {
+      machine =
+        {
+          x86_64-linux = "q35";
+          aarch64-linux = "virt";
+        }
+        .${globalConfig.platform.hostSystem or "aarch64-linux"};
+    };
+  }
+  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
+    let
+      compLevelSuffix = lib.optionalString (
+        globalConfig.storage.storeOnDisk.compression.level != null
+      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
+    in
+    {
+      storeOnDisk = true;
+      storeDiskType = "erofs";
+      storeDiskErofsFlags = [
+        "-Eztailpacking"
+        "-Efragments"
+        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
+      ]
+      ++ {
+        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
+        zstd = [
+          "-zzstd${compLevelSuffix}"
+          "-E48bit"
+        ];
+      }
+      .${globalConfig.storage.storeOnDisk.compression.algorithm};
+    }
+  );
+}

--- a/modules/microvm/sysvms/dispvm.nix
+++ b/modules/microvm/sysvms/dispvm.nix
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Disp VM Configuration Module
+#
+# globalConfig pattern: global settings via globalConfig specialArg,
+# host-specific (networking.hosts) via hostConfig. Self-contained; all
+# platforms use the evaluatedConfig pattern with a profile's dispvmBase.
+#
+# dispvmBase (like gpuvmBase) is exported by the orin profile, which also
+# wires dispvm.evaluatedConfig. Inert unless that wiring is present: enable
+# is only true when ghaf.hardware.nvidia.passthroughs.disp_vm.enable is true
+# (Orin AGX only); the assertion below fires if enable is set without it.
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
+let
+  vmName = "disp-vm";
+
+  cfg = config.ghaf.virtualization.microvm.dispvm;
+in
+{
+  _file = ./dispvm.nix;
+
+  options.ghaf.virtualization.microvm.dispvm = {
+    enable = lib.mkEnableOption "DispVM";
+
+    evaluatedConfig = lib.mkOption {
+      type = lib.types.nullOr lib.types.unspecified;
+      default = null;
+      description = "Pre-evaluated NixOS configuration for Disp VM set via profile's dispvmBase.extendModules.";
+    };
+
+    extraNetworking = lib.mkOption {
+      type = lib.types.networking;
+      description = "Extra Networking option";
+      default = { };
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      ghaf.virtualization.microvm.sysvm.vms.dispvm = {
+        inherit vmName;
+        inherit (cfg) enable evaluatedConfig extraNetworking;
+      };
+    }
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = cfg.evaluatedConfig != null;
+          message = ''
+            ghaf.virtualization.microvm.dispvm.evaluatedConfig must be set.
+            Use a profile that provides dispvmBase (orin).
+
+            For Jetson (Orin AGX), the orin profile wires it as:
+              dispvm.evaluatedConfig = config.ghaf.profiles.orin.dispvmBase.extendModules {
+                modules = lib.ghaf.vm.applyVmConfig {
+                  inherit config;
+                  vmName = "dispvm";
+                };
+              };
+          '';
+        }
+      ];
+
+      ghaf.common = {
+        extraNetworking.hosts.${vmName} = cfg.extraNetworking;
+        policies = lib.mkIf cfg.evaluatedConfig.config.ghaf.givc.policyClient.enable {
+          "${vmName}" = cfg.evaluatedConfig.config.ghaf.givc.policyClient.policies;
+        };
+        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream.enable {
+          "${vmName}" = {
+            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agents.downstream)
+              nodeAttestationMode
+              workloads
+              ;
+          };
+        };
+      };
+
+      microvm.vms."${vmName}" = {
+        autostart = !config.ghaf.microvm-boot.enable;
+        restartIfChanged = false;
+        inherit (inputs) nixpkgs;
+        inherit (cfg) evaluatedConfig;
+      };
+    })
+  ];
+}

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -97,6 +97,16 @@ in
         Profiles can extend this with extendModules if customization needed.
       '';
     };
+
+    # Disp VM base configuration for profiles to extend
+    dispvmBase = lib.mkOption {
+      type = lib.types.unspecified;
+      readOnly = true;
+      description = ''
+        Orin Disp VM base configuration.
+        Profiles can extend this with extendModules if customization needed.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -174,6 +184,30 @@ in
             hostConfig = lib.ghaf.vm.mkHostConfig {
               inherit config;
               vmName = "gpu-vm";
+            };
+          };
+        };
+
+        # Export Disp VM base for profiles to extend
+        orin.dispvmBase = lib.nixosSystem {
+          modules = [
+            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.dispvm-base
+            # Import nixpkgs config module to get overlays
+            {
+              nixpkgs = {
+                hostPlatform.system = "aarch64-linux";
+                inherit (config.nixpkgs) overlays;
+                inherit (config.nixpkgs) config;
+              };
+            }
+          ];
+          specialArgs = lib.ghaf.vm.mkSpecialArgs {
+            inherit lib inputs;
+            globalConfig = hostGlobalConfig;
+            hostConfig = lib.ghaf.vm.mkHostConfig {
+              inherit config;
+              vmName = "disp-vm";
             };
           };
         };
@@ -272,6 +306,19 @@ in
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
                 vmName = "gpuvm";
+              };
+            };
+          };
+
+          # Disp VM: enable comes from the disp_vm passthrough module (sets
+          # dispvm.enable under its own mkIf). Here we only provide
+          # evaluatedConfig, extending dispvmBase with
+          # hardware.definition.dispvm.extraModules (DTB, vfio, guest kernel).
+          dispvm = {
+            evaluatedConfig = config.ghaf.profiles.orin.dispvmBase.extendModules {
+              modules = lib.ghaf.vm.applyVmConfig {
+                inherit config;
+                vmName = "dispvm";
               };
             };
           };

--- a/modules/reference/hardware/jetpack/agx/orin-agx.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx.nix
@@ -44,6 +44,14 @@
       # p3737 carrier); pass it through to net-vm. Orin NX has no MGBE0.
       nvidia.passthroughs.mgbe0_net_vm.enable = true;
       nvidia.passthroughs.gpu_vm.enable = true;
+      # host1x-ownership experiment selector (branch-only,
+      # experiment/orin-two-vm-host1x). "compute-with-host1x" = concurrent GPU
+      # VM: keeps host1x/gpu/media, releases scanout for disp-vm; paired with
+      # disp_vm.enable below (Step 2 two-VM build). Never promote off "off".
+      nvidia.passthroughs.gpu_vm.host1xExperiment = "compute-with-host1x";
+      # Display-only microvm for the two-VM build (branch-only). Owns only
+      # scanout_p/disp_caps_pt/disp_chan_pt, disjoint from gpu_vm above.
+      nvidia.passthroughs.disp_vm.enable = true;
 
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/bpmp-virt-common/sources/drivers/firmware/tegra/bpmp-host-proxy/bpmp-host-proxy.c
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/bpmp-virt-common/sources/drivers/firmware/tegra/bpmp-host-proxy/bpmp-host-proxy.c
@@ -447,6 +447,13 @@ static ssize_t write(struct file *filep, const char *buffer, size_t len, loff_t 
 		goto out_nomem;
 	}
 
+	/* Short write -> kbuf->mrq/tx.size/rx.size below read past kmalloc(len). */
+	if (len < sizeof(*kbuf)) {
+		deb_error("count %zu shorter than message header, aborting write\n", len);
+		ret = -EINVAL;
+		goto out_nomem;
+	}
+
 	ret = -ENOMEM;
 	kbuf = kmalloc(len, GFP_KERNEL);
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.c
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.c
@@ -408,6 +408,13 @@ static ssize_t write(struct file *filep, const char *buffer, size_t len, loff_t 
 		goto out_nomem;
 	}
 
+	/* Short write -> kbuf->iface/tx.size/rx.size below read past kmalloc(len). */
+	if (len < sizeof(*kbuf)) {
+		deb_error("count %zu shorter than message header, aborting write\n", len);
+		ret = -EINVAL;
+		goto out_nomem;
+	}
+
 	ret = -ENOMEM;
 	kbuf = kmalloc(len, GFP_KERNEL);
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.c
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.c
@@ -46,6 +46,11 @@ static const struct { u64 pa; u64 size; } dce_hi_ranges[] = {
 	{ 0x60000000, 0x04000000 },  /* vm_hs */
 	{ 0x80000000, 0x30000000 },  /* vm_cma */
 	{ 0xb0000000, 0x08000000 },  /* scanout */
+	{ 0xe2000000, 0x04000000 },  /* disp-vm CMA (split-RAM low bank): NVKMS
+				      * allocates 3440x1440 scanout from here, not
+				      * from 0xb0 scanout pool. Inside 1:1 dispram_lo
+				      * (0xb8..0xe6), stops before the DMA32/WLAN hole.
+				      * Without this, SID-7 faults on 0x7fe2xxxxxx. */
 };
 
 static int ovcs_id;
@@ -55,6 +60,7 @@ static struct platform_device *niso_anchor_pdev;
 static int dce_iso_anchor_probe(struct platform_device *pdev)
 {
 	struct iommu_domain *dom = iommu_get_domain_for_dev(&pdev->dev);
+	bool mapped[ARRAY_SIZE(dce_hi_ranges)] = { false };
 	int i, ret;
 
 	if (!dom) {
@@ -77,10 +83,19 @@ static int dce_iso_anchor_probe(struct platform_device *pdev)
 		dev_info(&pdev->dev, "iso map 0x%llx -> 0x%llx sz 0x%llx = %d\n",
 			 iova, dce_hi_ranges[i].pa, dce_hi_ranges[i].size, ret);
 		if (ret)
-			return ret;
+			goto err_unmap;
+		mapped[i] = true;
 	}
 
 	return 0;
+
+err_unmap:
+	/* Undo only what this probe mapped; leave pre-existing maps intact. */
+	while (--i >= 0)
+		if (mapped[i])
+			iommu_unmap(dom, DCE_HI_BASE + dce_hi_ranges[i].pa,
+				    dce_hi_ranges[i].size);
+	return ret;
 }
 
 static const struct of_device_id dce_iso_anchor_of_match[] = {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/default.nix
@@ -8,5 +8,6 @@
     ./passthrough/uarti-net-vm
     ./passthrough/mgbe0-net-vm
     ./passthrough/gpu-vm
+    ./passthrough/disp-vm
   ];
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/default.nix
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Second microvm disp-vm, DISPLAY-ONLY (no host1x/gpu/media), runs concurrently
+# with gpu-vm (experiment/orin-two-vm-host1x, Step 2). Owns 3 physical devices via
+# 1:1 vfio-platform mmio-base -- scanout carveout + two display keyhole MMIO
+# windows -- all already declared+reserved by gpu-vm's gpu_passthrough_overlay.dts
+# (`_p` dummy nodes + reserved-memory). No new host carveouts here.
+#
+# The companion gpu-vm runs host1xExperiment = "compute-with-host1x": keeps
+# host1x/gpu/media/shim, shrinks its guest RAM bank1 to 0x80000000..0xb0000000,
+# drops its scanout claim -- releasing 0xb0000000 for disp-vm. See
+# ../gpu-vm/default.nix and orin-agx.nix.
+#
+# Guest RAM (see tegra234-dispvm.dts): general guest RAM is plain QEMU -m emulated
+# RAM, NOT a 1:1 carveout (no vm_cma_p claimed), so no host-PA collision with
+# gpu-vm's separate QEMU process using the same GPA range. Only the scanout region
+# (0xb0000000, real 1:1 GPA=HPA) and the display MMIO keyholes are passthrough.
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.ghaf.hardware.nvidia.passthroughs.disp_vm;
+
+  # Host-side virtualization config (sourcesPatch), same pattern as gpu-vm.
+  virt = config.ghaf.hardware.nvidia.virtualization;
+
+  # disp-vm's only physical devices: scanout carveout (1:1 GPA=HPA via mmio-base)
+  # + two display keyhole MMIO windows. No engines (gpu/host1x/vic/nvdec/nvjpg),
+  # no vm_cma_p/vm_hs_p/vm_cma_vram_p -- those stay with gpu-vm as host1x owner.
+  # scanout_p/disp_caps_pt/disp_chan_pt are declared+reserved in
+  # ../gpu-vm/gpu_passthrough_overlay.dts.
+  reservedMem = [
+    {
+      dev = "b0000000.scanout_p";
+      base = "0xb0000000";
+    }
+    # disp-vm guest RAM, 1:1 GPA=HPA carveout (0xb8000000..0x100000000, 1.125GB).
+    # QEMU -m doesn't reliably back the guest here (virt RAM base != DTB memory@),
+    # so RAM comes from this carveout, like gpu-vm's vm_cma. Disjoint from all
+    # gpu-vm carveouts.
+    {
+      dev = "b8000000.dispram_lo_p";
+      base = "0xb8000000";
+    }
+    {
+      dev = "200000000.dispram_hi_p";
+      base = "0x200000000";
+    }
+  ];
+  dispCaps = [
+    {
+      dev = "13830000.disp_caps_pt";
+      base = "0x66230000";
+    }
+    {
+      dev = "13870000.disp_chan_pt";
+      base = "0x66270000";
+    }
+  ];
+  allDevs = map (r: r.dev) (reservedMem ++ dispCaps);
+
+  vfioArgs = lib.concatMap (r: [
+    "-device"
+    "vfio-platform,host=${r.dev},mmio-base=${r.base}"
+  ]) (reservedMem ++ dispCaps);
+
+  # Guest device tree -> dtb. Mirrors ../gpu-vm/default.nix's gpuvm-dtb; reuses
+  # gpu-vm's vendored NVIDIA-only dt-bindings headers rather than duplicating.
+  dispvm-dtb = pkgs.stdenv.mkDerivation {
+    name = "dispvm-dtb";
+    # Composition root + disp-vm-specific memory .dtsi. base/proxies/display/
+    # dummies come from ../gpu-vm via the -I path below (single source of truth),
+    # built with EXP_DROP_HOST1X + EXP_DROP_GPU so the shared dtsi resolve to the
+    # display-only guest.
+    src = lib.fileset.toSource {
+      root = ./.;
+      fileset = lib.fileset.unions [
+        ./tegra234-dispvm.dts
+        ./tegra234-dispvm-memory.dtsi
+      ];
+    };
+    nativeBuildInputs = [
+      pkgs.buildPackages.dtc
+      pkgs.buildPackages.gcc
+    ];
+    buildPhase =
+      let
+        kernel = config.boot.kernelPackages.kernel;
+        mainInc = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
+        # Shared gpu-vm component .dtsi (+ generated DCB), reused verbatim.
+        gpuvmDtsi = lib.fileset.toSource {
+          root = ../gpu-vm;
+          fileset = lib.fileset.unions [
+            ../gpu-vm/tegra234-gpuvm-base.dtsi
+            ../gpu-vm/tegra234-gpuvm-proxies.dtsi
+            ../gpu-vm/tegra234-gpuvm-display.dtsi
+            ../gpu-vm/tegra234-gpuvm-dummies.dtsi
+            ../gpu-vm/generated
+          ];
+        };
+      in
+      ''
+        $CC -E -nostdinc -undef -D__DTS__ -DEXP_DROP_HOST1X -DEXP_DROP_GPU -x assembler-with-cpp \
+          -I${mainInc} \
+          -I${../gpu-vm/nv-dt-bindings} \
+          -I${gpuvmDtsi} \
+          -I. \
+          tegra234-dispvm.dts > preprocessed.dts
+        dtc -I dts -O dtb -o tegra234-dispvm.dtb preprocessed.dts
+      '';
+    installPhase = ''
+      mkdir -p $out
+      cp tegra234-dispvm.dtb $out/
+    '';
+  };
+in
+{
+  _file = ./default.nix;
+
+  options.ghaf.hardware.nvidia.passthroughs.disp_vm.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = "Pass the Tegra234 display path through to a second microvm, disp-vm, on NVIDIA Orin AGX";
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Register the disp-vm microvm (extraModules populated below).
+    ghaf.virtualization.microvm.dispvm.enable = true;
+
+    # BPMP allow-list, host bpmp.enable, host graphics/nvpmodel/nvidia-docker
+    # disable, host1x/gpu module blacklist, and gpu_passthrough_overlay.dts
+    # registration all come from ../gpu-vm/default.nix (gpu_vm) unconditionally on
+    # its cfg.enable. disp_vm is only enabled alongside gpu_vm (see orin-agx.nix),
+    # so none of that is duplicated here.
+
+    systemd.services.bindDispVm = {
+      description = "Bind disp-vm's display devices to the vfio-platform driver";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "microvm@disp-vm.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = "yes";
+        ExecStartPre = map (
+          d:
+          "${pkgs.bash}/bin/bash -c \"echo vfio-platform > /sys/bus/platform/devices/${d}/driver_override\""
+        ) allDevs;
+        # Idempotent bind: skip devices already on vfio-platform (re-bind writes
+        # EBUSY). Unlike a blanket "|| true", this still fails hard if a device is
+        # absent (driver symlink stays non-vfio-platform).
+        ExecStart = map (
+          d:
+          "${pkgs.bash}/bin/bash -c '"
+          + "cur=$(basename \"$(readlink -f /sys/bus/platform/devices/${d}/driver 2>/dev/null)\"); "
+          + "if [ \"$cur\" != vfio-platform ]; then echo ${d} > /sys/bus/platform/drivers/vfio-platform/bind; fi'"
+        ) allDevs;
+      };
+    };
+    # Requires (not just after): after= alone never STARTS the bind service, so
+    # a manual/socket start of the VM could race past unbound devices.
+    systemd.services."microvm@disp-vm" = {
+      after = [ "bindDispVm.service" ];
+      requires = [ "bindDispVm.service" ];
+      # disp-vm is the DCE display owner: opt into the QEMU DCE bridge so only it
+      # opens /dev/dce-host. See GHAF_DCE_GUEST gate in ghaf-qemu-bpmp patch 0002.
+      environment.GHAF_DCE_GUEST = "1";
+    };
+
+    # Guest config: the proven display-no-host1x guest (Exp B, hardware-validated)
+    # -- nvidia-modeset/nvidia-drm/tegra-dce/dce-guest-proxy, the no-syncpt patch
+    # (unconditional here: disp-vm is always display-only), the DCE guest-proxy
+    # postPatch splice, nvidia-drm.modeset=1, hardware.graphics. Patches referenced
+    # from ../gpu-vm/patches, not duplicated.
+    # ponytail: kmscube/mesa-demos/drm_info debug tools and GPU-falcon l4t-firmware
+    # from gpu-vm's extraModules are NOT carried here (display bring-up doesn't need
+    # them). Add back if HW debugging on disp-vm needs a KMS test client.
+    ghaf.hardware.definition.dispvm.extraModules = [
+      (
+        { config, pkgs, ... }:
+        {
+          # NVIDIA/Jetson graphics userspace (EGL/GLES/GBM) via /run/opengl-driver,
+          # mirroring ../gpu-vm/default.nix and jetpack-nixos modules/graphics.nix.
+          hardware.graphics = {
+            enable = true;
+            package = pkgs.symlinkJoin {
+              name = "l4t-3d-core-egl-gbm-1.1.3";
+              paths = [
+                (pkgs.egl-gbm.overrideAttrs (o: {
+                  patches = (o.patches or [ ]) ++ [
+                    ../gpu-vm/patches/userspace/egl-gbm-single-device-fallback.patch
+                  ];
+                }))
+                pkgs.nvidia-jetpack.l4t-3d-core
+              ];
+              postBuild = ''
+                rm -f $out/share/egl/egl_external_platform.d/nvidia_gbm.json
+              '';
+            };
+            extraPackages =
+              (with pkgs.nvidia-jetpack; [
+                l4t-core
+                l4t-cuda
+                l4t-nvsci
+                l4t-wayland
+              ])
+              ++ [
+                (pkgs.symlinkJoin {
+                  name = "l4t-gbm-sans-egl-gbm";
+                  paths = [ pkgs.nvidia-jetpack.l4t-gbm ];
+                  postBuild = ''
+                    rm -f $out/lib/libnvidia-egl-gbm.so*
+                    rm -f $out/share/egl/egl_external_platform.d/nvidia_gbm.json
+                  '';
+                })
+              ];
+          };
+          # libEGL_nvidia.so.0 discovers its EGL platform modules here.
+          environment.etc."egl/egl_external_platform.d".source =
+            "${pkgs.addDriverRunpath.driverLink}/share/egl/egl_external_platform.d/";
+
+          # Guest kernel = vanilla 6.12 + jetpack OOT overlay (bring-your-own),
+          # same display-passthrough patch set as gpu-vm's display-no-host1x mode,
+          # from ../gpu-vm/patches.
+          boot.kernelPackages = lib.mkForce (
+            (pkgs.linuxPackages_6_12.extend pkgs.nvidia-jetpack.kernelPackagesOverlay).extend (
+              _final: prev: {
+                nvidia-oot-modules = prev.nvidia-oot-modules.overrideAttrs (o: {
+                  patches = (o.patches or [ ]) ++ [
+                    ../gpu-vm/patches/0001-gpu-add-support-for-passthrough.patch
+                    ../gpu-vm/patches/0002-add-support-for-gpu-display-passthrough.patch
+                    ../gpu-vm/patches/0003-add-support-for-display-passthrough.patch
+                    ../gpu-vm/patches/0005-force-niso-display-surfaces-contiguous.patch
+                    ../gpu-vm/patches/0006-dce-addresses-cpu-phys-high-iova.patch
+                    ../gpu-vm/patches/0008-fix-dual-mode-honor-rm-connect-state.patch
+                    ../gpu-vm/patches/0009-core-notifier-plain-write-no-awaken.patch
+                    ../gpu-vm/patches/0020-synthesize-boot-hotplug-long-pulse.patch
+                    ../gpu-vm/patches/0010-dce-drop-r5-completion-event.patch
+                    ../gpu-vm/patches/0011-window-notifier-plain-write.patch
+                    ../gpu-vm/patches/0013-drm-vblank-flip-completion.patch
+                    # disp-vm is always display-only: no-syncpt NVKMS path applies
+                    # unconditionally (gpu-vm gates it on the displayOnly arm).
+                    ../gpu-vm/patches/0021-nvkms-force-no-syncpt-support.patch
+                  ];
+                  postPatch = (o.postPatch or "") + ''
+                    patch -p1 -d nvidia-oot < ${../../common/dce-virt-common/patches/0001-dce-virt-hooks.patch}
+                    patch -p1 -d nvidia-oot < ${../../common/dce-virt-common/patches/0002-dce-client-ipc-inject.patch}
+                    install -D ${../../common/dce-virt-common/sources/drivers/platform/tegra/dce-guest-proxy/dce-guest-proxy.c} \
+                      nvidia-oot/drivers/platform/tegra/dce/dce-guest-proxy.c
+                    echo 'obj-m += dce-guest-proxy.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
+                  '';
+                });
+              }
+            )
+          );
+
+          # nvidia-drm.modeset=1 + fbdev=1: bring up NVIDIA KMS + fbcon; the modeset
+          # drives the DCE handshake through the proxy to scanout. See
+          # ../gpu-vm/default.nix for full rationale.
+          boot.kernelParams = [
+            "clk_ignore_unused"
+            "pd_ignore_unused"
+            "nvidia-drm.modeset=1"
+            "drm.vblankoffdelay=0"
+            "nvidia-drm.fbdev=1"
+          ];
+
+          boot.extraModulePackages = [ config.boot.kernelPackages.nvidia-oot-modules ];
+          boot.kernelModules = [
+            "nvmap"
+            "tegra-dce"
+            "dce-guest-proxy"
+            "nvidia-modeset"
+            "nvidia-drm"
+          ];
+
+          boot.kernelPatches = [
+            {
+              name = "tegra fixed chip id";
+              patch = ../gpu-vm/patches/0004-tegra-fixed-chip-id.patch;
+            }
+            {
+              name = "bpmp-virt proxy drivers";
+              patch = virt.sourcesPatch;
+            }
+            {
+              name = "bpmp-virt core hooks";
+              patch = ../../common/bpmp-virt-common/patches/0001-bpmp-virt-hooks-6.12.patch;
+            }
+            {
+              name = "bpmp guest proxy kernel configuration";
+              patch = null;
+              structuredExtraConfig = with lib.kernel; {
+                ARCH_TEGRA = yes;
+                ARCH_TEGRA_234_SOC = yes;
+                TEGRA_HSP_MBOX = yes;
+                TEGRA_IVC = yes;
+                TEGRA_BPMP = yes;
+                TEGRA_BPMP_GUEST_PROXY = yes;
+                TEGRA_BPMP_HOST_PROXY = no;
+                CLK_TEGRA_BPMP = yes;
+                RESET_TEGRA_BPMP = yes;
+                PM_GENERIC_DOMAINS = yes;
+                ARM64_PMEM = yes;
+              };
+            }
+          ];
+
+          ghaf.virtualization.qemu.package = lib.mkForce pkgs.ghaf-qemu-bpmp-gpu;
+
+          microvm.qemu.extraArgs = [
+            "-dtb"
+            "${dispvm-dtb}/tegra234-dispvm.dtb"
+          ]
+          ++ vfioArgs;
+        }
+      )
+    ];
+  };
+}

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/tegra234-dispvm-memory.dtsi
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/tegra234-dispvm-memory.dtsi
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+//
+// disp-vm guest memory: split-RAM (LOW 0xb8000000..0xe6000000, HIGH
+// 0x200000000..0x21a000000) with its own reserved-memory carveouts, icc, and
+// the carveouts consumer. Distinct from gpu-vm memory.dtsi (0x80000000-based);
+// disp-vm reuses base/proxies/display/dummies from ../gpu-vm/ unchanged.
+
+/ {
+	// disp-vm guest RAM = 1:1 GPA=HPA carveout, like gpu-vm's vm_cma. QEMU -m does
+	// not reliably back the guest in this tegra passthrough setup (virt -m base !=
+	// DTB memory@), so RAM comes from a reserved host carveout mapped 1:1 via vfio
+	// mmio-base. 0xb8000000..0x100000000 sits between disp-vm's scanout (0xb0..0xb8)
+	// and gpu-vm's vram (0x100000000+), disjoint from every gpu-vm carveout. No GPU
+	// VRAM bank (no GPU here). Split: LOW bank (0xb8000000..0xe6000000, 736MB =
+	// 672MB normal + 64MB CMA) holds kernel/initrd + working set; HIGH bank
+	// (0x200000000..0x21a000000, 416MB) holds GPU-style carveouts (generic/vpr/fsi).
+	// DMA32 hole 0xe6000000..0x100000000 left to the host for PCIe MSI / WLAN.
+	memory@b8000000 {
+		reg = <0x00 0xb8000000 0x00 0x2e000000>,
+		      <0x02 0x00000000 0x00 0x1a000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		// All carveouts sit in disp-vm's backed carveout RAM (not gpu-vm's bank1
+		// 0x80..0xb0, unbacked here and overlapping the GPU VM). All backed by
+		// dispram_p; below-4GB DMA32 host RAM left untouched so PCIe MSI works.
+		// CMA in the LOW bank (backed, cma-default) for dumb buffers.
+		linux,cma {
+			compatible = "shared-dma-pool";
+			reusable;
+			reg = <0x00 0xE2000000 0x00 0x04000000>; // 64MB @ 0xe2000000 (low bank top)
+			linux,cma-default;
+			status = "okay";
+		};
+
+		// GPU-style carveouts in the HIGH bank (0x200000000..0x21a000000).
+		generic_reserved: generic_carveout {
+			compatible = "nvidia,generic_carveout";
+			reg = <0x02 0x00000000 0x00 0x18000000>; // 384MB @ 0x200000000..0x218000000
+			no-map;
+			status = "okay";
+		};
+
+		vpr: vpr-carveout {
+			compatible = "removed-dma-pool";
+			reg = <0x02 0x18000000 0x00 0x01000000>; // 16MB @ 0x218000000
+			status = "okay";
+		};
+
+		fsi_reserved: fsi-carveout {
+			compatible = "removed-dma-pool";
+			reg = <0x02 0x19000000 0x00 0x01000000>; // 16MB @ 0x219000000
+			no-map;
+			status = "okay";
+		};
+
+		// 1:1 GPA=HPA scanout carveout. nvdisplay allocates the scanout surface
+		// here; the host-owned DCE R5 DMAs it at the same physical address. Backed
+		// 1:1 by scanout_p in gpu_passthrough_overlay.dts (host removed-dma-pool +
+		// vfio mmio-base=0xb0000000), reused here -- disp-vm is sole owner in
+		// compute-with-host1x mode, where the GPU VM drops its scanout claim.
+		// Sits OUTSIDE every guest RAM bank.
+		dce_scanout: dce_scanout@b0000000 {
+			// NOT reusable: this carveout is OUTSIDE every guest RAM bank.
+			// "reusable" would make it CMA, and cma_init_reserved_areas walks
+			// pfn_valid(0xb0000) -> faults on out-of-System-RAM pages -> early
+			// kill-init. Plain shared-dma-pool = dedicated coherent DMA pool (no
+			// CMA pfn walk); dma_alloc_coherent still returns 0xb0000000-range addrs.
+			compatible = "shared-dma-pool";
+			reg = <0x00 0xB0000000 0x00 0x01000000>; // 16MB (rest unclaimed)
+			status = "okay";
+		};
+	};
+
+	tegra_icc: icc {
+		#interconnect-cells = <1>;
+		clocks = <&bpmp TEGRA234_CLK_EMC>;
+		clock-names = "emc";
+		compatible = "nvidia,tegra23x-icc";
+		nvidia,bpmp = <&bpmp>;
+		status = "okay";
+	};
+
+
+	// Carveout regions for the carveouts driver (no vidmem_reserved: GPU-only,
+	// dropped for disp-vm).
+	tegra-carveouts {
+		compatible = "nvidia,carveouts";
+		memory-region = <&generic_reserved &vpr &fsi_reserved>;
+		status = "okay";
+	};
+};

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/tegra234-dispvm.dts
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/tegra234-dispvm.dts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+//
+// disp-vm guest device tree (display-only, no host1x/gpu/media). Composed from
+// the shared gpu-vm .dtsi built with EXP_DROP_HOST1X + EXP_DROP_GPU (drops the
+// engine ranges/nodes), plus disp-vm's own split-RAM memory. base/proxies/
+// display/dummies are reused verbatim from ../gpu-vm so the two VMs share one
+// source of truth; only tegra234-dispvm-memory.dtsi is disp-vm-specific.
+
+#include <dt-bindings/clock/tegra234-clock.h>
+#include <dt-bindings/reset/tegra234-reset.h>
+#include <dt-bindings/mailbox/tegra186-hsp.h>
+#include <dt-bindings/memory/tegra234-mc.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/interrupt/tegra234-irq.h>
+#include <dt-bindings/gpio/tegra234-gpio.h>
+#include <dt-bindings/p2u/tegra234-p2u.h>
+#include <dt-bindings/power/tegra234-powergate.h>
+#include <dt-bindings/pinctrl/pinctrl-tegra.h>
+
+/dts-v1/;
+
+/ {
+	interrupt-parent = <0x8005>;
+	model = "linux,dummy-virt";
+	#size-cells = <0x02>;
+	#address-cells = <0x02>;
+
+	// Some drivers need the root node to carry this compatible.
+	compatible = "nvidia,tegra234";
+
+	// No host1x alias: physical host1x stays with the GPU VM.
+	aliases {
+	};
+};
+
+#include "tegra234-gpuvm-base.dtsi"
+#include "tegra234-dispvm-memory.dtsi"
+#include "tegra234-gpuvm-proxies.dtsi"
+#include "tegra234-gpuvm-display.dtsi"
+#include "tegra234-gpuvm-dummies.dtsi"

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/default.nix
@@ -3,16 +3,15 @@
 #
 # Pass the AGX Orin's on-SoC GPU (ga10b) and supporting engines to gpu-vm.
 #
-# Data:    vfio-platform hands the GPU + host1x/vic/nvdec/nvjpg + three
-#          reserved-memory carveouts to the guest. Carveouts use mmio-base for
-#          1:1 GPA=HPA (see ghaf-qemu-bpmp-gpu).
-# Control: clocks/resets/power-domains route through the BPMP host proxy, gated
-#          by the union allow-list (ids enumerated on hardware).
+# Data:    vfio-platform hands GPU + host1x/vic/nvdec/nvjpg + three reserved-memory
+#          carveouts to the guest. Carveouts use mmio-base for 1:1 GPA=HPA.
+# Control: clocks/resets/power-domains route through the BPMP host proxy, gated by
+#          the union allow-list.
 #
-# Display (13800000.display) is NOT passed through: the host-owned DCE R5 keeps
-# it and drives scanout. vfio-binding display resets it under the R5, which then
-# aborts at dce_ss_set (DCE_HALTED) -- the binding alone, not guest activity.
-# The guest reaches the panel only via the DCE host-proxy IPC path, never MMIO.
+# display@13800000 is NOT passed through: the host-owned DCE R5 owns it and drives
+# scanout. vfio-binding display resets it under the R5, which aborts at dce_ss_set
+# (DCE_HALTED) -- the vfio binding alone does this, even with the guest stopped.
+# The guest reaches the panel only via the DCE host-proxy IPC path, never display MMIO.
 {
   lib,
   pkgs,
@@ -22,66 +21,107 @@
 let
   cfg = config.ghaf.hardware.nvidia.passthroughs.gpu_vm;
 
-  # Host-side virtualization config (sourcesPatch is here, not on the guest);
-  # captured from host scope so guest extraModules can reference it without the
-  # inner `config` shadow resolving to the guest config.
+  # Host-side virt config (sourcesPatch lives here, not on the guest). Captured from
+  # the host scope so the guest extraModules can reference it without the inner
+  # `config` shadow picking up the guest config.
   virt = config.ghaf.hardware.nvidia.virtualization;
 
-  # Reserved-memory carveouts take an explicit mmio-base for 1:1 GPA=HPA;
-  # engines use the default mapping.
-  reservedMem = [
-    {
+  # Host1x-ownership experiment (experiment/orin-two-vm-host1x). Both no-host1x
+  # directions drop physical host1x + 64MiB syncpoint shim + media (one unit).
+  # compute-no-host1x also drops display/DCE; display-no-host1x also drops
+  # GA10B/nvgpu and forces NVKMS no-syncpt mode.
+  exp = cfg.host1xExperiment;
+  computeNoHost1x = exp == "compute-no-host1x";
+  computeWithHost1x = exp == "compute-with-host1x";
+  displayOnly = exp == "display-no-host1x";
+  # host1x + 64MiB shim + media move as one unit; dropped only where host1x is
+  # removed (the two no-host1x experiments), kept for off and compute-with-host1x.
+  dropHost1x = computeNoHost1x || displayOnly;
+  # display/DCE/scanout/keyholes dropped for both compute VMs (neither drives display).
+  dropDisplay = computeNoHost1x || computeWithHost1x;
+
+  # cpp -D flags that strip/resize guest DT nodes for the host1x experiment.
+  expDtDefines =
+    lib.optionalString dropHost1x "-DEXP_DROP_HOST1X "
+    + lib.optionalString dropDisplay "-DEXP_DROP_DISPLAY "
+    + lib.optionalString displayOnly "-DEXP_DROP_GPU "
+    # Shrink memory@ bank1 to 0x80000000..0xb0000000 so it no longer needs the
+    # scanout carveout, releasing 0xb0000000 for the GUI VM.
+    + lib.optionalString computeWithHost1x "-DEXP_SHRINK_BANK1 ";
+
+  # Devices passed to gpu-vm. Reserved-memory carveouts take an explicit
+  # mmio-base for 1:1 GPA=HPA; engines use the default mapping.
+  reservedMem =
+    # 64MiB syncpoint shim: moves with physical host1x -- dropped in both experiments.
+    lib.optional (!dropHost1x) {
       dev = "60000000.vm_hs_p";
       base = "0x60000000";
     }
-    {
-      dev = "80000000.vm_cma_p";
-      base = "0x80000000";
-    }
-    {
-      dev = "100000000.vm_cma_vram_p";
-      base = "0x100000000";
-    }
-    # 1:1 scanout carveout: nvdisplay allocates its scanout surface here, the
-    # host DCE R5 DMAs it at the same PA. Mirrors scanout_p in the overlay dts
-    # and dce_scanout in tegra234-gpuvm.dts.
-    {
+    ++ [
+      {
+        dev = "80000000.vm_cma_p";
+        base = "0x80000000";
+      }
+    ]
+    # GPU VRAM carveout (4GiB @ 0x100000000). LOAD-BEARING for the guest RAM map:
+    # the guest memory node's bank2 (0x100000000..0x200000000) is backed 1:1 ONLY
+    # by this carveout. Dropping it leaves bank2 unbacked -> guest panics in early
+    # mem init before console. Keep it in every mode; a display VM never uses it as
+    # VRAM, it just backs the RAM bank. Proper fix (slim guest memory map) is a follow-up.
+    ++ [
+      {
+        dev = "100000000.vm_cma_vram_p";
+        base = "0x100000000";
+      }
+    ]
+    # 1:1 scanout carveout (128MiB @ 0xb0000000). Beyond the scanout surface,
+    # LOAD-BEARING for the guest RAM map: guest memory bank1 (0x80000000..0xb8000000)
+    # has its top 128MiB tail (0xb0000000..0xb8000000) backed 1:1 ONLY by this
+    # carveout. Dropping it leaves the tail unbacked, so swiotlb_init memsets into a
+    # hole and the guest panics at start_kernel before console. Keep it in every mode;
+    # the compute VM never touches it as display. Proper fix (slim guest memory map)
+    # is a follow-up.
+    #
+    # compute-with-host1x is that follow-up: EXP_SHRINK_BANK1 ends guest bank1 at
+    # 0xb0000000 so it no longer spans this carveout -- drops scanout here AND
+    # releases 0xb0000000 for the concurrent GUI VM.
+    ++ lib.optional (!computeWithHost1x) {
       dev = "b0000000.scanout_p";
       base = "0xb0000000";
-    }
-  ];
-  # GPU compute engines. Neither dce@d800000 nor display@13800000 is here:
-  # host keeps the real DCE and its R5 drives display directly (vfio-binding
-  # display halts the R5, DCE_HALTED at dce_ss_set). Guest reaches the panel
-  # only via the DCE host-proxy IPC path.
+    };
+  # GPU compute engines. Neither dce@d800000 nor display@13800000 is here: the host
+  # keeps the real DCE and its R5 drives display directly (see header).
   #
-  # host1x@13e00000 is passed: the guest GPU stack (nvgpu) needs host1x
-  # syncpoints. If the R5 still halts, host1x is the next candidate to keep
-  # host-side (costs guest GPU compute until the guest gets a virtual host1x).
-  engines = [
-    "17000000.gpu"
-    "13e00000.host1x_pt"
-    "15340000.vic"
-    "15480000.nvdec"
-    "15540000.nvjpg"
-  ];
-  # Keyhole MMIO passthrough: single 4KB read-only EVO display-capabilities strap
-  # page (0x13830000 = display+0x30000), placed in the guest at its caps offset
-  # (0x66230000 = 0x66200000+0x30000) via mmio-base. Backs the guest nvdisplay
-  # EvoGetCapabilities read WITHOUT handing over the display control aperture
-  # (that needs rewriting display@13800000, which kills the host DCE R5). See
-  # overlay fragment@9. Only this page is backed, so any OTHER display-register
-  # access still aborts (exposes the guest's real MMIO footprint).
-  # Second keyhole: EVO channel doorbell (PUT/GET) region -- core at
-  # display+0x70000, window channels from display+0x80000 -- mapped to guest
-  # 0x66270000 (0x66200000+0x70000), size 0x20000. nvkms writes PUT here to tell
-  # the DCE R5 to fetch a channel's pushbuffer; unbacked, the window channel's
-  # GET never advances. See overlay fragment@10. CPU-RM user doorbells; R5-safe.
-  # NOTE: dpaux0 (0x155C0000) and MIPI_CAL (0x03990000) deliberately NOT keyholed
-  # -- tried, proved INERT: on T234D the CPU-side RM never instantiates OBJDPAUX,
-  # so no guest code touches them; EDID/AUX are RmControl -> DCE-RPC on the R5,
-  # which owns the pads. Keyholing them changed nothing.
-  dispCaps = [
+  # host1x@13e00000 is passed in off/default because the guest GPU stack (nvgpu)
+  # needs host1x syncpoints. It (+ shim + media) is dropped in both experiments
+  # (!dropHost1x). Next candidate to keep host-side if the R5 still halts -- would
+  # cost guest GPU compute until the guest gets a virtual host1x.
+  engines =
+    # GA10B is dropped in the display-only VM.
+    lib.optional (!displayOnly) "17000000.gpu"
+    # host1x + media move together, dropped in both experiments.
+    ++ lib.optionals (!dropHost1x) [
+      "13e00000.host1x_pt"
+      "15340000.vic"
+      "15480000.nvdec"
+      "15540000.nvjpg"
+    ];
+  # Keyhole MMIO passthrough. Keyhole 1: the single 4KB read-only EVO
+  # display-capabilities strap page (0x13830000), placed in the guest at caps offset
+  # 0x66230000. Backs the guest nvdisplay EvoGetCapabilities read WITHOUT handing over
+  # the display control aperture (rewriting display@13800000 kills the host DCE R5).
+  # See gpu_passthrough_overlay.dts fragment@9. The guest node declares the full
+  # aperture but only this page is backed, so any other display-register access aborts.
+  # Keyhole 2: the EVO channel doorbell (PUT/GET) region -- core at display+0x70000,
+  # window channels from display+0x80000 -- at guest 0x66270000, size 0x20000. The
+  # guest nvkms writes PUT here to tell the DCE R5 to fetch a channel's pushbuffer;
+  # without it the window channel's GET pointer never advances. See fragment@10.
+  # CPU-RM-facing user doorbells (guest is the CPU RM); R5-safe.
+  # NOTE: dpaux0 (0x155C0000) and MIPI_CAL (0x03990000) deliberately NOT keyholed --
+  # INERT: on T234D the CPU-side RM never instantiates OBJDPAUX, so no guest code
+  # touches them; EDID/AUX are RmControl -> DCE-RPC serviced by the R5 that owns the pads.
+  # Entire list dropped in compute-only (keyholes meaningless without display stack).
+  dispCaps = lib.optionals (!dropDisplay) [
     {
       dev = "13830000.disp_caps_pt";
       base = "0x66230000";
@@ -104,10 +144,9 @@ let
     ]) engines);
 
   # Guest device tree -> dtb. dt-bindings come from the guest kernel's mainline
-  # headers; their TEGRA234_CLK_*/RESET_*/POWER_DOMAIN_* ids equal the SoC's
-  # live-DT ids, so the guest requests exactly what the host proxy allow-list
-  # grants. Two NVIDIA-only headers (tegra234-irq.h, tegra234-p2u.h) are vendored
-  # under ./nv-dt-bindings.
+  # headers; their TEGRA234_CLK_*/RESET_*/POWER_DOMAIN_* ids equal the SoC's live-DT
+  # ids, so the guest requests exactly what the host proxy allow-list grants. Two
+  # NVIDIA-only headers (tegra234-irq.h, tegra234-p2u.h) are vendored under ./nv-dt-bindings.
   gpuvm-dtb = pkgs.stdenv.mkDerivation {
     name = "gpuvm-dtb";
     # Composition root + component .dtsi fragments (see the include list in
@@ -146,20 +185,24 @@ let
       ''
         # $CC = stdenv's compiler (triple-prefixed under cross); -E only
         # preprocesses, so the target triple is irrelevant to the text output.
-        $CC -E -nostdinc -undef -D__DTS__ -x assembler-with-cpp \
+        $CC -E -nostdinc -undef -D__DTS__ ${expDtDefines}-x assembler-with-cpp \
           -I${mainInc} \
           -I${./nv-dt-bindings} \
           -I. \
           tegra234-gpuvm.dts > preprocessed.dts
         dtc -I dts -O dtb -o tegra234-gpuvm.dtb preprocessed.dts
-
+      ''
+      # DCB gate only applies when the display node is present. The host1x
+      # experiment modes drop it (-DEXP_DROP_DISPLAY), so the skip is keyed on
+      # the same eval-time `dropDisplay` flag that drops the node -- NOT on
+      # fdtget's exit code, which would silently no-op the check if the node
+      # were ever renamed/moved in a display-on build.
+      + lib.optionalString (!dropDisplay) ''
         # Verify the DCB payload that actually landed in the DTB against the
         # pinned stock AGX blob; fail the build on any drift. The display node
-        # is always present in this baseline DTB, so the check is mandatory:
-        # if the node can't be extracted (renamed/moved, or fdtget missing) the
-        # supply-chain gate must fail loudly rather than silently skip. The
-        # experiment modes that legitimately drop the display node gate this
-        # skip on their own eval-time flag, not on fdtget's exit code.
+        # is present in this build, so the check is mandatory: if it can't be
+        # extracted (renamed/moved, or fdtget missing) the supply-chain gate
+        # must fail loudly rather than silently skip.
         if ! fdtget tegra234-gpuvm.dtb \
              /platform-bus@70000000/display@13800000 nvidia,dcb-image >/dev/null 2>&1; then
           echo "DCB gate: display@13800000/nvidia,dcb-image not found in DTB" >&2
@@ -195,6 +238,26 @@ in
     description = "Pass the Tegra234 GPU and engines through to gpu-vm on NVIDIA Orin AGX";
   };
 
+  options.ghaf.hardware.nvidia.passthroughs.gpu_vm.host1xExperiment = lib.mkOption {
+    type = lib.types.enum [
+      "off"
+      "compute-no-host1x"
+      "display-no-host1x"
+      "compute-with-host1x"
+    ];
+    default = "off";
+    description = ''
+      Branch-only host1x-ownership experiment selector (experiment/orin-two-vm-host1x).
+      "off" reproduces the validated combined-gpuvm build. "compute-no-host1x"
+      strips host1x/shim/media/display for the GPU-compute feasibility gate.
+      "display-no-host1x" strips host1x/shim/media/gpu and forces NVKMS no-syncpt
+      mode for the software-display feasibility gate. "compute-with-host1x" is the
+      concurrent-test GPU VM: KEEPS host1x/shim/media/gpu, drops display, and
+      shrinks guest RAM bank1 to release the scanout carveout for the GUI VM.
+      Never promote to a target.
+    '';
+  };
+
   config = lib.mkIf cfg.enable {
     ghaf.hardware.nvidia.virtualization.host.bpmp.enable = true;
 
@@ -202,35 +265,42 @@ in
     ghaf.virtualization.microvm.gpuvm.enable = true;
 
     # The closed BPMP host-proxy allow-list is the host-safety boundary;
-    # bpmpAllowAllDomains bypasses it. Fail the build rather than ship a guest
-    # that can reach every SoC clock/power domain.
+    # bpmpAllowAllDomains bypasses it. Fail the build rather than ship a guest that
+    # can reach every SoC clock/power domain.
     assertions = [
       {
         assertion = !config.ghaf.hardware.nvidia.virtualization.bpmpAllowAllDomains;
         message = "gpu_vm passthrough requires the closed BPMP allow-list; ghaf.hardware.nvidia.virtualization.bpmpAllowAllDomains must stay false.";
       }
+      {
+        # Only one VM may open /dev/dce-host and drain the single DCE event ring
+        # (patch 0002's gate). gpu-vm sets GHAF_DCE_GUEST unless dropDisplay;
+        # disp-vm sets it whenever enabled -- so the two must not overlap.
+        assertion = !((!dropDisplay) && config.ghaf.hardware.nvidia.passthroughs.disp_vm.enable);
+        message = "gpu-vm still owns the display (host1xExperiment = \"${exp}\") while disp_vm is enabled: both would set GHAF_DCE_GUEST and race the DCE ring. Use a display-dropping host1xExperiment mode or disable disp_vm.";
+      }
     ];
 
-    # gpu_vm force-disables the host graphics stack below (no per-device opt-out);
-    # warn so a build expecting a host desktop is not silently shipped without one.
+    # gpu_vm force-disables the host graphics stack below; warn so a build expecting
+    # a host desktop isn't silently shipped without one.
     warnings = [
       "gpu_vm passthrough is enabled: the host GPU is assigned to gpu-vm, so the host graphics stack (COSMIC desktop), nvpmodel, and NVIDIA Docker are force-disabled. The host has no local GUI."
     ];
 
     # BPMP allow-list: union of the bpmp ids the passed-through compute engines
-    # declare in the live host DT (cells whose phandle is &bpmp):
+    # declare in the live host DT (only cells whose phandle is &bpmp):
     #   gpu@17000000    clocks 304 41 236   reset 19    pd 35
     #   host1x@13e00000 clocks 46 1
     #   vic@15340000    clock 167           reset 113   pd 29
     #   nvdec@15480000  clocks 83 40 154    reset 44    pd 23
     #   nvjpg@15540000  clock 20            reset 10    pd 36
-    # display@13800000 is host-side now, so the guest no longer requests these
-    # display ids -- left in the closed allow-list harmlessly (still NOT allow-all)
-    # so it need not change if the guest re-acquires a display path. They are the
-    # exact ids the guest display@13800000 node declares. dce@d800000 needs no ids
-    # (host owns the real DCE; the guest's synthetic dce node has no clocks). Host
-    # proxy logging "clock not allowed" for probed parent PLLs is the boundary
-    # working; add an id only if display/GPU init actually fails on that denied id.
+    # display@13800000 is host-side now, so the guest no longer requests these display
+    # ids, but they stay in the closed allow-list (still NOT allow-all) so it need not
+    # change if the guest re-acquires a display path. They are the exact ids the guest
+    # display@13800000 node declares. dce@d800000 needs no ids (host owns the real DCE;
+    # the guest's synthetic dce node has no clocks). The host proxy logging "clock not
+    # allowed" for probed parent PLLs is the boundary working; add an id only if
+    # display/GPU init actually fails on that denied id.
     ghaf.hardware.nvidia.virtualization.host.bpmp.allow = {
       # compute engines (see per-device breakdown above)
       clocks = [
@@ -248,13 +318,11 @@ in
       # 13800000.display: nvdisplayhub/disp/p0/p1, dpaux, fuse, the DSI/SP/V
       # PLL tree, RG/SOR/SF paths, mipi-cal, osc, dsc, maud, aza.
       ++ [
-        # Root parents of the SOR clock tree: clk_prepare_enable on sor0
-        # propagates up to these, and a denied parent fails the WHOLE chain
-        # (SOR never turns on despite a completed modeset -- CLK_ENABLE cmd 7
-        # denials for 14/102). These are host-critical always-on roots, so the
-        # bpmp-host-proxy allow-list gates them by command: a guest enable is a
-        # BPMP refcount no-op, but disable/reparent/rerate are denied
-        # (clk_root_is_protected) so a compromised guest cannot take them down.
+        # Root parents of the SOR clock tree. The guest's clk_prepare_enable on sor0
+        # propagates enables up to these; a denied parent fails the WHOLE chain, so
+        # the SOR never turns on (no video despite a completed modeset). Host-critical
+        # always-on roots: a guest enable is a BPMP refcount no-op, and the guest runs
+        # clk_ignore_unused so it never mass-disables them.
         14 # TEGRA234_CLK_CLK_M
         102 # TEGRA234_CLK_PLLP_OUT0
         19
@@ -282,12 +350,11 @@ in
         182
         183
         184
-        # NOTE: the guest display RM also probes host-critical clocks in its
-        # clock-tree walk (denials 429-434=CPU DSU/SCE/RCE/DCE_CPU, 472=MCHUB).
-        # Those denials are CORRECT and HARMLESS (host already runs them) and
-        # must STAY denied -- never add CPU/coprocessor/memory clocks here. The
-        # list above is exactly the 62 clock ids the guest display@13800000 node
-        # declares (guest 6.12 tegra234-clock.h): the complete closed display set.
+        # NOTE: the guest display RM also probes host-critical clocks during its
+        # clock-tree walk (429-434=CPU DSU/SCE/RCE/DCE_CPU, 472=MCHUB, etc). Those
+        # denials are CORRECT and HARMLESS (host already runs them) and must STAY
+        # denied -- never add CPU/coprocessor/memory clocks here. The list above is
+        # exactly the 62 clock ids the guest display@13800000 node declares.
         435
         436
         437
@@ -354,21 +421,20 @@ in
       SUBSYSTEM=="vfio", GROUP="kvm"
     '';
 
-    # Host must not touch the GPU once it is vfio'd: leaving host graphics on
-    # faults the host the instant bindGpuVm hands the GPU/host1x to vfio.
+    # Host must not touch the GPU once it is vfio'd: leaving host graphics on faults
+    # the host the instant bindGpuVm hands the GPU/host1x to vfio.
     ghaf.profiles.graphics.enable = lib.mkForce false;
 
-    # nvpmodel needs host-GPU-driver sysfs that is gone under vfio, so its
-    # service fails and restarts forever. (TODO: split CPU/EMC vs GPU limits.)
+    # nvpmodel needs host-GPU-driver sysfs that is gone under vfio, so it fails and
+    # restarts forever. (TODO: split CPU/EMC vs GPU limits.)
     services.nvpmodel.enable = lib.mkForce false;
 
-    # NVIDIA Docker can't reach the GPU under vfio. (TODO: run GPU containers
-    # inside gpu-vm instead.)
+    # NVIDIA Docker can't reach the GPU under vfio. (TODO: run GPU containers in gpu-vm.)
     ghaf.virtualization.nvidia-docker.daemon.enable = lib.mkForce false;
 
-    # Blacklist so vfio binds pristine devices (as MGBE0 does). host1x too: the
-    # GPU + vic/nvdec/nvjpg are its clients, so with the bus down the host never
-    # binds them and they hand over cleanly.
+    # Blacklist so vfio binds pristine devices. host1x too: the GPU + vic/nvdec/nvjpg
+    # are its clients, so with the bus down the host never binds them and they hand
+    # over cleanly.
     boot.blacklistedKernelModules = [
       "nvgpu"
       "nvidia"
@@ -394,7 +460,14 @@ in
         ) allDevs;
       };
     };
-    systemd.services."microvm@gpu-vm".after = [ "bindGpuVm.service" ];
+    systemd.services."microvm@gpu-vm" = {
+      after = [ "bindGpuVm.service" ];
+      # Exclusive DCE ownership (opt-in): the QEMU DCE bridge is created only when
+      # GHAF_DCE_GUEST=1 (ghaf-qemu-bpmp patch 0002). A display-capable GPU-VM opts
+      # in; a display-less one leaves it unset -> never opens /dev/dce-host, so it
+      # can't steal disp-vm's DCE events.
+      environment = lib.mkIf (!dropDisplay) { GHAF_DCE_GUEST = "1"; };
+    };
 
     # Host DT overlay exposing the GPU nodes to passthrough.
     hardware.deviceTree.overlays = [
@@ -409,15 +482,13 @@ in
       (
         { config, pkgs, ... }:
         {
-          # DRM userspace: this nvidia-drm build has no fbdev (rejects
-          # nvidia-drm.fbdev), so no fbcon triggers a modeset -- connector is
-          # detected with a full mode list but nothing asks for a mode, panel
-          # stays dark. Ship modetest to drive a modeset from userspace until a
-          # compositor runs here.
+          # DRM userspace: this nvidia-drm build has no fbdev support, so there's no
+          # fbcon to trigger a modeset and the panel stays dark. Ship modetest so a
+          # modeset can be driven from userspace until a compositor runs here.
           environment.systemPackages =
             let
-              # Forces plain no-modifier GBM window surfaces; see the shim
-              # source for why the modifier path EGL_BAD_ALLOCs on this guest.
+              # Forces plain no-modifier GBM window surfaces; see the shim source for
+              # why the modifier path EGL_BAD_ALLOCs on this guest.
               gbm-nomod-shim = pkgs.runCommandCC "gbm-nomod-shim" { } ''
                 mkdir -p $out/lib
                 $CC -O2 -fPIC -shared -o $out/lib/gbm-nomod-shim.so \
@@ -437,31 +508,29 @@ in
             [
               pkgs.libdrm
               kmscube-wrapped
-              # Graphics ABI verification (accel-rendering bring-up): eglinfo/
-              # eglgears prove NVIDIA EGL + a GA10B renderer string, drm_info
-              # maps render/KMS nodes.
+              # Graphics ABI verification: eglinfo/eglgears prove the NVIDIA EGL impl
+              # and a GA10B renderer string, drm_info maps render/KMS nodes.
               pkgs.mesa-demos
               pkgs.drm_info
             ];
 
           # NVIDIA/Jetson graphics userspace (EGL/GLES/GBM) via /run/opengl-driver,
-          # mirroring jetpack-nixos modules/graphics.nix. Guest can't enable
+          # mirroring jetpack-nixos modules/graphics.nix. The guest can't enable
           # hardware.nvidia-jetpack (BYO kernel), so lift just the userspace wiring.
           # l4t-3d-core ships the GL vendor libs; extras carry runtime deps
           # (nvrm/gbm/wayland/nvsci).
           hardware.graphics = {
             enable = true;
-            # l4t-3d-core's bundled libnvidia-egl-gbm 1.1.0 shadowed by nixpkgs
-            # egl-gbm 1.1.3: 1.1.0's EGL GBM platform heap-corrupts eglInitialize
-            # under mesa 26's libgbm (surfaceless/device platforms are fine).
-            # First path wins in the join; drop the l4t json so the platform
-            # module isn't loaded twice.
+            # l4t-3d-core's bundled libnvidia-egl-gbm 1.1.0 shadowed by nixpkgs egl-gbm
+            # 1.1.3: the 1.1.0 EGL GBM platform heap-corrupts eglInitialize under mesa
+            # 26's libgbm (surfaceless/device platforms are fine). First path wins in
+            # the join; drop the l4t json so the platform module isn't loaded twice.
             package = pkgs.symlinkJoin {
               name = "l4t-3d-core-egl-gbm-1.1.3";
               paths = [
-                # single-device fallback: on Tegra the EGL device's DRM node
-                # (tegra-drm) never path-matches the gbm fd (nvidia-drm), so
-                # stock matching always fails eglInitialize on GBM.
+                # single-device fallback: on Tegra the EGL device's DRM node (tegra-drm)
+                # never path-matches the gbm fd (nvidia-drm), so stock matching always
+                # fails eglInitialize on GBM.
                 (pkgs.egl-gbm.overrideAttrs (o: {
                   patches = (o.patches or [ ]) ++ [
                     ./patches/userspace/egl-gbm-single-device-fallback.patch
@@ -481,9 +550,9 @@ in
                 l4t-wayland
               ])
               ++ [
-                # l4t-gbm minus its bundled libnvidia-egl-gbm 1.1.0 (and its
-                # platform json): the nixpkgs egl-gbm 1.1.3 in `package`
-                # provides that library; keep only the nvidia-drm_gbm backend.
+                # l4t-gbm minus its bundled libnvidia-egl-gbm 1.1.0 (and platform
+                # json): egl-gbm 1.1.3 in `package` provides that library; keep only
+                # the nvidia-drm_gbm backend.
                 (pkgs.symlinkJoin {
                   name = "l4t-gbm-sans-egl-gbm";
                   paths = [ pkgs.nvidia-jetpack.l4t-gbm ];
@@ -498,77 +567,77 @@ in
           environment.etc."egl/egl_external_platform.d".source =
             "${pkgs.addDriverRunpath.driverLink}/share/egl/egl_external_platform.d/";
 
-          # Guest kernel = vanilla 6.12 + jetpack OOT overlay (Bring-Your-Own-
-          # Kernel), GPU passthrough patches applied to nvidia-oot-modules (base
-          # OOT builds clean on 6.12.93). 0003 (display passthrough) IS applied
-          # for the guest display path: it force-returns the Xen dom0/vgx
-          # virtualization predicates TRUE, which the in-VM nvdisplay stack needs.
+          # Guest kernel = vanilla 6.12 + jetpack OOT overlay (BYO-kernel), GPU
+          # passthrough patches applied to nvidia-oot-modules.
           boot.kernelPackages = lib.mkForce (
             (pkgs.linuxPackages_6_12.extend pkgs.nvidia-jetpack.kernelPackagesOverlay).extend (
               _final: prev: {
                 nvidia-oot-modules = prev.nvidia-oot-modules.overrideAttrs (o: {
-                  patches = (o.patches or [ ]) ++ [
-                    ./patches/0001-gpu-add-support-for-passthrough.patch
-                    ./patches/0002-add-support-for-gpu-display-passthrough.patch
-                    ./patches/0003-add-support-for-display-passthrough.patch
-                    # Force NISO display surfaces (pushbuffer, notifier,
-                    # semaphores) contiguous so they land in the 1:1 carveout the
-                    # host DCE R5 can resolve -- else the window channel never
-                    # advances ("waiting for GPU progress", NVC67E).
-                    ./patches/0005-force-niso-display-surfaces-contiguous.patch
-                    # Address policy for everything handed to the host DCE R5
-                    # (inst-mem base, pushbuffers, ctxdma FrameAddrs): CPU
-                    # physical (1:1 carveout), offset into the native display
-                    # high-IOVA range (raw physicals abort the R5's UPDATE),
-                    # ctxdma Limit computed after the offset. Host maps
-                    # hi->carveout in the display SMMU domains and retags scanout
-                    # readers' MC SIDs (dce-iso-anchor).
-                    ./patches/0006-dce-addresses-cpu-phys-high-iova.patch
-                    # DP++ dual-mode: a passive HDMI adapter asserts HPD but has
-                    # no DP sink; trust RM DDC/LOAD detection over the DP lib's
-                    # HPD-only guess so detection falls through to the TMDS
-                    # partner displayId where the sink is.
-                    ./patches/0008-fix-dual-mode-honor-rm-connect-state.patch
-                    # Core notifier: plain WRITE, never WRITE_AWAKEN -- awaken
-                    # rides the DCE async event path the guest can't receive and
-                    # the R5 aborts the whole completion write. Dropping this for
-                    # awaken-paced completions (retried with the ch3 relay live)
-                    # stops flips completing entirely; keep plain WRITE.
-                    ./patches/0009-core-notifier-plain-write-no-awaken.patch
-                    # Boot hotplug: a panel connected at boot produces no HPD
-                    # edge, so the host DCE never sends the hotplug event and the
-                    # SOR is never assigned (dark until replug). Schedule the same
-                    # deferred hotplug work once at init.
-                    ./patches/0020-synthesize-boot-hotplug-long-pulse.patch
-                    # Drop the host DCE R5's flip-completion event: lands ~130ms
-                    # after kickoff (~8-10fps ceiling), not a usable per-flip
-                    # signal under passthrough. Completion comes from 0013's
-                    # vblank qualification instead.
-                    ./patches/0010-dce-drop-r5-completion-event.patch
-                    # Window-channel completion notifier: plain WRITE, never
-                    # WRITE_AWAKEN -- same R5 abort as the core channel (0009).
-                    # Native-R5 60fps completion (WRITE_AWAKEN gated on the active
-                    # primary) is blocked on an intermittent window-channel
-                    # BEGUN->FINISHED latch failure at 60fps (closed R5 firmware);
-                    # see native-r5-experimental.
-                    ./patches/0011-window-notifier-plain-write.patch
-                    # Complete each committed flip 2 physical vblank callbacks
-                    # after it was armed -- a scanout-latch margin, tear-free at
-                    # ~30fps. The R5-latch-reliable path while native-R5 60fps
-                    # stays blocked on closed R5/window-channel firmware.
-                    ./patches/0013-drm-vblank-flip-completion.patch
-                  ];
-                  # DCE display proxy (guest side): redirect the guest's DCE IPC
-                  # through the shared MMIO window, skip the R5 bootstrap (R5 is
-                  # host-owned). Hook patch is against the nvidia-oot project root
-                  # (no prefix) so apply it scoped to nvidia-oot/; splice the guest
-                  # proxy in as its own obj-m .ko (links tegra-dce exports, so it
-                  # must build inside nvidia-oot).
+                  patches =
+                    (o.patches or [ ])
+                    ++ [
+                      ./patches/0001-gpu-add-support-for-passthrough.patch
+                      ./patches/0002-add-support-for-gpu-display-passthrough.patch
+                      ./patches/0003-add-support-for-display-passthrough.patch
+                      # Force NISO display surfaces (channel pushbuffer, notifier,
+                      # semaphores) contiguous so they land in the 1:1 physical carveout
+                      # the host DCE R5 can resolve -- else the window channel never
+                      # advances ("waiting for GPU progress", NVC67E).
+                      ./patches/0005-force-niso-display-surfaces-contiguous.patch
+                      # Address policy for everything handed to the host-owned DCE R5
+                      # (inst-mem base, channel pushbuffers, ctxdma FrameAddrs): CPU
+                      # physical (1:1 GPA=HPA carveout), offset into the native display
+                      # high-IOVA range (raw physicals abort the R5's UPDATE), absolute
+                      # ctxdma Limit computed after the offset. The host maps
+                      # hi->carveout in the display SMMU domains and retags the scanout
+                      # readers' MC SIDs (dce-iso-anchor).
+                      ./patches/0006-dce-addresses-cpu-phys-high-iova.patch
+                      # DP++ dual-mode: a passive HDMI adapter asserts HPD but has no DP
+                      # sink; trust RM's DDC/LOAD detection over the DP lib's HPD-only
+                      # guess so detection falls through to the TMDS partner displayId
+                      # where the sink really is.
+                      ./patches/0008-fix-dual-mode-honor-rm-connect-state.patch
+                      # Core notifier: plain WRITE, never WRITE_AWAKEN -- the awaken
+                      # rides the DCE async event path the guest can't receive and the
+                      # R5 aborts the whole completion write. Dropping this (even with
+                      # the ch3 relay live) stops flips completing entirely; keep plain WRITE.
+                      ./patches/0009-core-notifier-plain-write-no-awaken.patch
+                      # Boot hotplug: a panel connected at boot produces no HPD edge, so
+                      # the host DCE never sends the hotplug event and the SOR is never
+                      # assigned (dark until manual replug). Schedule the deferred
+                      # hotplug work once at init.
+                      ./patches/0020-synthesize-boot-hotplug-long-pulse.patch
+                      # Drop the host DCE R5's flip-completion event: it lands ~130ms
+                      # after kickoff (~8-10fps ceiling), not a usable per-flip signal
+                      # under passthrough. Completion is driven by 0013's vblank
+                      # qualification instead.
+                      ./patches/0010-dce-drop-r5-completion-event.patch
+                      # Window-channel completion notifier: plain WRITE, never
+                      # WRITE_AWAKEN -- same R5 abort as the core channel (0009).
+                      # Native-R5 60fps completion (WRITE_AWAKEN gated on the active
+                      # primary) is blocked on an intermittent window-channel
+                      # BEGUN->FINISHED latch failure at 60fps kickoff (closed R5
+                      # firmware); see branch native-r5-experimental.
+                      ./patches/0011-window-notifier-plain-write.patch
+                      # Complete each committed flip 2 physical vblank callbacks after
+                      # it was armed -- a scanout-latch margin, tear-free at ~30fps. The
+                      # R5-latch-reliable path while native-R5 60fps stays blocked on
+                      # closed R5/window-channel firmware.
+                      ./patches/0013-drm-vblank-flip-completion.patch
+                    ]
+                    # Experiment B (display-no-host1x): NVKMS no-syncpt path.
+                    # Branch-scoped — never globally disable syncpoints.
+                    ++ lib.optional displayOnly ./patches/0021-nvkms-force-no-syncpt-support.patch;
+                  # DCE display proxy (guest side): redirect the guest's DCE IPC through
+                  # the shared MMIO window and skip the R5 bootstrap (R5 is host-owned).
+                  # The hook patch targets the nvidia-oot project root (no nvidia-oot/
+                  # prefix), so apply it scoped to nvidia-oot/; splice the guest proxy in
+                  # as its own obj-m .ko (it links tegra-dce's exports, so it must build
+                  # inside nvidia-oot).
                   postPatch = (o.postPatch or "") + ''
                     patch -p1 -d nvidia-oot < ${../../common/dce-virt-common/patches/0001-dce-virt-hooks.patch}
-                    # Reverse-doorbell stage 2: export the async-event injector
-                    # the guest proxy uses to deliver relayed ch3 events to
-                    # nvdisplay's RM_EVENT client.
+                    # Reverse-doorbell stage 2: export the async-event injector the guest
+                    # proxy uses to deliver relayed ch3 events to nvdisplay's RM_EVENT client.
                     patch -p1 -d nvidia-oot < ${../../common/dce-virt-common/patches/0002-dce-client-ipc-inject.patch}
                     install -D ${../../common/dce-virt-common/sources/drivers/platform/tegra/dce-guest-proxy/dce-guest-proxy.c} \
                       nvidia-oot/drivers/platform/tegra/dce/dce-guest-proxy.c
@@ -578,33 +647,33 @@ in
               }
             )
           );
-          # nvidia-drm.modeset=1 + fbdev=1: bring up the NVIDIA KMS layer and its
-          # fbcon. fbcon drawing to the panel is the modeset TRIGGER that makes
-          # nvdisplay bring up display -> DCE handshake via the proxy -> scanout.
-          # Without a modeset request nothing drives the display (binds but idle).
+          # nvidia-drm.modeset=1 + fbdev=1: bring up the NVIDIA KMS layer and fbcon.
+          # fbcon drawing to the panel is the modeset TRIGGER that makes nvdisplay
+          # bring up display -> DCE handshake via proxy -> scanout. Without a modeset
+          # request the device binds but stays idle.
           boot.kernelParams = [
             "clk_ignore_unused"
             "pd_ignore_unused"
             "nvidia-drm.modeset=1"
-            # Never auto-disable vblank interrupts. nvidia-drm disables them when
-            # the last flip completes; under the DCE proxy each re-enable is a
-            # synchronous EVENT_SET_NOTIFICATION RPC to the R5 (~10ms) plus a slow
-            # stream restart, quantizing flips to ~122ms (~8 fps). Always-on, the
+            # Never auto-disable vblank interrupts. nvidia-drm disables them when the
+            # last flip completes; under the DCE proxy each re-enable is a synchronous
+            # EVENT_SET_NOTIFICATION RPC to the R5 (~10ms) plus a slow stream restart,
+            # quantizing flips to ~122ms (~8 fps). With the vblank stream always on the
             # R5 emits completions at the 60Hz vblank cadence.
             "drm.vblankoffdelay=0"
-            # NB: this nvidia-drm build REJECTS fbdev ("unknown parameter"), so no
-            # fbcon and nothing auto-requests a modeset -- connector detected with
-            # a full mode list but unlit until a DRM client sets a mode. Kept in
-            # case a driver that supports it is used later.
+            # NB: this nvidia-drm build REJECTS fbdev, so there's no fbcon and nothing
+            # auto-requests a modeset -- the connector is detected but stays unlit until
+            # a DRM client sets a mode. Kept only in case a driver that supports it is
+            # used later.
             "nvidia-drm.fbdev=1"
-            # NOTE: do NOT add "video=DP-1:...e" here. The trailing 'e' forces the
-            # connector on (DRM_FORCE_ON) -> nvidia-drm sets forceConnected ->
-            # nvDpyGetDynamicData short-circuits to "connected" for the DP displayId
-            # before consulting the DP lib or RM. The AGX DP port is DP++ dual-mode
-            # (0x100 SOR_DP_A and 0x200 SINGLE_TMDS_A share one DRM connector, two
-            # encoders); forcing the DP encoder on stops detect there, so the TMDS
-            # partner -- where a passive HDMI adapter's sink lives -- is never
-            # probed, and every EDID read fails on AUX.
+            # NOTE: do NOT add "video=DP-1:...e". The trailing 'e' forces the connector
+            # on (DRM_FORCE_ON) -> nvidia-drm sets forceConnected and nvDpyGetDynamicData
+            # short-circuits to "connected" for the DisplayPort displayId before it
+            # consults the DP lib or RM. The AGX DP port is DP++ dual-mode (0x100
+            # SOR_DP_A + 0x200 SINGLE_TMDS_A are one connector, two encoders); forcing
+            # the DP encoder on stops connector detect there, so the TMDS partner --
+            # where a passive HDMI adapter's sink lives -- is never probed and every
+            # EDID read fails on AUX forever.
           ];
 
           assertions = [
@@ -616,32 +685,42 @@ in
             }
           ];
 
-          # OOT GPU drivers don't autoload from a DT match (unlike in-tree
-          # dwmac), so load them explicitly -- else nothing binds gpu@17000000,
-          # no /dev/nvgpu|nvmap|nvhost-*, and CUDA's NvRmMemMgr init fails.
+          # OOT GPU drivers don't autoload from a DT match, so load them explicitly --
+          # else nothing binds gpu@17000000, no /dev/nvgpu|nvmap|nvhost-*, and CUDA's
+          # NvRmMemMgr init fails.
           boot.extraModulePackages = [ config.boot.kernelPackages.nvidia-oot-modules ];
-          boot.kernelModules = [
-            "nvmap"
-            "host1x"
-            "nvhost"
-            "nvgpu"
+          boot.kernelModules =
+            # nvmap/host1x(sw)/nvhost/nvgpu: the GPU compute stack. host1x here is the
+            # software module satisfying nvgpu's symbols, not the physical VFIO device.
+            # Dropped in the display-only VM (no GA10B there).
+            lib.optionals (!displayOnly) [
+              "nvmap"
+              "host1x"
+              "nvhost"
+              "nvgpu"
+            ]
             # DCE display proxy (guest): tegra-dce binds the synthetic dce node
             # (dce-virtual-pa, no reg) in proxy mode; dce-guest-proxy binds the
-            # nvidia,dce-guest-proxy node, ioremaps the shared window, installs the
-            # send redirect. Neither autoloads (OOT), so load explicitly;
-            # dce-guest-proxy links tegra-dce's redirect symbol, so tegra-dce first.
-            "tegra-dce"
-            "dce-guest-proxy"
+            # nvidia,dce-guest-proxy node, ioremaps the shared window and installs the
+            # send redirect. Neither autoloads from a DT match, so load explicitly.
+            # dce-guest-proxy links tegra-dce's redirect symbol, so tegra-dce is ordered first.
+            #
             # Display KMS stack: gives the guest a /dev/dri KMS device + crtcs for
-            # display@13800000 (bound by nv_platform). With modeset=1 + fbdev=1
-            # fbcon draws to the panel -> modeset -> nvdisplay display -> DCE
-            # handshake via the proxy. nvidia-drm pulls nvidia-modeset + nvidia.
-            "nvidia-modeset"
-            "nvidia-drm"
-          ];
+            # display@13800000. With nvidia-drm.modeset=1 + fbdev=1 fbcon draws to the
+            # panel -> the modeset that brings up display -> DCE handshake via proxy.
+            # nvidia-drm pulls nvidia-modeset + nvidia via deps. Dropped in compute-only.
+            # nvmap appears in both arms deliberately (list de-dups) so either arm alone
+            # is complete.
+            ++ lib.optionals (!dropDisplay) [
+              "nvmap"
+              "tegra-dce"
+              "dce-guest-proxy"
+              "nvidia-modeset"
+              "nvidia-drm"
+            ];
 
-          # gk20a loads falcon microcode from /lib/firmware at probe; without it
-          # the probe times out (-110). Ship the L4T GPU firmware.
+          # gk20a loads falcon microcode from /lib/firmware at probe; without it the
+          # probe times out (-110). Ship the L4T GPU firmware.
           hardware.firmware = [ pkgs.nvidia-jetpack.l4t-firmware ];
 
           boot.kernelPatches = [

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/gpu_passthrough_overlay.dts
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/gpu_passthrough_overlay.dts
@@ -13,6 +13,12 @@
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 
+/*
+ * StreamID for the disp-vm-owned wrapper nodes. Disjoint SMMU group from the
+ * GPU: 0x7d is unassigned on T234 (SIDs jump 0x72 -> 0x7f in tegra234-mc.h) and
+ * != TEGRA234_SID_PASSTHROUGH (0x7f), so gpu-vm and disp-vm never share a stream.
+ */
+#define GHAF_SID_DISPVM 0x7d
 
 / {
     overlay-name = "BPMP host proxy 2";
@@ -44,6 +50,21 @@
                 scanout: scanout@b0000000 {
                     compatible = "removed-dma-pool";
                     reg = <0x0 0xB0000000 0x0 0x08000000>;				// 128MB
+                    status = "okay";
+                };
+                // disp-vm guest RAM = SPLIT carveout (1:1 GPA=HPA). LOW bank:
+                // kernel/initrd + 672MB RAM + 64MB CMA (QEMU -M virt loads kernel
+                // low; all-high -> init killed; <672MB -> init SIGSEGV). HIGH bank
+                // (>4GB): GPU-style carveouts. DMA32 hole 0xe6000000..0x100000000
+                // (416MB) left to host so 14100000.pcie MSI page allocates (WLAN/net-vm).
+                dispram_lo: dispram_lo@b8000000 {
+                    compatible = "removed-dma-pool";
+                    reg = <0x0 0xB8000000 0x0 0x2E000000>;				// 736MB (0xb8..0xe6)
+                    status = "okay";
+                };
+                dispram_hi: dispram_hi@200000000 {
+                    compatible = "removed-dma-pool";
+                    reg = <0x2 0x00000000 0x0 0x1A000000>;				// 416MB @ 8GB (0x200..0x21a)
                     status = "okay";
                 };
             };
@@ -78,8 +99,25 @@
             // (mmio-base=0xb0000000) into the guest for the nvdisplay scanout.
             scanout_p: scanout_p@b0000000 {
                 compatible = "nvidia,dummy";
-                iommus = <&smmu_niso0 TEGRA234_SID_PASSTHROUGH>;
+                iommus = <&smmu_niso0 GHAF_SID_DISPVM> /* concurrent: distinct group from GPU, DMA-less wrapper */;
                 reg = <0x0 0xB0000000 0x0 0x08000000>;				// 128MB
+                dma-coherent;
+                status = "okay";
+            };
+            // disp-vm RAM carveout, 1:1 vfio (mmio-base=0x200000000).
+            // GHAF_SID_DISPVM -> same IOMMU group as the other disp-vm wrappers,
+            // disjoint from GPU.
+            dispram_lo_p: dispram_lo_p@b8000000 {
+                compatible = "nvidia,dummy";
+                iommus = <&smmu_niso0 GHAF_SID_DISPVM>;
+                reg = <0x0 0xB8000000 0x0 0x2E000000>;				// 736MB
+                dma-coherent;
+                status = "okay";
+            };
+            dispram_hi_p: dispram_hi_p@200000000 {
+                compatible = "nvidia,dummy";
+                iommus = <&smmu_niso0 GHAF_SID_DISPVM>;
+                reg = <0x2 0x00000000 0x0 0x1A000000>;				// 416MB @ 8GB
                 dma-coherent;
                 status = "okay";
             };
@@ -87,15 +125,14 @@
     };
 
     // Passthrough devices: set dummy driver + iommus + dma-coherent.
-    // fragment@1 (display@13800000 dummy override) removed: display is NOT
-    // passed through, so the host keeps the REAL display node (stock compatible +
-    // SID_NVDISPLAY). Rewriting it to dummy at DT-parse (before vfio) halts the
-    // host DCE R5 at dce_ss_set (DCE_HALTED @18s, before any vfio bind @28s).
-    // Guest reaches the panel via the DCE host-proxy, never this node.
+    // fragment@1 (display@13800000 dummy override) removed: display NOT passed
+    // through; host keeps the REAL display node (stock compatible + SID_NVDISPLAY).
+    // Rewriting it to dummy halts the host DCE R5 at dce_ss_set. Guest reaches the
+    // panel via the DCE host-proxy.
 
-    // fragment@2 (dce@d800000 dummy override) removed: DCE is NOT passed
-    // through. Host keeps the REAL dce node so host tegra-dce bootstraps and
-    // owns the R5; guest drives the panel via the DCE host-proxy.
+    // fragment@2 (dce@d800000 dummy override) removed: DCE NOT passed through.
+    // Host keeps the REAL dce node so host tegra-dce owns the R5; guest drives the
+    // panel via the DCE host-proxy.
 
     // Dummy framebuffer compatible so UEFI doesn't enable the host framebuffer.
     fragment@3 {
@@ -166,8 +203,7 @@
         };
     };
     
-    // Recreated from scratch: DT can't remove properties from a node, and we
-    // need some of the originals gone.
+    // Recreated from scratch: DT can't remove properties, and some originals must go.
     fragment@7 {
         target-path = "/bus@0";
         __overlay__ {
@@ -268,42 +304,38 @@
         };
     };
 
-    // Keyhole: expose ONLY the 4KB read-only EVO display-capabilities strap page
+    // Keyhole: expose ONLY the 4KB RO EVO display-capabilities strap page
     // (display + 0x30000 = 0x13830000). Guest nvdisplay reads caps here
-    // (NVC673_DISP_CAPABILITIES) at EvoGetCapabilities3; unbacked -> nvidia_modeset
-    // takes a synchronous external abort. Only this RO page, not the whole display
-    // aperture (full passthrough kills the host DCE R5). Straps are RO and not in
-    // DCE's live control plane, so dual-mapping alongside the R5 is safe. Isolated
-    // SID_PASSTHROUGH (group 15, with the carveouts); node does no DMA so SID is inert.
+    // (NVC673_DISP_CAPABILITIES); unbacked -> nvidia_modeset takes a synchronous
+    // external abort. Not the whole display aperture (full passthrough kills the
+    // host DCE R5). Straps are RO, outside DCE's live control plane, so dual-mapping
+    // alongside the R5 is safe. Isolated SID_PASSTHROUGH; node does no DMA so SID is inert.
     fragment@9 {
         target-path = "/";
         __overlay__ {
             disp_caps_pt: disp_caps_pt@13830000 {
                 compatible = "nvidia,dummy";
                 reg = <0x0 0x13830000 0x0 0x1000>;
-                iommus = <&smmu_niso0 TEGRA234_SID_PASSTHROUGH>;
+                iommus = <&smmu_niso0 GHAF_SID_DISPVM> /* concurrent: distinct group */;
                 dma-coherent;
                 status = "okay";
             };
         };
     };
 
-    // Second keyhole: EVO channel DOORBELL registers (PUT/GET). Guest nvkms maps
-    // each DMA channel's control page and writes PUT to tell the DCE R5 to fetch
-    // the pushbuffer. UDISP FE channel-assembly region: core at 0x13870000, window
-    // channels from 0x13880000, 4KB pages. Unbacked -> PUT writes never reach HW,
-    // R5 never fetches, GET stays 0 (nvidia-modeset: waiting for GPU progress,
-    // NVC67E). These are CPU-RM user doorbells (guest IS the CPU RM); R5 owns
-    // core/control -> intended CPU-RM/DCE split. Map the whole region
-    // 0x13870000..0x1388ffff (core + windows + cursor/IMM). Isolated
-    // SID_PASSTHROUGH, no reset -> R5-safe, like the caps page.
+    // Second keyhole: EVO channel DOORBELL registers (PUT/GET). Guest nvkms writes
+    // PUT to tell the DCE R5 to fetch the pushbuffer. Unbacked -> PUT never reaches
+    // HW, R5 never fetches, GET stays 0 (nvidia-modeset: waiting for GPU progress).
+    // CPU-RM user doorbells (guest IS the CPU RM); R5 owns core/control. Map the
+    // whole region 0x13870000..0x1388ffff (core + windows + cursor/IMM). Isolated
+    // SID_PASSTHROUGH, no reset -> R5-safe.
     fragment@10 {
         target-path = "/";
         __overlay__ {
             disp_chan_pt: disp_chan_pt@13870000 {
                 compatible = "nvidia,dummy";
                 reg = <0x0 0x13870000 0x0 0x20000>;
-                iommus = <&smmu_niso0 TEGRA234_SID_PASSTHROUGH>;
+                iommus = <&smmu_niso0 GHAF_SID_DISPVM> /* concurrent: distinct group */;
                 dma-coherent;
                 status = "okay";
             };

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/patches/0021-nvkms-force-no-syncpt-support.patch
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/patches/0021-nvkms-force-no-syncpt-support.patch
@@ -1,0 +1,25 @@
+From: Ghaf contributors <ghaf@tii.ae>
+Subject: [PATCH] nvkms: force no-syncpt support (host1x-ownership experiment)
+
+experiment/orin-two-vm-host1x, display-no-host1x direction. Without a
+physical host1x assigned to the GUI VM, pDevEvo->supportsSyncpts must be
+false or NVKMS's mandatory per-window post-syncpoint allocation fails.
+Force the no-syncpt path so the software compositor drives display with
+CPU buffers and no explicit fences.
+---
+diff --git a/nvdisplay/kernel-open/nvidia-modeset/nvidia-modeset-linux.c b/nvdisplay/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
+--- a/nvdisplay/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
++++ b/nvdisplay/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
+@@ -100,6 +100,12 @@
+ }
+ 
+ NvBool nvkms_kernel_supports_syncpts(void)
+ {
++    /*
++     * experiment/orin-two-vm-host1x (display-no-host1x): force the NVKMS
++     * no-syncpt path so post-syncpoint allocation is skipped when no
++     * physical host1x is assigned to this GUI VM.
++     */
++    return NV_FALSE;
+ /*
+  * Note this only checks that the kernel has the prerequisite

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0002-nvidia-dce-guest-hooks.patch
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0002-nvidia-dce-guest-hooks.patch
@@ -46,7 +46,7 @@ the MMIO at the address the DTS hardcodes.
      [VIRT_NVIDIA_BPMP_GUEST] =  { 0x090d0000, 0x00001000 },
      [VIRT_MMIO] =               { 0x0a000000, 0x00000200 },
      /* ...repeating for a total of NUM_VIRTIO_TRANSPORTS, each of that size */
-@@ -1188,14 +1190,34 @@
+@@ -1188,14 +1190,49 @@
      qemu_fdt_setprop_cell(ms->fdt, "/bpmp", "phandle",
                            qemu_fdt_alloc_phandle(ms->fdt));
  }
@@ -66,6 +66,21 @@ the MMIO at the address the DTS hardcodes.
 +static void create_nvidia_dce_guest(const VirtMachineState *vms)
 +{
 +    hwaddr base = vms->memmap[VIRT_NVIDIA_DCE_GUEST].base;
++
++    /*
++     * Exclusive DCE ownership (opt-in). The host proxy has a single global
++     * event ring; only ONE guest may bridge to it. But EVERY ghaf VM runs this
++     * QEMU, so an unconditional bridge made net-vm/admin-vm/compute-GPU-VM all
++     * open /dev/dce-host and run a reverse-doorbell pump -- racing disp-vm for
++     * that ring (host proxy returns -EAGAIN) and stealing DCE events destined
++     * for disp-vm, holding them forever (they never ack the reverse window) ->
++     * disp-vm scanout starves (black panel). Create the bridge ONLY for the VM
++     * the launcher marks as the display owner via GHAF_DCE_GUEST=1 (disp-vm,
++     * or a display-capable GPU-VM). All other VMs never touch /dev/dce-host.
++     */
++    if (g_strcmp0(getenv("GHAF_DCE_GUEST"), "1") != 0) {
++        return;
++    }
 +
 +    nvidia_dce_guest_create(base);
 +}

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/sources/hw/misc/nvidia_bpmp_guest.c
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/sources/hw/misc/nvidia_bpmp_guest.c
@@ -56,11 +56,14 @@ static uint64_t nvidia_bpmp_guest_read(void *opaque, hwaddr addr, unsigned int s
 {
 	NvidiaBpmpGuestState *s = opaque;
 
-	if (addr >= MEM_SIZE)
+	// Bound the full width, not just addr: a tail read must not leak adjacent
+	// NvidiaBpmpGuestState fields.
+	if (addr > MEM_SIZE - size)
 		return 0xDEADBEEF;
 
-	// Cast buffer location as uint64_t
-	return *(uint64_t*)&s->mem[addr];
+	uint64_t val = 0;
+	memcpy(&val, &s->mem[addr], size); // honor size, not a fixed u64 deref
+	return val;
 }
 
 static void nvidia_bpmp_guest_write(void *opaque, hwaddr addr, uint64_t data, unsigned int size)
@@ -86,8 +89,10 @@ static void nvidia_bpmp_guest_write(void *opaque, hwaddr addr, uint64_t data, un
 
 	memset(&messg, 0, sizeof(messg));
 
-	if (addr >= MEM_SIZE){
-		qemu_log_mask(LOG_UNIMP, "qemu: Error addr >= MEM_SIZE in 0x%lX data: 0x%lX\n", addr, data);
+	// Bound the full width: a tail write must not clobber adjacent
+	// NvidiaBpmpGuestState fields.
+	if (addr > MEM_SIZE - size){
+		qemu_log_mask(LOG_UNIMP, "qemu: Error addr+size > MEM_SIZE in 0x%lX data: 0x%lX\n", addr, data);
 		return;
 	}
 
@@ -125,6 +130,16 @@ static const MemoryRegionOps nvidia_bpmp_guest_ops = {
 	.read = nvidia_bpmp_guest_read,
 	.write = nvidia_bpmp_guest_write,
 	.endianness = DEVICE_NATIVE_ENDIAN,
+	// QEMU clamps to 1..8-byte aligned accesses before the handlers run.
+	.valid = {
+		.min_access_size = 1,
+		.max_access_size = 8,
+		.unaligned = false,
+	},
+	.impl = {
+		.min_access_size = 1,
+		.max_access_size = 8,
+	},
 };
 
 static void nvidia_bpmp_guest_instance_init(Object *obj)

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/sources/hw/misc/nvidia_dce_guest.c
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/sources/hw/misc/nvidia_dce_guest.c
@@ -170,11 +170,14 @@ static uint64_t nvidia_dce_guest_read(void *opaque, hwaddr addr, unsigned int si
 {
 	NvidiaDceGuestState *s = opaque;
 
-	if (addr >= MEM_SIZE)
+	// Bound the full width, not just addr: a tail read must not leak adjacent
+	// NvidiaDceGuestState fields.
+	if (addr > MEM_SIZE - size)
 		return 0xDEADBEEF;
 
-	// Cast buffer location as uint64_t
-	return *(uint64_t*)&s->mem[addr];
+	uint64_t val = 0;
+	memcpy(&val, &s->mem[addr], size); // honor size, not a fixed u64 deref
+	return val;
 }
 
 static void nvidia_dce_guest_write(void *opaque, hwaddr addr, uint64_t data, unsigned int size)
@@ -186,8 +189,10 @@ static void nvidia_dce_guest_write(void *opaque, hwaddr addr, uint64_t data, uns
 
 	memset(&messg, 0, sizeof(messg));
 
-	if (addr >= MEM_SIZE){
-		qemu_log_mask(LOG_UNIMP, "qemu: Error addr >= MEM_SIZE in 0x%lX data: 0x%lX\n", addr, data);
+	// Bound the full width: a tail write must not clobber adjacent
+	// NvidiaDceGuestState fields (host_device_fd, thread state, evt_seq).
+	if (addr > MEM_SIZE - size){
+		qemu_log_mask(LOG_UNIMP, "qemu: Error addr+size > MEM_SIZE in 0x%lX data: 0x%lX\n", addr, data);
 		return;
 	}
 
@@ -225,6 +230,16 @@ static const MemoryRegionOps nvidia_dce_guest_ops = {
 	.read = nvidia_dce_guest_read,
 	.write = nvidia_dce_guest_write,
 	.endianness = DEVICE_NATIVE_ENDIAN,
+	// QEMU clamps to 1..8-byte aligned accesses before the handlers run.
+	.valid = {
+		.min_access_size = 1,
+		.max_access_size = 8,
+		.unaligned = false,
+	},
+	.impl = {
+		.min_access_size = 1,
+		.max_access_size = 8,
+	},
 };
 
 static void nvidia_dce_guest_instance_init(Object *obj)


### PR DESCRIPTION

## Description of Changes

Adds an Orin AGX two-VM topology where **physical host1x belongs to exactly one
VM** while the other still performs its role, resolving the host1x-ownership
question on hardware.

A branch-only selector `ghaf.hardware.nvidia.passthroughs.gpu_vm.host1xExperiment`
(`off` | `compute-no-host1x` | `display-no-host1x` | `compute-with-host1x`) gates
VFIO engine/carveout/keyhole ownership, guest kernel-module load, and cpp `-D`
flags that strip nodes from the guest device tree. **`off` is byte-identical to
the baseline.** A second `disp-vm` microvm provides the display role.

**Measured verdict (Orin AGX):**
- GPU compute **without** host1x: **FAIL** — `cuInit` returns `801 NOT_SUPPORTED`
  (3/3). CUDA requires physical host1x.
- Software display **without** host1x: **PASS** — no-syncpoint NVKMS lights the
  physical panel.
- **Concurrent split: PASS** — the `compute-with-host1x` GPU VM runs CUDA
  (`sm_87`, `gpu-vm-load` ~229–243 iters) at the same instant `disp-vm` holds a
  3440×1440 modeset with color bars on the physical DP-1 monitor, with **disjoint
  IOMMU groups**. Held through ~20 min soak and a GPU-VM restart (display
  survived; CUDA recovered).

Six enabling fixes are included (see commits): split-RAM disp-vm layout
(preserves the host DMA32 hole so PCIe MSI / net-vm WLAN keep working); a distinct
SMMU StreamID (`0x7d`) on the DMA-less display wrappers for a separate IOMMU
group; dropping `reusable` from the out-of-RAM `dce_scanout` node (fixes a
deterministic CMA `pfn_valid` panic); mapping the disp-vm scanout CMA at
`0xe2000000` into both the ISO SID-1 and NISO SID-7 DCE anchors (fixes the SID-7
scanout fault); and making the QEMU DCE guest bridge **opt-in** via
`GHAF_DCE_GUEST` so only the display VM opens `/dev/dce-host` (stops other VMs
stealing its DCE events).

### Type of Change

- [x] New feature
- [x] Documentation


## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed (DCO sign-off on all commits)
- [x] Ghaf documentation updated with the commit
- [x] Author has added reviewers and removed PR draft status — **kept as draft**

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`

### Installation Method

- [x] Requires full re-installation (deployed here as a persistent ESP generation)

### Test Steps To Verify:

1. Build the AGX debug toplevel from this branch:
   `nix build .#nixosConfigurations."nvidia-jetson-orin-agx-debug-from-x86_64".config.system.build.toplevel`.
2. Set `nvidia.passthroughs.gpu_vm.host1xExperiment = "compute-with-host1x"` and
   `nvidia.passthroughs.disp_vm.enable = true` (already set in `orin-agx.nix` on
   this branch); flash/boot the AGX.
3. Confirm three VMs active concurrently (`microvm@{net,gpu,disp}-vm`) with
   disjoint IOMMU groups for `17000000.gpu` vs the disp-vm scanout devices.
4. On the GPU VM run `gpu-vm-load` → expect `GPU_LOAD_OK`, `sm_87`.
5. On the display VM, hold a modeset:
   `sleep infinity | modetest -M nvidia-drm -s <DP-1 conn>@<crtc>:1920x1080` →
   expect color bars on the physical monitor, zero SID-7 SMMU faults.
6. Set `host1xExperiment = "off"` and confirm the built DTB/closure is
   byte-identical to the baseline (no behavior change).

