### PR TITLE
USB Filtering using USBIP via periph-vm POC

### DIFF
--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -151,6 +151,11 @@ in
           default = [ { } ];
           description = "List of USB devices enabled for passthrough.";
         };
+        usbControllers = mkOption {
+          type = types.listOf types.attrs;
+          default = [ { } ];
+          description = "List of USB controllers enabled for passthrough.";
+        };
       };
     };
     type = mkOption {
@@ -274,6 +279,7 @@ in
               gpus = config.ghaf.hardware.definition.gpu.pciDevices;
               audio = config.ghaf.hardware.definition.audio.pciDevices;
               usb = config.ghaf.hardware.definition.usb.devices;
+              usbControllers = config.ghaf.hardware.definition.usbControllers.pciDevices;
             };
           };
         };

--- a/modules/common/security/default.nix
+++ b/modules/common/security/default.nix
@@ -14,5 +14,6 @@
     ./spire
     ./tpm2-packages.nix
     ../../secureboot/secureboot.nix
+    ./usb-filtering
   ];
 }

--- a/modules/common/security/usb-filtering/default.nix
+++ b/modules/common/security/usb-filtering/default.nix
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  ...
+}:
+{
+  _file = ./default.nix;
+
+  options.ghaf.services.usb-filtering = {
+    enable = lib.mkEnableOption "USB device filtering using peripherals VM" // {
+      default = false;
+    };
+
+    targetVms = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "periph-vm" ];
+      description = "VMs that should have USB device filtering support";
+    };
+  };
+}

--- a/modules/hardware/common/devices.nix
+++ b/modules/hardware/common/devices.nix
@@ -69,6 +69,7 @@ let
   gpuPciDevices = config.ghaf.hardware.definition.gpu.pciDevices;
   sndPciDevices = config.ghaf.hardware.definition.audio.pciDevices;
   evdevDevices = config.ghaf.hardware.definition.input.misc.evdev;
+  usbPciDevices = config.ghaf.hardware.definition.usbControllers.pciDevices;
   busPrefix = config.ghaf.hardware.passthrough.pciPorts.pcieBusPrefix;
 in
 {
@@ -112,6 +113,13 @@ in
       default = { };
       description = ''
         Evdev devices to passthrough.
+      '';
+    };
+    usbControllers = mkOption {
+      type = types.attrs;
+      default = { };
+      description = ''
+        USB controller PCI devices to passthrough.
       '';
     };
   };
@@ -176,6 +184,18 @@ in
           "virtio-input-host-pci,evdev=${d},id=evdev-${toString i}"
         ]) evdevDevices
       );
+
+      usbControllers.microvm.devices = imap1 (i: d: {
+        bus = "pci";
+        path = pciPath d;
+        qemu = {
+          inherit (d.qemu) deviceExtraArgs;
+        }
+        // optionalAttrs cfg.hotplug {
+          id = "pci${toString i}";
+          bus = "${busPrefix}${toString i}";
+        };
+      }) usbPciDevices;
     };
   };
 }

--- a/modules/hardware/common/kernel.nix
+++ b/modules/hardware/common/kernel.nix
@@ -39,6 +39,11 @@ in
       default = { };
       description = "NetVM kernel configuration";
     };
+    peripheralsvm = mkOption {
+      type = types.attrs;
+      default = { };
+      description = "PeripheralVM kernel configuration";
+    };
   };
 
   options.ghaf.host.kernel.memory-wipe = {
@@ -78,6 +83,7 @@ in
               config.ghaf.hardware.definition.network.pciDevices
               ++ config.ghaf.hardware.definition.gpu.pciDevices
               ++ config.ghaf.hardware.definition.audio.pciDevices
+              ++ config.ghaf.hardware.definition.usbControllers.pciDevices
             );
             hasPciPassthrough =
               pciDevices != [ ] || config.ghaf.hardware.definition.host.extraVfioPciIds != [ ];
@@ -96,6 +102,7 @@ in
                   config.ghaf.hardware.definition.network.pciDevices
                   ++ config.ghaf.hardware.definition.gpu.pciDevices
                   ++ config.ghaf.hardware.definition.audio.pciDevices
+                  ++ config.ghaf.hardware.definition.usbControllers.pciDevices
                 )
               )
               ++ config.ghaf.hardware.definition.host.extraVfioPciIds;
@@ -133,6 +140,15 @@ in
             };
             inherit (config.ghaf.hardware.definition.network.kernelConfig.stage2) kernelModules;
             inherit (config.ghaf.hardware.definition.network.kernelConfig) kernelParams;
