### PR TITLE
feat(spire): attest GIVC workloads

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -244,6 +244,11 @@ in
             type = lib.types.listOf lib.types.str;
             description = "Selector of the workload";
           };
+          dnsNames = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = "DNS names to include in the workload X.509-SVID";
+          };
         };
       }
     );

--- a/modules/common/security/fleet/default.nix
+++ b/modules/common/security/fleet/default.nix
@@ -9,9 +9,12 @@
 let
   cfg = config.ghaf.services.orbit;
 
-  givc-cli = "${lib.getExe' pkgs.givc-cli "givc-cli"} ${
-    lib.replaceString "/run" "/etc" config.ghaf.givc.cliArgs
-  }";
+  givcCliArgs =
+    if config.ghaf.givc.spireWorkload.enable then
+      config.ghaf.givc.cliArgs
+    else
+      lib.replaceString "/run" "/etc" config.ghaf.givc.cliArgs;
+  givc-cli = "${lib.getExe' pkgs.givc-cli "givc-cli"} ${givcCliArgs}";
 
   nullOrBoolToString = v: if v == null then null else lib.boolToString v;
 

--- a/modules/common/security/spire/create-workload-entries.nix
+++ b/modules/common/security/spire/create-workload-entries.nix
@@ -20,6 +20,8 @@ pkgs.writeShellApplication {
   ];
   text = ''
     SOCKET="${socketPath}"
+    MANAGED_HINT_PREFIX="ghaf-managed/"
+    declare -A desired_entry_keys=()
     echo "=== SPIRE Workload Entry Creator ==="
 
     # Wait for server
