### PR TITLE
feat(jetson): Add support for UKI image generation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -393,16 +393,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781773180,
-        "narHash": "sha256-VtaK7KGlQRS4hKlYAMGAy3exjGjE0wB0upk8+EKRcq0=",
+        "lastModified": 1786040753,
+        "narHash": "sha256-yazxijtId1x+roCrSJ3Smcn3iPTN4lZj2cIjA2aBPU0=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "8c59a2ac4f226a2275247e535ba5aafa180177b3",
+        "rev": "06305c64c3a152c5a55f7d1fa98f6485c6f934c9",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
-        "ref": "hotfix-ghaf-bump",
+        "ref": "uki-sec-boot",
         "repo": "jetpack-nixos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,7 @@
     # Nvidia Orin support for NixOS
     jetpack-nixos = {
       #url = "github:anduril/jetpack-nixos";
-      url = "github:tiiuae/jetpack-nixos/hotfix-ghaf-bump";
+      url = "github:tiiuae/jetpack-nixos/uki-sec-boot";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -179,15 +179,30 @@ let
       if [ -n "''${SIGNED_ARTIFACTS_DIR:-}" ]; then
         echo "Using signed artifacts from $SIGNED_ARTIFACTS_DIR"
 
-        for artifact in BOOTAA64.EFI Image; do
-          if [ ! -f "$SIGNED_ARTIFACTS_DIR/$artifact" ]; then
-            echo "ERROR: Missing $artifact in $SIGNED_ARTIFACTS_DIR" >&2
-            exit 1
-          fi
-        done
+        ls -la "$SIGNED_ARTIFACTS_DIR"
+        # Verify of existence necessary artifacts
+        ${
+          if config.ghaf.image.sdcard.uki.enable then
+            ''
+              if [ ! -f "$SIGNED_ARTIFACTS_DIR/nixos.efi" ]; then
+                echo "ERROR: Missing nixos.efi (UKI) in $SIGNED_ARTIFACTS_DIR" >&2
+                exit 1
+              fi''
+          else
+            ''
+              if [ ! -f "$SIGNED_ARTIFACTS_DIR/Image" ]; then
+                echo "ERROR: Missing Image in $SIGNED_ARTIFACTS_DIR" >&2
+                exit 1
+              fi
+              export KERNEL_IMAGE="$SIGNED_ARTIFACTS_DIR/Image"
+            ''
+        }
 
+        if [ ! -f "$SIGNED_ARTIFACTS_DIR/BOOTAA64.EFI" ]; then
+          echo "ERROR: Missing BOOTAA64.EFI in $SIGNED_ARTIFACTS_DIR" >&2
+          exit 1
+        fi
         export BOOTAA64_EFI="$SIGNED_ARTIFACTS_DIR/BOOTAA64.EFI"
-        export KERNEL_IMAGE="$SIGNED_ARTIFACTS_DIR/Image"
 
         # NOTE: initrd and DTB swaps are currently a no-op for Secure Boot.
         # UEFI on Orin only verifies the loaded EFI binary (BOOTAA64.EFI);
@@ -216,15 +231,17 @@ let
         cp -f "$BOOTAA64_EFI" "$WORKDIR/bootloader/BOOTAA64.efi"
       fi
 
-      if [ -n "''${KERNEL_IMAGE:-}" ]; then
-        if [ ! -f "$KERNEL_IMAGE" ]; then
-          echo "ERROR: KERNEL_IMAGE not found: $KERNEL_IMAGE" >&2
-          exit 1
+      ${lib.optionalString (!config.ghaf.image.sdcard.uki.enable) ''
+        if [ -n "''${KERNEL_IMAGE:-}" ]; then
+          if [ ! -f "$KERNEL_IMAGE" ]; then
+            echo "ERROR: KERNEL_IMAGE not found: $KERNEL_IMAGE" >&2
+            exit 1
+          fi
+          echo "Using external kernel Image: $KERNEL_IMAGE"
+          mkdir -pv "$WORKDIR/kernel"
+          cp -f "$KERNEL_IMAGE" "$WORKDIR/kernel/Image"
         fi
-        echo "Using external kernel Image: $KERNEL_IMAGE"
-        mkdir -pv "$WORKDIR/kernel"
-        cp -f "$KERNEL_IMAGE" "$WORKDIR/kernel/Image"
-      fi
+      ''}
 
       ${lib.optionalString (!cfg.flashScriptOverrides.onlyQSPI) ''
         image_source_root=${

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -11,6 +11,12 @@
 # EFI-directory and proper kind of structure, it finds the EFI-applications and
 # boots them successfully.
 #
+# When ghaf.image.sdcard.uki.enable is set, the ESP is populated with a Unified
+# Kernel Image (Type #2 BLS entry) instead of the traditional Type #1 entry
+# produced by mk-esp-contents.py. The UKI bundles kernel, initrd, cmdline, DTB,
+# and os-release into a single PE/COFF binary discovered automatically by
+# systemd-boot from EFI/Linux/.
+#
 {
   config,
   pkgs,
@@ -38,153 +44,238 @@ let
           "--with-luks2-lock-path=/tmp/cryptsetup"
         ];
       });
+
+  cfg = config.ghaf.image.sdcard;
+  inherit (pkgs.stdenv.hostPlatform) efiArch;
+  fdtPath = "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
 in
 {
   imports = [ (modulesPath + "/installer/sd-card/sd-image.nix") ];
 
-  boot.loader.grub.enable = false;
-  hardware.enableAllHardware = lib.mkForce false;
+  options.ghaf.image.sdcard.uki = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Populate the SD image ESP with a Unified Kernel Image (Type #2 BLS
+        entry) instead of the traditional Type #1 entries from
+        mk-esp-contents.py.
 
-  sdImage =
-    let
-      # TODO do we really need replaceVars just to set the python string in the
-      # shbang?
-      mkESPContentSource = pkgs.replaceVars ./mk-esp-contents.py {
-        inherit (pkgs.buildPackages) python3;
-      };
-      mkESPContent =
-        pkgs.runCommand "mk-esp-contents"
-          {
-            nativeBuildInputs = with pkgs; [
-              mypy
-              python3
-            ];
-          }
-          ''
-            install -m755 ${mkESPContentSource} $out
-            mypy \
-              --no-implicit-optional \
-              --disallow-untyped-calls \
-              --disallow-untyped-defs \
-              $out
-          '';
-      fdtPath = "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
-    in
-    {
-      firmwareSize = 256;
+        The UKI bundles kernel, initrd, cmdline, DTB, and os-release into a
+        single PE/COFF binary that systemd-boot discovers automatically from
+        EFI/Linux/.
 
-      # The initrd resize-partitions service grows the root partition and
-      # filesystem for both the plain and the LUKS layout, so the stock
-      # stage-2 expand-root-partition.service is redundant everywhere (and
-      # broken for LUKS: it resolves the root device via `lsblk -npo PKNAME /`,
-      # which is empty for a /dev/mapper/cryptroot root).
-      expandOnBoot = false;
-      populateFirmwareCommands = ''
-        mkdir -pv firmware
-        ${mkESPContent} \
-          --toplevel ${config.system.build.toplevel} \
-          --output firmware/ \
-          --device-tree ${fdtPath}
-      '';
-      populateRootCommands = "";
-
-      preBuildCommands = ''
-        ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
-          printf "\nGeneric LUKS rootfs encryption is enabled.\n"
-
-          ROOT_IMAGE=$root_fs
-
-          if [ ! -w "$ROOT_IMAGE" ]; then
-            chmod 755 $ROOT_IMAGE
-          fi
-
-          e2fsck -fy "$ROOT_IMAGE"
-
-          # Reserve space for LUKS
-          current_blocks=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block count:[[:space:]]*//p')
-          block_size=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block size:[[:space:]]*//p')
-          extra_blocks=$(( ${toString rootfsExtraSlackMiB} * 1024 * 1024 / block_size ))
-          resize2fs "$ROOT_IMAGE" "$((current_blocks + extra_blocks))"
-
-          LUKS_REDUCTION_BYTES=$((16 * 1024 * 1024))
-          LUKS_DATA_OFFSET_BYTES=$((8 * 1024 * 1024))
-          # Host-side verification of root.enc.img shows the mapped device ends up
-          # four additional LUKS data offsets smaller than the final image file.
-          # Account for that before reencrypting so the ext4 filesystem fits the
-          # post-conversion payload exactly.
-          LUKS_PAYLOAD_SLACK_BYTES=$((4 * LUKS_DATA_OFFSET_BYTES))
-
-          GHAF_LUKS_PASSPHRASE_FILE=$(mktemp ".luks-passphrase.XXXXXX")
-          chmod 600 "$GHAF_LUKS_PASSPHRASE_FILE"
-          printf '%s' "${
-            if config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.enable then
-              config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase
-            else
-              config.ghaf.hardware.nvidia.orin.diskEncryption.userPassphrase.passphrase
-          }" > "$GHAF_LUKS_PASSPHRASE_FILE"
-
-          echo "Shrinking plaintext root filesystem before LUKS conversion ..."
-          e2fsck -fy "$ROOT_IMAGE"
-          BLOCK_SIZE=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block size:[[:space:]]*//p')
-          TARGET_PAYLOAD_BYTES=$(( $(stat -c %s "$ROOT_IMAGE") - LUKS_REDUCTION_BYTES - LUKS_DATA_OFFSET_BYTES - LUKS_PAYLOAD_SLACK_BYTES ))
-          TARGET_BLOCKS=$(( TARGET_PAYLOAD_BYTES / BLOCK_SIZE ))
-          resize2fs "$ROOT_IMAGE" "$TARGET_BLOCKS"
-          # Keep the plaintext file one LUKS data offset larger than the
-          # ext4 payload so reencrypt does not collapse the final image size
-          # together with the resized filesystem.
-          truncate -s "$(( TARGET_PAYLOAD_BYTES + LUKS_DATA_OFFSET_BYTES ))" "$ROOT_IMAGE"
-
-          echo "Encrypting extracted root image with LUKS2 ..."
-          # cryptsetup is built with --with-luks2-lock-path=/tmp/cryptsetup;
-          # newer releases refuse to take the reencryption lock if that
-          # directory does not already exist.
-          mkdir -p /tmp/cryptsetup
-          ${cryptsetup}/bin/cryptsetup reencrypt \
-            --encrypt \
-            --type luks2 \
-            --batch-mode \
-            --uuid "${luksUuid}" \
-            --reduce-device-size "$LUKS_REDUCTION_BYTES" \
-            --key-file "$GHAF_LUKS_PASSPHRASE_FILE" \
-            "$ROOT_IMAGE"
-
-          # Re-materialize the final APP image as a fully allocated raw file.
-          # The flash pipeline should see a dense payload, not a sparse file
-          # with holes introduced by truncate during the sizing step above.
-          ROOT_IMAGE_DENSE_PATH="root.enc.dense.img"
-          cp --sparse=never "$ROOT_IMAGE" "$ROOT_IMAGE_DENSE_PATH"
-          mv "$ROOT_IMAGE_DENSE_PATH" "$ROOT_IMAGE"
-
-          rm -f "$GHAF_LUKS_PASSPHRASE_FILE"
-        ''}
-      '';
-      postBuildCommands = ''
-        fdisk_output=$(fdisk -l "$img")
-
-        # Offsets and sizes are in 512 byte sectors
-        blocksize=512
-
-        # ESP partition offset and sector count
-        part_esp=$(echo -n "$fdisk_output" | tail -n 2 | head -n 1 | tr -s ' ')
-        part_esp_begin=$(echo -n "$part_esp" | cut -d ' ' -f2)
-        part_esp_count=$(echo -n "$part_esp" | cut -d ' ' -f4)
-
-        # root-partition offset and sector count
-        part_root=$(echo -n "$fdisk_output" | tail -n 1 | head -n 1 | tr -s ' ')
-        part_root_begin=$(echo -n "$part_root" | cut -d ' ' -f3)
-        part_root_count=$(echo -n "$part_root" | cut -d ' ' -f4)
-
-        echo -n $part_esp_begin > $out/esp.offset
-        echo -n $part_esp_count > $out/esp.size
-        echo -n $part_root_begin > $out/root.offset
-        echo -n $part_root_count > $out/root.size
+        Note: Enabling this produces an image without bootloader-level
+        generation rollback. A single UKI is placed in the ESP.
       '';
     };
 
