### PR TITLE
feat(orin): let EMC reach its trained maximum frequency

### DIFF
--- a/modules/reference/hardware/jetpack/agx/orin-agx.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx.nix
@@ -31,6 +31,8 @@
         kernelVersion = "upstream-6-6";
         somType = "agx";
         agx.enableNetvmWlanPCIPassthrough = true;
+        # Run DRAM at its trained maximum (3199 MHz vs the 2133 boot rate).
+        emcBoost.enable = true;
         carrierBoard = "devkit";
         # AGX devkit boots rootfs from eMMC.
         flashScriptOverrides = {

--- a/modules/reference/hardware/jetpack/agx/orin-agx64.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx64.nix
@@ -22,6 +22,8 @@
         kernelVersion = "upstream-6-6";
         somType = "agx64";
         agx.enableNetvmWlanPCIPassthrough = true;
+        # Run DRAM at its trained maximum (3199 MHz vs the 2133 boot rate).
+        emcBoost.enable = true;
         carrierBoard = "devkit";
         # AGX64 devkit boots rootfs from eMMC.
         flashScriptOverrides = {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/default.nix
@@ -10,5 +10,6 @@
     ./pci-passthrough-common.nix
     ./virtualization
     ./optee/optee.nix
+    ./emc-boost
   ];
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/emc-boost/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/emc-boost/default.nix
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Let the EMC (DRAM) clock reach its trained maximum instead of being
+# capped at the boot rate.
+#
+# BPMP firmware boots with an internal bandwidth-manager cap at the DRAM
+# boot rate (2133 MHz on AGX Orin), so without intervention the memory bus
+# never reaches the trained maximum (3199 MHz on AGX Orin — a ~50% memory
+# bandwidth loss under load, for every workload on the device). Stock
+# JetPack lifts the cap from the nvphs service; Ghaf does not run it, and
+# the nvpmodel sysfs cap interface cannot raise the cap (its own request
+# is rounded through a call the cap clamps). See
+# emc-boost/module/emc_cap_lift.c for the full analysis.
+#
+# The emc_cap_lift.ko module lifts the cap once at boot (a kernel module,
+# because the CAP_SET MRQ is not reachable from userspace). No rate
+# pinning is done: with the cap lifted, the demand-driven EMC DVFS
+# governor ranges freely — validated on AGX Orin hardware to reach
+# 3199 MHz under memory load and drop back to 204 MHz at idle.
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.ghaf.hardware.nvidia.orin.emcBoost;
+in
+{
+  _file = ./default.nix;
+
+  options.ghaf.hardware.nvidia.orin.emcBoost = {
+    enable = lib.mkEnableOption "running the EMC (DRAM) clock at its trained maximum";
+
+    frequencyHz = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 3199000000;
+      description = ''
+        EMC frequency cap to request from BPMP, in Hz. The default is the
+        trained maximum on AGX Orin (and Orin NX). This is a ceiling for
+        the demand-driven DVFS governor, not a fixed rate.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.extraModulePackages = [
+      (config.boot.kernelPackages.callPackage ./module { })
+    ];
+    boot.kernelModules = [ "emc_cap_lift" ];
+    boot.kernelParams = [ "emc_cap_lift.cap_hz=${toString cfg.frequencyHz}" ];
+  };
+}

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/emc-boost/module/Makefile
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/emc-boost/module/Makefile
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Out-of-tree build Makefile for the EMC cap lift module
+#
+# Override KERNEL_DIR if you want a different kernel build tree:
+#   make KERNEL_DIR=/path/to/kernel/build
+
+KERNELRELEASE ?= $(shell uname -r)
+KERNEL_DIR  ?= /lib/modules/$(KERNELRELEASE)/build
+PWD := $(shell pwd)
+
+obj-m := emc_cap_lift.o
+
+all:
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules
+
+install:
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules_install
+
+clean:
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) clean

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/emc-boost/module/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/emc-boost/module/default.nix
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  stdenv,
+  kernel,
+  kernelModuleMakeFlags,
+  kmod,
+}:
+
+stdenv.mkDerivation {
+  pname = "emc-cap-lift";
+  version = "0.1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+
+  # External modules should not be PIC.
+  hardeningDisable = [ "pic" ];
+
+  makeFlags =
+    kernelModuleMakeFlags
+    ++ [
+      "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      "INSTALL_MOD_PATH=$(out)"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "CROSS_COMPILE=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}"
+    ];
+
+  dontStrip = true;
+
+  meta = {
+    description = "Out-of-tree module lifting the BPMP-internal EMC frequency cap on Tegra234";
+    license = lib.licenses.gpl2Only;
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/emc-boost/module/emc_cap_lift.c
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/emc-boost/module/emc_cap_lift.c
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * One-shot lift of the BPMP-internal EMC bandwidth-manager frequency cap.
+ *
+ * BPMP boots with its bwmgr EMC cap at the DRAM boot rate (2133 MHz on
+ * AGX Orin) and re-evaluates the EMC clock against it every second, so the
+ * memory bus never reaches the trained maximum (3199 MHz on AGX Orin, a
+ * ~50% bandwidth loss). The stock sysfs path
+ * (/sys/kernel/nvpmodel_clk_cap/emc) cannot raise the cap: its store
+ * handler sends CAP_SET(clk_round_rate(S64_MAX)) and round_rate is itself
+ * clamped by the current cap. Stock JetPack lifts the cap from the nvphs
+ * service, which Ghaf does not run.
+ *
+ * This module sends the one CAP_SET the sysfs path cannot. Nothing else
+ * is needed: with the cap lifted, the demand-driven EMC DVFS governor
+ * ranges freely between its idle and maximum rates.
+ */
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_platform.h>
+#include <linux/platform_device.h>
+#include <soc/tegra/bpmp.h>
+
+static unsigned long cap_hz = 3199000000UL;
+module_param(cap_hz, ulong, 0444);
+MODULE_PARM_DESC(cap_hz, "EMC frequency cap to request from BPMP (Hz)");
+
+/*
+ * From NVIDIA's downstream bpmp-abi.h (nv-oot tree); declared locally
+ * because the upstream kernel's copy lacks the bwmgr_int MRQ. The MRQ is
+ * served by BPMP firmware, so it is kernel-version independent.
+ */
+#define MRQ_BWMGR_INT		83
+#define CMD_BWMGR_INT_CAP_SET	3
+
+struct bwmgr_int_cap_set_req {
+	u32 cmd;
+	u64 rate;
+} __packed;
+
+static int __init emc_cap_lift_init(void)
+{
+	struct bwmgr_int_cap_set_req req = {
+		.cmd = CMD_BWMGR_INT_CAP_SET,
+		.rate = cap_hz,
+	};
+	u64 resp = 0;
+	struct tegra_bpmp_message msg = {
+		.mrq = MRQ_BWMGR_INT,
+		.tx = { .data = &req, .size = sizeof(req) },
+		.rx = { .data = &resp, .size = sizeof(resp) },
+	};
+	struct device_node *np;
+	struct platform_device *pdev;
+	struct tegra_bpmp *bpmp;
+	int ret;
+
+	/*
+	 * Same lookup tegra_bpmp_get() performs, without needing a bound
+	 * device: the BPMP platform device's drvdata is the tegra_bpmp
+	 * handle. The tegra186 compatible is carried by the tegra234 node
+	 * as well.
+	 */
+	np = of_find_compatible_node(NULL, NULL, "nvidia,tegra186-bpmp");
+	if (!np)
+		return -ENODEV;
+	pdev = of_find_device_by_node(np);
+	of_node_put(np);
+	if (!pdev)
+		return -ENODEV;
+	bpmp = platform_get_drvdata(pdev);
+	if (!bpmp) {
+		put_device(&pdev->dev);
+		return -EPROBE_DEFER;
+	}
+
+	ret = tegra_bpmp_transfer(bpmp, &msg);
+	put_device(&pdev->dev);
+	if (ret) {
+		pr_err("emc_cap_lift: transfer failed: %d\n", ret);
+		return ret;
+	}
+	if (msg.rx.ret) {
+		pr_err("emc_cap_lift: BPMP refused cap %lu Hz: %d\n",
+		       cap_hz, msg.rx.ret);
+		return -EINVAL;
+	}
+	pr_info("emc_cap_lift: EMC cap set to %lu Hz\n", cap_hz);
+	return 0;
+}
+module_init(emc_cap_lift_init);
+
+static void __exit emc_cap_lift_exit(void)
+{
+	/* Nothing to undo: the cap stays until the next BPMP reset. */
+}
+module_exit(emc_cap_lift_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("One-shot BPMP EMC bwmgr cap lift");


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

On Orin, BPMP firmware boots with an internal bandwidth-manager cap on the EMC (DRAM) clock at the boot rate — 2133 MHz on AGX Orin — and every rate request is clamped to it. The trained maximum is 3199 MHz, so Ghaf devices leave roughly a third of their memory bandwidth unused under load, for every workload on the device (host, VMs, GPU).

The cap cannot be raised from stock userspace: the `nvpmodel_clk_cap` sysfs store sends `CAP_SET(clk_round_rate(S64_MAX))`, and `round_rate` is itself clamped by the current cap, so the request can never exceed it (a self-deadlock). Stock JetPack escapes this via the nvphs power-hinting service, which Ghaf does not run.

This PR adds a `ghaf.hardware.nvidia.orin.emcBoost` option backed by `emc_cap_lift.ko`, a ~100-line out-of-tree module that sends the `MRQ_BWMGR_INT`/`CMD_BWMGR_INT_CAP_SET` request once at boot. The MRQ is served by BPMP firmware, so the module is kernel-version independent (built and tested against the 6.6.129 host kernel; also validated on an r36.5 L4T 5.15 kernel). No rate pinning is done: with the cap lifted, the demand-driven EMC DVFS governor ranges freely — full bandwidth under load, low clocks (and power) at idle. The option is enabled for the AGX and AGX64 reference boards; the frequency is configurable (`emcBoost.frequencyHz`, default 3199 MHz).

**A note on why this exists at all:** there is no indication this is a deliberate restriction — the CAP_SET MRQ is not gated or authenticated in BPMP firmware, and it accepts the request from any kernel module. **It is, however, a consequence of NVIDIA's stack architecture: the only component that ever lifts the boot-time cap is the closed-source nvphs service, and the equivalent EMC scaling support has not been upstreamed to mainline. Any OS that does not run NVIDIA's closed userspace therefore silently loses ~1/3 of memory bandwidth, with `max_rate` still advertising the full 3199 MHz.** This module reimplements the single firmware request needed to remove that dependency.

### Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

None.

## Checklist
- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

## Testing Instructions
### Applicable Targets
- [x] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`
### Installation Method
- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
### Test Steps To Verify:
1. Boot an AGX Orin target with this change; `dmesg | grep emc_cap_lift` shows `EMC cap set to 3199000000 Hz`.
2. Idle: `sudo cat /sys/kernel/debug/bpmp/debug/clk/emc/rate` reads a low rate (204/665 MHz) — demand DVFS active.
3. Load: run several parallel memory-bound streams (e.g. `for i in $(seq 12); do dd if=/dev/zero of=/dev/null bs=256M count=100 & done`) and re-read the rate — it reaches `3199000000`.
4. Without the module (baseline), step 3 never exceeds `2133000000`.

Hardware validation already performed on an AGX Orin 64GB devkit (steps 1-4, including the 2133-ceiling baseline): idle 204 MHz, loaded 3199 MHz, and the previously deadlocked `/sys/kernel/nvpmodel_clk_cap/emc` interface becomes functional after the cap lift.

