### PR TITLE
fix(cosmic): make panel applets respond to touch

### DIFF
--- a/overlays/custom-packages/cosmic/cosmic-panel/0001-Emulate-pointer-clicks-for-touch-input.patch
+++ b/overlays/custom-packages/cosmic/cosmic-panel/0001-Emulate-pointer-clicks-for-touch-input.patch
@@ -1,0 +1,273 @@
+Subject: [PATCH] Emulate pointer clicks for touch input on panel applets
+
+Panel applets are ordinary Wayland clients and most of them bind only
+wl_pointer, so a touch sequence forwarded as pure wl_touch never reaches
+them as a click: tapping an applet in the panel does nothing on a
+touchscreen device.
+
+Mirror touch into the emulated pointer, following the existing pointer
+handler rather than adding a parallel path: update the hovered surface,
+send a pointer motion, run space.handle_button so panel focus and popup
+behaviour match a mouse click, set keyboard focus from its result, then
+send BTN_LEFT.
+
+A new client_state.touch_pointer_slot records the touch slot that
+actually produced the press, so the release is emitted for that slot and
+only that slot. A tap that lands where touch_under finds no surface
+therefore cannot produce an unpaired release, multi-touch cannot produce
+multiple clicks, and cancel always clears an outstanding press so the
+button can never be left stuck down.
+
+Based on an earlier incomplete attempt by Kajus Naujokaitis
+<kajus.naujokaitis@unikie.com>, which synthesised pointer motion but no
+button event.
+
+---
+--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/state.rs	2026-07-29 01:39:08.321906055 +0400
++++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/state.rs	2026-07-29 01:39:08.366871316 +0400
+@@ -160,6 +160,8 @@
+     pub(crate) last_key_pressed: Vec<(String, (u32, u32), wl_surface::WlSurface)>,
+     pub(crate) outputs: Vec<(WlOutput, Output, GlobalId)>,
+     pub(crate) touch_surfaces: HashMap<i32, WlSurface>,
++    /// Touch slot currently driving the emulated pointer, if any.
++    pub(crate) touch_pointer_slot: Option<i32>,
+ 
+     pub delayed_surface_motion: HashMap<SmithayWlSurface, (PointerEvent, WlPointer, u128)>,
+ 
+@@ -301,6 +303,7 @@
+ 
+             outputs: Default::default(),
+             touch_surfaces: HashMap::new(),
++            touch_pointer_slot: None,
+             registry_state,
+             multipool: None,
+             cursor_surface: None,
+--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/touch.rs	2026-07-29 01:39:08.319786409 +0400
++++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/touch.rs	2026-07-29 01:39:08.320505740 +0400
+@@ -1,3 +1,4 @@
++use crate::xdg_shell_wrapper::client_state::FocusStatus;
+ use crate::xdg_shell_wrapper::server_state::{SeatPair, ServerPointerFocus};
+ use crate::xdg_shell_wrapper::shared_state::GlobalState;
+ use crate::xdg_shell_wrapper::space::WrapperSpace;
+@@ -6,23 +7,64 @@
+ use sctk::reexports::client::protocol::wl_touch::WlTouch;
+ use sctk::reexports::client::{Connection, QueueHandle};
+ use sctk::seat::touch::TouchHandler;
++use smithay::backend::input::ButtonState;
++use smithay::input::pointer::{ButtonEvent, MotionEvent};
+ use smithay::input::touch::{self, TouchHandle};
+ use smithay::utils::{Point, SERIAL_COUNTER};
+ 
+-fn get_touch_handle(state: &GlobalState, touch: &WlTouch) -> (String, TouchHandle<GlobalState>) {
+-    let seat_index = state
++/// Linux evdev code for the left mouse button, as used by `wl_pointer.button`.
++const BTN_LEFT: u32 = 0x110;
++
++fn get_seat_index(state: &GlobalState, touch: &WlTouch) -> usize {
++    state
+         .server_state
+         .seats
+         .iter()
+         .position(|SeatPair { client, .. }| {
+             client.touch.as_ref().map(|t| t == touch).unwrap_or(false)
+         })
+-        .unwrap();
++        .unwrap()
++}
++
++fn get_touch_handle(state: &GlobalState, touch: &WlTouch) -> (String, TouchHandle<GlobalState>) {
++    let seat_index = get_seat_index(state, touch);
+     let seat_name = state.server_state.seats[seat_index].name.to_string();
+     let touch = state.server_state.seats[seat_index].server.seat.get_touch().unwrap();
+     (seat_name, touch)
+ }
+ 
++impl GlobalState {
++    /// Emulate a left pointer button press or release for a touch event.
++    ///
++    /// Panel applets are ordinary Wayland clients and most of them bind only
++    /// `wl_pointer`, so a plain touch sequence never reaches them as a click and
++    /// tapping an applet does nothing. Mirror the touch into the pointer the
++    /// same way the real pointer handler does, so that applets, their popups and
++    /// keyboard focus all behave identically under touch and mouse.
++    fn touch_emulate_button(&mut self, seat_index: usize, seat_name: &str, time: u32, press: bool) {
++        let ptr = self.server_state.seats[seat_index].server.seat.get_pointer().unwrap();
++        let kbd = self.server_state.seats[seat_index].server.seat.get_keyboard().unwrap();
++
++        if !press {
++            self.server_state.last_button.replace(BTN_LEFT);
++        }
++
++        let focus = self.space.handle_button(seat_name, press);
++        kbd.set_focus(self, focus, SERIAL_COUNTER.next_serial());
++
++        ptr.button(
++            self,
++            &ButtonEvent {
++                serial: SERIAL_COUNTER.next_serial(),
++                time,
++                button: BTN_LEFT,
++                state: if press { ButtonState::Pressed } else { ButtonState::Released },
++            },
++        );
++        ptr.frame(self);
++    }
++}
++
+ impl TouchHandler for GlobalState {
+     fn down(
+         &mut self,
+@@ -35,34 +77,55 @@
+         id: i32,
+         location: (f64, f64),
+     ) {
+-        let seat_index = self
+-            .server_state
+-            .seats
+-            .iter()
+-            .position(|SeatPair { client, .. }| {
+-                client.touch.as_ref().map(|t| t == touch).unwrap_or(false)
+-            })
+-            .unwrap();
++        let seat_index = get_seat_index(self, touch);
+         let seat_name = self.server_state.seats[seat_index].name.to_string();
+         let touch = self.server_state.seats[seat_index].server.seat.get_touch().unwrap();
+         self.server_state.seats[seat_index].client.last_touch_down = (serial, time);
+ 
++        // Only one touch point drives the emulated pointer; additional fingers
++        // must not each generate their own click.
++        let emulate_pointer = self.client_state.touch_pointer_slot.is_none();
++        let c_surface = surface.clone();
+         self.client_state.touch_surfaces.insert(id, surface.clone());
+ 
+         if let Some(ServerPointerFocus { surface, c_pos, s_pos, .. }) =
+             self.space.touch_under((location.0 as i32, location.1 as i32), &seat_name, surface)
+         {
++            let location = c_pos.to_f64() + Point::from(location);
++
+             touch.down(
+                 self,
+-                Some((surface, s_pos)),
++                Some((surface.clone(), s_pos)),
+                 &touch::DownEvent {
+                     slot: Some(id as u32).into(),
+-                    location: c_pos.to_f64() + Point::from(location),
++                    location,
+                     serial: SERIAL_COUNTER.next_serial(),
+                     time,
+                 },
+             );
+             touch.frame(self);
++
++            if emulate_pointer {
++                // Record the slot only here, where the press is actually sent,
++                // so `up` can never emit a release without a matching press.
++                self.client_state.touch_pointer_slot = Some(id);
++                self.server_state.seats[seat_index].client.last_enter = serial;
++                {
++                    let mut c_hovered_surface = self.client_state.hovered_surface.borrow_mut();
++                    c_hovered_surface.clear();
++                    c_hovered_surface.push((c_surface, seat_name.clone(), FocusStatus::Focused));
++                }
++
++                let ptr = self.server_state.seats[seat_index].server.seat.get_pointer().unwrap();
++                ptr.motion(
++                    self,
++                    Some((surface, s_pos)),
++                    &MotionEvent { location, serial: SERIAL_COUNTER.next_serial(), time },
++                );
++                ptr.frame(self);
++
++                self.touch_emulate_button(seat_index, &seat_name, time, true);
++            }
+         }
+     }
+ 
+@@ -75,6 +138,8 @@
+         time: u32,
+         id: i32,
+     ) {
++        let seat_index = get_seat_index(self, touch);
++        let seat_name = self.server_state.seats[seat_index].name.to_string();
+         let (_, touch) = get_touch_handle(self, touch);
+ 
+         touch.up(
+@@ -85,6 +150,15 @@
+                 time,
+             },
+         );
++        touch.frame(self);
++
++        // Release only for the slot that actually produced the press, so a
++        // touch that landed on no applet cannot emit an unpaired release.
++        self.client_state.touch_surfaces.remove(&id);
++        if self.client_state.touch_pointer_slot == Some(id) {
++            self.client_state.touch_pointer_slot = None;
++            self.touch_emulate_button(seat_index, &seat_name, time, false);
++        }
+     }
+ 
+     fn motion(
+@@ -96,6 +170,7 @@
+         id: i32,
+         location: (f64, f64),
+     ) {
++        let seat_index = get_seat_index(self, touch);
+         let (seat_name, touch) = get_touch_handle(self, touch);
+ 
+         if let Some(surface) = self.client_state.touch_surfaces.get(&id)
+@@ -105,16 +180,26 @@
+                 surface.clone(),
+             )
+         {
++            let location = c_pos.to_f64() + Point::from(location);
++
+             touch.motion(
+                 self,
+-                Some((surface, s_pos)),
+-                &touch::MotionEvent {
+-                    slot: Some(id as u32).into(),
+-                    location: c_pos.to_f64() + Point::from(location),
+-                    time,
+-                },
++                Some((surface.clone(), s_pos)),
++                &touch::MotionEvent { slot: Some(id as u32).into(), location, time },
+             );
+             touch.frame(self);
++
++            // Drag the emulated pointer along with the touch point that owns
++            // it, so press-and-drag inside an applet behaves as with a mouse.
++            if self.client_state.touch_pointer_slot == Some(id) {
++                let ptr = self.server_state.seats[seat_index].server.seat.get_pointer().unwrap();
++                ptr.motion(
++                    self,
++                    Some((surface, s_pos)),
++                    &MotionEvent { location, serial: SERIAL_COUNTER.next_serial(), time },
++                );
++                ptr.frame(self);
++            }
+         }
+     }
+ 
+@@ -142,8 +227,19 @@
+     }
+ 
+     fn cancel(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, touch: &WlTouch) {
++        let seat_index = get_seat_index(self, touch);
++        let seat_name = self.server_state.seats[seat_index].name.to_string();
+         let (_, touch) = get_touch_handle(self, touch);
+         touch.cancel(self);
++
++        // The sequence was aborted, so drop the emulated press rather than
++        // leaving the button held down forever.
++        let was_emulating = self.client_state.touch_pointer_slot.is_some();
++        self.client_state.touch_surfaces.clear();
++        self.client_state.touch_pointer_slot = None;
++        if was_emulating {
++            self.touch_emulate_button(seat_index, &seat_name, 0, false);
++        }
+     }
+ }
+ 
+--
+2.51.2