+          };
+        };
+        peripheralsvm = {
+          boot = {
+            initrd = {
+              inherit (config.ghaf.hardware.definition.usbControllers.kernelConfig.stage1) kernelModules;
+            };
+            inherit (config.ghaf.hardware.definition.usbControllers.kernelConfig.stage2) kernelModules;
+            inherit (config.ghaf.hardware.definition.usbControllers.kernelConfig) kernelParams;
           };
         };
       };

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -251,6 +251,29 @@ in
         };
       };
 
+      usbControllers = {
+        # TODO? Should add PeripheralVM enabler here?
+        # peripheral.enable = mkEnableOption = "Peripheral";
+
+        pciDevices = mkOption {
+          description = "PCI USB controllers to passthrough to PeripheralVM";
+          type = types.listOf pciDevSubmodule;
+          default = [ ];
+          example = literalExpression ''
+            [{
+                path = "0000:00:0d.0";
+                vendorId = "8086";
+                productId = "a71e";
+            }]
+          '';
+        };
+        kernelConfig = mkOption {
+          description = "Hardware specific kernel configuration for filtered USB controllers";
+          type = kernelConfig;
+          default = { };
+        };
+      };
+
       gpu = {
         # TODO? Should add GuiVM enabler here?
         # guivm.enable = mkEnableOption = "NetVM";
@@ -468,5 +491,34 @@ in
           '';
         };
       };
+
+      peripheralsvm = {
+        extraModules = mkOption {
+          description = ''
+            Hardware-specific NixOS modules for Peripherals VM configuration.
+
+            This option allows hardware definitions to provide VM-specific
+            configuration that will be merged with the base Peripherals VM
+            config.
+
+            Use this ONLY for hardware-specific settings like:
+            - PCIe root ports configuration
+            - Network device passthrough
+            - Custom kernel parameters
+
+            For resource allocation (memory, vCPUs) or profile-specific modules,
+            use ghaf.virtualization.vmConfig.sysvms.peripheralsvm instead.
+          '';
+          type = types.listOf types.unspecified;
+          default = [ ];
+          example = literalExpression ''
+            [
+              ./peripherals-config.nix
+              { microvm.qemu.extraArgs = [ ... ]; }
+            ]
+          '';
+        };
+      };
+
     };
 }

--- a/modules/hardware/passthrough/pci-ports.nix
+++ b/modules/hardware/passthrough/pci-ports.nix
@@ -32,6 +32,8 @@ let
     "net-vm" = staticPciCount "network" + 2;
     # Audio controllers often include multiple devices in the same IOMMU group
     "audio-vm" = staticPciCount "audio" + 7;
+    # Peripherals VM may need ports for USB controllers and other devices
+    "periph-vm" = staticPciCount "usbControllers" + 2;
   };
 
   # Helper function to create PCIe root ports in a microvm
@@ -93,6 +95,11 @@ in
       netvm.extraModules = [
         {
           microvm.qemu.pcieRootPorts = mkPcieRootPorts "net-vm";
+        }
+      ];
+      peripheralsvm.extraModules = [
+        {
+          microvm.qemu.pcieRootPorts = mkPcieRootPorts "periph-vm";
         }
       ];
     };

--- a/modules/hardware/passthrough/pci-rules.nix
+++ b/modules/hardware/passthrough/pci-rules.nix
@@ -110,6 +110,33 @@ let
       }
     ];
 
