### PR TITLE
fix(orin): stabilize BPMP proxy wire ABI

### DIFF
--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/bpmp-virt-common/sources/drivers/firmware/tegra/bpmp-host-proxy/bpmp-host-proxy.c
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/bpmp-virt-common/sources/drivers/firmware/tegra/bpmp-host-proxy/bpmp-host-proxy.c
@@ -62,8 +62,8 @@ static struct device *bpmp_host_proxy_device = NULL; ///< The device-driver devi
  */
 static int open(struct inode *, struct file *);
 static int close(struct inode *, struct file *);
-static ssize_t read(struct file *, char *, size_t, loff_t *);
-static ssize_t write(struct file *, const char *, size_t, loff_t *);
+static ssize_t read(struct file *, char __user *, size_t, loff_t *);
+static ssize_t write(struct file *, const char __user *, size_t, loff_t *);
 
 /**
  * File operations structure and the functions it points to.
@@ -287,7 +287,7 @@ static int close(struct inode *inodep, struct file *filep)
 /*
  * Reads from device, displays in userspace, and deletes the read data
  */
-static ssize_t read(struct file *filep, char *buffer, size_t len, loff_t *offset)
+static ssize_t read(struct file *filep, char __user *buffer, size_t len, loff_t *offset)
 {
 	deb_info("read stub");
 	return 0;
@@ -425,53 +425,61 @@ static bool check_if_allowed(struct tegra_bpmp_message *msg)
 extern int tegra_bpmp_transfer(struct tegra_bpmp *, struct tegra_bpmp_message *);
 extern struct tegra_bpmp *tegra_bpmp_host_device;
 
-#define BUF_SIZE 1024 
+#define BUF_SIZE 1024
+
+/*
+ * Stable userspace ABI shared with QEMU's nvidia_bpmp_guest device.
+ *
+ * Do not use struct tegra_bpmp_message as the wire format: NVIDIA's host 6.6
+ * kernel adds an unsigned long flags member to that internal structure, while
+ * the upstream 6.12 guest and QEMU header end at rx.ret. On aarch64 those
+ * layouts are 56 and 48 bytes respectively.
+ */
+struct bpmp_proxy_wire_message {
+	u32 mrq;
+	u32 reserved0;
+
+	struct {
+		u64 data;
+		u64 size;
+	} tx;
+
+	struct {
+		u64 data;
+		u64 size;
+		s32 ret;
+		u32 reserved0;
+	} rx;
+};
+
+static_assert(sizeof(struct bpmp_proxy_wire_message) == 48);
 
 /*
  * Writes to the device
  */
 
-static ssize_t write(struct file *filep, const char *buffer, size_t len, loff_t *offset)
+static ssize_t write(struct file *filep, const char __user *buffer, size_t len, loff_t *offset)
 {
-
-	int ret = len;
-	struct tegra_bpmp_message *kbuf = NULL;
+	struct bpmp_proxy_wire_message wire;
+	struct tegra_bpmp_message message = { 0 };
+	void __user *usertxbuf;
+	void __user *userrxbuf;
 	void *txbuf = NULL;
 	void *rxbuf = NULL;
-	void *usertxbuf = NULL;
-	void *userrxbuf = NULL;
+	int ret;
 
-	if (len > 65535) {	/* paranoia */
-		deb_error("count %zu exceeds max # of bytes allowed, "
-			"aborting write\n", len);
-		goto out_nomem;
+	if (len != sizeof(wire)) {
+		deb_error("count %zu does not match message header size %zu\n",
+			  len, sizeof(wire));
+		return -EINVAL;
 	}
 
-	/* Short write -> kbuf->mrq/tx.size/rx.size below read past kmalloc(len). */
-	if (len < sizeof(*kbuf)) {
-		deb_error("count %zu shorter than message header, aborting write\n", len);
-		ret = -EINVAL;
-		goto out_nomem;
-	}
-
-	ret = -ENOMEM;
-	kbuf = kmalloc(len, GFP_KERNEL);
-
-
-	if (!kbuf)
-		goto out_nomem;
-
-	memset(kbuf, 0, len);
-
-	ret = -EFAULT;
-	
-	// Copy header
-	if (copy_from_user(kbuf, buffer, len)) {
+	if (copy_from_user(&wire, buffer, sizeof(wire))) {
 		deb_error("copy_from_user(1) failed\n");
-		goto out_cfu;
+		return -EFAULT;
 	}
 
-	deb_info("\nwants to write %zu bytes, with mrq: %d\n", len, kbuf->mrq);
+	deb_info("\nwants to write %zu bytes, with mrq: %d\n", len, wire.mrq);
 
 	// A malformed or malicious guest can set tx.size/rx.size larger than the
 	// BUF_SIZE bounce buffers below; copy_from_user would then overflow the host
@@ -479,91 +487,105 @@ static ssize_t write(struct file *filep, const char *buffer, size_t len, loff_t 
 	// __kmem_cache_alloc_node from unrelated syscalls). Real MRQs are bounded by
 	// the guest BPMP window (< MESSAGE_SIZE), so anything larger is rejected. The
 	// guest proxy only caps tx.size, so rx.size must be checked here.
-	if (kbuf->tx.size > BUF_SIZE || kbuf->rx.size > BUF_SIZE) {
-		deb_error("tx.size %zu / rx.size %zu exceeds %d, rejecting\n",
-			  kbuf->tx.size, kbuf->rx.size, BUF_SIZE);
-		goto out_cfu;
+	if (wire.tx.size > BUF_SIZE || wire.rx.size > BUF_SIZE) {
+		deb_error("tx.size %llu / rx.size %llu exceeds %d, rejecting\n",
+			  wire.tx.size, wire.rx.size, BUF_SIZE);
+		return -EINVAL;
 	}
 
-	if(kbuf->tx.size > 0){
+	usertxbuf = u64_to_user_ptr(wire.tx.data);
+	userrxbuf = u64_to_user_ptr(wire.rx.data);
+
+	if (wire.tx.size > 0) {
 		txbuf = kmalloc(BUF_SIZE, GFP_KERNEL);
-		if (!txbuf)
-			goto out_nomem;
+		if (!txbuf) {
+			ret = -ENOMEM;
+			goto out;
+		}
 		memset(txbuf, 0, BUF_SIZE);
-		if (copy_from_user(txbuf, kbuf->tx.data, kbuf->tx.size)) {
+		if (copy_from_user(txbuf, usertxbuf, wire.tx.size)) {
 			deb_error("copy_from_user(2) failed\n");
-			goto out_cfu;
+			ret = -EFAULT;
+			goto out;
 		}
 	}
 
 	rxbuf = kmalloc(BUF_SIZE, GFP_KERNEL);
-	if (!rxbuf)
-		goto out_nomem;
-	
+	if (!rxbuf) {
+		ret = -ENOMEM;
+		goto out;
+	}
+
 	memset(rxbuf, 0, BUF_SIZE);
-	if (copy_from_user(rxbuf, kbuf->rx.data, kbuf->rx.size)) {
+	if (copy_from_user(rxbuf, userrxbuf, wire.rx.size)) {
 		deb_error("copy_from_user(3) failed\n");
-		goto out_cfu;
-	}	
+		ret = -EFAULT;
+		goto out;
+	}
 
+	message.mrq = wire.mrq;
+	message.tx.data = txbuf;
+	message.tx.size = wire.tx.size;
+	message.rx.data = rxbuf;
+	message.rx.size = wire.rx.size;
 
-	usertxbuf = (void*)kbuf->tx.data; //save userspace buffers addresses
-	userrxbuf = kbuf->rx.data;
-
-
-	kbuf->tx.data = txbuf; //reassing to kernel space buffers
-	kbuf->rx.data = rxbuf;
-
-	if(!tegra_bpmp_host_device){
+	if (!tegra_bpmp_host_device) {
 		deb_error("host device not initialised, can't do transfer!");
-		goto out_cfu;
+		ret = -ENODEV;
+		goto out;
 	}
 
 	// Only continue if allowed or BPMP_HOST_ALLOWS_ALL
-	if(!check_if_allowed(kbuf) && !BPMP_HOST_ALLOWS_ALL){
-		goto out_cfu;
+	if (!check_if_allowed(&message) && !BPMP_HOST_ALLOWS_ALL) {
+		ret = -EPERM;
+		goto out;
 	}
 
-	hexDump (DEVICE_NAME ": kbuf", kbuf, len);
-	hexDump (DEVICE_NAME ": txbuf", txbuf, kbuf->tx.size);
+	hexDump(DEVICE_NAME ": message", &message, sizeof(message));
+	hexDump(DEVICE_NAME ": txbuf", txbuf, message.tx.size);
 
-	ret = tegra_bpmp_transfer(tegra_bpmp_host_device, (struct tegra_bpmp_message *)kbuf);
+	ret = tegra_bpmp_transfer(tegra_bpmp_host_device, &message);
+	if (ret < 0)
+		goto out;
 
+	if (message.rx.size > BUF_SIZE) {
+		deb_error("response size %zu exceeds %d\n", message.rx.size, BUF_SIZE);
+		ret = -EOVERFLOW;
+		goto out;
+	}
 
-
-	if (copy_to_user((void *)usertxbuf, kbuf->tx.data, kbuf->tx.size)) {
+	if (copy_to_user(usertxbuf, message.tx.data, message.tx.size)) {
 		deb_error("copy_to_user(2) failed\n");
-		goto out_notok;
+		ret = -EFAULT;
+		goto out;
 	}
 
-	if (copy_to_user((void *)userrxbuf, kbuf->rx.data, kbuf->rx.size)) {
+	if (copy_to_user(userrxbuf, message.rx.data, message.rx.size)) {
 		deb_error("copy_to_user(3) failed\n");
-		goto out_notok;
+		ret = -EFAULT;
+		goto out;
 	}
 
-	kbuf->tx.data=usertxbuf;
-	kbuf->rx.data=userrxbuf;
-	
-	if (copy_to_user((void *)buffer, kbuf, len)) {
+	wire.rx.size = message.rx.size;
+	wire.rx.ret = message.rx.ret;
+
+	/*
+	 * This character-device write ABI is intentionally bidirectional: QEMU
+	 * consumes the updated response fields from the same userspace header.
+	 * file_operations.write requires a const buffer, so cast away const only
+	 * for this response copy.
+	 */
+	if (copy_to_user((void __user *)buffer, &wire, sizeof(wire))) {
 		deb_error("copy_to_user(1) failed\n");
-		goto out_notok;
+		ret = -EFAULT;
+		goto out;
 	}
 
-
-
-	kfree(kbuf);
+	ret = len;
+out:
 	kfree(txbuf);
 	kfree(rxbuf);
-	return len;
-out_notok:
-out_nomem:
-	deb_error("memory allocation failed");
-out_cfu:
-	kfree(kbuf);
-	kfree(txbuf);
-	kfree(rxbuf);
-    return -EINVAL;
-
+	return ret;
 }
 
 static const struct of_device_id bpmp_host_proxy_ids[] = {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/bpmp-virt-common/sources/drivers/firmware/tegra/bpmp-host-proxy/bpmp-host-proxy.c
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/bpmp-virt-common/sources/drivers/firmware/tegra/bpmp-host-proxy/bpmp-host-proxy.c
@@ -343,8 +343,16 @@ static bool check_if_allowed(struct tegra_bpmp_message *msg)
 		return true;
 	}
 
+	/* The policed MRQs below read a request struct out of tx. tx.data is NULL
+	 * when the guest sends tx.size == 0, and both fields are guest-controlled,
+	 * so a missing or truncated request must be denied, not dereferenced. */
+
 	// Check for reset and clock mrq
 	if(msg->mrq == MRQ_RESET){
+		if (!msg->tx.data || msg->tx.size < sizeof(*reset_req)) {
+			deb_warn("Warning, reset mrq with truncated tx (%zu), denied", msg->tx.size);
+			return false;
+		}
 		reset_req = (struct mrq_reset_request*) msg->tx.data;
 
 		for(i = 0; i < bpmp_ares.resets_size; i++){
@@ -356,6 +364,10 @@ static bool check_if_allowed(struct tegra_bpmp_message *msg)
 		return false;
 	}
 	else if (msg->mrq == MRQ_CLK){
+		if (!msg->tx.data || msg->tx.size < sizeof(clock_req->cmd_and_id)) {
+			deb_warn("Warning, clk mrq with truncated tx (%zu), denied", msg->tx.size);
+			return false;
+		}
 		clock_req = (struct mrq_clk_request*) msg->tx.data;
 		clk_cmd = (clock_req->cmd_and_id >> 24) & 0x000F;
 
@@ -388,6 +400,10 @@ static bool check_if_allowed(struct tegra_bpmp_message *msg)
 		return false;
 	}
 	else if(msg->mrq == MRQ_PG){
+		if (!msg->tx.data || msg->tx.size < offsetofend(struct mrq_pg_request, id)) {
+			deb_warn("Warning, pg mrq with truncated tx (%zu), denied", msg->tx.size);
+			return false;
+		}
 		pg_req = (struct mrq_pg_request*) msg->tx.data;
 
 		for(i = 0; i < bpmp_ares.pd_size; i++){
@@ -425,15 +441,23 @@ static bool check_if_allowed(struct tegra_bpmp_message *msg)
 extern int tegra_bpmp_transfer(struct tegra_bpmp *, struct tegra_bpmp_message *);
 extern struct tegra_bpmp *tegra_bpmp_host_device;
 
-#define BUF_SIZE 1024
+/*
+ * Matches the QEMU device's 512-byte TX/RX windows (MESSAGE_SIZE in
+ * nvidia_bpmp_guest.c). A larger bound would let copy_to_user() reach past
+ * those windows into adjacent QEMU device state.
+ */
+#define BUF_SIZE 512
 
 /*
  * Stable userspace ABI shared with QEMU's nvidia_bpmp_guest device.
  *
- * Do not use struct tegra_bpmp_message as the wire format: NVIDIA's host 6.6
- * kernel adds an unsigned long flags member to that internal structure, while
- * the upstream 6.12 guest and QEMU header end at rx.ret. On aarch64 those
- * layouts are 56 and 48 bytes respectively.
+ * Do not use struct tegra_bpmp_message as the wire format. It is a
+ * kernel-internal type: it gained an `unsigned long flags` member in v6.7
+ * (backported to 6.6.y as 9c9312fccdc9), so it is 56 bytes on both the
+ * 6.6.129 host and the 6.12 guest. QEMU's device previously declared its own
+ * copy of that layout, written before `flags` existed, and so sent 48 bytes
+ * into a 56-byte cast. This struct is the contract instead; it is 48 bytes by
+ * definition and must not track the kernel type.
  */
 struct bpmp_proxy_wire_message {
 	u32 mrq;

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/sources/hw/misc/nvidia_bpmp_guest.c
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/sources/hw/misc/nvidia_bpmp_guest.c
@@ -119,8 +119,12 @@ static void nvidia_bpmp_guest_write(void *opaque, hwaddr addr, uint64_t data, un
 		ret = write(s->host_device_fd, &messg, sizeof(messg)); // Send the data to the host module
 		if (ret < 0)
 		{
+			/* The host proxy denied or failed the transfer without filling
+			 * the response fields. Report a defined failure instead of
+			 * leaving RET_COD/RX_SIZ at the previous transaction's values. */
+			messg.rx.ret = -EIO;
+			messg.rx.size = 0;
 			qemu_log_mask(LOG_UNIMP, "%s: Failed to write the host device..\n", __func__);
-			return;
 		}
 
 		memcpy(&s->mem[RET_COD], &messg.rx.ret, sizeof(messg.rx.ret));

--- a/packages/pkgs-by-name/ghaf-qemu-bpmp/sources/hw/misc/nvidia_bpmp_guest.c
+++ b/packages/pkgs-by-name/ghaf-qemu-bpmp/sources/hw/misc/nvidia_bpmp_guest.c
@@ -19,6 +19,31 @@ DECLARE_INSTANCE_CHECKER(NvidiaBpmpGuestState, NVIDIA_BPMP_GUEST, TYPE_NVIDIA_BP
 #define HOST_DEVICE_PATH "/dev/bpmp-host"
 #define MESSAGE_SIZE 0x0200
 
+/*
+ * Stable userspace ABI shared with bpmp-host-proxy.
+ *
+ * Keep this separate from struct tegra_bpmp_message: NVIDIA's host kernel adds
+ * internal fields that are not part of the QEMU-to-host wire protocol.
+ */
+typedef struct BpmpProxyWireMessage {
+	uint32_t mrq;
+	uint32_t reserved0;
+
+	struct {
+		uint64_t data;
+		uint64_t size;
+	} tx;
+
+	struct {
+		uint64_t data;
+		uint64_t size;
+		int32_t ret;
+		uint32_t reserved0;
+	} rx;
+} BpmpProxyWireMessage;
+
+G_STATIC_ASSERT(sizeof(BpmpProxyWireMessage) == 48);
+
 // qemu_log_mask(LOG_UNIMP, "%s: \n", __func__ );
 
 struct NvidiaBpmpGuestState
@@ -69,23 +94,8 @@ static uint64_t nvidia_bpmp_guest_read(void *opaque, hwaddr addr, unsigned int s
 static void nvidia_bpmp_guest_write(void *opaque, hwaddr addr, uint64_t data, unsigned int size)
 {
 	NvidiaBpmpGuestState *s = opaque;
+	BpmpProxyWireMessage messg;
 	int ret;
-
-	struct
-	{
-		unsigned int mrq;
-		struct
-		{
-			void *data;
-			size_t size;
-		} tx;
-		struct
-		{
-			void *data;
-			size_t size;
-			int ret;
-		} rx;
-	} messg;
 
 	memset(&messg, 0, sizeof(messg));
 
@@ -101,9 +111,9 @@ static void nvidia_bpmp_guest_write(void *opaque, hwaddr addr, uint64_t data, un
 	case MRQ:
 		// set up the structure
 		messg.mrq = data;
-		messg.tx.data = &s->mem[TX_BUF];
+		messg.tx.data = (uintptr_t)&s->mem[TX_BUF];
 		memcpy(&messg.tx.size, &s->mem[TX_SIZ], sizeof(messg.tx.size));
-		messg.rx.data = &s->mem[RX_BUF];
+		messg.rx.data = (uintptr_t)&s->mem[RX_BUF];
 		memcpy(&messg.rx.size, &s->mem[RX_SIZ], sizeof(messg.rx.size));
 
 		ret = write(s->host_device_fd, &messg, sizeof(messg)); // Send the data to the host module


### PR DESCRIPTION
## Description of Changes

Fix the BPMP proxy transport used by Orin MGBE0 passthrough.

QEMU sends a 48-byte proxy request, while the NVIDIA 6.6 host kernel uses a 56-byte internal `struct tegra_bpmp_message`. The host proxy currently treats the userspace request as that internal structure. With the short-write hardening enabled, the host rejects every request with:

```
bpmp-host: count 48 shorter than message header, aborting write
```

The NetVM consequently never registers BPMP clocks and `tegra-mgbe` ends deferred probing with error `-110`. Without the short-write check, the same cast can read beyond the 48-byte allocation.

Define a fixed-width 48-byte wire structure on both QEMU and host endpoints. The host translates it into a zero-initialized internal BPMP message before transfer, while retaining the MRQ allowlist, bounce-buffer limits, and userspace-copy checks.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

None.

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - no configuration or documented interface changes
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Build the Orin AGX debug image:
   ```sh
   nix build .#nixosConfigurations.nvidia-jetson-orin-agx-debug.config.system.build.image
   ```
2. Flash and boot the resulting generation.
3. Confirm the host log no longer contains `count 48 shorter than message header`.
4. On the NetVM serial console, confirm BPMP firmware and clocks register.
5. Confirm `tegra-mgbe` binds, a network interface appears, and the log contains no deferred-probe timeout or error `-110`.

Completed validation:

- `git diff --check`
- `nix fmt -- --fail-on-change`
- `nix develop --accept-flake-config --command reuse lint`
- All configured pre-commit hooks
- Native Linux 6.6.129 and `ghaf-qemu-bpmp` 10.1.5 builds on the aarch64 builder

Post-fix hardware validation requires flashing the complete generation and remains pending.