-  #TODO: should we use the default
-  #https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/sd-card/sd-image.nix#L177
-  fileSystems."/boot" = {
-    device = "/dev/disk/by-label/${config.sdImage.firmwarePartitionName}";
-    fsType = "vfat";
+    dtbPadding = lib.mkOption {
+      type = lib.types.int;
+      default = 65536;
+      description = ''
+        Extra padding bytes added to the device tree blob.
+        systemd-stub needs room in the FDT for runtime modifications
+        (e.g. adding /chosen properties). Increase if firmware rejects
+        the DTB with "Invalid header detected on UEFI supplied FDT".
+      '';
+    };
+  };
+
+  config = {
+    boot.loader.grub.enable = false;
+    hardware.enableAllHardware = lib.mkForce false;
+
+    # Jetson-specific UKI build configuration
+    boot.uki.settings = lib.mkIf cfg.uki.enable (
+      let
+        # When packed in a UKI, the dtb needs some padding to avoid error:
+        # "Invalid header detected on UEFI supplied FDT"
+        # The default value of 64K for dtbPadding should be more than enough.
+        paddedDtb =
+          pkgs.runCommand "padded-dtb"
+            {
+              nativeBuildInputs = [ pkgs.dtc ];
+            }
+            ''
+              mkdir -p $out
+              dtc -I dtb -O dtb -p ${toString cfg.uki.dtbPadding} ${fdtPath} -o $out/padded.dtb
+            '';
+      in
+      {
+        UKI = {
+          DeviceTree = "${paddedDtb}/padded.dtb";
+        };
+      }
+    );
+
+    sdImage =
+      let
+        # TODO do we really need replaceVars just to set the python string in the
+        # shbang?
+        mkESPContentSource = pkgs.replaceVars ./mk-esp-contents.py {
+          inherit (pkgs.buildPackages) python3;
+        };
+        mkESPContent =
+          pkgs.runCommand "mk-esp-contents"
+            {
+              nativeBuildInputs = with pkgs; [
+                mypy
+                python3
+              ];
+            }
+            ''
+              install -m755 ${mkESPContentSource} $out
+              mypy \
+                --no-implicit-optional \
+                --disallow-untyped-calls \
+                --disallow-untyped-defs \
+                $out
+            '';
+        # fdtPath = "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
+      in
+      {
+        firmwareSize = if cfg.uki.enable then 512 else 256;
+
+        # The initrd resize-partitions service grows the root partition and
+        # filesystem for both the plain and the LUKS layout, so the stock
+        # stage-2 expand-root-partition.service is redundant everywhere (and
+        # broken for LUKS: it resolves the root device via `lsblk -npo PKNAME /`,
+        # which is empty for a /dev/mapper/cryptroot root).
+        expandOnBoot = false;
+        populateFirmwareCommands =
+          if cfg.uki.enable then
+            ''
+              mkdir -pv firmware/EFI/BOOT
+              mkdir -pv firmware/EFI/Linux
+              mkdir -pv firmware/loader
+
+              # Install systemd-boot as the UEFI bootloader
+              cp -v ${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi \
+                    firmware/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI
+
+              # Install the UKI (Type #2 entry). systemd-boot discovers it
+              # automatically from EFI/Linux/
+              cp -v ${config.system.build.uki}/${config.system.boot.loader.ukiFile} \
+                    firmware/EFI/Linux/${config.system.boot.loader.ukiFile}
+
+              # Minimal loader configuration
+              cat > firmware/loader/loader.conf << EOF
+              timeout 0
+              editor no
+              console-mode keep
+              EOF
+            ''
+          else
+            ''
+              mkdir -pv firmware
+              ${mkESPContent} \
+                --toplevel ${config.system.build.toplevel} \
+                --output firmware/ \
+                --device-tree ${fdtPath}
+            '';
+
+        populateRootCommands = "";
+
+        preBuildCommands = ''
+          ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
+            printf "\nGeneric LUKS rootfs encryption is enabled.\n"
+
+            ROOT_IMAGE=$root_fs
+
+            if [ ! -w "$ROOT_IMAGE" ]; then
+              chmod 755 $ROOT_IMAGE
+            fi
+
+            e2fsck -fy "$ROOT_IMAGE"
+
+            # Reserve space for LUKS
+            current_blocks=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block count:[[:space:]]*//p')
+            block_size=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block size:[[:space:]]*//p')
+            extra_blocks=$(( ${toString rootfsExtraSlackMiB} * 1024 * 1024 / block_size ))
+            resize2fs "$ROOT_IMAGE" "$((current_blocks + extra_blocks))"
+
+            LUKS_REDUCTION_BYTES=$((16 * 1024 * 1024))
+            LUKS_DATA_OFFSET_BYTES=$((8 * 1024 * 1024))
+            # Host-side verification of root.enc.img shows the mapped device ends up
+            # four additional LUKS data offsets smaller than the final image file.
+            # Account for that before reencrypting so the ext4 filesystem fits the
+            # post-conversion payload exactly.
+            LUKS_PAYLOAD_SLACK_BYTES=$((4 * LUKS_DATA_OFFSET_BYTES))
+
+            GHAF_LUKS_PASSPHRASE_FILE=$(mktemp ".luks-passphrase.XXXXXX")
+            chmod 600 "$GHAF_LUKS_PASSPHRASE_FILE"
+            printf '%s' "${
+              if config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.enable then
+                config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase
+              else
+                config.ghaf.hardware.nvidia.orin.diskEncryption.userPassphrase.passphrase
+            }" > "$GHAF_LUKS_PASSPHRASE_FILE"
+
+            echo "Shrinking plaintext root filesystem before LUKS conversion ..."
+            e2fsck -fy "$ROOT_IMAGE"
+            BLOCK_SIZE=$(dumpe2fs -h "$ROOT_IMAGE" 2>/dev/null | sed -n 's/^Block size:[[:space:]]*//p')
+            TARGET_PAYLOAD_BYTES=$(( $(stat -c %s "$ROOT_IMAGE") - LUKS_REDUCTION_BYTES - LUKS_DATA_OFFSET_BYTES - LUKS_PAYLOAD_SLACK_BYTES ))
+            TARGET_BLOCKS=$(( TARGET_PAYLOAD_BYTES / BLOCK_SIZE ))
+            resize2fs "$ROOT_IMAGE" "$TARGET_BLOCKS"
+            # Keep the plaintext file one LUKS data offset larger than the
+            # ext4 payload so reencrypt does not collapse the final image size
+            # together with the resized filesystem.
+            truncate -s "$(( TARGET_PAYLOAD_BYTES + LUKS_DATA_OFFSET_BYTES ))" "$ROOT_IMAGE"
+
+            echo "Encrypting extracted root image with LUKS2 ..."
+            # cryptsetup is built with --with-luks2-lock-path=/tmp/cryptsetup;
+            # newer releases refuse to take the reencryption lock if that
+            # directory does not already exist.
+            mkdir -p /tmp/cryptsetup
+            ${cryptsetup}/bin/cryptsetup reencrypt \
+              --encrypt \
+              --type luks2 \
+              --batch-mode \
+              --uuid "${luksUuid}" \
+              --reduce-device-size "$LUKS_REDUCTION_BYTES" \
+              --key-file "$GHAF_LUKS_PASSPHRASE_FILE" \
+              "$ROOT_IMAGE"
+
+            # Re-materialize the final APP image as a fully allocated raw file.
+            # The flash pipeline should see a dense payload, not a sparse file
+            # with holes introduced by truncate during the sizing step above.
+            ROOT_IMAGE_DENSE_PATH="root.enc.dense.img"
+            cp --sparse=never "$ROOT_IMAGE" "$ROOT_IMAGE_DENSE_PATH"
+            mv "$ROOT_IMAGE_DENSE_PATH" "$ROOT_IMAGE"
+
+            rm -f "$GHAF_LUKS_PASSPHRASE_FILE"
+          ''}
+        '';
+        postBuildCommands = ''
+          fdisk_output=$(fdisk -l "$img")
+
+          # Offsets and sizes are in 512 byte sectors
+          blocksize=512
+
+          # ESP partition offset and sector count
+          part_esp=$(echo -n "$fdisk_output" | tail -n 2 | head -n 1 | tr -s ' ')
+          part_esp_begin=$(echo -n "$part_esp" | cut -d ' ' -f2)
+          part_esp_count=$(echo -n "$part_esp" | cut -d ' ' -f4)
+
+          # root-partition offset and sector count
+          part_root=$(echo -n "$fdisk_output" | tail -n 1 | head -n 1 | tr -s ' ')
+          part_root_begin=$(echo -n "$part_root" | cut -d ' ' -f3)
+          part_root_count=$(echo -n "$part_root" | cut -d ' ' -f4)
+
+          echo -n $part_esp_begin > $out/esp.offset
+          echo -n $part_esp_count > $out/esp.size
+          echo -n $part_root_begin > $out/root.offset
+          echo -n $part_root_count > $out/root.size
+        '';
+      };
+
+    #TODO: should we use the default
+    #https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/sd-card/sd-image.nix#L177
+    fileSystems."/boot" = {
+      device = "/dev/disk/by-label/${config.sdImage.firmwarePartitionName}";
+      fsType = "vfat";
+    };
+
   };
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -99,7 +99,7 @@ in
             }
             ''
               mkdir -p $out
-              dtc -I dtb -O dtb -p ${toString cfg.uki.dtbPadding} ${fdtPath} -o $out/padded.dtb
+              dtc -I dtb -O dtb -p ${toString cfg.uki.dtbPadding} -o $out/padded.dtb ${fdtPath}
             '';
       in
       {
@@ -151,7 +151,7 @@ in
               mkdir -pv firmware/loader
 
               # Install systemd-boot as the UEFI bootloader
-              cp -v ${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi \
+              cp -v ${config.systemd.package}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi \
                     firmware/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI
 
               # Install the UKI (Type #2 entry). systemd-boot discovers it

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -464,6 +464,8 @@ let
     # supplies one, so keying Secure Boot off it bricked all unsigned
     # flashes.
     #
+    # Use the `-u` flag if the image contains a UKI.
+    #
     # Both variants share substituted store paths (jetpack-nixos
     # `flashScript` is a thin wrapper around the same per-target
     # derivations), so the second build is mostly a Nix-eval cost.


### PR DESCRIPTION
This is rebased PR of #[1852](https://github.com/tiiuae/ghaf/pull/1852)
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