+  defaultPeripheralsvmPciRules =
+    optionals (hasHardwareDefinition && config.ghaf.services.usb-filtering.enable) [
+      {
+        description = "Static PCI Devices for PeripheralsVM";
+        targetVm = "periph-vm";
+        tag = "periph";
+        allow = map (d: {
+          address = d.path;
+          deviceId = d.productId;
+          inherit (d) vendorId;
+        }) config.ghaf.hardware.definition.usbControllers.pciDevices;
+      }
+    ]
+    ++ optionals cfg.autoDetectFilteredUsb [
+      {
+        description = "Auto-detected PCI Devices for PeripheralsVM";
+        targetVm = "periph-vm";
+        tag = "periph";
+        allow = [
+          {
+            deviceClass = 12;
+            description = "USB Devices";
+          }
+        ];
+      }
+    ];
+
   # ACPI NHLT table passthrough is required for the microphone array on some devices
   audiovmAcpiRules = [
     {
@@ -155,11 +182,19 @@ in
       default = defaultAudiovmPciRules;
     };
 
+    peripheralsvmRules = mkOption {
+      description = "PCI Device Passthrough Rules for PeripheralsVM";
+      type = types.listOf types.attrs;
+      default = defaultPeripheralsvmPciRules;
+    };
+
     autoDetectGpu = mkEnableOption "auto-detection of GPU PCI devices";
 
     autoDetectNet = mkEnableOption "auto-detection of network PCI devices";
 
     autoDetectAudio = mkEnableOption "auto-detection of audio PCI devices";
+
+    autoDetectFilteredUsb = mkEnableOption "auto-detection of filtered USB PCI devices";
   };
 
   config = lib.mkMerge [
@@ -167,7 +202,8 @@ in
       ghaf.hardware.passthrough.vhotplug.pciRules =
         optionals config.ghaf.virtualization.microvm.guivm.enable cfg.guivmRules
         ++ optionals config.ghaf.virtualization.microvm.netvm.enable cfg.netvmRules
-        ++ optionals config.ghaf.virtualization.microvm.audiovm.enable cfg.audiovmRules;
+        ++ optionals config.ghaf.virtualization.microvm.audiovm.enable cfg.audiovmRules
+        ++ optionals config.ghaf.virtualization.microvm.peripheralsvm.enable cfg.peripheralsvmRules;
 
       # ACPI rules are host-side vhotplug config (not VM extraModules)
       # They pass the NHLT ACPI table needed for microphone arrays
@@ -179,6 +215,7 @@ in
         guivm.extraModules = optionals cfg.autoDetectGpu (hwDetectModule "gui-vm");
         audiovm.extraModules = optionals cfg.autoDetectAudio (hwDetectModule "audio-vm");
         netvm.extraModules = optionals cfg.autoDetectNet (hwDetectModule "net-vm");
+        peripheralsvm.extraModules = optionals cfg.autoDetectFilteredUsb (hwDetectModule "periph-vm");
       };
     })
   ];

--- a/modules/hardware/passthrough/usb-rules.nix
+++ b/modules/hardware/passthrough/usb-rules.nix
@@ -32,11 +32,6 @@ let
           description = "Chip/SmartCard (e.g. YubiKey)";
         }
         {
-          interfaceClass = 8;
-          interfaceSubclass = 6;
-          description = "Mass Storage - SCSI (USB drives)";
-        }
-        {
           interfaceClass = 17;
           description = "USB-C alternate modes supported by device";
         }
@@ -117,6 +112,24 @@ in
       type = types.listOf types.attrs;
       default = defaultAudiovmUsbRules;
     };
+
+    peripheralsvmRules = mkOption {
+      description = "USB Device Passthrough Rules for PeripheralsVM";
+      type = types.listOf types.attrs;
+      default = [
+        {
+          description = "USB Devices for PeripheralsVM";
+          targetVm = "periph-vm";
+          allow = [
+            {
+              interfaceClass = 8;
+              interfaceSubclass = 6;
+              description = "Mass Storage - SCSI (USB drives)";
+            }
+          ];
+        }
+      ];
+    };
   };
 
   config = mkIf (config.ghaf.hardware.passthrough.mode != "none") {
@@ -124,7 +137,8 @@ in
     ghaf.hardware.passthrough.vhotplug.usbRules =
       optionals config.ghaf.virtualization.microvm.guivm.enable cfg.guivmRules
       ++ optionals config.ghaf.virtualization.microvm.netvm.enable cfg.netvmRules
-      ++ optionals config.ghaf.virtualization.microvm.audiovm.enable cfg.audiovmRules;
+      ++ optionals config.ghaf.virtualization.microvm.audiovm.enable cfg.audiovmRules
+      ++ optionals config.ghaf.virtualization.microvm.peripheralsvm.enable cfg.peripheralsvmRules;
 
   };
 }

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -20,6 +20,7 @@ _: {
       ./sysvms/idsvm/idsvm.nix
       ./common/microvm-store-mode.nix
       ./sysvm-registry.nix
+      ./sysvms/peripheralsvm.nix
       ./vm-config.nix
     ];
 
