### PR TITLE
fix(flake): avoid eager verity target evaluation

### DIFF
--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -71,7 +71,7 @@ let
     }
   ];
 
-  # All Orin configurations using mkGhafConfiguration
+  # Non-verity Orin configurations using mkGhafConfiguration
   target-configs = [
     # ============================================================
     # Debug Configurations
@@ -200,15 +200,14 @@ let
       };
     })
 
-    # ============================================================
-    # A/B Verity Boot Configurations (AGX only)
-    # ============================================================
-  ]
-  ++
+  ];
+
+  # A/B Verity Boot Configurations (AGX only)
+  verity-target-configs =
     map
       (
         variant:
-        ghaf-configuration {
+        (ghaf-configuration {
           name = "nvidia-jetson-orin-agx-verity";
           inherit system;
           profile = "orin";
@@ -228,12 +227,16 @@ let
               variant == "debug"
             ) ../../modules/secureboot/dev-keys;
           };
+        })
+        // {
+          isVerity = true;
         }
       )
       [
         "debug"
         "release"
       ];
+  all-target-configs = target-configs ++ verity-target-configs;
 
   generate-nodemoapps =
     tgt:
@@ -277,12 +280,12 @@ let
 
   # LUKS and dm-verity are mutually exclusive root strategies (see the assertion
   # in jetson-orin.nix), so the verity targets get no -luks variant.
-  luksable-target-configs = builtins.filter (t: !isVerityTarget t) target-configs;
+  luksable-target-configs = builtins.filter (t: !isVerityTarget t) all-target-configs;
 
   # Add nodemoapps targets
   targets =
-    target-configs
-    ++ (map generate-nodemoapps target-configs)
+    all-target-configs
+    ++ (map generate-nodemoapps all-target-configs)
     ++ (map generate-luks luksable-target-configs)
     ++ (map (t: generate-luks (generate-nodemoapps t)) luksable-target-configs);
   crossTargets = map generate-cross-from-x86_64 targets;
@@ -367,8 +370,9 @@ let
       '';
     };
 
-  # Filter verity targets (those with verity-volume enabled) for ghafImage output
-  isVerityTarget = t: (t.hostConfiguration.config.ghaf.partitioning.verity.enable or false);
+  # Filter verity targets without forcing every hostConfiguration.config during
+  # package-set evaluation.
+  isVerityTarget = t: t.isVerity or false;
   verityCrossTargets = builtins.filter isVerityTarget crossTargets;
 in
 {


### PR DESCRIPTION
Reduce flake eval memory by avoiding eager NixOS configuration evaluation when classifying Jetson Orin verity targets.

Previously, verity detection read `hostConfiguration.config`, which forced full Orin config evaluation while constructing package sets. That cost affected unrelated attrs too, including docs, x86 images, laptop images, and native arm Orin images.

This PR uses explicit target metadata instead.

Measured from clean archived source trees:

- base: `origin/main` at `3aee63a7`
- PR: this pr at `742bb61`
- x86 host: `builder.vedenemo.dev`
- arm host: `hetzarm.vedenemo.dev`
- sequential, no builds, 24 GiB VM cap
- `nix-eval-jobs --workers 1 --max-memory-size 4096 --option eval-cache false`

“Sample sum” in the below table means the sum of the measured representative targets, not the whole package set. The x86 sample uses the same six attrs from the eval-memory analysis. The arm sample uses AGX and NX native Orin image attrs to confirm the fix also helps native aarch64 evaluation. 


| Eval target | Host | main RSS GiB | PR RSS GiB | Delta | Reduction |
|---|---|---:|---:|---:|---:|
| `packages.x86_64-linux.doc` | `builder` | 6.45 | 1.55 | -4.90 | 75.9% |
| `packages.x86_64-linux.generic-x86_64-debug` | `builder` | 6.54 | 1.60 | -4.93 | 75.5% |
| `packages.x86_64-linux.intel-laptop-debug` | `builder` | 13.13 | 8.16 | -4.97 | 37.8% |
| `packages.x86_64-linux.intel-laptop-debug-installer` | `builder` | 13.82 | 8.93 | -4.89 | 35.4% |
| `packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64` | `builder` | 10.00 | 5.19 | -4.81 | 48.1% |
| `packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64` | `builder` | 8.94 | 4.14 | -4.80 | 53.7% |
| **x86 sample sum** | `builder` | **58.87** | **29.58** | **-29.29** | **49.8%** |
| `packages.aarch64-linux.nvidia-jetson-orin-agx-debug` | `hetzarm` | 3.87 | 3.03 | -0.84 | 21.7% |
| `packages.aarch64-linux.nvidia-jetson-orin-nx-debug` | `hetzarm` | 3.31 | 2.49 | -0.81 | 24.6% |
| **arm sample sum** | `hetzarm` | **7.17** | **5.52** | **-1.65** | **23.0%** |

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