--- a/overlays/custom-packages/cosmic/cosmic-panel/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-panel/default.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# Make panel applets respond to touch input.
+# Applets bind only wl_pointer, so plain wl_touch events never reach them as
+# clicks and tapping an applet does nothing on a touchscreen device.
+# Ref: https://github.com/pop-os/cosmic-panel
+{ prev }:
+prev.cosmic-panel.overrideAttrs (oldAttrs: {
+  patches = oldAttrs.patches ++ [
+    ./0001-Emulate-pointer-clicks-for-touch-input.patch
+  ];
+})

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -13,6 +13,7 @@
   cosmic-greeter = import ./cosmic/cosmic-greeter { inherit prev; };
   cosmic-initial-setup = import ./cosmic/cosmic-initial-setup { inherit prev; };
   cosmic-osd = import ./cosmic/cosmic-osd { inherit prev; };
+  cosmic-panel = import ./cosmic/cosmic-panel { inherit prev; };
   cosmic-player = import ./cosmic/cosmic-player { inherit prev; };
   cosmic-reader = import ./cosmic/cosmic-reader { inherit prev; };
   cosmic-settings = import ./cosmic/cosmic-settings { inherit prev; };


### PR DESCRIPTION
## Description of Changes

Panel applets are ordinary Wayland clients and most of them bind only `wl_pointer`. `cosmic-panel` forwards touchscreen input as pure `wl_touch`, so those events never reach an applet as a click — **tapping an applet in the panel does nothing on a touchscreen device**.