@@ -78,6 +79,9 @@ _: {
     # Net VM feature modules (nics hardware passthrough)
     netvm-features = ./netvm-features;
 
+    # Peripherals VM feature modules (USB/IP, USB device filtering, etc.)
+    peripheralsvm-features = ./peripheralsvm-features;
+
     # Net VM base module for layered composition
     # Use with extendModules pattern:
     #   lib.nixosSystem { modules = [ inputs.self.nixosModules.netvm-base ]; ... }
@@ -90,6 +94,11 @@ _: {
     #   lib.nixosSystem { modules = [ inputs.self.nixosModules.gpuvm-base ]; ... }
     #     .extendModules { modules = [ ... ]; }
     gpuvm-base = ./sysvms/gpuvm-base.nix;
+    # Peripherals VM feature modules (USB/IP, USB device filtering, etc.)
+    # Use with extendModules pattern:
+    #   lib.nixosSystem { modules = [ inputs.self.nixosModules.peripheralsvm-base ]; ... }
+    #     .extendModules { modules = [ ... ]; }
+    peripheralsvm-base = ./sysvms/peripheralsvm-base.nix;
 
     # App VM base module for layered composition
     # Unlike singleton VMs, App VMs are instantiated multiple times using mkAppVm.
@@ -159,6 +168,10 @@ _: {
     # IDS VM - Intrusion Detection System
     # Requires: Network tap access
     idsvm = ./sysvms/idsvm/idsvm-base.nix;
+
+    # Peripherals VM - Hardware device management
+    # Requires: Various hardware passthrough
+    peripheralsvm = ./sysvms/peripheralsvm-base.nix;
 
     # App VM - Template for application VMs
     # Instantiated multiple times (chrome-vm, comms-vm, etc.)

--- a/modules/microvm/peripheralsvm-features/default.nix
+++ b/modules/microvm/peripheralsvm-features/default.nix
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Peripherals VM Features Module
+#
+# This module aggregates all Peripherals VM feature modules and auto-includes them
+# based on their respective conditions.
+#
+# Usage:
+#   In profile's lib.nixosSystem call:
+#     modules = [
+#       inputs.self.nixosModules.peripheralsvm-base
+#       inputs.self.nixosModules.peripheralsvm-features
+#     ];
+#
+# Feature modules:
+#   - hardware-passthrough.nix: usb config (from hostConfig)
+#
+{ ... }:
+{
+  _file = ./default.nix;
+
+  imports = [
+    ./hardware-passthrough.nix
+  ];
+}

--- a/modules/microvm/peripheralsvm-features/hardware-passthrough.nix
+++ b/modules/microvm/peripheralsvm-features/hardware-passthrough.nix
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Peripherals VM Hardware Passthrough Feature Module
+#
+# This module handles hardware-specific configurations for the Peripherals VM:
+# - USB device passthrough
+#
+# These settings are host-bound and cannot be globalized, so they must
+# come from hostConfig which is passed via specialArgs.
+#
+# Auto-enables when: hostConfig has USB hardware devices
+#
+{
+  lib,
+  hostConfig,
+  ...
+}:
+let
+  # Get USB controllers config, defaulting to empty attrset
+  usbControllersConfig = hostConfig.hardware.devices.usbControllers or { };
+
+  # Check if we have actual devices to passthrough (non-empty config)
+  hasUsbControllers = usbControllersConfig != { };
+
+  # Get kernel/qemu configs (can be null)
+  kernelConfig = hostConfig.kernel or null;
+  qemuConfig = hostConfig.qemu or null;
+in
+{
+  _file = ./hardware-passthrough.nix;
+
+  config = lib.mkMerge (
+    # Import USB controller passthrough config from host
+    lib.optional hasUsbControllers usbControllersConfig
+    # Kernel configuration from host (if defined)
+    ++ lib.optional (kernelConfig != null) kernelConfig
+    # QEMU configuration from host (if defined)
+    ++ lib.optional (qemuConfig != null) qemuConfig
+  );
+}

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -336,6 +336,13 @@ in
       pkgs.ctrl-panel
       pkgs.waypipe
       pkgs.wlopm
+
+      # jarekk: enable usbip for gui-vm by default
+      # jarekk: we should probably add a feature flag for this
+      pkgs.linuxPackages.usbip
+      # jarekk: remove the packages after testing
+      pkgs.usbutils
+      pkgs.pciutils
     ]
     # For GIVC debugging/testing
     ++ lib.optional (globalConfig.debug.enable or false) pkgs.givc-cli
@@ -446,4 +453,12 @@ in
       .${globalConfig.storage.storeOnDisk.compression.algorithm};
     }
   );
+
+  # jarekk: enable usbip for gui-vm by default
+  # jarekk: we should probably add a feature flag for this, but for now we just enable it
+  boot.kernelModules = [
+    "vhci_hcd"
+    "usbip-core"
+    "usbip-host"
+  ];
 }

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -298,4 +298,20 @@ in
       .${globalConfig.storage.storeOnDisk.compression.algorithm};
     }
   );
+
+  # jarekk: enable usbip for net-vm by default
+  # jarekk: we should probably add a feature flag for this, but for now we just enable it
+  boot.kernelModules = [
+    "vhci_hcd"
+    "usbip-core"
+    "usbip-host"
+  ];
+
+  environment.systemPackages = [
+    pkgs.linuxPackages.usbip
+    # jarekk: remove the packages after testing
+    pkgs.usbutils
+    pkgs.pciutils
+  ];
+
 }