@@ -32,28 +34,174 @@ pkgs.writeShellApplication {
       sleep 2
     done
 
+    update_entry() {
+      local entry_id="$1"
+      local parentID="$2"
+      local spiffeID="$3"
+      local managed_hint="$4"
+      local dns_count="$5"
+      shift 5
+
+      local dns_names=()
+      local i
+      for ((i = 0; i < dns_count; i++)); do
+        dns_names+=("$1")
+        shift
+      done
+      local selectors=("$@")
+
+      local cmd=(
+        spire-server entry update
+        -socketPath "$SOCKET"
+        -entryID "$entry_id"
+        -parentID "$parentID"
+        -spiffeID "$spiffeID"
+        -hint "$managed_hint"
+      )
+
+      for selector in "''${selectors[@]}"; do
+        cmd+=(-selector "$selector")
+      done
+
+      for dns_name in "''${dns_names[@]}"; do
+        cmd+=(-dns "$dns_name")
+      done
+
+      "''${cmd[@]}"
+    }
+
     create_entry() {
       local parentID="$1"
       local spiffeID="$2"
       local is_node="$3"
-      shift 3
+      local managed_hint="$4"
+      local dns_count="$5"
+      shift 5
+
+      local dns_names=()
+      local i
+      for ((i = 0; i < dns_count; i++)); do
+        dns_names+=("$1")
+        shift
+      done
       local selectors=("$@")
 
-      local entry_count
-      entry_count="$(
-        spire-server entry count \
+      desired_entry_keys["$managed_hint $spiffeID"]=1
+
+      local entries_json
+      entries_json="$(
+        spire-server entry show \
           -socketPath "$SOCKET" \
           -spiffeID "$spiffeID" \
-          -output json | jq -er '.count'
+          -output json
       )"
 
-      if [ "$entry_count" -gt 0 ]; then
-        echo "Entry exists: $spiffeID"
+      local desired_selectors
+      local desired_dns_names
+      desired_selectors="$(
+        printf '%s\n' "''${selectors[@]}" |
+          jq -Rsc 'split("\n") | map(select(length > 0)) | sort'
+      )"
+      desired_dns_names="$(
+        printf '%s\n' "''${dns_names[@]}" |
+          jq -Rsc 'split("\n") | map(select(length > 0)) | sort'
+      )"
+
+      local entry_summary
+      entry_summary="$(
+        jq -c \
+          --arg managedHint "$managed_hint" \
+          --arg parentID "$parentID" \
+          --argjson selectors "$desired_selectors" \
+          --argjson dnsNames "$desired_dns_names" \
+          '
+            def id_string:
+              "spiffe://\(.trust_domain)\(.path)";
+            def has_desired_shape:
+              ((.parent_id | id_string) == $parentID)
+              and (((.selectors // []) | map(.type + ":" + .value) | sort) == $selectors)
+              and (((.dns_names // []) | sort) == $dnsNames)
+              and ((.admin // false) == false)
+              and ((.downstream // false) == false)
+              and (((.federates_with // []) | length) == 0)
+              and ((.store_svid // false) == false)
+              and (((.x509_svid_ttl // 0) | tonumber) == 0)
+              and (((.jwt_svid_ttl // 0) | tonumber) == 0)
+              and (((.expires_at // 0) | tonumber) == 0)
+              and ((.additional_attributes.disable_x509_svid_prefetch // false) == false);
+            {
+              managed_ids: [
+                .entries[]?
+                | select((.hint // "") == $managedHint)
+                | .id
+              ],
+              managed_exact_ids: [
+                .entries[]?
+                | select((.hint // "") == $managedHint)
+                | select(has_desired_shape)
+                | .id
+              ],
+              legacy_exact_ids: [
+                .entries[]?
+                | select((.hint // "") == "")
+                | select(has_desired_shape)
+                | .id
+              ]
+            }
+          ' <<<"$entries_json"
+      )"
+
+      local managed_count
+      local managed_exact_count
+      local legacy_exact_count
+      managed_count="$(jq -er '.managed_ids | length' <<<"$entry_summary")"
+      managed_exact_count="$(jq -er '.managed_exact_ids | length' <<<"$entry_summary")"
+      legacy_exact_count="$(jq -er '.legacy_exact_ids | length' <<<"$entry_summary")"
+
+      if [ "$managed_count" -gt 0 ]; then
+        local primary_id
+        if [ "$managed_exact_count" -gt 0 ]; then
+          primary_id="$(jq -er '.managed_exact_ids[0]' <<<"$entry_summary")"
+          echo "Entry is current: $spiffeID"
+        else
+          primary_id="$(jq -er '.managed_ids[0]' <<<"$entry_summary")"
+          echo "Updating changed managed entry: $spiffeID"
+          update_entry \
+            "$primary_id" "$parentID" "$spiffeID" "$managed_hint" "$dns_count" \
+            "''${dns_names[@]}" "''${selectors[@]}"
+        fi
+
+        # Collapse duplicate managed entries, but leave every unmanaged entry alone.
+        while IFS= read -r entry_id; do
+          if [ "$entry_id" != "$primary_id" ]; then
+            echo "Deleting duplicate managed entry: $spiffeID ($entry_id)"
+            spire-server entry delete -socketPath "$SOCKET" -entryID "$entry_id"
+          fi
+        done < <(jq -r '.managed_ids[]' <<<"$entry_summary")
         return
       fi
 
+      if [ "$legacy_exact_count" -eq 1 ]; then
+        local legacy_entry_id
+        legacy_entry_id="$(jq -er '.legacy_exact_ids[0]' <<<"$entry_summary")"
+        echo "Adopting exact legacy entry: $spiffeID"
+        update_entry \
+          "$legacy_entry_id" "$parentID" "$spiffeID" "$managed_hint" "$dns_count" \
+          "''${dns_names[@]}" "''${selectors[@]}"
+        return
+      fi
+
+      if [ "$legacy_exact_count" -gt 1 ]; then
+        echo "Multiple exact legacy entries found; leaving them unmanaged: $spiffeID" >&2
+      fi
+
       echo "Creating entry: $spiffeID"
-      local cmd=(spire-server entry create -socketPath "$SOCKET" -spiffeID "$spiffeID")
+      local cmd=(
+        spire-server entry create
+        -socketPath "$SOCKET"
+        -spiffeID "$spiffeID"
+        -hint "$managed_hint"
+      )
 
       if [ "$is_node" = "true" ]; then
         cmd+=(-node)
@@ -65,7 +213,43 @@ pkgs.writeShellApplication {
         cmd+=(-selector "$s")
       done
 
+      for dns_name in "''${dns_names[@]}"; do
+        cmd+=(-dns "$dns_name")
+      done
+
       "''${cmd[@]}"
+    }
+
+    prune_stale_managed_entries() {
+      local managed_entries_json
+      managed_entries_json="$(
+        spire-server entry show \
+          -socketPath "$SOCKET" \
+          -output json
+      )"
+
+      while IFS=$'\t' read -r entry_id entry_hint entry_spiffe_id; do
+        if [ -z "$entry_id" ]; then
+          continue
+        fi
+        if [ -z "''${desired_entry_keys["$entry_hint $entry_spiffe_id"]+x}" ]; then
+          echo "Deleting stale managed entry: $entry_spiffe_id ($entry_id)"
+          spire-server entry delete -socketPath "$SOCKET" -entryID "$entry_id"
+        fi
+      done < <(
+        jq -r \
+          --arg managedHintPrefix "$MANAGED_HINT_PREFIX" \
+          '
+            .entries[]?
+            | select((.hint // "") | startswith($managedHintPrefix))
+            | [
+                .id,
+                .hint,
+                ("spiffe://\(.spiffe_id.trust_domain)\(.spiffe_id.path)")
+              ]
+            | @tsv
+          ' <<<"$managed_entries_json"
+      )
     }
 
     ${concatMapStringsSep "\n" (
@@ -73,25 +257,29 @@ pkgs.writeShellApplication {
       let
         agentCfg = config.ghaf.common.spire.agents.${vmName};
         agentSpiffeID = "spiffe://${config.ghaf.common.spire.server.trustDomain}/${vmName}";
+        serverSpiffeID = "spiffe://${config.ghaf.common.spire.server.trustDomain}/spire/server";
 
         nodeEntryCmd = ''
-          create_entry "" ${escapeShellArg agentSpiffeID} "true" "x509pop:subject:cn:${escapeShellArg vmName}"
+          create_entry ${escapeShellArg serverSpiffeID} ${escapeShellArg agentSpiffeID} "true" "ghaf-managed/node" "0" ${escapeShellArg "x509pop:subject:cn:${vmName}"}
         '';
 
         workloadCmds = concatMapStringsSep "\n" (
           workload:
           let
             workloadSpiffeID = "spiffe://${config.ghaf.common.spire.server.trustDomain}/${vmName}/${workload.name}";
+            managedHint = "ghaf-managed/${workload.name}";
+            dnsNames = concatMapStringsSep " " escapeShellArg workload.dnsNames;
             selectors = concatMapStringsSep " " escapeShellArg workload.selectors;
           in
           ''
-            create_entry ${escapeShellArg agentSpiffeID} ${escapeShellArg workloadSpiffeID} "false" ${selectors}
+            create_entry ${escapeShellArg agentSpiffeID} ${escapeShellArg workloadSpiffeID} "false" ${escapeShellArg managedHint} ${toString (builtins.length workload.dnsNames)} ${dnsNames} ${selectors}
           ''
         ) agentCfg.workloads;
       in
       nodeEntryCmd + workloadCmds
     ) spireAgentVMs}
 
+    prune_stale_managed_entries
     echo "Node and workload entries created successfully."
   '';
 }

--- a/modules/common/security/spire/server.nix
+++ b/modules/common/security/spire/server.nix
@@ -19,7 +19,7 @@ let
   # corrected downwards. Slack rather than an exact bound, so a future change to
   # ca_ttl does not silently start forcing a rotation on every sync.
   caLifetimeSlackSeconds = 7 * 24 * 3600;
-  dataDir = "${runtimeDataDir}";
+  dataDir = "/var/lib/spire-server";
 
   spire-package = config.ghaf.common.spire.package;
   spireAgents = config.ghaf.common.spire.agents;
@@ -64,8 +64,10 @@ let
           connection_string = "${dataDir}/datastore.sqlite3"
         }
       }
-      KeyManager "memory" {
-        plugin_data {}
+      KeyManager "disk" {
+        plugin_data {
+          keys_path = "${dataDir}/keys.json"
+        }
       }
       ${x509popPlugin}
     }
@@ -335,6 +337,7 @@ in
           wantedBy = [ "multi-user.target" ];
           after = [ "spire-server.service" ];
           wants = [ "spire-server.service" ];
+          restartTriggers = [ spireCreateWorkloadEntriesApp ];
 
           serviceConfig = {
             Type = "oneshot";
@@ -354,6 +357,12 @@ in
         };
       };
     };
+    ghaf.storagevm.directories = mkIf (config.ghaf.storagevm.enable or false) [
+      {
+        directory = "/var/lib/private/spire-server";
+        mode = "0700";
+      }
+    ];
     networking.firewall.allowedTCPPorts = [
       config.ghaf.common.spire.server.port
       config.ghaf.common.spire.server.healthCheckPort

--- a/modules/common/services/performance/guests.nix
+++ b/modules/common/services/performance/guests.nix
@@ -26,9 +26,12 @@ let
 
   useGivc = config.ghaf.givc.enable;
 
-  givc-cli = "${getExe' pkgs.givc-cli "givc-cli"} ${
-    replaceString "/run" "/etc" config.ghaf.givc.cliArgs
-  }";
+  givcCliArgs =
+    if config.ghaf.givc.spireWorkload.enable then
+      config.ghaf.givc.cliArgs
+    else
+      replaceString "/run" "/etc" config.ghaf.givc.cliArgs;
+  givc-cli = "${getExe' pkgs.givc-cli "givc-cli"} ${givcCliArgs}";
 
   guiVmSchedulerAssignments = {
     desktop-environment = {

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -31,7 +31,12 @@ let
     ;
 
   useGivc = config.ghaf.givc.enable;
-  givc-cli = "${pkgs.givc-cli}/bin/givc-cli ${replaceString "/run" "/etc" config.ghaf.givc.cliArgs}";
+  givcCliArgs =
+    if config.ghaf.givc.spireWorkload.enable then
+      config.ghaf.givc.cliArgs
+    else
+      replaceString "/run" "/etc" config.ghaf.givc.cliArgs;
+  givc-cli = "${pkgs.givc-cli}/bin/givc-cli ${givcCliArgs}";
   ghaf-powercontrol = pkgs.ghaf-powercontrol.override { ghafConfig = config.ghaf; };
 
   # List of all passthrough nic and audio PCI devices. The generated list of "vendorId:productId" strings

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -37,6 +37,7 @@ let
     else
       replaceString "/run" "/etc" config.ghaf.givc.cliArgs;
   givc-cli = "${pkgs.givc-cli}/bin/givc-cli ${givcCliArgs}";
+  wait-for-unit = pkgs.wait-for-unit.override { cliArgs = givcCliArgs; };
   ghaf-powercontrol = pkgs.ghaf-powercontrol.override { ghafConfig = config.ghaf; };
 
   # List of all passthrough nic and audio PCI devices. The generated list of "vendorId:productId" strings
@@ -144,7 +145,7 @@ let
       pkgs.grpcurl
       pkgs.socat
       pkgs.vhotplug
-      pkgs.wait-for-unit
+      wait-for-unit
     ];
     text = ''
       if [[ $# -lt 3 || -z "$1" || -z "$2" || -z "$3" ]]; then
@@ -182,15 +183,13 @@ let
               echo "Signaling suspend to $vm_name..."
               ${givc-cli} start service --vm "$vm_name" suspend.target &
               # Wait until suspend is active
-              ${getExe pkgs.wait-for-unit} ${config.ghaf.networking.hosts.admin-vm.ipv4} 9001 \
+              ${getExe wait-for-unit}  \
               "$vm_name" systemd-suspend.service 10 \
               activating start
               ;;
             resume)
               echo "Signaling resume to $vm_name..."
-              # Stop unit command not yet implemented in GIVC admin service
-              grpcurl -cacert /etc/givc/ca-cert.pem -cert /etc/givc/cert.pem -key /etc/givc/key.pem \
-              -d '{"UnitName":"systemd-suspend.service"}' "$vm_name":9000 systemd.UnitControlService.StopUnit
+              ${givc-cli} stop service systemd-suspend.service --vm "$vm_name"
               ;;
             *)
               echo "Invalid action: $action"
@@ -199,7 +198,6 @@ let
               ;;
           esac
           ;;
-
         pci-suspend)
           case "$action" in
             suspend)

--- a/modules/givc/common.nix
+++ b/modules/givc/common.nix
@@ -45,6 +45,11 @@ let
     (config.ghaf.virtualization.microvm.idsvm.enable or false)
     && (config.ghaf.virtualization.microvm.idsvm.mitmproxy.enable or false);
   idsExtraArgs = optionalString mitmEnabled "--user-data-dir=/home/${config.ghaf.users.appUser.name}/.config/google-chrome/Default --test-type --ignore-certificate-errors-spki-list=Bq49YmAq1CG6FuBzp8nsyRXumW7Dmkp7QQ/F82azxGU=";
+  spireWorkloadEnabled = config.ghaf.givc.spireWorkload.enable;
+  useSpireTls = config.ghaf.givc.enableTls && spireWorkloadEnabled;
+  useLegacyTls = config.ghaf.givc.enableTls && !spireWorkloadEnabled;
+  spireAgent = config.ghaf.security.spire.agents.downstream;
+  spireTrustDomain = config.ghaf.common.spire.server.trustDomain;
 in
 {
   _file = ./common.nix;
@@ -152,9 +157,12 @@ in
           --name ${adminAddress.name}
           --addr ${adminAddress.addr}
           --port ${adminAddress.port}
-          ${optionalString config.ghaf.givc.enableTls "--cacert /run/givc/ca-cert.pem"}
-          ${optionalString config.ghaf.givc.enableTls "--cert /run/givc/cert.pem"}
-          ${optionalString config.ghaf.givc.enableTls "--key /run/givc/key.pem"}
+          ${optionalString useSpireTls "--auth-type spire"}
+          ${optionalString useSpireTls "--spire-agent-socket ${spireAgent.socketPath}"}
+          ${optionalString useSpireTls "--trust-domain ${spireTrustDomain}"}
+          ${optionalString useLegacyTls "--cacert /run/givc/ca-cert.pem"}
+          ${optionalString useLegacyTls "--cert /run/givc/cert.pem"}
+          ${optionalString useLegacyTls "--key /run/givc/key.pem"}
           ${optionalString (!config.ghaf.givc.enableTls) "--notls"}
         '';
         # Givc admin server configuration

--- a/modules/givc/flake-module.nix
+++ b/modules/givc/flake-module.nix
@@ -13,6 +13,7 @@
       inputs.givc.nixosModules.sysvm
       inputs.givc.nixosModules.appvm
       ./common.nix
+      ./spire-workload.nix
       ./adminvm.nix
       ./host.nix
       ./guivm.nix

--- a/modules/givc/spire-workload.nix
+++ b/modules/givc/spire-workload.nix
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.ghaf.givc.spireWorkload;
+  inherit (lib)
+    mkIf
+    mkMerge
+    mkOption
+    optional
+    types
+    unique
+    ;
+
+  trustDomain = config.ghaf.common.spire.server.trustDomain;
+  agent = config.ghaf.security.spire.agents.downstream;
+  agentService = "spire-agent.service";
+
+  adminEnabled = config.givc.admin.enable;
+  hostEnabled = config.givc.host.enable;
+  sysvmEnabled = config.givc.sysvm.enable;
+  appvmEnabled = config.givc.appvm.enable;
+  hasGivcService = adminEnabled || hostEnabled || sysvmEnabled || appvmEnabled;
+
+  appUser = config.ghaf.users.appUser;
+  primaryUid = if appvmEnabled then appUser.uid else 0;
+
+  # GUI-side GIVC clients run as the login user when the upstream sysvm
+  # module explicitly enables user TLS access.
+  userTlsAccess = sysvmEnabled && config.givc.sysvm.enableUserTlsAccess;
+  homedUser = config.ghaf.users.homedUser;
+  staticTlsUsers = lib.attrNames (
+    lib.filterAttrs (_: user: user.isNormalUser or false) config.users.users
+  );
+  staticTlsUids = map (userName: config.users.users.${userName}.uid) (
+    lib.filter (userName: config.users.users.${userName}.uid != null) staticTlsUsers
+  );
+  userTlsUids = unique (
+    lib.optionals (userTlsAccess && homedUser.enable) [ homedUser.uid ]
+    ++ lib.optionals userTlsAccess staticTlsUids
+  );
+  additionalUids = lib.filter (uid: uid != primaryUid) userTlsUids;
+
+  workloadForUid = uid: {
+    name = if uid == primaryUid then "givc" else "givc-user-${toString uid}";
+    selectors = [ "unix:uid:${toString uid}" ];
+  };
+
+  spireTls = {
+    enable = true;
+    type = "spire";
+    spire = {
+      agentSocketPath = agent.socketPath;
+      inherit trustDomain;
+    };
+  };
+
+  systemTransportNames = unique (
+    optional hostEnabled config.givc.host.network.agent.transport.name
+    ++ optional sysvmEnabled config.givc.sysvm.network.agent.transport.name
+  );
+  systemServiceNames =
+    optional adminEnabled "givc-admin" ++ map (name: "givc-${name}") systemTransportNames;
+
+  givcSystemServiceConfig = {
+    after = [ agentService ];
+    wants = [ agentService ];
+  };
+in
+{
+  _file = ./spire-workload.nix;
+
+  options.ghaf.givc.spireWorkload.enable = mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      Use the SPIRE Workload API to issue and rotate identities for the local
+      GIVC services and clients.
+    '';
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [
+        {
+          assertion = config.ghaf.givc.enable && config.ghaf.givc.enableTls;
+          message = "The GIVC SPIRE workload requires GIVC TLS to be enabled.";
+        }
+        {
+          assertion = agent.enable;
+          message = "The GIVC SPIRE workload requires the downstream SPIRE agent.";
+        }
+        {
+          assertion = hasGivcService;
+          message = "The GIVC SPIRE workload requires a local GIVC service.";
+        }
+      ];
+
+      # GIVC daemons and CLI callers previously shared a certificate by Unix
+      # user. Preserve that access boundary while letting GIVC consume and
+      # rotate the SVID directly through the Workload API.
+      ghaf.security.spire.agents.downstream.workloads = lib.mkAfter (
+        map workloadForUid ([ primaryUid ] ++ additionalUids)
+      );
+
+      givc.admin.tls = mkIf adminEnabled spireTls;
+      givc.host.network.tls = mkIf hostEnabled spireTls;
+      givc.sysvm.network.tls = mkIf sysvmEnabled spireTls;
+      givc.appvm.network.tls = mkIf appvmEnabled spireTls;
+
+      # Non-root GIVC daemons and CLI callers need access to the agent socket.
+      users.groups.spire-agent.members = lib.mkAfter (
+        lib.optionals appvmEnabled [ appUser.name ] ++ lib.optionals userTlsAccess staticTlsUsers
+      );
+      ghaf.users.homedUser.extraGroups = mkIf (userTlsAccess && homedUser.enable) (
+        lib.mkAfter [ "spire-agent" ]
+      );
+
+      # The static credentials in /etc/givc remain available to the x509pop
+      # node attestor, but GIVC now obtains its own identity from SPIRE.
+      systemd.services = {
+        givc-user-key-setup.enable = lib.mkForce false;
+      }
+      // lib.genAttrs systemServiceNames (_: givcSystemServiceConfig);
+    }
+  ]);
+}

--- a/modules/microvm/host/boot.nix
+++ b/modules/microvm/host/boot.nix
@@ -19,8 +19,14 @@ let
     removeSuffix
     optionalAttrs
     ;
-  inherit (config.ghaf.networking) hosts;
   inherit (config.ghaf.virtualization.microvm) appvm;
+
+  givcCliArgs =
+    if config.ghaf.givc.spireWorkload.enable then
+      config.ghaf.givc.cliArgs
+    else
+      lib.replaceString "/run" "/etc" config.ghaf.givc.cliArgs;
+  wait-for-unit = pkgs.wait-for-unit.override { cliArgs = givcCliArgs; };
 
   # Filter system and enabled app VMs
   appVms = lib.attrNames (filterAttrs (_: vm: vm.enable) appvm.vms);
@@ -163,8 +169,7 @@ in
               serviceConfig = {
                 Type = "oneshot";
                 ExecStart = ''
-                  ${pkgs.wait-for-unit}/bin/wait-for-unit \
-                  ${hosts.admin-vm.ipv4} 9001 \
+                  ${wait-for-unit}/bin/wait-for-unit \
                   gui-vm \
                   greetd.service \
                   60
@@ -184,8 +189,7 @@ in
               serviceConfig = {
                 Type = "oneshot";
                 ExecStart = ''
-                  ${pkgs.wait-for-unit}/bin/wait-for-unit \
-                  ${hosts.admin-vm.ipv4} 9001 \
+                  ${wait-for-unit}/bin/wait-for-unit \
                   gui-vm \
                   user-login.service \
                   120
@@ -196,7 +200,6 @@ in
             };
           };
       };
-
       # Boot UI config for GUI VM is now provided by guivm-desktop-features module
       # See: modules/desktop/guivm/boot-ui.nix
     })

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -131,6 +131,8 @@ in
           withHardenedConfigs = true;
         };
         givc.host.enable = true;
+        givc.spireWorkload.enable =
+          config.ghaf.global-config.givc.enable && config.ghaf.global-config.spire.enable;
         graphics.boot = {
           enable = true; # Enable graphical boot on host
           renderer = "simpledrm"; # Force simpledrm framebuffer for graphical boot on host

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -151,6 +151,7 @@ in
     givc = {
       inherit (globalConfig.givc) enable;
       inherit (globalConfig.givc) debug;
+      spireWorkload.enable = (globalConfig.givc.enable or false) && (globalConfig.spire.enable or false);
     };
 
     # Security

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -186,6 +186,7 @@ in
         givc = {
           enable = globalConfig.givc.enable or false;
           debug = globalConfig.givc.debug or false;
+          spireWorkload.enable = (globalConfig.givc.enable or false) && (globalConfig.spire.enable or false);
         };
         givc.appvm = {
           enable = true;

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -193,6 +193,7 @@ in
     givc = {
       enable = globalConfig.givc.enable or false;
       debug = globalConfig.givc.debug or false;
+      spireWorkload.enable = (globalConfig.givc.enable or false) && (globalConfig.spire.enable or false);
     };
 
     # Security - from globalConfig

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -30,6 +30,7 @@
 #   base.extendModules { modules = [ ../services ]; }
 #
 {
+  config,
   lib,
   pkgs,
   inputs,
@@ -135,6 +136,7 @@ in
     givc = {
       enable = globalConfig.givc.enable or false;
       debug = globalConfig.givc.debug or false;
+      spireWorkload.enable = (globalConfig.givc.enable or false) && (globalConfig.spire.enable or false);
     };
     givc.guivm.enable = true;
     givc.sni.enable = true;
@@ -336,11 +338,20 @@ in
         GIVC_ADDR = hostConfig.networking.hosts."admin-vm".ipv4 or "192.168.101.10";
         GIVC_PORT = "9001";
       }
-      // lib.optionalAttrs (hostConfig.givc.enableTls or false) {
-        GIVC_CA_CERT = "/run/givc/ca-cert.pem";
-        GIVC_HOST_CERT = "/run/givc/cert.pem";
-        GIVC_HOST_KEY = "/run/givc/key.pem";
-      }
+      // lib.optionalAttrs (hostConfig.givc.enableTls or false) (
+        if config.ghaf.givc.spireWorkload.enable then
+          {
+            AUTH_TYPE = "spire";
+            SPIRE_AGENT_SOCKET = config.ghaf.security.spire.agents.downstream.socketPath;
+            TRUST_DOMAIN = config.ghaf.common.spire.server.trustDomain;
+          }
+        else
+          {
+            GIVC_CA_CERT = "/run/givc/ca-cert.pem";
+            GIVC_HOST_CERT = "/run/givc/cert.pem";
+            GIVC_HOST_KEY = "/run/givc/key.pem";
+          }
+      )
     );
     # Add flatpak desktop entries if the flatpak VM is enabled AND its share is
     # actually provisioned. Enabling the VM and granting it the share are two separate decisions.

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -88,6 +88,7 @@ in
     givc = {
       enable = globalConfig.givc.enable or false;
       debug = globalConfig.givc.debug or false;
+      spireWorkload.enable = (globalConfig.givc.enable or false) && (globalConfig.spire.enable or false);
     };
     givc.netvm.enable = true;
 

--- a/overlays/custom-packages/spire4ghaf/0001-spire-with-basic-plugins.patch
+++ b/overlays/custom-packages/spire4ghaf/0001-spire-with-basic-plugins.patch
@@ -336,7 +336,7 @@ new file mode 100644
 index 000000000..17727a4a5
 --- /dev/null
 +++ b/pkg/server/catalog/keymanager_base.go
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,39 @@
 +//go:build !withplugins
 +
 +package catalog
@@ -345,6 +345,7 @@ index 000000000..17727a4a5
 +	"github.com/spiffe/spire/pkg/common/catalog"
 +
 +	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
++	"github.com/spiffe/spire/pkg/server/plugin/keymanager/disk"
 +	"github.com/spiffe/spire/pkg/server/plugin/keymanager/memory"
 +)
 +
@@ -366,6 +367,7 @@ index 000000000..17727a4a5
 +
 +func (repo *keyManagerRepository) BuiltIns() []catalog.BuiltIn {
 +	return []catalog.BuiltIn{
++		disk.BuiltIn(),
 +		memory.BuiltIn(),
 +	}
 +}
@@ -544,4 +546,3 @@ index 000000000..b7a4defbc
 +func (upstreamAuthorityV1) Deprecated() bool    { return false }
 -- 
 2.51.2
-

--- a/packages/pkgs-by-name/wait-for-unit/package.nix
+++ b/packages/pkgs-by-name/wait-for-unit/package.nix
@@ -2,18 +2,27 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   writeShellApplication,
-  grpcurl,
-  jq,
+  givc-cli ? null,
+  cliArgs ? "",
 }:
+let
+  givc-cli-pkg =
+    if givc-cli != null then
+      givc-cli
+    else
+      writeShellApplication {
+        name = "givc-cli";
+        text = "exit 1";
+      };
+in
 writeShellApplication {
   name = "wait-for-unit";
 
   runtimeInputs = [
-    grpcurl
-    jq
+    givc-cli-pkg
   ];
 
-  text = builtins.readFile ./wait-for-unit.sh;
+  text = builtins.replaceStrings [ "@GIVC_ARGS@" ] [ cliArgs ] (builtins.readFile ./wait-for-unit.sh);
 
   meta = {
     description = "Script to query a systemd unit status across VMs.";

--- a/packages/pkgs-by-name/wait-for-unit/wait-for-unit.sh
+++ b/packages/pkgs-by-name/wait-for-unit/wait-for-unit.sh
@@ -5,48 +5,52 @@
 # Assert root
 [[ $EUID -ne 0 ]] && echo "Please run as root." && exit 1
 
-# Usage
-if [[ $# -lt 5 || $# -gt 7 ]]; then
-  echo "Usage: $0 <admin service ip> <admin service port> <vm-name> <unit-name> <timeout in seconds> [<status>] [<sub_status>]"
-  exit 1
+GIVC_ARGS="@GIVC_ARGS@"
+if [[ -z ${GIVC_ARGS} ]]; then
+  GIVC_ARGS="${GIVC_OPTS:-}"
 fi
 
-# Check if key/certificates exist
-[[ ! -f /etc/givc/ca-cert.pem ]] && echo "CA certificate not found." && exit 1
-[[ ! -f /etc/givc/cert.pem ]] && echo "Client certificate not found." && exit 1
-[[ ! -f /etc/givc/key.pem ]] && echo "Client key not found." && exit 1
+if [[ -z ${GIVC_ARGS} ]]; then
+  # Check if key/certificates exist (only for fallback configuration)
+  [[ ! -f /etc/givc/ca-cert.pem ]] && echo "CA certificate not found." && exit 1
+  [[ ! -f /etc/givc/cert.pem ]] && echo "Client certificate not found." && exit 1
+  [[ ! -f /etc/givc/key.pem ]] && echo "Client key not found." && exit 1
 
-# Function to fetch the unit status
-ADDR="$1:$2"
-VM="$3"
-UNIT="$4"
-args=(
-  "-cacert" "/etc/givc/ca-cert.pem"
-  "-cert" "/etc/givc/cert.pem"
-  "-key" "/etc/givc/key.pem"
-  "-d" "{\"VmName\":\"$VM\",\"UnitName\":\"$UNIT\"}"
-  "$ADDR"
-  "admin.AdminService.GetUnitStatus"
-)
-TIMEOUT="$5"
+  args=(
+    "--addr" "192.168.100.5"
+    "--port" "9001"
+    "--name" "admin-vm"
+    "--cacert" "/etc/givc/ca-cert.pem"
+    "--cert" "/etc/givc/cert.pem"
+    "--key" "/etc/givc/key.pem"
+  )
+else
+  # Parse GIVC_ARGS into the array
+  read -r -a args <<<"$GIVC_ARGS"
+fi
+
+VM="$1"
+UNIT="$2"
+TIMEOUT="$3"
 
 # Optional inputs for expected unit status
 EXPECTED_STATUS=""
-if [ "$#" -ge 6 ]; then
-  EXPECTED_STATUS="$6"
+if [ "$#" -ge 4 ]; then
+  EXPECTED_STATUS="$4"
 fi
 SUB_STATUS=""
-if [ "$#" -eq 7 ]; then
-  SUB_STATUS="$7"
+if [ "$#" -eq 5 ]; then
+  SUB_STATUS="$5"
 fi
 
 # Wait until the unit is running
 echo "Waiting for unit '$UNIT' in VM '$VM' ..."
 SECONDS=0
 while [ $SECONDS -lt "$TIMEOUT" ]; do
-  if status_response="$(grpcurl "${args[@]}" 2>/dev/null)"; then
-    active_status=$(echo "$status_response" | jq -rj '.ActiveState')
-    sub_status=$(echo "$status_response" | jq -rj '.SubState')
+  if status_response="$(givc-cli "${args[@]}" get-status "$VM" "$UNIT" 2>/dev/null)"; then
+    active_status=$(echo "$status_response" | sed -n 's/.*active_state: "\([^"]*\)".*/\1/p')
+    sub_status=$(echo "$status_response" | sed -n 's/.*sub_state: "\([^"]*\)".*/\1/p')
+    echo wait for unit status: "$active_status" "$sub_status"
     if [[ -n $EXPECTED_STATUS ]]; then
       if [[ -z $SUB_STATUS ]]; then
         # No sub-state eval


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->
## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

This PR integrates GIVC with SPIRE workload attestation across the Ghaf host and virtual machines.

- Registers GIVC workload identities for the host, AdminVM, SystemVMs and AppVMs.
- Uses UID-based workload selectors for root services, AppVM users and the GUI desktop user.
- Configures GIVC to consume and rotate X.509-SVIDs directly through the SPIRE Workload API.
- Preserves legacy file-based GIVC TLS for configurations where SPIRE workload attestation is disabled.
- Persists the SPIRE SQLite datastore and disk-backed signing keys across rebuilds and reboots.
- Adds the disk KeyManager to the reduced SPIRE package used by Ghaf (`spire4ghaf`).
- Keeps the existing `/etc/givc` credentials available for X.509 PoP node attestation.
- **This PR requires [tiiuae/ghaf-givc#461](https://github.com/tiiuae/ghaf-givc/pull/461) to be merged.**

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets
https://jira.tii.ae/browse/SSRCSP-8416
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. SSH to `admin-vm` and verify the SPIRE and GIVC services:

   ```bash
   sudo systemctl is-active \
     spire-server \
     spire-agent \
     spire-create-workload-entries \
     givc-admin

   sudo systemctl --failed --no-pager
   ```
   
   All services should report active, and no failed units should be listed.

2. Verify that the GIVC workload entries were created:

   ```bash
   sudo journalctl -b \
     -u spire-create-workload-entries \
     --no-pager |
   grep -E 'Entry is current|Creating entry|Updating changed|successfully'
   ```

   The output should contain GIVC identities such as:

   ```text
   spiffe://ghaf.internal/admin-vm/givc
   spiffe://ghaf.internal/net-vm/givc
   spiffe://ghaf.internal/gui-vm/givc
   spiffe://ghaf.internal/gui-vm/givc-user-1000
   spiffe://ghaf.internal/chrome-vm/givc
   ```

3. Inspect an individual workload entry:

   ```bash
   sudo spire-server entry show \
     -socketPath /run/spire-server/api.sock \
     -spiffeID spiffe://ghaf.internal/admin-vm/givc
   ```

   The entry should contain:

   ```text
   SPIFFE ID : spiffe://ghaf.internal/admin-vm/givc
   Selector  : unix:uid:0
   ```

4. Verify that the GIVC admin process can retrieve its SVID:

   ```bash
   sudo spire-agent api fetch x509 \
     -socketPath /run/spire-agent/agent.sock \
     -timeout 5s
   ```

   Expected SPIFFE ID:

   ```text
   spiffe://ghaf.internal/admin-vm/givc
   ```

5. On `net-vm` (or other system VM), verify its services and retrieve its workload SVID:

   ```bash
   systemctl is-active spire-agent givc-net-vm
   systemctl --failed --no-pager

   sudo spire-agent api fetch x509 \
     -socketPath /run/spire-agent/agent.sock \
     -timeout 5s
   ```

   Expected SPIFFE ID:

   ```text
   spiffe://ghaf.internal/net-vm/givc
   ```

   Verify that GIVC selected SPIRE authentication:

   ```bash
   sudo journalctl -b -u givc-net-vm --no-pager |
   grep -F 'using spire svid'
   ```

6. On `gui-vm`, verify both the system-service and desktop-user identities:

   ```bash
   systemctl is-active spire-agent givc-gui-vm
   systemctl --failed --no-pager

   sudo spire-agent api fetch x509 \
     -socketPath /run/spire-agent/agent.sock \
     -timeout 5s
   ```

   The root process should receive:

   ```text
   spiffe://ghaf.internal/gui-vm/givc
   ```

   Retrieve the desktop-user identity as UID `1000`:

   ```bash
   sudo -u '#1000' -- spire-agent api fetch x509 \
     -socketPath /run/spire-agent/agent.sock \
     -timeout 5s
   ```

   Expected SPIFFE ID:

   ```text
   spiffe://ghaf.internal/gui-vm/givc-user-1000
   ```

7. On an AppVM such as `chrome-vm`, verify the AppVM identity:

   ```bash
   systemctl is-active spire-agent
   systemctl --failed --no-pager
   sudo -u appuser id
   ```

   `appuser` should be a member of the `spire-agent` group.

   ```bash
   sudo -u appuser spire-agent api fetch x509 \
     -socketPath /run/spire-agent/agent.sock \
     -timeout 5s
   ```

   Expected SPIFFE ID:

   ```text
   spiffe://ghaf.internal/chrome-vm/givc
   ```

   Verify the AppVM GIVC user service:

   ```bash
   sudo -u appuser env \
     XDG_RUNTIME_DIR=/run/user/1000 \
     DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus \
     systemctl --user is-active givc-chrome-vm
   ```

   Expected result:

   ```text
   active
   ```

8. Reboot the system. SSH into `admin-vm` and verify that the SPIRE state was preserved:

    ```bash
    sudo journalctl -b \
      -u spire-create-workload-entries \
      --no-pager |
    grep -F 'Entry is current'
    ```

    The entries should report `Entry is current` instead of being recreated.

    Confirm that the SPIRE server did not initialize a new database:

    ```bash
    sudo journalctl -b -u spire-server --no-pager |
    grep -F 'Initializing new database'
    ```

    Expected result: no output.