This adds a `cosmic-panel` overlay that mirrors touch into the emulated pointer, following the existing pointer handler rather than introducing a parallel path:

| event | behaviour |
|---|---|
| `down` | update `hovered_surface`, send a pointer motion, call `space.handle_button(seat, true)` so panel focus and popup behaviour match a mouse click, set keyboard focus from its result, then send `BTN_LEFT` `Pressed` |
| `motion` | drag the emulated pointer along with a single touch point |
| `up` | release `BTN_LEFT` once the last touch point is up |
| `cancel` | release `BTN_LEFT`, so an aborted sequence cannot leave the button stuck down |

A new `client_state.touch_pointer_slot` records the slot that actually produced the press, so the release is emitted for that slot and only that slot. This matters: `touch_surfaces` is populated unconditionally in `down`, but the press only happens when `touch_under` finds a surface — inferring the release from map emptiness would emit an unpaired release for a tap that landed on nothing. Multi-touch therefore cannot produce multiple clicks, and `cancel` always clears an outstanding press so the button is never left stuck down. The `touch_surfaces` map is also now cleaned up on `up` and `cancel`; previously entries were only ever inserted.

### Why here and not just downstream

This is not product-specific: any Ghaf device with a touchscreen (e.g. the Dell Latitude 7230 Rugged) has an unusable panel without it. Ghaf already owns the COSMIC desktop for its downstreams and carries overlays for `cosmic-applets`, `cosmic-comp`, `cosmic-greeter`, `cosmic-initial-setup`, `cosmic-osd`, `cosmic-player`, `cosmic-reader`, `cosmic-settings` and `cosmic-settings-daemon`, so `cosmic-panel` belongs alongside them.