--- a/modules/microvm/sysvms/peripheralsvm-base.nix
+++ b/modules/microvm/sysvms/peripheralsvm-base.nix
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Peripherals VM Base Module
+#
+# This module contains the core Peripherals VM configuration and can be composed using extendModules.
+# It takes globalConfig and hostConfig via specialArgs for configuration.
+#
+# Usage in profiles:
+#   lib.nixosSystem {
+#     modules = [ inputs.self.nixosModules.peripheralsvm-base ];
+#     specialArgs = { inherit globalConfig hostConfig; };
+#   }
+#
+# Then extend with:
+#   base.extendModules { modules = [ ... ]; }
+#
+{
+  lib,
+  pkgs,
+  inputs,
+  globalConfig,
+  hostConfig,
+  ...
+}:
+let
+  vmName = "periph-vm";
+
+  timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+
+  # jarekk: clean it
+  # globalConfig -> nixosConfigurations.lenovo-x1-carbon-gen11-debug.config.ghaf.global-config.
+  usbipCfg =
+    # globalConfig.virtualization.microvm.peripheralsvm.usbip or
+    {
+      enable = true;
+      targetVms = [ ];
+      port = 3240;
+    };
+in
+{
+  _file = ./peripheralsvm-base.nix;
+
+  imports = [
+    inputs.preservation.nixosModules.preservation
+    inputs.self.nixosModules.givc
+    inputs.self.nixosModules.hardware-x86_64-guest-kernel
+    inputs.self.nixosModules.vm-modules
+    inputs.self.nixosModules.profiles
+  ];
+
+  ghaf = {
+    # Profiles - from globalConfig
+    profiles.debug.enable = globalConfig.debug.enable;
+
+    development = {
+      ssh.daemon.enable = lib.mkDefault (globalConfig.development.ssh.daemon.enable or false);
+      debug.tools.enable = lib.mkDefault (globalConfig.development.debug.tools.enable or false);
+      nix-setup.enable = lib.mkDefault (globalConfig.development.nix-setup.enable or false);
+    };
+
+    # System
+    type = "system-vm";
+
+    # Enable dynamic hostname export for VMs
+    identity.vmHostNameExport.enable = true;
+
+    # Storage - from globalConfig
+    storagevm = {
+      enable = true;
+      name = vmName;
+      encryption.enable = globalConfig.storage.encryption.enable or false;
+    };
+
+    # Networking
+    virtualization.microvm = {
+      swap.enable = true;
+
+      vm-networking = {
+        enable = true;
+        inherit vmName;
+      };
+
+    };
+
+    # Logging - from globalConfig
+    logging = {
+      inherit (globalConfig.logging) enable listener;
+      journalClient = {
+        inherit (globalConfig.logging) enable;
+      };
+    };
+
+    # jarekk: TODO: fix it. Probablyit causes ssh disconnections
+    # security = {
+    #   fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+    #   spire.agent = {
+    #     enable = globalConfig.spire.enable or false;
+    #     logLevel = if globalConfig.spire.debug then "DEBUG" else "INFO";
+    #     nodeAttestationMode = if globalConfig.givc.enable then "x509pop" else "join_token";
+    #   };
+    # };
+
+    # Networking hosts - from hostConfig (for vm-networking.nix to look up MAC/IP)
+    networking.hosts = hostConfig.networking.hosts or { };
+    # Common namespace - from hostConfig (previously from commonModule in modules.nix)
+    common = hostConfig.common or { };
+
+    # User configuration - from hostConfig
+    users = {
+      profile = hostConfig.users.profile or { };
+      admin = hostConfig.users.admin or { };
+      managed = hostConfig.users.managed or { };
+    };
+
+    # GIVC configuration - from globalConfig
+    givc = {
+      enable = globalConfig.givc.enable or false;
+      debug = globalConfig.givc.debug or false;
+    };
+
+    # Security - from globalConfig
+    security.audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+  };
+
+  # USB/IP server for forwarding USB devices to target VMs
+  boot = lib.mkIf usbipCfg.enable {
+    kernelModules = [
+      "usbip_core"
+      "usbip_host"
+    ];
+  };
+
+  environment.systemPackages = lib.mkIf usbipCfg.enable [
+    pkgs.linuxPackages.usbip
+    # jarekk: remove the packages after testing
+    pkgs.usbutils
+    pkgs.pciutils
+  ];
+
+  systemd.services = lib.mkIf usbipCfg.enable {
+    usbipd = {
+      description = "USB/IP daemon for forwarding USB devices to target VMs";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.linuxPackages.usbip}/bin/usbipd --debug";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        Type = "simple";
+      };
+    };
+  };
+
+  networking.firewall = lib.mkIf usbipCfg.enable {
+    allowedTCPPorts = [ usbipCfg.port ];
+  };
+
+  time.timeZone = lib.mkIf (!timezoneEnabled) (lib.mkDefault globalConfig.platform.timeZone);
+
+  system.stateVersion = lib.trivial.release;
+
+  nixpkgs = {
+    buildPlatform.system = globalConfig.platform.buildSystem or "x86_64-linux";
+    hostPlatform.system = globalConfig.platform.hostSystem or "x86_64-linux";
+  };
+
+  microvm = {
+    # Optimize is disabled because when it is enabled, qemu is built without libusb
+    optimize.enable = false;
+    # Sensible defaults - can be overridden via vmConfig
+    vcpu = lib.mkDefault 2;
+    mem = lib.mkDefault 512;
+    hypervisor = "qemu";
+
+    shares = [
+      {
+        tag = "ghaf-common";
+        source = "/persist/common";
+        mountPoint = "/etc/common";
+        proto = "virtiofs";
+      }
+    ]
+    # Shared store (when not using storeOnDisk)
+    ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
+      {
+        tag = "ro-store";
+        source = "/nix/store";
+        mountPoint = "/nix/.ro-store";
+        proto = "virtiofs";
+        cache = "always";
+      }
+    ];
+
+    writableStoreOverlay = lib.mkIf (
+      !(globalConfig.storage.storeOnDisk.enable or false)
+    ) "/nix/.rw-store";
+
+    qemu = {
+      machine =
+        {
+          # Use the same machine type as the host
+          x86_64-linux = "q35";
+          aarch64-linux = "virt";
+        }
+        .${globalConfig.platform.hostSystem or "x86_64-linux"};
+      extraArgs = [
+        "-device"
+        "qemu-xhci"
+      ];
+    };
+  }
+  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
+    let
+      compLevelSuffix = lib.optionalString (
+        globalConfig.storage.storeOnDisk.compression.level != null
+      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
+    in
+    {
+      storeOnDisk = true;
+      storeDiskType = "erofs";
+      # Defaults: -zlz4hc (all kernels), -Eztailpacking (5.16+), -Efragments (6.1+)
+      # -zzstd requires Linux 6.15+ due to -E48bit (extended addressing, needed for zstd)
+      # Setting storeDiskErofsFlags overrides the entire list; include defaults explicitly if needed.
+      storeDiskErofsFlags = [
+        "-Eztailpacking"
+        "-Efragments"
+        # no need to hammer all available cores
+        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
+      ]
+      ++ {
+        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
+        zstd = [
+          "-zzstd${compLevelSuffix}"
+          "-E48bit"
+        ];
+      }
+      .${globalConfig.storage.storeOnDisk.compression.algorithm};
+    }
+  );
+}

