### PR TITLE
fix(lib): stop vmConfig dropping mem when vcpu is also set

### DIFF
--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -845,9 +845,16 @@ rec {
         vmConfigModules = vmCfg.extraModules or [ ];
 
         # Resource allocation module (applies vmConfig.mem/vcpu)
-        resourceModule =
-          lib.optionalAttrs (vmCfg.mem or null != null) { microvm.mem = vmCfg.mem; }
-          // lib.optionalAttrs (vmCfg.vcpu or null != null) { microvm.vcpu = vmCfg.vcpu; };
+        #
+        # Merge inside `microvm`, not at the top level: `//` is a shallow
+        # update, so combining { microvm.mem = ...; } with
+        # { microvm.vcpu = ...; } would replace the whole microvm attrset and
+        # silently drop mem whenever both are set.
+        resourceModule = {
+          microvm =
+            lib.optionalAttrs (vmCfg.mem or null != null) { inherit (vmCfg) mem; }
+            // lib.optionalAttrs (vmCfg.vcpu or null != null) { inherit (vmCfg) vcpu; };
+        };
       in
       [ resourceModule ] ++ hwModules ++ vmConfigModules;
   };


### PR DESCRIPTION
## Description of Changes

`lib.ghaf.vm.applyVmConfig` builds its resource module like this:

```nix
resourceModule =
  lib.optionalAttrs (vmCfg.mem  or null != null) { microvm.mem  = vmCfg.mem; }
  // lib.optionalAttrs (vmCfg.vcpu or null != null) { microvm.vcpu = vmCfg.vcpu; };
```

`//` is a **shallow** update. When a downstream sets both `mem` and `vcpu` on a system VM, the second attrset replaces the whole `microvm` attrset and **`mem` is silently discarded** — the VM falls back to the base module's `mkDefault` with no error and no warning.

Minimal repro, independent of any config:

```
$ nix eval --impure --expr 'with (import <nixpkgs> {}).lib;
    optionalAttrs true { microvm.mem = 10240; } // optionalAttrs true { microvm.vcpu = 6; }'
{ microvm = { vcpu = 6; }; }
```

The fix merges inside `microvm` so both keys survive.

### Impact

Anything that sets both fields on a sys-VM gets the default memory instead of the configured value. Setting only one of the two was unaffected, which is why this went unnoticed — and because it evaluates and builds cleanly, the only symptom is a VM that is quietly smaller than intended.

Found while bumping [`ghaf-fmo-laptop`](https://github.com/tiiuae/ghaf-fmo-laptop) onto current ghaf: all seven of its targets set `mem` and `vcpu` together, so every one of them would have shipped a 6144 MB gui-VM instead of the configured size.

### Verification

Downstream config `ghaf.virtualization.vmConfig.sysvms.guivm = { mem = 10496; vcpu = 7; }`, evaluating `microvm.vms.gui-vm.evaluatedConfig.config.microvm`:

| | `mem` | `vcpu` |
|---|---|---|
| before | **6144** (guivm-base `mkDefault`) | 7 |
| after | **10496** | 7 |

Also checked that a VM which sets no `vmConfig` at all is unaffected (audio-vm still evaluates to its default 512).

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!-- none -->

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit
- [x] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets
- [x] Any target whose `vmConfig.sysvms.<vm>` sets both `mem` and `vcpu`
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] Alienware `x86_64`

### Installation Method
- [x] Evaluation-only change; no reinstall needed

### Test Steps To Verify

```shell
# 1. the merge semantics, in isolation
nix eval --impure --expr 'with (import <nixpkgs> {}).lib;
  optionalAttrs true { microvm.mem = 10240; } // optionalAttrs true { microvm.vcpu = 6; }'
#   before this PR's reasoning: { microvm = { vcpu = 6; }; }   <- mem gone

# 2. end to end, on any target that sets both fields
#    set  ghaf.virtualization.vmConfig.sysvms.guivm = { mem = 10496; vcpu = 7; }
nix eval .#nixosConfigurations.<target>.config \
  .microvm.vms.gui-vm.evaluatedConfig.config.microvm.mem
#   before: 6144
#   after:  10496
```

No behaviour change for configurations that set only `mem` or only `vcpu`, or neither.