The proper long-term home is [pop-os/cosmic-panel](https://github.com/pop-os/cosmic-panel) — this overlay should be dropped once an equivalent lands upstream.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!-- add ticket reference if there is one -->

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit
- [x] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets
- [x] Dell Latitude `x86_64` (7230 Rugged — the touchscreen target)
- [ ] Lenovo X1 `x86_64`
- [ ] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`nix build ...installer`)
- [x] Can be updated with `nixos-rebuild ...`

### Test Steps To Verify

Build verification (no hardware needed):

```shell
# the patch applies and the package compiles cleanly
nix build --impure --expr '(import <nixpkgs> {
  overlays = [ (import ./overlays/custom-packages) ];
}).cosmic-panel'
```

Behaviour verification (needs a touchscreen device):

1. Boot a Ghaf image with a touchscreen and log into the COSMIC session.
2. Tap a panel applet — e.g. the network, audio or battery applet.
3. **Before:** nothing happens; the applet popup never opens.
   **After:** the popup opens exactly as it does with a mouse click.
4. Tap elsewhere to dismiss the popup; confirm it closes.
5. Press and drag across the panel, then lift — confirm no button is left stuck (a stuck button shows up as the next tap being swallowed).
6. Confirm mouse and trackpad clicking on applets still behaves exactly as before.