--- a/modules/microvm/sysvms/peripheralsvm.nix
+++ b/modules/microvm/sysvms/peripheralsvm.nix
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Peripherals VM Configuration Module
+#
+# This module requires evaluatedConfig to be set via profile composition.
+# The actual VM configuration is in peripheralsvm-base.nix.
+#
+# Usage in profiles:
+#   ghaf.virtualization.microvm.peripheralsvm.evaluatedConfig =
+#     config.ghaf.profiles.laptop-x86.peripheralsvmBase.extendModules { ... };
+#
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
+let
+  vmName = "periph-vm";
+  cfg = config.ghaf.virtualization.microvm.peripheralsvm;
+  enable = config.ghaf.services.usb-filtering.enable;
+  targetVms = config.ghaf.services.usb-filtering.targetVms;
+in
+{
+  _file = ./peripheralsvm.nix;
+
+  options.ghaf.virtualization.microvm.peripheralsvm = {
+    enable = lib.mkEnableOption "PeripheralsVM" // {
+      default = enable;
+    };
+    evaluatedConfig = lib.mkOption {
+      type = lib.types.nullOr lib.types.unspecified;
+      default = null;
+      description = ''
+        Pre-evaluated NixOS configuration for Peripherals VM.
+        Profiles must set this using peripheralsvmBase.extendModules from a profile
+        (e.g., laptop-x86 or orin).
+      '';
+    };
+
+    extraNetworking = lib.mkOption {
+      type = lib.types.networking;
+      default = { };
+      description = "Extra networking configuration for this system VM.";
+    };
+
+    usbip = {
+      enable = lib.mkEnableOption "USB/IP support for forwarding USB devices to target VMs" // {
+        default = enable;
+      };
+
+      targetVms = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = targetVms;
+        description = "List of VM names that USB devices should be forwarded to via USB/IP.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 3240;
+        description = "TCP port used by the USB/IP server.";
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      ghaf.virtualization.microvm.sysvm.vms.peripheralsvm = {
+        inherit vmName enable;
+        inherit (cfg) evaluatedConfig extraNetworking;
+      };
+    }
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = cfg.evaluatedConfig != null;
+          message = ''
+            ghaf.virtualization.microvm.peripheralsvm.evaluatedConfig must be set.
+            Use peripheralsvmBase.extendModules from a profile (laptop-x86, orin, etc.).
+            Example:
+              ghaf.virtualization.microvm.peripheralsvm.evaluatedConfig =
+                config.ghaf.profiles.laptop-x86.peripheralsvmBase.extendModules { modules = [...]; };
+          '';
+        }
+      ];
+
+      ghaf.common = {
+        extraNetworking.hosts.${vmName} = cfg.extraNetworking;
+        policies = lib.mkIf cfg.evaluatedConfig.config.ghaf.givc.policyClient.enable {
+          "${vmName}" = cfg.evaluatedConfig.config.ghaf.givc.policyClient.policies;
+        };
+        spire.agents = lib.mkIf cfg.evaluatedConfig.config.ghaf.security.spire.agent.enable {
+          "${vmName}" = {
+            inherit (cfg.evaluatedConfig.config.ghaf.security.spire.agent) nodeAttestationMode workloads;
+          };
+        };
+      };
+
+      # Open USB/IP port in the firewall for each target VM
+      ghaf.firewall = lib.mkIf cfg.usbip.enable {
+        allowedTCPPorts = [ cfg.usbip.port ];
+      };
+
+      microvm.vms."${vmName}" = {
+        autostart = !config.ghaf.microvm-boot.enable;
+        inherit (inputs) nixpkgs;
+        inherit (cfg) evaluatedConfig;
+      };
+    })
+  ];
+}

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -66,6 +66,16 @@ in
       '';
     };
 
