### PR TITLE
fix(qemu-bpmp): restore vfio-platform irqfd fast path on gicv3

### DIFF
--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/mgbe0-net-vm/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/mgbe0-net-vm/default.nix
@@ -181,7 +181,11 @@ in
           # the nvidia,tegra234-mgbe binding in sysbus-fdt.c); there is no -dtb.
           microvm.qemu.extraArgs = [
             "-device"
-            "vfio-platform,host=6800000.ethernet"
+            # startup-rearm recovers MGBE0's level IRQ if it asserts during the
+            # ~17s bring-up gap before the guest stmmac driver claims the SPI.
+            # Default-off in QEMU; enabled here only, bounded to 30s (see
+            # ghaf-qemu-bpmp patch 0006).
+            "vfio-platform,host=6800000.ethernet,startup-rearm=on"
           ];
         }
       )

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp-gpu/package.nix
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp-gpu/package.nix
@@ -20,6 +20,9 @@
 { ghaf-qemu-bpmp }:
 ghaf-qemu-bpmp.override {
   variantName = "-gpu";
+  # irqfd fast path was validated on MGBE0 only; the GPU/host1x/display devices have
+  # not been tried on it and the display bring-up depends on their interrupt behaviour.
+  withIrqfdFastPath = false;
   extraPatches = [
     ../ghaf-qemu-bpmp/patches/0002-vfio-platform-mmio-base.patch
     ../ghaf-qemu-bpmp/patches/0003-nop-predefined-dtb-memory.patch

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/package.nix
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/package.nix
@@ -12,6 +12,10 @@
 # is the last release that has it. Only the VM receiving such a device uses this
 # QEMU (set via microvm.qemu.package); everything else stays on pkgs.ghaf-qemu.
 #
+# 11.0.1 still lacks vfio-platform (checked 2026-07-21), so the pin holds. When
+# base ghaf-qemu bumps QEMU its patches may stop applying here -- fix the
+# prev.patches filter below, don't drop the pin.
+#
 # The pin is a security liability: net-vm is network-facing and won't get QEMU
 # fixes past 10.1.x. Revisit if upstream restores platform passthrough.
 #
@@ -19,11 +23,13 @@
 # and rename the binary. pkgs-by-name auto-calls with {}, so both default to the
 # net-vm build -- pkgs.ghaf-qemu-bpmp is byte-identical to before.
 {
+  lib,
   ghaf-qemu,
   fetchurl,
-  lib,
   extraPatches ? [ ],
   variantName ? "",
+  # validated on MGBE0 only; the GPU variant opts out
+  withIrqfdFastPath ? true,
   ...
 }:
 ghaf-qemu.overrideAttrs (
@@ -40,11 +46,25 @@ ghaf-qemu.overrideAttrs (
     # series (extended-GPE / Battery / AC-adapter / lid-button) no longer applies
     # to the pinned 10.1.5 and is irrelevant to the Orin aarch64 microvm. Drop it
     # so the package builds; keep everything else.
+    #
+    # 0004-0006 fix vfio-platform's irqfd fast path on GICv3 (the GICv3 model never
+    # registered the qemu_irq->GSI map, so every IRQ trapped to userspace). One unit,
+    # do not split: 0004 alone kills the NIC. With 0001's AXI config: 76 -> 944 Mbit/s.
+    # net-vm only; the GPU variant sets withIrqfdFastPath = false.
+    # The hw-acpi- series is x86-only in base ghaf-qemu (isx86_64-guarded), so on
+    # the aarch64 Orin guest prev.patches carries none and this filter is a no-op;
+    # it only bites if base ever makes them cross-platform. No count assert: the
+    # expected number is 0 here and 4 on x86, so a fixed check would be wrong.
     patches =
       (lib.filter (p: !(lib.hasInfix "hw-acpi-" (baseNameOf p))) (prev.patches or [ ]))
       ++ [
         ./patches/0001-nvidia-bpmp-guest-hooks.patch
         ./patches/0002-nvidia-dce-guest-hooks.patch
+      ]
+      ++ lib.optionals withIrqfdFastPath [
+        ./patches/0004-arm-gicv3-kvm-register-qemuirq-gsi.patch
+        ./patches/0005-vfio-platform-unmask-after-resamplefd.patch
+        ./patches/0006-vfio-platform-rearm-automasked-lines.patch
       ]
       ++ extraPatches;
 

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0001-nvidia-bpmp-guest-hooks.patch
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0001-nvidia-bpmp-guest-hooks.patch
@@ -125,7 +125,7 @@ Rebased from tiiuae/ghaf PR #1240 (QEMU 9.2). The MGBE0 binding is new.
      VIRT_UART1,
 --- a/hw/core/sysbus-fdt.c
 +++ b/hw/core/sysbus-fdt.c
-@@ -509,11 +509,151 @@
+@@ -509,11 +509,172 @@
  #define TYPE_BINDING(type, add_fn) {(type), NULL, (add_fn), NULL}
  
  /* list of supported dynamic sysbus bindings */
@@ -259,6 +259,27 @@ Rebased from tiiuae/ghaf PR #1240 (QEMU 9.2). The MGBE0 binding is new.
 +                              "resets", bpmp_phandle, 2);
 +    tegra_mgbe_copy_bpmp_prop(host_fdt, guest_fdt, node_path[0], nodename,
 +                              "power-domains", bpmp_phandle, 2);
++
++    /*
++     * snps,axi-config: mainline stmmac skips DMA burst/osr programming without
++     * this child. Synthesize a guest-local one (the host phandle is meaningless
++     * here). snps,blen is 7 cells: mainline reads it with AXI_BLEN=7 and drops
++     * the whole property (-EOVERFLOW) on fewer.
++     */
++    {
++        char *axi_node = g_strdup_printf("%s/stmmac-axi-config", nodename);
++        uint32_t axi_phandle = qemu_fdt_alloc_phandle(guest_fdt);
++
++        qemu_fdt_add_subnode(guest_fdt, axi_node);
++        qemu_fdt_setprop_cell(guest_fdt, axi_node, "phandle", axi_phandle);
++        qemu_fdt_setprop_cells(guest_fdt, axi_node, "snps,blen",
++                               256, 128, 64, 32, 16, 8, 4);
++        qemu_fdt_setprop_cell(guest_fdt, axi_node, "snps,rd_osr_lmt", 63);
++        qemu_fdt_setprop_cell(guest_fdt, axi_node, "snps,wr_osr_lmt", 63);
++        qemu_fdt_setprop_cell(guest_fdt, nodename, "snps,axi-config",
++                              axi_phandle);
++        g_free(axi_node);
++    }
 +
 +    g_free(host_fdt);
 +    g_strfreev(node_path);

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0004-arm-gicv3-kvm-register-qemuirq-gsi.patch
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0004-arm-gicv3-kvm-register-qemuirq-gsi.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ghaf contributors <ghaf@tii.ae>
+Date: Mon, 20 Jul 2026 12:00:00 +0300
+Subject: [PATCH] hw/intc/arm_gicv3_kvm: register qemu_irq -> GSI mapping
+
+kvm_irqchip_add_irqfd_notifier() resolves a qemu_irq to a KVM GSI via
+KVMState->gsimap, which is populated only by kvm_irqchip_set_qemuirq_gsi().
+Its sole caller is the GICv2 KVM model (hw/intc/arm_gic_kvm.c); the GICv3
+model never registered its lines. On a GICv3 machine the lookup therefore
+always misses and the notifier returns -ENXIO.
+
+vfio-platform reacts to that failure by falling back from the irqfd fast
+path to userspace eventfd injection (hw/vfio/platform.c:382). In that mode
+vfio_intp_interrupt() calls vfio_mmap_set_enabled(vdev, false) on every
+interrupt so the guest's status-register clear can be trapped and treated as
+EOI, and it re-arms the mmap timer unconditionally on each interrupt. Under
+sustained load the timeout (default 1100 ms) is refreshed faster than it can
+expire, so the device MMIO is never re-mapped and every register access in
+the guest's interrupt path becomes a userspace exit.
+
+Measured on a Jetson AGX Orin passing the on-SoC MGBE0 ethernet controller
+to a guest: ~12 userspace MMIO exits per interrupt, ~60% of a vCPU in
+hard-IRQ context, and throughput pinned at ~100 Mbit/s on a 1 Gbps link.
+
+arm64 KVM has advertised KVM_CAP_IRQFD_RESAMPLE since commit 52882b9c7a76,
+and the vGICv3 signals EOI for level-triggered SPIs via kvm_notify_acked_irq,
+so the resampling irqfd path works once the mapping exists.
+---
+--- a/hw/intc/arm_gicv3_kvm.c
++++ b/hw/intc/arm_gicv3_kvm.c
+@@ -823,6 +823,22 @@
+ 
+     gicv3_init_irqs_and_mmio(s, kvm_arm_gicv3_set_irq, NULL);
+ 
++    /*
++     * Register the qemu_irq -> GSI mapping for every SPI. Devices that inject
++     * interrupts via an irqfd (notably vfio-platform) look their line up here
++     * through kvm_irqchip_add_irqfd_notifier(); without an entry that call
++     * fails with -ENXIO and the device silently falls back to routing every
++     * interrupt through userspace. For vfio-platform that fallback also
++     * disables the MMIO mmap on each interrupt to infer EOI, so a busy device
++     * traps every register access and loses most of its throughput.
++     *
++     * The GICv2 KVM model has always done this (hw/intc/arm_gic_kvm.c); the
++     * GICv3 model never did, leaving the fast path unreachable on GICv3.
++     */
++    for (i = 0; i < s->num_irq - GIC_INTERNAL; i++) {
++        kvm_irqchip_set_qemuirq_gsi(kvm_state, qdev_get_gpio_in(dev, i), i);
++    }
++
+     for (i = 0; i < s->num_cpu; i++) {
+         ARMCPU *cpu = ARM_CPU(qemu_get_cpu(i));
+ 
+-- 
+2.49.0

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0005-vfio-platform-unmask-after-resamplefd.patch
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0005-vfio-platform-unmask-after-resamplefd.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ghaf contributors <ghaf@tii.ae>
+Date: Mon, 20 Jul 2026 17:00:00 +0300
+Subject: [PATCH] hw/vfio/platform: unmask the line after arming the resamplefd
+
+vfio enables the IRQ inside vfio_start_irqfd_injection() (from
+sysbus_connect_irq() during device connect), before the guest installs a
+handler for the SPI. An assertion in that window is auto-masked, and on the
+irqfd path only the resamplefd re-arms the line - which needs a guest EOI for
+an interrupt it never got, so it stays masked forever. (Measured on an AGX
+Orin: host vfio IRQ fires once, guest SPI stays 0, NIC receives nothing.) The
+userspace path self-heals via vfio_platform_eoi() on any MMIO.
+
+Unmask once after the resamplefd is armed, opt-in via the "startup-rearm"
+property so no other vfio-platform device is affected. This patch carries the
+struct field + property so it is independently buildable and bisectable; the
+bounded retry loop (next patch) builds on top of it.
+---
+--- a/hw/vfio/platform.c
++++ b/hw/vfio/platform.c
+@@ -403,6 +403,15 @@
+         if (vfio_set_resample_eventfd(intp) < 0) {
+             goto fail_vfio;
+         }
++
++        /*
++         * The line is armed during device connect, before the guest installs
++         * its SPI handler; a stale assertion then wedges it (only the resamplefd
++         * re-arms on irqfd, and it needs a guest EOI). Opt-in unmask once here.
++         */
++        if (vdev->startup_rearm) {
++            vfio_device_irq_unmask(&vdev->vbasedev, intp->pin);
++        }
+         trace_vfio_platform_start_level_irqfd_injection(intp->pin,
+                                     event_notifier_get_fd(intp->interrupt),
+                                     event_notifier_get_fd(intp->unmask));
+@@ -653,6 +662,7 @@
+     DEFINE_PROP_UINT32("mmap-timeout-ms", VFIOPlatformDevice,
+                        mmap_timeout, 1100),
+     DEFINE_PROP_BOOL("x-irqfd", VFIOPlatformDevice, irqfd_allowed, true),
++    DEFINE_PROP_BOOL("startup-rearm", VFIOPlatformDevice, startup_rearm, false),
+ #ifdef CONFIG_IOMMUFD
+     DEFINE_PROP_LINK("iommufd", VFIOPlatformDevice, vbasedev.iommufd,
+                      TYPE_IOMMUFD_BACKEND, IOMMUFDBackend *),
+--- a/include/hw/vfio/vfio-platform.h
++++ b/include/hw/vfio/vfio-platform.h
+@@ -60,6 +60,7 @@
+     unsigned int num_compat; /* number of compatible values */
+     uint32_t mmap_timeout; /* delay to re-enable mmaps after interrupt */
+     QEMUTimer *mmap_timer; /* allows fast-path resume after IRQ hit */
++    bool startup_rearm; /* opt-in: re-arm early automasked lines at boot */
+     QemuMutex intp_mutex; /* protect the intp_list IRQ state */
+     bool irqfd_allowed; /* debug option to force irqfd on/off */
+ };
+--
+2.49.0

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0006-vfio-platform-rearm-automasked-lines.patch
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/patches/0006-vfio-platform-rearm-automasked-lines.patch
@@ -1,0 +1,133 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ghaf contributors <ghaf@tii.ae>
+Date: Mon, 20 Jul 2026 18:00:00 +0300
+Subject: [PATCH] hw/vfio/platform: bounded opt-in re-arm for early automasked
+ lines
+
+Unmasking once when the resamplefd is armed (previous patch) is not enough:
+vfio arms the line from vfio_start_irqfd_injection() (sysbus_connect_irq(),
+during device connect), ~17s before the guest driver requests the SPI when it
+opens the interface. An assertion in that gap is injected while nobody is
+listening, never EOId, so the resamplefd never fires and the line stays masked
+forever - the device goes silent.
+
+The userspace path self-heals via vfio_platform_eoi() on any MMIO. A perpetual,
+all-device unmask would bypass the resamplefd contract (a paused/reset/quiesced
+guest would get its line rearmed with no matching EOI), so make it opt-in and
+bounded:
+
+  - off unless "startup-rearm=on" is set on the device (default false);
+  - runs only for "startup-rearm-window" ms after the first arm (default 30s);
+  - on QEMU_CLOCK_VIRTUAL, which freezes while the guest is paused.
+
+Note this re-arms *every* kvm_accel level line for the window, not only the
+startup-wedged one: on the irqfd path intp->state is not maintained (the
+eventfd goes straight to KVM, bypassing vfio_intp_interrupt), so the loop
+cannot distinguish a wedged line from a live one. Harmless in this deployment -
+unmasking an already-unmasked line is a no-op, and MGBE0, the only opted-in
+device, is single-IRQ and quiescent during bring-up.
+
+Set startup-rearm-window=0 for perpetual recovery if a deployment needs it
+past the window.
+---
+--- a/hw/vfio/platform.c
++++ b/hw/vfio/platform.c
+@@ -182,6 +182,41 @@ static void vfio_intp_mmap_enable(void *opaque)
+     vfio_mmap_set_enabled(vdev, true);
+ }
+ 
++/**
++ * vfio_platform_unmask_watchdog - re-arm level lines automasked before the
++ * guest was listening. On irqfd only the resamplefd re-arms an automasked
++ * line, and it fires only after a guest EOI - but the line is armed long
++ * before the guest requests the SPI, so an early assertion wedges it.
++ *
++ * NB: on the irqfd path intp->state is not maintained (the eventfd goes
++ * straight to KVM, bypassing vfio_intp_interrupt), so this cannot tell a
++ * startup-wedged line from one legitimately cycling - it re-arms EVERY
++ * kvm_accel level line once a second for the whole window. Harmless here:
++ * unmasking an already-unmasked line is a no-op, this is opt-in, and MGBE0
++ * (the only opted-in device) is single-IRQ and idle during bring-up. A future
++ * multi-IRQ opt-in must accept that all its level lines are re-armed for the
++ * window. Bounded to the startup window; QEMU_CLOCK_VIRTUAL freezes on pause.
++ */
++static void vfio_platform_unmask_watchdog(void *opaque)
++{
++    VFIOPlatformDevice *vdev = (VFIOPlatformDevice *)opaque;
++    int64_t now = qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL);
++    VFIOINTp *intp;
++
++    if (vdev->startup_rearm_window && now >= vdev->startup_rearm_deadline) {
++        return; /* window elapsed: let the resamplefd contract own the line */
++    }
++
++    WITH_QEMU_LOCK_GUARD(&vdev->intp_mutex) {
++        QLIST_FOREACH(intp, &vdev->intp_list, next) {
++            if (intp->kvm_accel && vfio_irq_is_automasked(intp)) {
++                vfio_device_irq_unmask(&vdev->vbasedev, intp->pin);
++            }
++        }
++    }
++    timer_mod(vdev->unmask_timer, now + 1000);
++}
++
+ /**
+  * vfio_intp_inject_pending_lockheld - Injects a pending IRQ
+  * @opaque: opaque pointer, in practice the VFIOINTp handle
+@@ -420,6 +455,15 @@ static void vfio_start_irqfd_injection(SysBusDevice *sbdev, qemu_irq irq)
+                                     event_notifier_get_fd(intp->interrupt));
+     }
+ 
++    /* The resamplefd alone cannot recover a line masked before the guest was
++     * listening. If this device opted in, run a low-rate re-arm bounded to the
++     * startup window. */
++    if (vdev->startup_rearm && !vdev->startup_rearm_deadline) {
++        int64_t now = qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL);
++        vdev->startup_rearm_deadline = now + vdev->startup_rearm_window;
++        timer_mod(vdev->unmask_timer, now + 1000);
++    }
++
+     intp->kvm_accel = true;
+ 
+     return;
+@@ -479,6 +523,8 @@ static bool vfio_populate_device(VFIODevice *vbasedev, Error **errp)
+ 
+     vdev->mmap_timer = timer_new_ms(QEMU_CLOCK_VIRTUAL,
+                                     vfio_intp_mmap_enable, vdev);
++    vdev->unmask_timer = timer_new_ms(QEMU_CLOCK_VIRTUAL,
++                                      vfio_platform_unmask_watchdog, vdev);
+ 
+     QSIMPLEQ_INIT(&vdev->pending_intp_queue);
+ 
+@@ -503,6 +549,7 @@ static bool vfio_populate_device(VFIODevice *vbasedev, Error **errp)
+     return true;
+ irq_err:
+     timer_del(vdev->mmap_timer);
++    timer_del(vdev->unmask_timer);
+     QLIST_FOREACH_SAFE(intp, &vdev->intp_list, next, tmp) {
+         QLIST_REMOVE(intp, next);
+         g_free(intp);
+@@ -647,6 +694,8 @@ static const Property vfio_platform_dev_properties[] = {
+                        mmap_timeout, 1100),
+     DEFINE_PROP_BOOL("x-irqfd", VFIOPlatformDevice, irqfd_allowed, true),
+     DEFINE_PROP_BOOL("startup-rearm", VFIOPlatformDevice, startup_rearm, false),
++    DEFINE_PROP_UINT32("startup-rearm-window", VFIOPlatformDevice,
++                       startup_rearm_window, 30000),
+ #ifdef CONFIG_IOMMUFD
+     DEFINE_PROP_LINK("iommufd", VFIOPlatformDevice, vbasedev.iommufd,
+                      TYPE_IOMMUFD_BACKEND, IOMMUFDBackend *),
+--- a/include/hw/vfio/vfio-platform.h
++++ b/include/hw/vfio/vfio-platform.h
+@@ -60,7 +60,10 @@ struct VFIOPlatformDevice {
+     unsigned int num_compat; /* number of compatible values */
+     uint32_t mmap_timeout; /* delay to re-enable mmaps after interrupt */
+     QEMUTimer *mmap_timer; /* allows fast-path resume after IRQ hit */
++    QEMUTimer *unmask_timer; /* re-arms lines masked before the guest listened */
+     bool startup_rearm; /* opt-in: re-arm early automasked lines at boot */
++    uint32_t startup_rearm_window; /* ms after first arm to keep re-arming (0 = forever) */
++    int64_t startup_rearm_deadline; /* QEMU_CLOCK_VIRTUAL ms; 0 until armed */
+     QemuMutex intp_mutex; /* protect the intp_list IRQ state */
+     bool irqfd_allowed; /* debug option to force irqfd on/off */
+ };
+-- 
+2.49.0


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

MGBE0 passthrough into net-vm topped out ~76 Mbit/s on a 1 Gbps link. Two independent causes, both in QEMU:

- **No irqfd on GICv3.** `arm_gic_kvm.c` registers the `qemu_irq->GSI` map `kvm_irqchip_add_irqfd_notifier()` needs; the GICv3 model never did, so vfio-platform fell back to userspace injection — ~12 MMIO exits per IRQ. `0004` mirrors the GICv2 loop.
- **No DMA burst config.** Mainline stmmac skips `stmmac_init_dma_engine` without an `snps,axi-config` child; the guest node had none. `add_tegra_mgbe_fdt_node()` now synthesizes a guest-local one. `snps,blen` is 7 cells — mainline reads it with `AXI_BLEN=7` and silently drops the whole property (`-EOVERFLOW`) on fewer.

Once irqfd binds, an assertion in the ~17 s gap between vfio arming the line (during device connect) and the guest requesting the SPI wedges it permanently. `0005`/`0006` recover it via a **default-off, MGBE0-only `startup-rearm`** property, bounded to `startup-rearm-window` ms (default 30 s), not a perpetual all-device timer.

Also: base `ghaf-qemu` moved to QEMU 11.0.1 (which still lacks vfio-platform, so the 10.1.5 pin stays); its ACPI laptop patches no longer apply to 10.1.5 and are filtered out.

## Testing

AGX Orin, net-vm TX, `dd | nc` 1 GB over MGBE0 (`tx_bytes` confirms the path), qemu the only variable:

| | throughput | IRQs / GB |
|---|---:|---:|
| before (no irqfd) | 9.5 MB/s (**76 Mbit/s**) | 183,639 |
| this PR | 118 MB/s (**944 Mbit/s**) | 37,889 |

**12.4× throughput, near 1 GbE line rate.** Lifecycle checks all recover with no wedge/storm: clean boot, delayed `ip link up` past the 30 s window, 20× down/up, and guest reboot (resamplefd handles reboot recovery). Guest DT verified live: `snps,axi-config` resolves, 7-cell `snps,blen`, `rd/wr_osr_lmt=63`, driver init clean. `nix fmt`, `reuse lint`, pre-commit, AGX+NX images, and `ghaf-qemu-bpmp-gpu` (fast path off) all build.

## Scope

net-vm only. `ghaf-qemu-bpmp-gpu` opts out via `withIrqfdFastPath = false`; the GPU/display VMs' irqfd behavior is unevaluated and load-bearing — a follow-up, not this PR.