+    # Peripherals VM base configuration for profiles to extend
+    peripheralsvmBase = lib.mkOption {
+      type = lib.types.unspecified;
+      readOnly = true;
+      description = ''
+        Laptop-x86 Peripherals VM base configuration.
+        Profiles can extend this with extendModules if customization needed.
+      '';
+    };
+
     # App VM factory function for creating app VMs
     mkAppVm = lib.mkOption {
       type = lib.types.unspecified;
@@ -202,6 +212,31 @@ in
               vmName = "net-vm";
             };
             # Note: netvm.wifi now controlled via globalConfig.features.wifi
+          };
+        };
+
+        # Export Peripherals VM base for profiles to extend
+        peripheralsvmBase = lib.nixosSystem {
+          modules = [
+            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.peripheralsvm-base
+            inputs.self.nixosModules.peripheralsvm-features
+            # Import nixpkgs config module to get overlays
+            {
+              nixpkgs = {
+                hostPlatform.system = "x86_64-linux";
+                inherit (config.nixpkgs) overlays;
+                inherit (config.nixpkgs) config;
+              };
+            }
+          ];
+          specialArgs = lib.ghaf.vm.mkSpecialArgs {
+            inherit lib inputs;
+            globalConfig = hostGlobalConfig;
+            hostConfig = lib.ghaf.vm.mkHostConfig {
+              inherit config;
+              vmName = "periph-vm";
+            };
           };
         };
 

--- a/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
+++ b/modules/reference/hardware/lenovo-x1/definitions/x1-gen11.nix
@@ -90,6 +90,28 @@
     kernelConfig.kernelParams = [ "snd_intel_dspcfg.dsp_driver=0" ];
   };
 
+  usbControllers = {
+    pciDevices = [
+      {
+        # Passthrough Intel Raptor Lake-P Thunderbolt 4 USB Controller
+        # It handles 2 right side USB Type-C ports
+        path = "0000:00:0d.0";
+        vendorId = "8086";
+        productId = "a71e";
+
+        # Intel Corporation Alder Lake PCH USB 3.2 xHCI Host Controller
+        # It handles:
+        # 1 left side USB Type-A ports
+        # 1 right side USB Type-A port
+        # Second USB controller:
+        # internal USB 2.0 hub for keyboard, touchpad, fingerprint reader, camera, and Bluetooth
+        # path = "0000:00:14.0";
+        # vendorId = "8086";
+        # productId = "51ed";
+      }
+    ];
+  };
+
   usb.devices = [
     # Integrated camera
     {

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -126,6 +126,14 @@ in
               vmName = "netvm";
             };
           };
+
+          # Peripherals VM: Use laptop base with vmConfig
+          peripheralsvm.evaluatedConfig = config.ghaf.profiles.laptop-x86.peripheralsvmBase.extendModules {
+            modules = lib.ghaf.vm.applyVmConfig {
+              inherit config;
+              vmName = "peripheralsvm";
+            };
+          };
         };
       };
 

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -238,6 +238,11 @@ let
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
+        # TODO: jarekk: remove
+        # services.usb-filtering.enable = false;
+        services.usb-filtering.enable = true;
+        virtualization.microvm.peripheralsvm.usbip.enable = true;
+        virtualization.microvm.peripheralsvm.usbip.targetVms = [ "netvm" ];
       };
       buildSysupdateImage = true;
     })


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->
USB Filtering via periph-vm using USBIP POC

This POC assumes that USB devices are not directly exposed to application or system VMs by default. Instead, selected USB controllers are assigned to a dedicated system VM, periph-vm, which acts as a USB mediation point. USB devices are exposed to other VMs using USBIP. In this build USBIP components are added to net-vm and gui-vm.

USB devices connected to the physical **USB-C ports on Lenovo X1 Gen 11** first appear inside periph-vm. From there, they may be selectively exported to client VMs using USB/IP.

### Current Status

The implementation is currently a POC.

The Nix changes are still in progress and require cleanup before they are ready for review or upstreaming. Manual USB/IP commands are currently used to validate the concept.

The current POC demonstrates the following flow:

A USB device is connected to one of the USB-C ports handled by the passed-through USB controller.
The USB device appears inside periph-vm.
The device can be bound to the USB/IP daemon inside periph-vm, for example:

### Memory stick example
Insert an USB memory stick.
The stick is visable on periph-vm and can be bind to `usbip`

```
[ghaf@periph-vm:~]$ sudo usbip list -l
 - busid 1-1 (0781:55bb)
   SanDisk Corp. : unknown product (0781:55bb)


[ghaf@periph-vm:~]$  sudo usbip bind -b 1-1
usbip: info: bind device on busid 1-1: complete

```
Attach the stick on gui-vm:

```
[ghaf@gui-vm:~]$ sudo usbip list -r periph-vm
Exportable USB devices
======================
 - periph-vm
        1-1: SanDisk Corp. : unknown product (0781:55bb)
           : /sys/devices/pci0000:00/0000:00:0a.0/usb1/1-1
           : (Defined at Interface level) (00/00/00)


[ghaf@gui-vm:~]$ sudo usbip attach -b 1-1  -r periph-vm
```
GUI on gui-vm notifies appearing memory stick.

### USB ethernet card example
Insert USB Ethernet card
```
[ghaf@periph-vm:~]$ usbip list -l
 - busid 4-1.1 (0b95:1790)
   ASIX Electronics Corp. : AX88179 Gigabit Ethernet (0b95:1790)

 - busid 4-1.2 (05e3:0749)
   Genesys Logic, Inc. : SD Card Reader and Writer (05e3:0749)


[ghaf@periph-vm:~]$ sudo usbip bind -b 4-1.1
usbip: info: bind device on busid 4-1.1: complete
```
Attach the card to the net-vm
```
[ghaf@ghaf-0098343652:~]$ usbip list -r periph-vm
Exportable USB devices
======================
 - periph-vm
      4-1.1: ASIX Electronics Corp. : AX88179 Gigabit Ethernet (0b95:1790)
           : /sys/devices/pci0000:00/0000:00:02.0/0000:01:00.0/usb4/4-1/4-1.1
           : (Defined at Interface level) (00/00/00)


[ghaf@ghaf-0098343652:~]$ sudo usbip attach -b 4-1.1 -r periph-vm

The card is normally handled and configured:

[ghaf@ghaf-0098343652:~]$ ifconfig 
enu1c2    Link encap:Ethernet  HWaddr 08:26:AE:3A:F3:5F  
          inet addr:10.181.84.218  Bcast:10.181.87.255  Mask:255.255.252.0
          inet6 addr: fe80::208f:ee78:70df:9aec/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:37 errors:0 dropped:5 overruns:0 frame:0
          TX packets:28 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:7016 (6.8 KiB)  TX bytes:4782 (4.6 KiB)


```

Performance:
Transfer with `dd` is slower by ~13%: using USB/IP is 36.3 MB/s, whereas on `periph-vm` it's 41.6 MB/s.

### Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
1. ...
-->


