### PR TITLE
feat(netboot): create a netboot installer mechanism for x86_64

### DIFF
--- a/.claude/skills/ghaf-deploy/SKILL.md
+++ b/.claude/skills/ghaf-deploy/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: ghaf-deploy
-description: Get a built Ghaf change onto a device - by nixos-rebuild when that is sufficient, by flashing an image when it is not - then reboot, wait for it to come back, and confirm what is actually running. Use whenever asked to deploy, flash, install, update or push a change to a Ghaf device, to reflash a laptop or Jetson, or after building an image that needs to go on hardware. Also use when deciding whether a change can be switched or needs a full flash.
+description: Get a built Ghaf change onto a device - by nixos-rebuild when that is sufficient, by flashing an image when it is not, or by netboot/PXE when you want the same install without USB media - then reboot, wait for it to come back, and confirm what is actually running. Use whenever asked to deploy, flash, install, update or push a change to a Ghaf device, to reflash a laptop or Jetson, to netboot or PXE boot a machine, or after building an image that needs to go on hardware. Also use when deciding whether a change can be switched, needs a full flash, or can be delivered over the network.
 ---
 
 # Deploying to a Ghaf device
 
-Two paths, and choosing wrong is expensive in opposite directions: flashing when a switch
-would do wastes half an hour per iteration, while switching when a flash was needed leaves
-a device that quietly disagrees with your source tree.
+Three paths. The first two are the usual choice, and choosing wrong is expensive in opposite
+directions: flashing when a switch would do wastes half an hour per iteration, while
+switching when a flash was needed leaves a device that quietly disagrees with your source
+tree. The third, netboot, delivers the same install as a flash without USB media — worth it
+when reinstalling repeatedly or when the machine is not on your desk.
 
 Read `ghaf-target` for addresses. Flashing is destructive — see the safety section before
 running it unattended.
@@ -99,6 +101,86 @@ Check it is the size you expect, `RM` is 1 for removable media, the model matche
 you plugged in, and nothing on it is mounted. Cross-check against `flash_drive` in the
 device config. If the config says one device and the user says another, stop and ask —
 device nodes renumber between reboots, and `/dev/sda` is a system disk on plenty of machines.
+
+## Path 3: netboot (tens of minutes, destructive, no USB)
+
+The same install as Path 2, delivered over PXE. Use it when you would otherwise walk a USB
+stick to the machine, or when reinstalling repeatedly: the boot artefacts are ~650 MB, carry
+no disk image, and are target-independent, so only the image URL changes per target.
+
+```bash
+nix build .#intel-laptop-debug-netboot-installer -o result-netboot
+nix build .#intel-laptop-debug -o result
+nix develop --command ghaf-netboot -i <iface> -m <target-mac> \
+  -n result-netboot -g result --dry-run          # always start here
+sudo ghaf-netboot -i <iface> -m <target-mac> \
+  -n result-netboot -g result --open-firewall --exit-after-serve
+```
+
+Preconditions, all of which fail quietly if unmet:
+
+- **Secure Boot off** on the target — the chain is unsigned, exactly as the ISO is.
+- **The target must have a network boot entry and firmware support for the NIC.** Not every
+  USB-C adapter qualifies: the firmware needs its own driver for the chipset. A vendor dock
+  usually works where a generic adapter emits no PXE request at all. Lenovo publishes the
+  entry as `PXE BOOT`, an abstract `VenMsg(...)`, **not** as a `MAC(...)` device path — so do
+  not test for `MAC(` when checking whether a machine can netboot.
+- **Same layer-2 network.** PXE is broadcast; it does not cross a router.
+- **`-i` is the build host's interface**, not the device's. `-m` is the target's PXE NIC —
+  which on a docked laptop is the dock's MAC, not the internal one.
+
+Flags that matter more than they look:
+
+- `--open-firewall` — without it a filtering host drops PXE **before the server sees it**.
+  The server logs nothing and looks healthy while the target times out.
+- `--exit-after-serve` — stops the server once the image has transferred. **On by default with
+  `--install-target`**: an unattended install reboots itself when done, so if network boot is
+  ahead of the disk, a server left running catches that reboot and reinstalls in a loop.
+  `--no-exit-after-serve` opts out and warns. Off for interactive runs, which need it up.
+- `--force-interface` — needed whenever the interface facing the target also carries the
+  default route, i.e. the normal case on a shared lab network.
+- `--mac` is an allowlist and is mandatory. Anything not on it gets a 404, which PXE reads as
+  "ignore me". On a shared network that is the only thing stopping an unrelated machine from
+  booting your installer.
+
+`--install-target /dev/nvme0n1` makes it unattended and destructive — see the safety section
+above; the same "confirm the device" discipline applies, with nobody at the console. When the
+write finishes the installer waits ten seconds and reboots itself into the new system; boot
+with `ghaf.install_noreboot` to stay in the installer when you need to diagnose a bad install
+rather than watch the evidence reboot away.
+
+The installer is reachable over ssh as **`nixos@<ip>`** with the builder key, with passwordless
+sudo. That is the honest completion check — `systemctl is-active ghaf-installer-tui.service`
+and `/proc/cmdline` on the booted machine — rather than inferring success from server logs.
+
+If nothing appears in the server log, work outwards in this order: is the firewall open, did
+the firmware emit a PXE request at all (`tcpdump -i <iface> -e -vv 'udp port 67 or 69 or
+4011'` — a real PXE request carries `PXEClient` and option 93), and does the MAC on the wire
+match the allowlist.
+
+### The decisive log line is `Sending ipxe boot script`
+
+Everything before it can succeed while the boot still fails. Read the log by which of these
+it looks like:
+
+| What the log does | What it means |
+| --- | --- |
+| Reaches `Sending ipxe boot script` | iPXE got DHCP and is chaining. This is the good case. |
+| A fresh `Got valid request ... (X64)` every ~35 s, forever | iPXE loaded but its own DHCP is failing — it retries ten times and reboots. |
+| Serves the iPXE binary again every ~20 s | Chainload loop: the iPXE being served has no embedded `user-class pixiecore` script. |
+| Nothing at all | Firewall, or the firmware never emitted a PXE request. See above. |
+
+Ghaf serves its own `snponly.efi`, which uses the **firmware's** SNP driver and embeds the
+`user-class pixiecore` handshake, so both loop cases should be history. If one reappears,
+check `--dry-run`'s reported `ipxe` path is that binary rather than `pixiecore built-in`.
+`--ipxe builtin` is the deliberate fallback for an adapter the firmware's SNP does not cover.
+
+**Recovery from either loop can need physical access.** A separately powered USB-C dock keeps
+its state across a laptop power cycle, so unplugging the dock is what actually clears it — do
+not burn time on reboots that cannot work.
+
+Every artefact can be served with a 200 while the target sits in an emergency shell. Assert on
+the booted system, never on the transport.
 
 ## After deploying
 

--- a/.claude/skills/ghaf-target/SKILL.md
+++ b/.claude/skills/ghaf-target/SKILL.md
@@ -25,8 +25,18 @@ Fields that matter here: `host_ip` (the device's reachable address), `usb_iface`
 host-side NIC facing it, typically `ghaf-usb`), `serial_device` / `serial_baud`,
 `flash_drive`, `ghaf_target`, `test_device_name`.
 
-If `host_ip` is null, ask the user for the address once and offer to write it into the
-config — guessing an address on a lab network can land you on someone else's device.
+Per-machine values — `host_ip`, `ssh_identity`, `netboot_iface`, `netboot_mac`, `flash_drive`,
+`serial_device` — live in the gitignored `config.local.yaml` beside it, merged over the shared
+file per field. `config.yaml` deliberately leaves them null, because they describe a particular
+desk rather than the project. `config.local.yaml.example` shows the shape.
+
+If `host_ip` is null in both, ask the user for the address once and offer to write it into
+**`config.local.yaml`** — guessing an address on a lab network can land you on someone else's
+device, and writing it to the shared file leaks lab topology into the repo.
+
+Note `ssh_identity`: when a device is reached by a key ssh would not offer by default, every
+command fails with "Permission denied (publickey)", which reads like the device being down
+rather than a missing key.
 
 ## The address map
 

--- a/.github/skills/ghaf-hw-test/SKILL.md
+++ b/.github/skills/ghaf-hw-test/SKILL.md
@@ -184,6 +184,16 @@ Without `--drive`/`--recovery`, the loop skips the build+flash step (useful when
 
 Device profiles and defaults are stored in `.github/skills/ghaf-hw-test/config.yaml`.
 
+That file is shared, so it holds only what is true for the project: which image a device takes,
+which name the Robot suite expects, how it is flashed. Anything specific to the hardware on
+your desk -- `host_ip`, `ssh_identity`, `netboot_iface`, `netboot_mac`, `flash_drive`,
+`serial_device` -- belongs in **`config.local.yaml`** beside it, which is gitignored. Copy
+`config.local.yaml.example` to get started, or point `GHAF_HW_TEST_LOCAL_CONFIG` elsewhere.
+
+The local file is merged over the shared one per device and per field. A `null` in the local
+file does not blank a value in the shared one, so a partly-filled override is safe, and you can
+add devices that do not appear in `config.yaml` at all.
+
 You can override defaults via command-line arguments or by editing the config file. Each device has a `boot_wait_seconds` setting that controls how long `wait_for_device` polls SSH after flashing.
 
 ## Output Files

--- a/.github/skills/ghaf-hw-test/config.local.yaml.example
+++ b/.github/skills/ghaf-hw-test/config.local.yaml.example
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Machine-local overrides for ghaf-hw-test. Copy to `config.local.yaml`
+# (gitignored) and fill in the hardware on your desk.
+#
+#     cp config.local.yaml.example config.local.yaml
+#
+# Only the fields you set are used: this file is merged over config.yaml per
+# device, and a `null` here does NOT blank a value set there -- so an example
+# full of nulls is harmless, and you can list only what you actually have.
+#
+# You may also add devices that do not exist in config.yaml at all; the merge
+# does not require a matching entry.
+#
+# Override the location with GHAF_HW_TEST_LOCAL_CONFIG if you keep your lab
+# config somewhere central rather than in the checkout.
+
+devices:
+  Lenovo-X1:
+    # Address ghaf-hw-test connects to. This is net-vm, which holds the
+    # passed-through NIC -- ghaf-host is one hop further in at 192.168.100.2.
+    # It is a DHCP lease and it MOVES when you change ethernet adapter.
+    host_ip: null # e.g. 192.168.10.99
+
+    # ssh identity for the device. Needed whenever the key is not one ssh would
+    # offer by default -- otherwise every command fails with "Permission denied
+    # (publickey)", which reads like the device being down.
+    ssh_identity: null # e.g. /run/secrets/builder-key
+
+    # --- netboot ---------------------------------------------------------
+    # The BUILD HOST's NIC facing the target: the one you would run tcpdump on.
+    # Deliberately not usb_iface, which is already overloaded as both an
+    # interface name and an ssh alias.
+    netboot_iface: null # e.g. eth1
+
+    # The TARGET's PXE NIC. On a laptop with no built-in RJ45 this is a dock or
+    # adapter, and not every adapter can PXE at all -- the firmware needs its own
+    # UEFI driver for the chipset. A vendor dock generally works where a generic
+    # USB-C adapter emits no PXE request whatsoever.
+    netboot_mac: null # e.g. 48:2a:e3:82:e8:31
+
+    # Longer than boot_wait_seconds on purpose: an install fetches several GB
+    # and writes them, on top of a normal boot.
+    netboot_install_wait_seconds: null # e.g. 1800
+
+    # --- flashing / console ----------------------------------------------
+    flash_drive: null # e.g. /dev/sda -- verify before any write
+    serial_device: null # e.g. /dev/ttyUSB0, or /dev/ttyACM0 on Orin AGX
+
+  Orin-AGX:
+    host_ip: null # e.g. 192.168.10.149
+    ssh_identity: null
+    serial_device: null # AGX enumerates as /dev/ttyACM*, not ttyUSB*
+
+  darter-pro:
+    host_ip: null
+    ssh_identity: null
+    flash_drive: null

--- a/.github/skills/ghaf-hw-test/config.yaml
+++ b/.github/skills/ghaf-hw-test/config.yaml
@@ -20,6 +20,20 @@
 # Keying this file by physical machine keeps both straight: the generic image goes on
 # any of them, but the test run still has to say which machine it is talking to.
 
+# Where the machine-specific values live
+# --------------------------------------
+# This file is shared, so it holds only what is true for the *project*: which
+# image a device takes, which name the Robot suite expects, how it is flashed.
+#
+# Anything that describes whoever's desk the hardware is sitting on -- addresses,
+# MAC addresses, ssh identities, drive and serial nodes -- goes in
+# `config.local.yaml` next to this file, which is gitignored. Those fields are
+# left `null` here. See `config.local.yaml.example` for the shape, and override
+# the path with GHAF_HW_TEST_LOCAL_CONFIG if you keep it elsewhere.
+#
+# Merge rule: local wins per field; a `null` in the local file does not blank a
+# value set here.
+
 # Device profiles
 # Each device has defaults that can be overridden via CLI
 devices:
@@ -51,11 +65,31 @@ devices:
     flash_method: ghaf-flash
     connection: ssh
     boot_wait_seconds: 180
-    host_ip: null
+    host_ip: null # set in config.local.yaml
     usb_iface: ghaf-usb
+    ssh_identity: null # set in config.local.yaml if not an ssh default
     flash_drive: null
     serial_device: null
     serial_baud: 115200
+    # Netboot. Verified end to end on this machine 2026-08-01: PXE -> iPXE ->
+    # kernel+initrd over HTTP -> installer -> image written to NVMe -> boots.
+    #
+    # netboot_iface is the BUILD HOST's NIC facing the target -- deliberately
+    # NOT usb_iface, which is already overloaded as both an interface name and
+    # an ssh alias. It is the interface you would run tcpdump on.
+    netboot_iface: null # set in config.local.yaml -- the BUILD HOST's NIC
+    # The TARGET's PXE NIC. The X1 Carbon has no built-in RJ45, and a generic
+    # ASIX USB-C dongle never emits a PXE request at all -- the firmware has no
+    # UEFI driver for it. A Lenovo USB-C dock does work, so this is the DOCK's
+    # MAC, which differs from the MAC the OS shows on its usual link.
+    netboot_mac: null # set in config.local.yaml -- the TARGET's PXE NIC
+    boot_menu_key: F12
+    # An install needs far longer than a boot: PXE, initrd, then several GB
+    # fetched over HTTP and written to NVMe. boot_wait_seconds (a boot budget)
+    # is not a substitute -- using it here reports failure mid-write.
+    netboot_install_wait_seconds: 1800
+    # The netboot chain is unsigned, exactly as the installer ISO is.
+    secureboot_must_be_off: true
 
   dell-7330:
     architecture: x86_64
@@ -102,9 +136,7 @@ devices:
     flash_script_target: nvidia-jetson-orin-agx-debug-from-x86_64-flash-script
     connection: ssh
     boot_wait_seconds: 240
-    # net-vm's address, held by MGBE0 (the on-SoC ethernet passed through to it).
-    # Verified on the devkit; it is a DHCP lease, so re-check if the lab moves it.
-    host_ip: 192.168.10.149
+    host_ip: null # set in config.local.yaml
     usb_iface: ghaf-usb
     flash_drive: null
     # The AGX devkit exposes its console over the USB-C debug port as a composite

--- a/.github/skills/ghaf-hw-test/ghaf-hw-test
+++ b/.github/skills/ghaf-hw-test/ghaf-hw-test
@@ -13,6 +13,11 @@ set -euo pipefail
 # Script location
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="$SCRIPT_DIR/config.yaml"
+# Per-machine overrides: addresses, MACs, ssh identities, drive and serial nodes.
+# Gitignored, because those are properties of whoever's desk the hardware is on,
+# not of the project. config.yaml keeps the structural fields (which image to
+# build, which name the Robot suite expects) and leaves the rest null.
+LOCAL_CONFIG_FILE="${GHAF_HW_TEST_LOCAL_CONFIG:-$SCRIPT_DIR/config.local.yaml}"
 LIB_DIR="$SCRIPT_DIR/lib"
 
 # Defaults
@@ -22,6 +27,31 @@ RESULTS_DIR="/tmp/test_results"
 
 # Global flags
 YES=false
+
+# Build locally by default. Shipping a multi-GB image out to a remote builder
+# and back is usually slower than building it here, and it makes the tool behave
+# differently from a hand-run `nix build`, which is confusing when the two
+# disagree. Override with GHAF_HW_TEST_BUILDERS if a remote builder is wanted.
+#
+# Passed to every nix invocation below via NIX_BUILD_OPTS so it cannot drift
+# between call sites.
+NIX_BUILD_OPTS=(--option builders "${GHAF_HW_TEST_BUILDERS-}")
+
+# Common ssh options, plus an optional identity. Devices reached by a key that
+# is not one of ssh's defaults (a lab builder key, say) otherwise fail with
+# "Permission denied (publickey)" from every command here, which reads as "the
+# device is down" rather than "the key is missing". Set per device with
+# `ssh_identity` in config.yaml, or with --ssh-key.
+SSH_OPTS=(-o StrictHostKeyChecking=no -o ConnectTimeout=5)
+set_ssh_identity() {
+    local key="$1"
+    [[ -z "$key" ]] && return 0
+    if [[ ! -r "$key" ]]; then
+        warn "ssh identity $key is not readable; falling back to ssh defaults"
+        return 0
+    fi
+    SSH_OPTS+=(-o IdentitiesOnly=yes -i "$key")
+}
 
 # Colors for output
 RED='\033[0;31m'
@@ -66,6 +96,7 @@ COMMANDS:
     status      Check device connectivity and readiness
     test        Run Robot Framework tests on a device
     flash       Flash a Ghaf image to a device
+    netboot     Install over PXE, no USB media (also via flash_method: netboot)
     analyze     Analyze test results and propose fixes
     run         Full workflow: test → analyze → [build → flash → wait] → retest
 
@@ -75,6 +106,11 @@ OPTIONS (vary by command):
     -p, --password <PASS>   SSH password (default: ghaf)
     -t, --tag <TAG>         Test tag to run (default: pre-merge)
     --drive <PATH>          Drive to flash (e.g., /dev/sda)
+    --iface <NAME>          Build host NIC facing the target (netboot)
+    --mac <MAC>             Target PXE NIC MAC (netboot)
+    --install-target <DEV>  Unattended netboot install to <DEV> (DESTRUCTIVE)
+    --ssh-key <PATH>        SSH identity for the device (netboot)
+    --skip-preflight        Skip netboot pre-flight checks
     --recovery              Use recovery mode for Jetson flash
     --results <PATH>        Path to test results directory
     --propose-fixes         Generate fix proposals for failures
@@ -97,6 +133,12 @@ EXAMPLES:
     # Flash Jetson in recovery mode
     ghaf-hw-test flash --device Orin-AGX --recovery
 
+    # Netboot install (interactive TUI on the target)
+    ghaf-hw-test netboot --device Lenovo-X1
+
+    # Netboot install, unattended and destructive
+    ghaf-hw-test -y netboot --device Lenovo-X1 --install-target /dev/nvme0n1
+
     # Analyze failures and propose fixes
     ghaf-hw-test analyze --propose-fixes
 
@@ -114,11 +156,33 @@ get_device_config() {
     local field="$2"
     run_with_nix python3 -c "
 import yaml
-with open('$CONFIG_FILE') as f:
-    config = yaml.safe_load(f)
-devices = config.get('devices', {})
-device = devices.get('$device', {})
-print(device.get('$field', ''))
+
+
+def _load(path):
+    try:
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return {}
+
+
+config = _load('$CONFIG_FILE')
+local = _load('$LOCAL_CONFIG_FILE')
+
+# Local wins, per field. A null in the local file does NOT blank a real value in
+# the base -- that would make a half-filled override file destructive, and the
+# example ships with nulls in it.
+device = dict(config.get('devices', {}).get('$device', {}))
+for k, v in local.get('devices', {}).get('$device', {}).items():
+    if v is not None:
+        device[k] = v
+value = device.get('$field', '')
+# A YAML null is None, and printing it gives the literal string 'None' -- which
+# every caller here then treats as a real value, because [[ -z \"\$x\" ]] is false
+# for 'None'. That turns an unset field into 'no such interface: None' rather
+# than a clear 'not configured'. Normalise it, along with the same trap for a
+# nested block, which would print a Python dict.
+print('' if value is None else value)
 "
 }
 
@@ -140,7 +204,7 @@ wait_for_device() {
     info "Waiting for $device ($ip) to become reachable (timeout: ${timeout_seconds}s)..."
 
     while [[ $elapsed -lt $timeout_seconds ]]; do
-        if timeout 10 ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 "ghaf@$ip" "echo OK" &>/dev/null; then
+        if timeout 10 ssh "${SSH_OPTS[@]}" "ghaf@$ip" "echo OK" &>/dev/null; then
             success "Device $device ($ip) is reachable after ${elapsed}s"
             return 0
         fi
@@ -280,7 +344,7 @@ cmd_test() {
     local exit_code=0
     (
         cd "$repo_root"
-        nix develop .#smoke-test --command robot-test -i "$ip" -d "$test_device_name" -p "$password" -t "$tag"
+        nix develop "${NIX_BUILD_OPTS[@]}" .#smoke-test --command robot-test -i "$ip" -d "$test_device_name" -p "$password" -t "$tag"
     ) || exit_code=$?
 
     if [[ $exit_code -eq 0 ]]; then
@@ -296,6 +360,404 @@ cmd_test() {
 }
 
 # FLASH command - flash device with Ghaf image
+# Run a command on ghaf-host, one hop in through net-vm.
+#
+# ProxyCommand rather than a nested `ssh ... ssh ghaf-host`: the nested form
+# needs the inner hop to authenticate from net-vm, which only works with a
+# forwarded agent, and an explicit -i key is not in an agent. Jumping keeps
+# authentication local so one identity covers both hops. Getting this wrong is
+# quiet -- the inner ssh fails and every check reads empty, which looks like
+# "the firmware cannot netboot" rather than "the key did not reach the host".
+run_on_ghaf_host() {
+    local ip="$1"
+    shift
+    local proxy="ssh ${SSH_OPTS[*]} -W %h:%p ghaf@$ip"
+    ssh "${SSH_OPTS[@]}" -o "ProxyCommand=$proxy" ghaf@192.168.100.2 "$@"
+}
+
+# Reboot the target into a network boot.
+#
+# BootNext (-n) rather than BootOrder (-o), always: it is one-shot and
+# self-clearing, so a netboot that fails falls back to disk instead of leaving a
+# machine you can only reach over the network stuck in firmware.
+netboot_trigger_reboot() {
+    local ip="$1"
+    local ebm="$2"
+    local net_entry="$3"
+    local password="${4:-}"
+
+    if [[ -n "$ebm" ]] && [[ -n "$net_entry" ]]; then
+        # Needs the NOPASSWD rule from modules/development/dt-host.nix.
+        if run_on_ghaf_host "$ip" "sudo -n $ebm -n $net_entry" &>/dev/null; then
+            success "Set BootNext to $net_entry (one-shot)"
+        else
+            warn "Could not set BootNext (no NOPASSWD rule for efibootmgr on this image?)"
+            warn "  Relying on the existing boot order instead"
+        fi
+    fi
+
+    # Record the boot id so we can prove the machine really restarted. Without
+    # this the caller cannot tell "installed and came back" from "never went
+    # down at all" -- and those look identical to an ssh reachability check.
+    local before_boot_id
+    before_boot_id=$(run_on_ghaf_host "$ip" "cat /proc/sys/kernel/random/boot_id" 2>/dev/null | tr -d '\r')
+
+    info "Rebooting $ip into netboot..."
+    # Three ladders, because over ssh the session is inactive: sudo -n needs the
+    # NOPASSWD rule, plain systemctl is refused by polkit, and sudo -S needs the
+    # lab password. Try each rather than assume the fleet is uniform.
+    local rebooted=false
+    # Same symlink trap as efibootmgr above: the sudoers rule names the
+    # /nix/store/...-systemd-*/bin/systemctl path, and `sudo -n systemctl` uses
+    # the /run/current-system/sw/bin symlink, which does not match. Resolve it
+    # so the NOPASSWD rule can actually apply; without this the password ladder
+    # below always fires and the rule looks broken when it is not.
+    if run_on_ghaf_host "$ip" 'sudo -n "$(readlink -f "$(command -v systemctl)")" reboot' &>/dev/null; then
+        rebooted=true
+    elif [[ -n "$password" ]] && run_on_ghaf_host "$ip" "echo '$password' | sudo -S systemctl reboot" &>/dev/null; then
+        rebooted=true
+    elif run_on_ghaf_host "$ip" "systemctl reboot" &>/dev/null; then
+        rebooted=true
+    fi
+
+    # A reboot cuts the connection, so a non-zero exit above proves nothing
+    # either way. What proves it is the machine going away.
+    info "Confirming $ip actually went down..."
+    local waited=0
+    while [[ $waited -lt 120 ]]; do
+        if ! timeout 5 ssh "${SSH_OPTS[@]}" "ghaf@$ip" "echo OK" &>/dev/null; then
+            success "$ip went down after ${waited}s"
+            NETBOOT_PREV_BOOT_ID="$before_boot_id"
+            return 0
+        fi
+        sleep 5
+        waited=$((waited + 5))
+    done
+
+    error "$ip never went down - the reboot did not take"
+    if [[ "$rebooted" != "true" ]]; then
+        error "  Every reboot method was refused. On this image:"
+        error "    sudo -n        needs the NOPASSWD rule in modules/development/dt-host.nix"
+        error "    systemctl      is refused by polkit for an inactive (ssh) session"
+        error "  Reboot the machine by hand, or install an image carrying that rule."
+    fi
+    return 1
+}
+
+# Pre-flight for a netboot, run over ssh BEFORE anything is rebooted.
+#
+# The point is to fail with a sentence a human can act on, rather than rebooting
+# a machine into a silent PXE timeout and leaving someone to guess. Every check
+# here corresponds to something that actually went wrong during bring-up.
+netboot_preflight() {
+    local ip="$1"
+    local ok=true
+
+    info "Pre-flight checks on $ip (nothing is rebooted yet)..."
+
+    if ! timeout 10 ssh "${SSH_OPTS[@]}" "ghaf@$ip" "echo OK" &>/dev/null; then
+        error "Cannot reach ghaf@$ip over ssh"
+        return 1
+    fi
+
+    # ghaf-host holds the firmware's efivarfs; net-vm does not. Everything below
+    # has to run there, one hop in.
+    # Findings the reboot trigger needs; empty means "could not determine".
+    PREFLIGHT_EBM=""
+    PREFLIGHT_NET_ENTRY=""
+
+    # efibootmgr is only on PATH on images built after the module change that
+    # added it; older ones still have it in the store, so fall back to that
+    # rather than failing a machine that is perfectly capable of netbooting.
+    local ebm
+    # readlink -f is load-bearing, not tidiness. `command -v efibootmgr` returns
+    # /run/current-system/sw/bin/efibootmgr, a symlink, while the sudoers rule in
+    # modules/development/dt-host.nix names the /nix/store/...-efibootmgr-18/bin
+    # path it points at. sudo matches the command as written and does NOT resolve
+    # symlinks, so the unresolved path silently misses the NOPASSWD rule and
+    # BootNext falls back to a password prompt -- reported as "no NOPASSWD rule
+    # for efibootmgr on this image?" on a machine that had the rule all along.
+    # Observed on hardware 2026-08-01. Resolving here makes the two agree.
+    ebm=$(run_on_ghaf_host "$ip" 'p=$(command -v efibootmgr || ls /nix/store/*-efibootmgr-*/bin/efibootmgr 2>/dev/null | head -1); [ -n "$p" ] && readlink -f "$p"' 2>/dev/null | tr -d '\r')
+    if [[ -z "$ebm" ]]; then
+        warn "efibootmgr not found on ghaf-host - cannot inspect boot entries"
+        ok=false
+    else
+        PREFLIGHT_EBM="$ebm"
+    fi
+
+    # SecureBoot is a 5-byte efivar: 4 attribute bytes then the value.
+    local sb
+    sb=$(run_on_ghaf_host "$ip" "od -An -t u1 /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c 2>/dev/null | awk '{print \$5}'" 2>/dev/null | tr -d ' \r')
+    if [[ "$sb" == "1" ]]; then
+        error "Secure Boot is ENABLED on $ip - the netboot chain is unsigned and will be rejected"
+        ok=false
+    elif [[ -z "$sb" ]]; then
+        warn "Could not read the SecureBoot efivar - proceeding, but the target may refuse an unsigned chain"
+    else
+        success "Secure Boot is off"
+    fi
+
+    # Do NOT test for 'MAC(' alone. Lenovo publishes network boot as an abstract
+    # VenMsg entry described 'PXE BOOT', with no MAC device path anywhere, so a
+    # MAC-only test rejects machines that netboot perfectly well.
+    if [[ -n "$ebm" ]]; then
+        local entries
+        entries=$(run_on_ghaf_host "$ip" "$ebm -v 2>/dev/null" 2>/dev/null || true)
+        if grep -qiE 'MAC\(|PXE|Network|IPv4' <<<"$entries"; then
+            success "Target has a network boot entry"
+            # Bootnum of the first network-ish entry, for a one-shot BootNext.
+            PREFLIGHT_NET_ENTRY=$(grep -iE '^Boot[0-9A-F]{4}' <<<"$entries" |
+                grep -iE 'MAC\(|PXE|Network|IPv4' | head -1 |
+                sed -E 's/^Boot([0-9A-Fa-f]{4}).*/\1/')
+            if grep -qE '^BootOrder:' <<<"$entries"; then
+                local first_entry first_desc
+                first_entry=$(grep '^BootOrder:' <<<"$entries" | awk '{print $2}' | cut -d, -f1)
+                first_desc=$(grep -iE "^Boot${first_entry}" <<<"$entries" | head -1)
+                if grep -qiE 'PXE|Network|IPv4|MAC\(' <<<"$first_desc"; then
+                    info "Network boot is FIRST in BootOrder - a plain reboot will netboot"
+                    info "  (and any netboot server left running will catch this machine again)"
+                else
+                    warn "Network boot is NOT first in BootOrder - a plain reboot boots the disk"
+                    warn "  Set BootNext by hand, or use the boot menu key, to netboot this machine"
+                fi
+            fi
+        else
+            warn "No network boot entry found in efibootmgr output"
+            warn "  The machine may still netboot from its one-time boot menu; enable"
+            warn "  the UEFI network stack in firmware setup if it does not"
+            ok=false
+        fi
+    fi
+
+    $ok && return 0
+    return 1
+}
+
+# NETBOOT command - serve a netboot install to one device
+cmd_netboot() {
+    local device="" ip="" iface="" mac="" install_target="" skip_preflight=false dry_run=false ssh_key=""
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        -d | --device)
+            device="$2"
+            shift 2
+            ;;
+        -i | --ip)
+            ip="$2"
+            shift 2
+            ;;
+        --iface)
+            iface="$2"
+            shift 2
+            ;;
+        --mac)
+            mac="$2"
+            shift 2
+            ;;
+        --install-target)
+            install_target="$2"
+            shift 2
+            ;;
+        --skip-preflight)
+            skip_preflight=true
+            shift
+            ;;
+        --ssh-key)
+            ssh_key="$2"
+            shift 2
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        esac
+    done
+
+    [[ -z "$device" ]] && {
+        error "Device is required"
+        echo "Usage: ghaf-hw-test netboot --device <NAME> [--install-target /dev/nvme0n1]"
+        exit 1
+    }
+
+    local ghaf_target
+    ghaf_target=$(get_device_config "$device" "ghaf_target")
+    [[ -z "$iface" ]] && iface=$(get_device_config "$device" "netboot_iface")
+    [[ -z "$mac" ]] && mac=$(get_device_config "$device" "netboot_mac")
+    [[ -z "$ip" ]] && ip=$(get_device_config "$device" "host_ip")
+    [[ -z "$ssh_key" ]] && ssh_key=$(get_device_config "$device" "ssh_identity")
+    set_ssh_identity "$ssh_key"
+
+    # netboot_iface is the BUILD HOST's NIC facing the target, not the device's
+    # -- unlike usb_iface, which is overloaded as both an interface name and an
+    # ssh alias elsewhere in this config.
+    [[ -z "$iface" ]] && {
+        error "No netboot_iface for $device (the build host's NIC facing the target)"
+        echo "Set it in config.yaml or pass --iface"
+        exit 1
+    }
+    # The target's PXE NIC. On a docked laptop this is the DOCK's MAC, not the
+    # internal one, and not necessarily the MAC the OS shows on its usual link.
+    [[ -z "$mac" ]] && {
+        error "No netboot_mac for $device (the target's PXE NIC)"
+        echo "Set it in config.yaml or pass --mac"
+        exit 1
+    }
+
+    info "Netboot $device: target=$ghaf_target iface=$iface mac=$mac"
+
+    if [[ -n "$ip" ]] && [[ "$skip_preflight" != "true" ]]; then
+        if ! netboot_preflight "$ip"; then
+            error "Pre-flight failed - refusing to reboot into a probable silent failure"
+            echo "Re-run with --skip-preflight to override."
+            exit 1
+        fi
+    else
+        warn "Skipping pre-flight (no host_ip, or --skip-preflight given)"
+    fi
+
+    # Everything above this point is read-only, so --dry-run is a real
+    # pre-flight: it answers "can this machine netboot at all" without building
+    # anything, rebooting anything, or putting a DHCP server on the network.
+    if [[ "$dry_run" == "true" ]]; then
+        info "Would build: .#${ghaf_target}-netboot-installer and .#${ghaf_target}"
+        info "Would serve: -i $iface -m $mac --force-interface --open-firewall --exit-after-serve${install_target:+ --install-target $install_target}"
+        [[ -n "$install_target" ]] && warn "Would install UNATTENDED to $install_target (destructive)"
+        success "--dry-run: pre-flight only, nothing built or started"
+        return 0
+    fi
+
+    if [[ -n "$install_target" ]]; then
+        if [[ "$YES" != "true" ]]; then
+            warn "UNATTENDED INSTALL: this ERASES $install_target on $device with nobody at the console!"
+            echo "Press Ctrl+C to cancel or Enter to continue..."
+            read -r
+        else
+            warn "UNATTENDED INSTALL to $install_target (--yes: skipping confirmation)"
+        fi
+    fi
+
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+    info "Building netboot installer and image..."
+    (cd "$repo_root" && nix build "${NIX_BUILD_OPTS[@]}" ".#${ghaf_target}-netboot-installer" -o result-netboot)
+    (cd "$repo_root" && nix build "${NIX_BUILD_OPTS[@]}" ".#${ghaf_target}" -o result)
+
+    # --exit-after-serve is not optional here. If network boot is ahead of the
+    # disk in the target's boot order -- which it is on at least one lab X1 --
+    # a server left running catches the post-install reboot and reinstalls in a
+    # loop. --force-interface because on a shared lab LAN the NIC facing the
+    # target is also the default-route NIC, so the G1 guard can never be
+    # satisfied. --open-firewall because otherwise PXE is dropped before
+    # pixiecore ever sees it and everything looks healthy while nothing happens.
+    local netboot_args=(
+        -i "$iface" -m "$mac"
+        -n result-netboot -g result
+        --force-interface --open-firewall --exit-after-serve
+    )
+    [[ -n "$install_target" ]] && netboot_args+=(--install-target "$install_target")
+
+    info "Plan:"
+    (cd "$repo_root" && nix develop "${NIX_BUILD_OPTS[@]}" --command ghaf-netboot "${netboot_args[@]}" --dry-run) || {
+        error "ghaf-netboot refused the plan - see above"
+        exit 1
+    }
+
+    info "Starting netboot server (stops itself once the image has been served)..."
+    # Through `nix develop`, and NOT `sudo ghaf-netboot`: sudo resets PATH via
+    # secure_path, so the bare name does not resolve to the devshell's copy --
+    # nix/devshell.nix says so explicitly, and its wrapper already execs sudo on
+    # the store path itself. Adding our own sudo here just breaks it.
+    (cd "$repo_root" && nix develop "${NIX_BUILD_OPTS[@]}" --command ghaf-netboot "${netboot_args[@]}") &
+    local server_pid=$!
+
+    echo ""
+    if [[ -n "$ip" ]] && [[ "$skip_preflight" != "true" ]]; then
+        # Give the server a moment to bind before the target starts asking.
+        sleep 5
+        if ! netboot_trigger_reboot "$ip" "${PREFLIGHT_EBM:-}" "${PREFLIGHT_NET_ENTRY:-}" "$DEFAULT_PASSWORD"; then
+            kill "$server_pid" 2>/dev/null || true
+            error "Could not reboot $device - nothing was installed"
+            exit 1
+        fi
+    else
+        warn "Now boot $device from the network."
+        [[ -n "$ip" ]] && echo "  Reboot it with: ssh ghaf@$ip ssh ghaf-host systemctl reboot"
+        local menu_key
+        menu_key=$(get_device_config "$device" "boot_menu_key")
+        [[ -n "$menu_key" ]] && echo "  Or press $menu_key at power-on for the one-time boot menu."
+    fi
+    echo ""
+
+    if [[ -n "$ip" ]]; then
+        # The install itself takes minutes on top of the normal boot wait, so do
+        # not reuse boot_wait_seconds alone here.
+        # Wait for the *install* before waiting for the boot. boot_wait_seconds
+        # is a boot budget (180s by default); an install additionally has to
+        # fetch several GB and write them to disk, so reusing it here reports
+        # failure while the image is still being written -- and the old code
+        # then killed the server, severing the transfer it was waiting for.
+        #
+        # With --exit-after-serve the server exits once the image has gone out
+        # in full, so its lifetime is a far better signal than any fixed sleep.
+        local install_wait
+        install_wait=$(get_device_config "$device" "netboot_install_wait_seconds")
+        [[ -z "$install_wait" ]] && install_wait=1800
+        info "Waiting for the image to be served in full (up to ${install_wait}s)..."
+        local waited=0
+        while kill -0 "$server_pid" 2>/dev/null && [[ $waited -lt $install_wait ]]; do
+            sleep 10
+            waited=$((waited + 10))
+        done
+        if kill -0 "$server_pid" 2>/dev/null; then
+            error "Image not served within ${install_wait}s - the target never fetched it"
+            error "  Leaving the server running: a transfer may be in flight, and killing"
+            error "  it mid-write would leave the disk half-installed. Check the console."
+            exit 1
+        fi
+        success "Image served in full after ${waited}s; server stopped itself"
+
+        info "Waiting for $device to come back on the installed system..."
+        if wait_for_device "$ip" "$device"; then
+            # Reachability alone is not proof: if the machine never rebooted, or
+            # netbooted and fell back to the old disk, ssh answers just the same.
+            # Compare the boot id, and report what is actually running.
+            local now_boot_id now_system
+            now_boot_id=$(run_on_ghaf_host "$ip" "cat /proc/sys/kernel/random/boot_id" 2>/dev/null | tr -d '\r')
+            now_system=$(run_on_ghaf_host "$ip" "readlink /run/current-system" 2>/dev/null | tr -d '\r')
+            if [[ -n "${NETBOOT_PREV_BOOT_ID:-}" ]] && [[ "$now_boot_id" == "${NETBOOT_PREV_BOOT_ID}" ]]; then
+                error "$device has the same boot id as before - it never restarted"
+                kill "$server_pid" 2>/dev/null || true
+                exit 1
+            fi
+            success "Netboot install complete - $device is back up"
+            [[ -n "$now_system" ]] && info "  running: $now_system"
+        else
+            error "$device did not come back; check the console"
+            kill "$server_pid" 2>/dev/null || true
+            exit 1
+        fi
+    else
+        warn "No host_ip for $device - cannot confirm the install automatically"
+        info "Waiting for the server to finish serving (Ctrl+C to stop)..."
+        wait "$server_pid" || true
+    fi
+
+    kill "$server_pid" 2>/dev/null || true
+    success "Netboot finished for $device"
+}
+
 cmd_flash() {
     local device="" drive="" recovery=false
 
@@ -359,10 +821,10 @@ cmd_flash() {
         fi
 
         info "Building image..."
-        (cd "$repo_root" && nix build ".#$ghaf_target")
+        (cd "$repo_root" && nix build "${NIX_BUILD_OPTS[@]}" ".#$ghaf_target")
 
         info "Flashing to $drive..."
-        (cd "$repo_root" && nix develop --command ghaf-flash -d "$drive" -i result/ghaf-image.raw.zst)
+        (cd "$repo_root" && nix develop "${NIX_BUILD_OPTS[@]}" --command ghaf-flash -d "$drive" -i result/ghaf-image.raw.zst)
 
         success "Flash complete! Remove the drive and boot the device."
         ;;
@@ -383,12 +845,22 @@ cmd_flash() {
         fi
 
         info "Building flash script..."
-        (cd "$repo_root" && nix build ".#$flash_script_target")
+        (cd "$repo_root" && nix build "${NIX_BUILD_OPTS[@]}" ".#$flash_script_target")
 
         info "Running flash script (device must be in recovery mode)..."
         (cd "$repo_root" && sudo ./result/bin/flash-ghaf)
 
         success "Flash complete! The device will reboot automatically."
+        ;;
+
+    netboot)
+        # Same install as ghaf-flash, delivered over PXE. Kept behind the same
+        # flash_method switch so a device can be moved to netboot by editing
+        # config.yaml rather than by changing how it is invoked.
+        info "Device is configured for netboot; delegating to 'ghaf-hw-test netboot'"
+        local netboot_forward=(--device "$device")
+        [[ -n "$drive" ]] && netboot_forward+=(--install-target "$drive")
+        cmd_netboot "${netboot_forward[@]}"
         ;;
 
     *)
@@ -586,6 +1058,7 @@ main() {
     status) cmd_status "$@" ;;
     test) cmd_test "$@" ;;
     flash) cmd_flash "$@" ;;
+    netboot) cmd_netboot "$@" ;;
     analyze) cmd_analyze "$@" ;;
     run) cmd_run "$@" ;;
     *)

--- a/.github/skills/ghaf-hw-test/shell.nix
+++ b/.github/skills/ghaf-hw-test/shell.nix
@@ -33,6 +33,12 @@ pkgs.mkShell {
   shellHook = ''
     export SKILL_DIR="$(dirname "$(readlink -f "$0")")"
     export PYTHONPATH="$SKILL_DIR/lib:$PYTHONPATH"
-    echo "ghaf-hw-test skill environment loaded"
+    # >&2 is load-bearing. ghaf-hw-test runs `nix-shell --run` inside command
+    # substitution to read config.yaml, so anything this hook writes to stdout
+    # is captured as part of the value. On stdout this banner made every lookup
+    # two lines long -- `flash_method` became "...environment loaded\nghaf-flash",
+    # which matches no branch of the case statement, so flashing failed with
+    # "Unknown flash method" on any host where nix-shell exists.
+    echo "ghaf-hw-test skill environment loaded" >&2
   '';
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           - target: packages.x86_64-linux.generic-x86_64-debug
           - target: packages.x86_64-linux.intel-laptop-debug
           - target: packages.x86_64-linux.intel-laptop-debug-installer
+          - target: packages.x86_64-linux.intel-laptop-debug-netboot-installer
           - target: packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64
           - target: packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64
           - target: packages.x86_64-linux.doc

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ plans/
 # CLAUDE.md is tracked: it imports the shared AGENTS.md, which is how Claude Code picks up
 # the project instructions. Personal, machine-local notes belong in CLAUDE.local.md.
 CLAUDE.local.md
+# ghaf-hw-test device addresses, MACs, ssh identities and drive nodes: properties
+# of whoever's desk the hardware is on, not of the project. config.yaml keeps the
+# structural fields; see config.local.yaml.example for the shape.
+.github/skills/ghaf-hw-test/config.local.yaml
 .claude/worktrees/
 # Ignore VIM backup files (hide them from reuse lint)
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ plans/
 # CLAUDE.md is tracked: it imports the shared AGENTS.md, which is how Claude Code picks up
 # the project instructions. Personal, machine-local notes belong in CLAUDE.local.md.
 CLAUDE.local.md
-
+.claude/worktrees/
 # Ignore VIM backup files (hide them from reuse lint)
 *.swp
 .gcroots/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,9 @@ in {
 | Run hardware tests | `.github/skills/ghaf-hw-test/ghaf-hw-test test --device <name> --ip <IP>` | `ghaf-test` |
 
 Device details (addresses, drives, serial nodes, target and test names per machine) live in
-`.github/skills/ghaf-hw-test/config.yaml`. Read it rather than asking or guessing.
+`.github/skills/ghaf-hw-test/config.yaml`, with per-machine values (addresses, MACs, ssh
+identities, drive nodes) in the gitignored `config.local.yaml` beside it. Read them rather than
+asking or guessing; if a field is null in both, ask once and offer to write it to the local file.
 
 ## Things that bite
 

--- a/docs/src/content/docs/ghaf/dev/ref/installer.mdx
+++ b/docs/src/content/docs/ghaf/dev/ref/installer.mdx
@@ -89,3 +89,107 @@ A non-interactive installer is also available for scripted use:
 ```sh
 sudo ghaf-installer
 ```
+
+## Installing over the Network (Netboot)
+
+Instead of writing a ~7 GB ISO to a USB stick, the target can boot the installer over PXE and fetch the disk image over HTTP at install time. The boot artefacts are around 650 MB, contain no disk image, and are **target-independent** — one kernel and initrd serve the whole fleet, and only the image URL differs per target.
+
+<Aside type="caution">
+  The target must have **Secure Boot disabled**. The netboot chain is unsigned,
+  exactly as the installer ISO is — this is the same precondition the ISO's own
+  Secure Boot enrollment already imposes, since enrollment requires firmware in
+  Setup Mode.
+</Aside>
+
+### Prerequisites
+
+- The target must expose a **network boot entry** in its firmware, and the firmware must have a UEFI driver for the NIC you intend to boot from. On Lenovo machines this appears as `PXE BOOT` in the boot menu. Check from a running system with `efibootmgr -v`.
+- The build host and the target must be on the **same layer-2 network**. PXE uses broadcast; it does not cross a router.
+- The build host needs **root** (DHCP/PXE require ports 67, 69 and 4011).
+
+<Aside type="note">
+  Not every USB-C ethernet adapter can PXE boot. The firmware needs its own
+  driver for the chipset, which vendor docks generally provide and generic
+  adapters often do not — a machine with no built-in RJ45 may simply never emit
+  a PXE request. If nothing reaches the server, try a vendor dock before
+  debugging the server.
+</Aside>
+
+### Building the Artefacts
+
+```sh
+nix build .#intel-laptop-debug-netboot-installer -o result-netboot
+nix build .#intel-laptop-debug -o result
+```
+
+### Serving the Install
+
+Always start with `--dry-run`. It validates the arguments, prints the exact kernel command line and boot plan, and starts nothing:
+
+```sh
+nix develop --command ghaf-netboot \
+  --interface eth0 --mac aa:bb:cc:dd:ee:ff \
+  --netboot result-netboot --image result \
+  --dry-run
+```
+
+When the plan looks right, drop `--dry-run`:
+
+```sh
+sudo ghaf-netboot \
+  --interface eth0 --mac aa:bb:cc:dd:ee:ff \
+  --netboot result-netboot --image result \
+  --open-firewall --exit-after-serve
+```
+
+Key options:
+
+- `--mac` is an **allowlist and is mandatory**. Machines not on it are answered with a 404, which PXE treats as "ignore me". On a shared network this is the only thing preventing an unrelated machine from booting your installer.
+- `--open-firewall` opens ports 67, 69, 4011 and the HTTP port for the duration of the run, then closes them again on exit. Without it, a host that filters inbound traffic drops every PXE request **before the server sees it** — the server logs nothing and the target times out.
+- `--exit-after-serve` stops the server once the image has been transferred in full. It is **on by default with `--install-target`**, because an unattended install reboots itself when it finishes: if the target has network boot ahead of its disk, a server left running catches that reboot and reinstalls in a loop. `--no-exit-after-serve` opts out and warns. For interactive runs it is off, since nothing fetches the image and the server needs to stay up while an operator works through the TUI.
+- `--force-interface` is required when the interface facing the target also carries the default route, which is the normal case on a shared lab network.
+- `--ipxe` selects the iPXE binary served to 64-bit UEFI clients. The default is the `snponly.efi` Ghaf builds itself and is almost always what you want; see [The iPXE binary](#the-ipxe-binary) below before changing it.
+
+### Unattended Installs
+
+Adding `--install-target` writes to the given device with no prompts:
+
+```sh
+sudo ghaf-netboot ... --install-target /dev/nvme0n1
+```
+
+<Aside type="danger">
+  This destroys the contents of the target disk with nobody at the console.
+  Confirm the MAC allowlist and the device path before running it.
+</Aside>
+
+When the write finishes, the installer prints a ten-second notice and reboots into the system it just wrote — there is no installation medium to remove and nobody there to remove it. Boot with `ghaf.install_noreboot` to stay in the installer instead, which is what you want when diagnosing an install that went wrong, since otherwise the evidence reboots away.
+
+### How It Works
+
+The server runs Pixiecore in ProxyDHCP mode, so it never assigns addresses and cannot disturb an existing DHCP server. Pixiecore asks a small local HTTP API what to do with each machine that tries to boot; the API answers only for allowlisted MACs. The installer then fetches `ghaf-image.raw.zst` and `ghaf-image.bmap` over HTTP and writes the image with `bmaptool`, which verifies a SHA-256 per range as it copies. A missing `.bmap` is fatal rather than falling back to an unverified copy.
+
+### The iPXE Binary
+
+The target's firmware does not boot the kernel directly. It first loads iPXE over TFTP, and that iPXE then fetches the boot script, kernel and initrd over HTTP. Which iPXE build gets served matters more than it sounds, because the two obvious choices each fail in a different way:
+
+| iPXE build | NIC driver | Failure |
+| --- | --- | --- |
+| Pixiecore's built-in | iPXE's own native drivers | Broadcast DHCP replies never arrive on some adapters. iPXE retries ten times, reboots, and repeats forever. |
+| A stock `snp.efi` / `snponly.efi` | firmware SNP | Identifies as user-class `iPXE`, which Pixiecore reads as plain UEFI firmware, so it re-serves the iPXE binary in an endless chainload loop. |
+
+Ghaf therefore builds its own: `bin-x86_64-efi/snponly.efi`, which drives the NIC through the **firmware's** SNP driver, with an embedded script that sets **user-class `pixiecore`**. That user-class string is the entire test Pixiecore applies to decide it has already chainloaded a client, so setting it is what avoids the loop while keeping the MAC allowlist, the 404, and the assembled kernel command line on their normal path.
+
+This is the default, and on a machine whose firmware enumerates the NIC at all it should need no thought. Two escape hatches exist:
+
+- `--ipxe builtin` falls back to Pixiecore's own iPXE. Worth trying if the firmware's SNP does not cover the adapter, at the cost of the broadcast-DHCP problem above.
+- `--ipxe <FILE>` serves a binary you supply. It must carry an embedded script that sets user-class `pixiecore`, or it will chainload-loop.
+
+<Aside type="caution">
+  Recovering from the chainload loop or the DHCP retry loop can require
+  physically unplugging the adapter — a separately powered USB-C dock survives a
+  laptop power cycle. Prefer `--dry-run` and confirm the reported `ipxe` path
+  before booting a target you cannot easily reach.
+</Aside>
+
+On a non-x86_64 build host the custom binary is not built, and the server falls back to Pixiecore's built-in iPXE. Such a host can still serve an x86_64 target; it just inherits the first row of the table.

--- a/lib/builders/flake-module.nix
+++ b/lib/builders/flake-module.nix
@@ -10,5 +10,8 @@ _: {
 
     # Unified installer builder
     mkGhafInstaller = import ./mkGhafInstaller.nix;
+
+    # Same installer, delivered over the network instead of on an ISO
+    mkGhafNetbootInstaller = import ./mkGhafNetbootInstaller.nix;
   };
 }

--- a/lib/builders/installer-common.nix
+++ b/lib/builders/installer-common.nix
@@ -87,9 +87,9 @@ in
       self.packages.${system}.hardware-scan
     ];
 
-    # Autostart the installer TUI on tty1, replacing the default getty
+    # Autostart the installer on tty1, replacing the default getty.
     systemd.services.ghaf-installer-tui = {
-      description = "Ghaf Installer TUI";
+      description = "Ghaf Installer";
       after = [ "multi-user.target" ];
       wantedBy = [ "multi-user.target" ];
       conflicts = [ "getty@tty1.service" ];
@@ -97,7 +97,16 @@ in
         IMG_PATH = cfg.imageSource;
       };
       serviceConfig = {
-        ExecStart = "${self.packages.${system}.ghaf-installer-tui}/bin/ghaf-installer-tui";
+        ExecStart = pkgs.writeShellScript "ghaf-installer-autostart" ''
+          # ghaf-installer reads ghaf.install_target/_encrypt/_secureboot and
+          # ghaf.image_url itself, so the dispatch here is only about which of
+          # the two front-ends to run.
+          if grep -q 'ghaf\.install_target=' /proc/cmdline 2>/dev/null; then
+            echo "ghaf.install_target= on the kernel command line: installing unattended." >&2
+            exec ${self.packages.${system}.ghaf-installer}/bin/ghaf-installer
+          fi
+          exec ${self.packages.${system}.ghaf-installer-tui}/bin/ghaf-installer-tui
+        '';
         # Suppress kernel printk noise on tty1 while TUI is active
         ExecStartPre = "${pkgs.util-linux}/bin/dmesg -n 1";
         # Restore kernel log level and hand tty1 back to getty on exit

--- a/lib/builders/installer-common.nix
+++ b/lib/builders/installer-common.nix
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# installer-common - the media-agnostic half of the Ghaf installer
+#
+# Everything the installer needs regardless of how it was booted: the TUI unit,
+# plymouth, the installer packages, hostname and getty text. The media layer on
+# top adds the boot medium and says where the image lives:
+#
+#   mkGhafInstaller.nix         ISO   -> imageSource = "/iso/ghaf-image"
+#   mkGhafNetbootInstaller.nix  PXE   -> imageSource = an http(s) URL
+#
+# WHY THIS IS A SEPARATE MODULE RATHER THAN ONE SHARED nixosSystem:
+# ISO and netboot cannot coexist in a single evaluation. nixpkgs'
+# installer/cd-dvd/iso-image.nix and installer/netboot/netboot.nix both define
+# config.lib.isoFileSystems."/nix/.ro-store".device at the same priority (and
+# disagree on image.extension / image.filePath / system.build.image), so
+# importing both is a conflicting-definition error. Sharing therefore has to
+# mean sharing a *module*, evaluated twice, rather than one system built twice.
+#
+# KEEP THE TWO BUILDERS IN SYNC: anything added directly to mkGhafInstaller.nix
+# that is not genuinely ISO-specific will silently be missing from the netboot
+# installer. If it is not about the boot medium, it belongs here.
+#
+# Takes `self` and `system` at import time rather than reading them from module
+# arguments: the builders construct their nixosSystem with
+# `specialArgs = { inherit lib; }` only, so there is no `self` in scope inside
+# the modules themselves.
+{
+  self,
+  system,
+}:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.installer;
+in
+{
+  imports = [
+    # Enable plymouth graphical boot
+    "${self}/modules/desktop/graphics/boot.nix"
+  ];
+
+  options.ghaf.installer.imageSource = lib.mkOption {
+    type = lib.types.str;
+    default = "/iso/ghaf-image";
+    example = "http://192.0.2.1:8080/ghaf-image";
+    description = ''
+      Where ghaf-installer and ghaf-installer-tui look for ghaf-image.raw.zst
+      and ghaf-image.bmap.
+
+      A local directory (the ISO case) or an http(s) base URL (the netboot
+      case). Exported as IMG_PATH; the installer scripts branch on the scheme.
+      A `ghaf.image_url=` kernel parameter overrides it at runtime, which is how
+      one netboot artefact can serve every target.
+    '';
+  };
+
+  config = {
+    environment = {
+      sessionVariables.IMG_PATH = cfg.imageSource;
+      variables.IMG_PATH = cfg.imageSource;
+    };
+
+    ghaf.graphics.boot = {
+      enable = true;
+      renderer = "simpledrm";
+    };
+
+    # Skip NixOS installer
+    boot.loader.timeout = lib.mkForce 0;
+
+    systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];
+    systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
+    networking.networkmanager.enable = true;
+
+    image.baseName = lib.mkForce "ghaf";
+    networking.hostName = "ghaf-installer";
+
+    environment.systemPackages = [
+      self.packages.${system}.ghaf-installer-tui
+      self.packages.${system}.ghaf-installer
+      self.packages.${system}.hardware-scan
+    ];
+
+    # Autostart the installer TUI on tty1, replacing the default getty
+    systemd.services.ghaf-installer-tui = {
+      description = "Ghaf Installer TUI";
+      after = [ "multi-user.target" ];
+      wantedBy = [ "multi-user.target" ];
+      conflicts = [ "getty@tty1.service" ];
+      environment = {
+        IMG_PATH = cfg.imageSource;
+      };
+      serviceConfig = {
+        ExecStart = "${self.packages.${system}.ghaf-installer-tui}/bin/ghaf-installer-tui";
+        # Suppress kernel printk noise on tty1 while TUI is active
+        ExecStartPre = "${pkgs.util-linux}/bin/dmesg -n 1";
+        # Restore kernel log level and hand tty1 back to getty on exit
+        ExecStopPost = [
+          "${pkgs.util-linux}/bin/dmesg -n 7"
+          "${pkgs.systemd}/bin/systemctl start getty@tty1.service"
+        ];
+        StandardInput = "tty";
+        StandardOutput = "tty";
+        StandardError = "tty";
+        TTYPath = "/dev/tty1";
+        TTYReset = true;
+        TTYVHangup = true;
+        PrivateTmp = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+
+    services.getty = {
+      greetingLine = "<<< Welcome to the Ghaf installer >>>";
+      helpLine = lib.mkAfter ''
+
+        To start the interactive Ghaf installer, run
+        `sudo ghaf-installer-tui`.
+
+        To start the non-interactive Ghaf installer, run
+        `sudo ghaf-installer`.
+      '';
+    };
+
+    # NOTE: Stop nixos complains about "warning:
+    # mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash."
+    # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/installation-device.nix#L112
+    boot.swraid.mdadmConf = "PROGRAM ${pkgs.coreutils}/bin/true";
+
+    boot = {
+      kernelPackages = pkgs.linuxPackages_latest;
+      # Disable ZFS support - not compatible with latest. only supported on LTS.
+      supportedFilesystems.zfs = lib.mkForce false;
+    };
+
+    # Configure nixpkgs with Ghaf overlays for extended lib support
+    nixpkgs = {
+      hostPlatform.system = system;
+      config = {
+        allowUnfree = true;
+        permittedInsecurePackages = [
+          "jitsi-meet-1.0.8043"
+          "qtwebengine-5.15.19"
+        ];
+      };
+      overlays = [ self.overlays.default ];
+    };
+  };
+}

--- a/lib/builders/mkGhafInstaller.nix
+++ b/lib/builders/mkGhafInstaller.nix
@@ -49,112 +49,26 @@ let
       inherit lib;
     };
     modules = [
+      # Everything not about the boot medium lives in installer-common.nix and is
+      # shared with mkGhafNetbootInstaller.nix. Add ISO-specific settings here;
+      # add anything else there, or the netboot installer silently loses it.
+      (import ./installer-common.nix { inherit self system; })
       (
-        { pkgs, modulesPath, ... }:
+        { modulesPath, ... }:
         {
           imports = [
             "${toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
-            # Enable plymouth graphical boot
-            "${self}/modules/desktop/graphics/boot.nix"
           ];
 
+          # ISO-only: these options exist solely because iso-image.nix is imported.
           isoImage = {
             storeContents = [ ];
             contents = [ ];
             squashfsCompression = "zstd -Xcompression-level 3";
           };
 
-          environment = {
-            sessionVariables.IMG_PATH = "/iso/ghaf-image";
-            variables.IMG_PATH = "/iso/ghaf-image";
-          };
-
-          ghaf.graphics.boot = {
-            enable = true;
-            renderer = "simpledrm";
-          };
-
-          # Skip NixOS installer
-          boot.loader.timeout = lib.mkForce 0;
-
-          systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];
-          systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];
-          networking.networkmanager.enable = true;
-
-          image.baseName = lib.mkForce "ghaf";
-          networking.hostName = "ghaf-installer";
-
-          environment.systemPackages = [
-            self.packages.${system}.ghaf-installer-tui
-            self.packages.${system}.ghaf-installer
-            self.packages.${system}.hardware-scan
-          ];
-
-          # Autostart the installer TUI on tty1, replacing the default getty
-          systemd.services.ghaf-installer-tui = {
-            description = "Ghaf Installer TUI";
-            after = [ "multi-user.target" ];
-            wantedBy = [ "multi-user.target" ];
-            conflicts = [ "getty@tty1.service" ];
-            environment = {
-              IMG_PATH = "/iso/ghaf-image";
-            };
-            serviceConfig = {
-              ExecStart = "${self.packages.${system}.ghaf-installer-tui}/bin/ghaf-installer-tui";
-              # Suppress kernel printk noise on tty1 while TUI is active
-              ExecStartPre = "${pkgs.util-linux}/bin/dmesg -n 1";
-              # Restore kernel log level and hand tty1 back to getty on exit
-              ExecStopPost = [
-                "${pkgs.util-linux}/bin/dmesg -n 7"
-                "${pkgs.systemd}/bin/systemctl start getty@tty1.service"
-              ];
-              StandardInput = "tty";
-              StandardOutput = "tty";
-              StandardError = "tty";
-              TTYPath = "/dev/tty1";
-              TTYReset = true;
-              TTYVHangup = true;
-              PrivateTmp = true;
-              Restart = "on-failure";
-              RestartSec = "5s";
-            };
-          };
-
-          services.getty = {
-            greetingLine = "<<< Welcome to the Ghaf installer >>>";
-            helpLine = lib.mkAfter ''
-
-              To start the interactive Ghaf installer, run
-              `sudo ghaf-installer-tui`.
-
-              To start the non-interactive Ghaf installer, run
-              `sudo ghaf-installer`.
-            '';
-          };
-
-          # NOTE: Stop nixos complains about "warning:
-          # mdadm: Neither MAILADDR nor PROGRAM has been set. This will cause the `mdmon` service to crash."
-          # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/installation-device.nix#L112
-          boot.swraid.mdadmConf = "PROGRAM ${pkgs.coreutils}/bin/true";
-
-          boot = {
-            kernelPackages = pkgs.linuxPackages_latest;
-            # Disable ZFS support - not compatible with latest. only supported on LTS.
-            supportedFilesystems.zfs = lib.mkForce false;
-          };
-
-          # Configure nixpkgs with Ghaf overlays for extended lib support
-          nixpkgs = {
-            hostPlatform.system = system;
-            config = {
-              allowUnfree = true;
-              permittedInsecurePackages = [
-                "jitsi-meet-1.0.8043"
-                "qtwebengine-5.15.19"
-              ];
-            };
-            overlays = [ self.overlays.default ];
-          };
+          # The image rides along inside the ISO and is mounted at /iso.
+          ghaf.installer.imageSource = "/iso/ghaf-image";
         }
       )
     ]

--- a/lib/builders/mkGhafNetbootInstaller.nix
+++ b/lib/builders/mkGhafNetbootInstaller.nix
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# mkGhafNetbootInstaller - PXE/netboot counterpart to mkGhafInstaller
+#
+# Builds the same installer as the ISO (same TUI, same disko write, same Secure
+# Boot enrollment -- see installer-common.nix) but as netboot artefacts, and
+# WITHOUT the ~5.3 GB image embedded. The image is fetched over HTTP at install
+# time instead, which is the whole point:
+#
+#   ISO      ~7 GB per target, ~20 targets, image baked in
+#   netboot  ~1.5 GB once for the whole fleet, image chosen at serve time
+#
+# The kernel/initrd are therefore target-independent; the only per-target
+# difference is a URL, so per-target outputs are linkFarms over one shared
+# kernel+initrd and cost effectively nothing to add.
+#
+# Usage:
+#   let
+#     ghafNetboot = ghaf.builders.mkGhafNetbootInstaller {
+#       inherit self;
+#       extraModules = installerModules;   # the SAME list the ISO uses
+#     };
+#   in ghafNetboot { name = "intel-laptop-debug"; }
+#
+# Output:
+#   {
+#     name    - e.g. "intel-laptop-debug-netboot-installer"
+#     package - directory containing bzImage, initrd, netboot.ipxe
+#   }
+#
+# NOTE: the package is a linkFarm, i.e. symlinks into /nix/store. Copy it with
+# `cp -L` / `rsync -L` when staging it onto a TFTP/HTTP root, or the server will
+# serve dangling links.
+{
+  self,
+  lib ? self.lib,
+  system ? "x86_64-linux",
+  extraModules ? [ ],
+  # Where the installer fetches ghaf-image.raw.zst / .bmap from. The default
+  # defers to iPXE's DHCP-provided ${next-server}, so one built artefact works
+  # at any site and no site-specific URL is baked into the repo. A
+  # ghaf.image_url= kernel parameter still overrides it at boot.
+  imageBaseUrl ? null,
+}:
+let
+  netbootConfig = lib.nixosSystem {
+    specialArgs = {
+      inherit lib;
+    };
+    modules = [
+      # Everything not about the boot medium. Sharing this with
+      # mkGhafInstaller.nix is what keeps the two installers behaving
+      # identically -- do not inline installer settings here.
+      (import ./installer-common.nix { inherit self system; })
+      (
+        { modulesPath, ... }:
+        {
+          imports = [
+            "${toString modulesPath}/installer/netboot/netboot-minimal.nix"
+          ];
+
+          # The store squashfs measures ~1.45 GiB at the ISO's compression
+          # level 3, and it is loaded whole into RAM by iPXE. Trading build
+          # time for transfer size is clearly right here: this is sent over the
+          # network on every install and unpacked into a resident tmpfs.
+          netboot.squashfsCompression = "zstd -Xcompression-level 12";
+
+          # netboot-minimal disables this at mkOverride 70, so a plain
+          # definition would NOT win -- it needs mkForce to turn on. Left off
+          # deliberately: PXE implies a cable, and the firmware blobs are a
+          # large slice of an initrd that has to fit in RAM.
+          # hardware.enableRedistributableFirmware = lib.mkForce true;
+
+          # The TUI cannot do anything until the image is reachable, so wait
+          # for the network. Netboot only -- the ISO must not gain this, or it
+          # stalls on machines with no cable attached.
+          systemd.services.ghaf-installer-tui = {
+            wants = [ "network-online.target" ];
+            after = [ "network-online.target" ];
+          };
+        }
+        // lib.optionalAttrs (imageBaseUrl != null) {
+          ghaf.installer.imageSource = imageBaseUrl;
+        }
+      )
+    ]
+    ++ extraModules;
+  };
+
+  cfg = netbootConfig.config;
+  inherit (netbootConfig) pkgs;
+
+  # One kernel+initrd for every target; only the iPXE script differs.
+  sharedBoot = pkgs.linkFarm "ghaf-netboot-boot" [
+    {
+      name = "bzImage";
+      path = "${cfg.system.build.kernel}/${cfg.system.boot.loader.kernelFile}";
+    }
+    {
+      name = "initrd";
+      path = "${cfg.system.build.netbootRamdisk}/initrd";
+    }
+  ];
+
+  # Built from the NixOS-generated script rather than hand-written: it carries
+  # the correct init=/nix/store/... path, and getting that wrong is how you end
+  # up debugging a stage-1 panic. ${next-server} and ${cmdline} are expanded by
+  # iPXE at boot, not by Nix -- hence the '' escapes.
+  mkIpxe =
+    imageUrl:
+    pkgs.writeTextDir "netboot.ipxe" ''
+      #!ipxe
+      kernel bzImage init=${cfg.system.build.toplevel}/init ${toString cfg.boot.kernelParams} ghaf.image_url=${imageUrl} ''${cmdline}
+      initrd initrd
+      boot
+    '';
+
+  mkGhafNetbootInstaller =
+    {
+      name,
+      # \${next-server} is expanded by iPXE at boot, not by Nix -- in a normal
+      # (non-indented) string the escape is \$, whereas the ipxe script below
+      # is an indented string and uses ''$.
+      imageUrl ? "http://\${next-server}/ghaf-images/${name}",
+    }:
+    {
+      name = "${name}-netboot-installer";
+      package = pkgs.linkFarm "${name}-netboot-installer" [
+        {
+          name = "bzImage";
+          path = "${sharedBoot}/bzImage";
+        }
+        {
+          name = "initrd";
+          path = "${sharedBoot}/initrd";
+        }
+        {
+          name = "netboot.ipxe";
+          path = "${mkIpxe imageUrl}/netboot.ipxe";
+        }
+      ];
+    };
+in
+mkGhafNetbootInstaller

--- a/modules/development/dt-host.nix
+++ b/modules/development/dt-host.nix
@@ -19,6 +19,32 @@ in
   options.ghaf.development.debug.tools.host.enable = lib.mkEnableOption "Host Debugging Tools";
 
   config = lib.mkIf cfg.enable {
+    # Let the ghaf user set a one-shot BootNext without a password, and nothing
+    # else. `ghaf-hw-test netboot` needs this to reboot a machine into PXE by
+    # itself; without it the tool can only ask a human to do it.
+    #
+    # Scoped deliberately narrowly:
+    #   * this module only, so it is debug-only and never reaches a release image
+    #   * x86_64 only, matching where the netboot flow is used
+    #   * the efibootmgr binary alone, not a blanket NOPASSWD for wheel
+    security.sudo.extraRules = lib.mkIf (config.nixpkgs.hostPlatform.system == "x86_64-linux") [
+      {
+        users = [ "ghaf" ];
+        commands = [
+          {
+            command = "${pkgs.efibootmgr}/bin/efibootmgr";
+            options = [ "NOPASSWD" ];
+          }
+          # Setting a BootNext you cannot act on is useless, so this is scoped
+          # to the reboot verb alone rather than to systemctl generally.
+          {
+            command = "${config.systemd.package}/bin/systemctl reboot";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+      }
+    ];
+
     environment.systemPackages =
       (rmDesktopEntries [
         # EFI tools for enrolling certs

--- a/modules/hardware/x86_64-generic/x86_64-linux.nix
+++ b/modules/hardware/x86_64-generic/x86_64-linux.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -43,5 +44,9 @@ in
         (config.boot.kernelPackages.callPackage ./kernel/modules/fake-battery { })
       ];
     };
+
+    # canTouchEfiVariables already pulls efibootmgr into the closure for the
+    # bootloader installer, but nothing puts it on PATH, so add here
+    environment.systemPackages = [ pkgs.efibootmgr ];
   };
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -77,6 +77,16 @@
               category = "builder";
             }
             {
+              help = "Serve a Ghaf netboot install (root; one interface, one MAC)";
+              name = "ghaf-netboot";
+              # exec sudo the store path rather than the bare name: sudo resets
+              # PATH via secure_path, so `sudo ghaf-netboot` would not find the
+              # devshell's copy. The store path also carries its runtimeInputs,
+              # which is why this is a package rather than an inline command.
+              command = ''exec sudo -- "${self'.legacyPackages.ghaf-netboot}/bin/ghaf-netboot" "$@"'';
+              category = "builder";
+            }
+            {
               help = "Update the npm dependencies in the docs";
               name = "update-docs-depends";
               command = "update-docs-deps";

--- a/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-lib.sh
+++ b/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-lib.sh
@@ -25,6 +25,11 @@ debug() {
 # shellcheck disable=SC2329
 boot_device() {
   local source parent
+  # Netboot: the image arrives over the network, so there is no installer medium
+  # to exclude and every disk is a legitimate target. Returning empty is the
+  # correct answer here, not a failure -- findmnt on a URL would fall through to
+  # the `|| return 0` below anyway, but only by accident.
+  [[ ${IMG_PATH:-} =~ ^https?:// ]] && return 0
   source=$(findmnt -n -o SOURCE --target "${IMG_PATH:-/}" 2>/dev/null) || return 0
   parent=$(lsblk -no pkname "$source" 2>/dev/null | head -1)
   if [[ -n $parent ]]; then
@@ -124,49 +129,114 @@ find_esp_device() {
   return 1
 }
 
+# Work out where the image is coming from, and make sure the block map is a
+# local seekable file either way. Sets GHAF_REMOTE / GHAF_RAW_SRC / GHAF_BMAP.
+#
+# IMG_PATH is either a directory (booted from the ISO, which carries the image)
+# or an http(s) base URL (netboot, where the image is fetched at install time
+# and never embedded -- that is the whole point of netboot: the boot artefacts
+# stay ~1.5 GB instead of ~7 GB).
+# shellcheck disable=SC2329
+resolve_image_source() {
+  local cmdline_url bmap_url
+
+  # A ghaf.image_url= kernel parameter beats the built-in default, so a single
+  # netboot artefact can serve every target and the server picks. Parsed here
+  # rather than injected via the unit's Environment= so that the TUI and the
+  # scripted installer share exactly one code path.
+  cmdline_url=$(sed -n 's/.*[[:space:]]ghaf\.image_url=\([^[:space:]]*\).*/\1/p' /proc/cmdline 2>/dev/null)
+  [[ -n $cmdline_url ]] && IMG_PATH="$cmdline_url"
+
+  if [[ ${IMG_PATH:-} =~ ^https?:// ]]; then
+    GHAF_REMOTE=true
+    if [[ $IMG_PATH == *.raw.zst ]]; then
+      GHAF_RAW_SRC="$IMG_PATH"
+    else
+      GHAF_RAW_SRC="${IMG_PATH%/}/ghaf-image.raw.zst"
+    fi
+    bmap_url="${GHAF_RAW_SRC%.raw.zst}.bmap"
+
+    # bmaptool needs the map as a seekable local file; it is only ~50 KB, so
+    # /run (RAM-backed) is the right home and nothing touches the target disk.
+    # Overridable so this path can be exercised without root in tests.
+    local rundir="${GHAF_INSTALLER_RUNDIR:-/run/ghaf-installer}"
+    GHAF_BMAP="$rundir/ghaf-image.bmap"
+    if ! mkdir -p "$rundir"; then
+      show_error "Could not create $rundir for the block map"
+      return 1
+    fi
+    if ! curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o "$GHAF_BMAP" "$bmap_url"; then
+      # Deliberately fatal rather than falling back to an unverified dd. The
+      # bmap carries per-range sha256 checksums that bmaptool verifies while
+      # copying, and over plain HTTP that is the only integrity check there is.
+      show_error "Could not fetch block map $bmap_url"
+      return 1
+    fi
+  else
+    GHAF_REMOTE=false
+    shopt -s nullglob
+    local -a raw_files=("$IMG_PATH"/*.raw.zst)
+    shopt -u nullglob
+
+    if [[ ${#raw_files[@]} -eq 0 ]]; then
+      show_error "No .raw.zst image found in $IMG_PATH"
+      return 1
+    fi
+
+    GHAF_RAW_SRC="${raw_files[0]}"
+    GHAF_BMAP="${GHAF_RAW_SRC%.raw.zst}.bmap"
+  fi
+}
+
+# Produce the decompressed image on stdout, from disk or from the network.
+# shellcheck disable=SC2329
+feed_image() {
+  if [[ ${GHAF_REMOTE:-false} == true ]]; then
+    # --no-progress-meter: pv already draws the progress bar the TUI shows, and
+    # curl's own meter would scribble over it on the same tty.
+    curl -fL --no-progress-meter --retry 5 --retry-delay 2 --retry-all-errors "$GHAF_RAW_SRC"
+  else
+    cat "$GHAF_RAW_SRC"
+  fi | zstdcat -T0
+}
+
 # Decompress and write the raw image to the target device.
 # Uses bmaptool for a sparse-aware copy when a .bmap file is available,
-# piping directly from zstdcat so no temp storage is needed.
+# piping directly from the producer so no temp storage is needed.
 # Falls back to a streaming dd write if bmaptool is unavailable or fails.
 # shellcheck disable=SC2329
 do_install_image() {
   local dev="$1"
 
-  shopt -s nullglob
-  local -a raw_files=("$IMG_PATH"/*.raw.zst)
-  shopt -u nullglob
-
-  if [[ ${#raw_files[@]} -eq 0 ]]; then
-    show_error "No .raw.zst image found in $IMG_PATH"
-    return 1
-  fi
-
-  local raw_file="${raw_files[0]}"
-  local bmap_file="${raw_file%.raw.zst}.bmap"
+  resolve_image_source || return 1
 
   local IMGSIZE
-  if [[ -s $bmap_file ]]; then
-    IMGSIZE="$(grep -oP '<ImageSize>\s*\K\d+' "$bmap_file")"
-  else
+  if [[ -s $GHAF_BMAP ]]; then
+    IMGSIZE="$(grep -oP '<ImageSize>\s*\K\d+' "$GHAF_BMAP")"
+  elif [[ ${GHAF_REMOTE:-false} == false ]]; then
+    # `zstd -l` needs a seekable file, so this estimate is local-only. The
+    # remote path always has a bmap by now, or resolve_image_source bailed.
     show_info "Estimating image size..." ""
-    IMGSIZE="$(zstd -l "$raw_file" -v 2>/dev/null | awk '/Decompressed Size:/ {print $5}' | tr -d '()')"
+    IMGSIZE="$(zstd -l "$GHAF_RAW_SRC" -v 2>/dev/null | awk '/Decompressed Size:/ {print $5}' | tr -d '()')"
   fi
 
   local -a PV_CMD
-  PV_CMD=(pv --format '%{sgr:white,bold}Writing Ghaf image to disk - %r %40p %e%{sgr:reset}' -N "$raw_file")
+  PV_CMD=(pv --format '%{sgr:white,bold}Writing Ghaf image to disk - %r %40p %e%{sgr:reset}' -N "$GHAF_RAW_SRC")
   [[ -n $IMGSIZE ]] && PV_CMD+=(-s "$IMGSIZE")
 
-  if command -v bmaptool >/dev/null 2>&1 && [[ -s $bmap_file ]]; then
-    debug "Using bmaptool with block map: $bmap_file"
-    if zstdcat -T0 "$raw_file" | "${PV_CMD[@]}" | bmaptool copy --bmap "$bmap_file" - "$dev" >/dev/null 2>&1; then
+  if command -v bmaptool >/dev/null 2>&1 && [[ -s $GHAF_BMAP ]]; then
+    debug "Using bmaptool with block map: $GHAF_BMAP"
+    if feed_image | "${PV_CMD[@]}" | bmaptool copy --bmap "$GHAF_BMAP" - "$dev" >/dev/null 2>&1; then
       return 0
     fi
     debug "bmaptool failed, falling back to streaming write"
+    # Over the network this fallback re-fetches the whole image, so it is slow
+    # rather than free -- but a second pass beats a half-written disk.
     show_warning "Fast installation unavailable. Continuing with standard installation."
   fi
 
-  debug "Writing image: $raw_file -> $dev"
-  zstdcat -T0 "$raw_file" | "${PV_CMD[@]}" | dd of="$dev" bs=32M conv=fsync oflag=direct iflag=fullblock status=none
+  debug "Writing image: $GHAF_RAW_SRC -> $dev"
+  feed_image | "${PV_CMD[@]}" | dd of="$dev" bs=32M conv=fsync oflag=direct iflag=fullblock status=none
 }
 
 # Place a deferred encryption marker on the ESP partition

--- a/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-lib.sh
+++ b/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-lib.sh
@@ -165,7 +165,7 @@ resolve_image_source() {
       show_error "Could not create $rundir for the block map"
       return 1
     fi
-    if ! curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o "$GHAF_BMAP" "$bmap_url"; then
+    if ! curl -fsSL --connect-timeout 10 --retry 5 --retry-delay 2 --retry-all-errors -o "$GHAF_BMAP" "$bmap_url"; then
       # Deliberately fatal rather than falling back to an unverified dd. The
       # bmap carries per-range sha256 checksums that bmaptool verifies while
       # copying, and over plain HTTP that is the only integrity check there is.
@@ -194,7 +194,7 @@ feed_image() {
   if [[ ${GHAF_REMOTE:-false} == true ]]; then
     # --no-progress-meter: pv already draws the progress bar the TUI shows, and
     # curl's own meter would scribble over it on the same tty.
-    curl -fL --no-progress-meter --retry 5 --retry-delay 2 --retry-all-errors "$GHAF_RAW_SRC"
+    curl -fL --no-progress-meter --connect-timeout 10 --retry 5 --retry-delay 2 --retry-all-errors "$GHAF_RAW_SRC"
   else
     cat "$GHAF_RAW_SRC"
   fi | zstdcat -T0

--- a/packages/pkgs-by-name/ghaf-installer-tui/package.nix
+++ b/packages/pkgs-by-name/ghaf-installer-tui/package.nix
@@ -4,6 +4,7 @@
   bmaptool,
   brightnessctl,
   coreutils,
+  curl,
   e2fsprogs,
   efitools,
   gawk,
@@ -31,6 +32,7 @@ writeShellApplication {
     bmaptool
     brightnessctl # screen brightness on startup
     coreutils
+    curl # fetch the image and its block map when netbooted
     e2fsprogs # chattr in efivar cleanup
     efitools # Secure Boot key enrollment
     gawk

--- a/packages/pkgs-by-name/ghaf-installer/ghaf-installer.sh
+++ b/packages/pkgs-by-name/ghaf-installer/ghaf-installer.sh
@@ -6,11 +6,11 @@ if [ "$EUID" -ne 0 ]; then
   exit
 fi
 
-# Make sure $IMG_PATH env is set
-if [ -z "$IMG_PATH" ]; then
-  echo "IMG_PATH is not set!"
-  exit
-fi
+# Default it here rather than demanding it here. ghaf.image_url= on the kernel
+# command line is an equally valid source -- it is how netboot supplies it -- but
+# it is not parsed until below, and `set -u` aborts on the bare reference long
+# before that.
+IMG_PATH="${IMG_PATH:-}"
 
 help_msg() {
   cat <<EOF
@@ -31,9 +31,11 @@ in the URL case the image and its block map are fetched and streamed straight
 to the disk without being staged anywhere.
 
 Kernel parameters, for unattended netboot installs:
-  ghaf.install_target=/dev/nvme0n1   as -d, and implies -y
+  ghaf.install_target=/dev/nvme0n1   as -d, implies -y, and reboots when done
   ghaf.install_encrypt               as -e
   ghaf.install_secureboot            as -s
+  ghaf.install_noreboot              stay in the installer after an unattended
+                                     install instead of rebooting into it
 
 Examples:
   $(basename "$0") -w
@@ -50,6 +52,13 @@ ENCRYPTED_INSTALL=false
 SECUREBOOT_INSTALL=false
 DEVICE_NAME=""
 ASSUME_YES=false
+# Set only by ghaf.install_target=, never by -d/-y. The distinction matters: -d
+# is someone at a console who can reboot the machine themselves, whereas the
+# kernel parameter means nobody is there and there is no installation medium to
+# remove either -- so finishing with "please reboot" leaves the machine sitting
+# in the installer forever.
+UNATTENDED=false
+REBOOT_WHEN_DONE=true
 
 # Kernel-parameter defaults, so a netbooted lab machine can install unattended
 # with no console interaction. Command-line flags still win over these.
@@ -65,10 +74,29 @@ if [ -r /proc/cmdline ]; then
   *" ghaf.install_target="*)
     DEVICE_NAME=$(sed -n 's/.*[[:space:]]ghaf\.install_target=\([^[:space:]]*\).*/\1/p' /proc/cmdline)
     ASSUME_YES=true
+    UNATTENDED=true
     ;;
   esac
   case " $_cmdline " in *" ghaf.install_encrypt "*) ENCRYPTED_INSTALL=true ;; esac
   case " $_cmdline " in *" ghaf.install_secureboot "*) SECUREBOOT_INSTALL=true ;; esac
+  # Escape hatch for debugging a failed unattended install: without it the
+  # evidence reboots away before anyone can look at it.
+  case " $_cmdline " in *" ghaf.install_noreboot "*) REBOOT_WHEN_DONE=false ;; esac
+
+  # ghaf.image_url= overrides IMG_PATH, and on netboot it is the ONLY correct
+  # source. Without this the netboot installer inherits the ISO's baked-in
+  # imageSource (/iso/ghaf-image), a path that does not exist when booted over
+  # the network
+  case " $_cmdline " in
+  *" ghaf.image_url="*)
+    IMG_PATH=$(sed -n 's/.*[[:space:]]ghaf\.image_url=\([^[:space:]]*\).*/\1/p' /proc/cmdline)
+    ;;
+  esac
+fi
+
+if [ -z "$IMG_PATH" ]; then
+  echo "No image source: set IMG_PATH, or boot with ghaf.image_url=<url>."
+  exit 1
 fi
 
 while getopts "wesyd:h" opt; do
@@ -200,6 +228,55 @@ else
   esac
 fi
 
+# Resolve and validate the image source BEFORE anything destructive happens.
+resolve_image_source() {
+  # IMG_PATH is either a directory (booted from the ISO, which carries the image)
+  # or an http(s) base URL (netboot, where the image is fetched now and was never
+  # embedded).
+  GHAF_BMAP=""
+  if [[ $IMG_PATH =~ ^https?:// ]]; then
+    GHAF_REMOTE=true
+    if [[ $IMG_PATH == *.raw.zst ]]; then
+      GHAF_RAW_SRC="$IMG_PATH"
+    else
+      GHAF_RAW_SRC="${IMG_PATH%/}/ghaf-image.raw.zst"
+    fi
+
+    # bmaptool needs the map as a seekable local file; it is ~50 KB. Fatal if
+    # absent: its per-range sha256 checksums are the only integrity check on an
+    # image pulled over plain HTTP, so an unverified dd would be worse than
+    # stopping here.
+    rundir="${GHAF_INSTALLER_RUNDIR:-/run/ghaf-installer}"
+    mkdir -p "$rundir"
+    GHAF_BMAP="$rundir/ghaf-image.bmap"
+    if ! curl -fsSL --connect-timeout 10 --retry 5 --retry-delay 2 --retry-all-errors \
+      -o "$GHAF_BMAP" "${GHAF_RAW_SRC%.raw.zst}.bmap"; then
+      echo "Could not fetch block map ${GHAF_RAW_SRC%.raw.zst}.bmap"
+      exit 1
+    fi
+  else
+    GHAF_REMOTE=false
+    shopt -s nullglob
+    raw_file=("$IMG_PATH"/*.raw.zst)
+    shopt -u nullglob
+
+    if [ ${#raw_file[@]} -eq 0 ]; then
+      echo "No .raw.zst image found in $IMG_PATH"
+      exit 1
+    fi
+    GHAF_RAW_SRC="${raw_file[0]}"
+    [ -s "${GHAF_RAW_SRC%.raw.zst}.bmap" ] && GHAF_BMAP="${GHAF_RAW_SRC%.raw.zst}.bmap"
+  fi
+
+}
+
+# A wipe-only run needs no image, so do not make it depend on a reachable
+# source -- that would turn `--wipe` into something that can fail for reasons
+# entirely unrelated to wiping.
+if [ "$WIPE_ONLY" != true ]; then
+  resolve_image_source
+fi
+
 echo "Wiping device..."
 
 # Deactivate any active LVM volume groups on the device
@@ -241,49 +318,9 @@ fi
 
 echo "Installing..."
 
-# IMG_PATH is either a directory (booted from the ISO, which carries the image)
-# or an http(s) base URL (netboot, where the image is fetched now and was never
-# embedded). Keep this in step with resolve_image_source() in
-# ghaf-installer-tui/ghaf-installer-lib.sh -- the two are deliberately separate
-# because that lib depends on the gum helpers this script does not have.
-GHAF_BMAP=""
-if [[ $IMG_PATH =~ ^https?:// ]]; then
-  GHAF_REMOTE=true
-  if [[ $IMG_PATH == *.raw.zst ]]; then
-    GHAF_RAW_SRC="$IMG_PATH"
-  else
-    GHAF_RAW_SRC="${IMG_PATH%/}/ghaf-image.raw.zst"
-  fi
-
-  # bmaptool needs the map as a seekable local file; it is ~50 KB. Fatal if
-  # absent: its per-range sha256 checksums are the only integrity check on an
-  # image pulled over plain HTTP, so an unverified dd would be worse than
-  # stopping here.
-  rundir="${GHAF_INSTALLER_RUNDIR:-/run/ghaf-installer}"
-  mkdir -p "$rundir"
-  GHAF_BMAP="$rundir/ghaf-image.bmap"
-  if ! curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
-    -o "$GHAF_BMAP" "${GHAF_RAW_SRC%.raw.zst}.bmap"; then
-    echo "Could not fetch block map ${GHAF_RAW_SRC%.raw.zst}.bmap"
-    exit 1
-  fi
-else
-  GHAF_REMOTE=false
-  shopt -s nullglob
-  raw_file=("$IMG_PATH"/*.raw.zst)
-  shopt -u nullglob
-
-  if [ ${#raw_file[@]} -eq 0 ]; then
-    echo "No .raw.zst image found in $IMG_PATH"
-    exit 1
-  fi
-  GHAF_RAW_SRC="${raw_file[0]}"
-  [ -s "${GHAF_RAW_SRC%.raw.zst}.bmap" ] && GHAF_BMAP="${GHAF_RAW_SRC%.raw.zst}.bmap"
-fi
-
 feed_image() {
   if [ "$GHAF_REMOTE" = true ]; then
-    curl -fL --no-progress-meter --retry 5 --retry-delay 2 --retry-all-errors "$GHAF_RAW_SRC"
+    curl -fL --no-progress-meter --connect-timeout 10 --retry 5 --retry-delay 2 --retry-all-errors "$GHAF_RAW_SRC"
   else
     cat "$GHAF_RAW_SRC"
   fi | zstdcat -T0
@@ -436,4 +473,14 @@ if [ "$SECUREBOOT_INSTALL" = true ]; then
   echo "Secure Boot keys enrolled."
 fi
 
-echo "Installation done. Please remove the installation media and reboot"
+if [ "$UNATTENDED" = true ] && [ "$REBOOT_WHEN_DONE" = true ]; then
+  echo "Installation done. Rebooting into the installed system in 10 seconds."
+  echo "(boot the machine with ghaf.install_noreboot to stay in the installer)"
+  # A netbooted machine typically has network boot ahead of the disk in its
+  # BootOrder, so this reboot lands back in the installer unless the server has
+  # stopped.
+  sleep 10
+  systemctl reboot
+else
+  echo "Installation done. Please remove the installation media and reboot"
+fi

--- a/packages/pkgs-by-name/ghaf-installer/ghaf-installer.sh
+++ b/packages/pkgs-by-name/ghaf-installer/ghaf-installer.sh
@@ -22,12 +22,25 @@ Options:
   -w            Wipe only
   -e            Install with disk encryption
   -s            Install with Secure Boot enrollment
+  -d DEVICE     Target device, e.g. /dev/nvme0n1 (skips the device prompt)
+  -y            Do not ask for confirmation before writing
   -h, --help    Show this help message and exit.
+
+IMG_PATH may be a directory (ISO install) or an http(s) base URL (netboot);
+in the URL case the image and its block map are fetched and streamed straight
+to the disk without being staged anywhere.
+
+Kernel parameters, for unattended netboot installs:
+  ghaf.install_target=/dev/nvme0n1   as -d, and implies -y
+  ghaf.install_encrypt               as -e
+  ghaf.install_secureboot            as -s
+
 Examples:
   $(basename "$0") -w
   $(basename "$0") -e
   $(basename "$0") -s
   $(basename "$0") -e -s
+  $(basename "$0") -d /dev/nvme0n1 -y
 
 EOF
 }
@@ -35,8 +48,30 @@ EOF
 WIPE_ONLY=false
 ENCRYPTED_INSTALL=false
 SECUREBOOT_INSTALL=false
+DEVICE_NAME=""
+ASSUME_YES=false
 
-while getopts "wesh" opt; do
+# Kernel-parameter defaults, so a netbooted lab machine can install unattended
+# with no console interaction. Command-line flags still win over these.
+#   ghaf.install_target=/dev/nvme0n1   pick the disk and skip both prompts
+#   ghaf.install_encrypt               same as -e
+#   ghaf.install_secureboot            same as -s
+# Deliberately opt-in: with none of these the installer behaves exactly as it
+# always has, because skipping the confirmation before a destructive write
+# should never be the default.
+if [ -r /proc/cmdline ]; then
+  _cmdline=$(cat /proc/cmdline)
+  case " $_cmdline " in
+  *" ghaf.install_target="*)
+    DEVICE_NAME=$(sed -n 's/.*[[:space:]]ghaf\.install_target=\([^[:space:]]*\).*/\1/p' /proc/cmdline)
+    ASSUME_YES=true
+    ;;
+  esac
+  case " $_cmdline " in *" ghaf.install_encrypt "*) ENCRYPTED_INSTALL=true ;; esac
+  case " $_cmdline " in *" ghaf.install_secureboot "*) SECUREBOOT_INSTALL=true ;; esac
+fi
+
+while getopts "wesyd:h" opt; do
   case $opt in
   w)
     WIPE_ONLY=true
@@ -46,6 +81,12 @@ while getopts "wesh" opt; do
     ;;
   s)
     SECUREBOOT_INSTALL=true
+    ;;
+  d)
+    DEVICE_NAME="$OPTARG"
+    ;;
+  y)
+    ASSUME_YES=true
     ;;
   h)
     help_msg
@@ -84,35 +125,58 @@ echo "To install image or wipe installed image choose path to the device."
 hwinfo --disk --short
 
 while true; do
-  read -r -p "Device name [e.g. /dev/nvme0n1]: " DEVICE_NAME
+  # A device supplied by -d or ghaf.install_target= still goes through every
+  # check below; it just cannot be re-prompted on failure, so a bad value is
+  # fatal instead of looping forever against a console nobody is watching.
+  if [ -n "$DEVICE_NAME" ]; then
+    preset=true
+  else
+    preset=false
+    read -r -p "Device name [e.g. /dev/nvme0n1]: " DEVICE_NAME
+  fi
+
+  reject() {
+    echo "$1"
+    if [ "$preset" = true ]; then
+      echo "Refusing to continue with the preset target $DEVICE_NAME."
+      exit 1
+    fi
+    DEVICE_NAME=""
+  }
 
   # Input validation: ensure device name starts with /dev/ and contains no path traversal
   if [[ ! $DEVICE_NAME =~ ^/dev/[a-zA-Z0-9._-]+$ ]]; then
-    echo "Invalid device name format. Device must be in /dev/ and contain only alphanumeric characters, dots, underscores, and dashes."
+    reject "Invalid device name format. Device must be in /dev/ and contain only alphanumeric characters, dots, underscores, and dashes."
     continue
   fi
 
   # Additional security check: ensure the device exists as a block device
   if [ ! -b "$DEVICE_NAME" ]; then
-    echo "Device is not a valid block device!"
+    reject "Device is not a valid block device!"
     continue
   fi
 
   # Safely get basename to prevent directory traversal
   device_basename=$(basename "$DEVICE_NAME")
   if [ ! -d "/sys/block/$device_basename" ]; then
-    echo "Device not found in sysfs!"
+    reject "Device not found in sysfs!"
     continue
   fi
 
   # Check if removable
   if [ "$(cat "/sys/block/$device_basename/removable")" != "0" ]; then
+    if [ "$ASSUME_YES" = true ]; then
+      echo "Device $DEVICE_NAME is removable; continuing because -y was given."
+      break
+    fi
     read -r -p "Device provided is removable, do you want to continue? [y/N] " response
     case "$response" in
     [yY][eE][sS] | [yY])
       break
       ;;
     *)
+      $preset && exit 1
+      DEVICE_NAME=""
       continue
       ;;
     esac
@@ -122,15 +186,19 @@ while true; do
 done
 
 echo "Installing/Deleting Ghaf on $DEVICE_NAME"
-read -r -p 'Do you want to continue? [y/N] ' response
+if [ "$ASSUME_YES" = true ]; then
+  echo "Proceeding without confirmation (-y / ghaf.install_target=)."
+else
+  read -r -p 'Do you want to continue? [y/N] ' response
 
-case "$response" in
-[yY][eE][sS] | [yY]) ;;
-*)
-  echo "Exiting..."
-  exit
-  ;;
-esac
+  case "$response" in
+  [yY][eE][sS] | [yY]) ;;
+  *)
+    echo "Exiting..."
+    exit
+    ;;
+  esac
+fi
 
 echo "Wiping device..."
 
@@ -172,16 +240,64 @@ if [ "$WIPE_ONLY" = true ]; then
 fi
 
 echo "Installing..."
-shopt -s nullglob
-raw_file=("$IMG_PATH"/*.raw.zst)
-shopt -u nullglob
 
-if [ ${#raw_file[@]} -eq 0 ]; then
-  echo "No .raw.zst image found in $IMG_PATH"
-  exit 1
+# IMG_PATH is either a directory (booted from the ISO, which carries the image)
+# or an http(s) base URL (netboot, where the image is fetched now and was never
+# embedded). Keep this in step with resolve_image_source() in
+# ghaf-installer-tui/ghaf-installer-lib.sh -- the two are deliberately separate
+# because that lib depends on the gum helpers this script does not have.
+GHAF_BMAP=""
+if [[ $IMG_PATH =~ ^https?:// ]]; then
+  GHAF_REMOTE=true
+  if [[ $IMG_PATH == *.raw.zst ]]; then
+    GHAF_RAW_SRC="$IMG_PATH"
+  else
+    GHAF_RAW_SRC="${IMG_PATH%/}/ghaf-image.raw.zst"
+  fi
+
+  # bmaptool needs the map as a seekable local file; it is ~50 KB. Fatal if
+  # absent: its per-range sha256 checksums are the only integrity check on an
+  # image pulled over plain HTTP, so an unverified dd would be worse than
+  # stopping here.
+  rundir="${GHAF_INSTALLER_RUNDIR:-/run/ghaf-installer}"
+  mkdir -p "$rundir"
+  GHAF_BMAP="$rundir/ghaf-image.bmap"
+  if ! curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+    -o "$GHAF_BMAP" "${GHAF_RAW_SRC%.raw.zst}.bmap"; then
+    echo "Could not fetch block map ${GHAF_RAW_SRC%.raw.zst}.bmap"
+    exit 1
+  fi
+else
+  GHAF_REMOTE=false
+  shopt -s nullglob
+  raw_file=("$IMG_PATH"/*.raw.zst)
+  shopt -u nullglob
+
+  if [ ${#raw_file[@]} -eq 0 ]; then
+    echo "No .raw.zst image found in $IMG_PATH"
+    exit 1
+  fi
+  GHAF_RAW_SRC="${raw_file[0]}"
+  [ -s "${GHAF_RAW_SRC%.raw.zst}.bmap" ] && GHAF_BMAP="${GHAF_RAW_SRC%.raw.zst}.bmap"
 fi
 
-zstdcat "${raw_file[0]}" | dd of="$DEVICE_NAME" bs=32M status=progress
+feed_image() {
+  if [ "$GHAF_REMOTE" = true ]; then
+    curl -fL --no-progress-meter --retry 5 --retry-delay 2 --retry-all-errors "$GHAF_RAW_SRC"
+  else
+    cat "$GHAF_RAW_SRC"
+  fi | zstdcat -T0
+}
+
+# Prefer bmaptool: it skips unmapped ranges and verifies the per-range sha256
+# from the map as it copies. The bare dd below stays as the fallback.
+if [ -n "$GHAF_BMAP" ] && command -v bmaptool >/dev/null 2>&1 &&
+  feed_image | bmaptool copy --bmap "$GHAF_BMAP" - "$DEVICE_NAME"; then
+  echo "Image written and verified against the block map."
+else
+  [ -n "$GHAF_BMAP" ] && echo "bmaptool unavailable or failed; falling back to a plain streaming write."
+  feed_image | dd of="$DEVICE_NAME" bs=32M status=progress
+fi
 
 find_esp_device() {
   local esp_device=""

--- a/packages/pkgs-by-name/ghaf-installer/package.nix
+++ b/packages/pkgs-by-name/ghaf-installer/package.nix
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
+  bmaptool,
   coreutils,
+  curl,
   e2fsprogs,
   efitools,
   hwinfo,
@@ -15,7 +17,9 @@
 writeShellApplication {
   name = "ghaf-installer";
   runtimeInputs = [
+    bmaptool # sparse-aware copy + per-range sha256 verification
     coreutils
+    curl # fetch the image and its block map when netbooted
     e2fsprogs # Needed for chattr in efivar cleanup
     efitools # Needed for Secure Boot key enrollment
     hwinfo

--- a/packages/pkgs-by-name/ghaf-netboot/boot.ipxe
+++ b/packages/pkgs-by-name/ghaf-netboot/boot.ipxe
@@ -1,0 +1,85 @@
+#!ipxe
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-FileCopyrightText: 2016 Google Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Embedded script for the iPXE binary ghaf-netboot serves to 64-bit UEFI
+# clients. Derived from pixiecore's own pixiecore/boot.ipxe, deliberately and
+# almost verbatim -- see below for why that matters more than it looks.
+#
+# WHY WE SHIP OUR OWN iPXE AT ALL
+#
+# Pixiecore embeds bin-x86_64-efi/ipxe.efi (see its Makefile `update-ipxe`
+# target), which drives NICs with iPXE's *native* drivers. On the Lenovo USB-C
+# dock that is not enough: iPXE's unicast TFTP works, but broadcast DHCP replies
+# never arrive, so it burns its ten retries and reboots -- forever, until the
+# dock is physically unplugged. We therefore build bin-x86_64-efi/snponly.efi
+# instead, which talks to the NIC through the firmware's own SNP driver -- the
+# same driver the firmware's PXE stack uses, and that one works throughout.
+#
+# WHY THIS SCRIPT IS A COPY RATHER THAN SOMETHING SIMPLER
+#
+# A *stock* iPXE (no embedded script) chainload-loops against pixiecore: it
+# defaults to user-class "iPXE", pixiecore classifies it as plain 64-bit UEFI
+# firmware, and re-serves the iPXE binary, roughly every 20 s, forever.
+#
+# The whole of pixiecore's "have I already chainloaded this client?" test is a
+# string compare on DHCP option 77 (pixiecore/dhcp.go:139):
+#
+#     if userClass == "pixiecore" { fwtype = FirmwarePixiecoreIpxe }
+#
+# and that branch answers with
+#
+#     BootFilename = http://<server>:<http-port>/_/ipxe?arch=..&mac=..
+#
+# So `set user-class pixiecore` below is the entire contract, and `${filename}`
+# then carries pixiecore's HTTP port without us having to know it. Everything
+# downstream -- the MAC allowlist, the 404 for machines we were not pointed at,
+# the assembled kernel command line -- keeps working exactly as before.
+#
+# Do not "simplify" this into `chain http://${next-server}:8080/...`: that bakes
+# a port into the binary that --port can then contradict, and moves the boot
+# decision off the allowlisted path.
+
+set attempts:int32 10
+set x:int32 0
+
+# The contract with pixiecore. Without this line the binary chainload-loops.
+set user-class pixiecore
+
+# iPXE configures itself from the first DHCP response it sees and can miss the
+# ProxyDHCP one that says how to boot, so retry rather than fall out of the PXE
+# path. This is what the iPXE documentation recommends and what pixiecore's own
+# script does; the loop is ugly and it is also load-bearing.
+:loop
+dhcp || goto nodhcp
+isset ${filename} || goto nobootconfig
+goto boot
+
+:nodhcp
+echo No DHCP response, retrying (attempt ${x}/${attempts})
+goto retry
+
+:nobootconfig
+echo No ProxyDHCP response, retrying (attempt ${x}/${attempts})
+goto retry
+
+:retry
+iseq ${x} ${attempts} && goto fail ||
+inc x
+goto loop
+
+:boot
+chain ${filename}
+
+# Reaching here means pixiecore stopped offering to boot this machine midway
+# through the cycle -- most likely --exit-after-serve fired, or the MAC is no
+# longer allowlisted. Rebooting is right: the machine falls through to disk.
+:fail
+echo Failed to get a ProxyDHCP response after ${attempts} attempts
+echo
+echo ghaf-netboot: is the server still running, and is this MAC in --mac?
+echo
+echo Rebooting in 5 seconds...
+sleep 5
+reboot

--- a/packages/pkgs-by-name/ghaf-netboot/ghaf-netboot-api.py
+++ b/packages/pkgs-by-name/ghaf-netboot/ghaf-netboot-api.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The shebang is load-bearing: patchShebangs has nothing to rewrite without it,
+# and the file then gets executed as a shell script, which "runs" this docstring
+# as commands and fails in a thoroughly confusing way.
+"""HTTP side of ghaf-netboot: the Pixiecore boot API plus the static files.
+
+Pixiecore in `api` mode asks us what to do with every machine that tries to PXE
+boot, by GETting /v1/boot/<mac>. Answering 404 tells it to ignore that machine.
+That is the whole reason this exists rather than `pixiecore boot`: on a shared
+lab LAN we must serve exactly the machines we were pointed at and nothing else.
+An unattended install is destructive, so "boots whatever asks" is not an option.
+
+Also serves the netboot artefacts and the image directory, so there is one
+process and one port for everything on the HTTP side.
+
+  /v1/boot/<mac>          boot instructions, or 404 for machines not allowlisted
+  /boot/bzImage,/initrd   the netboot kernel and initrd
+  /ghaf-image/...         ghaf-image.raw.zst and ghaf-image.bmap
+
+Threaded because the image is multi-GB: a single-threaded server would block
+every API call for the duration of one machine's download.
+"""
+
+import argparse
+import http.server
+import json
+import os
+import re
+import socketserver
+import sys
+import threading
+
+MAC_RE = re.compile(r"^[0-9a-f]{2}(:[0-9a-f]{2}){5}$")
+
+
+def normalise_mac(value):
+    """Accept the usual spellings and return aa:bb:cc:dd:ee:ff, or None."""
+    cleaned = value.strip().lower().replace("-", ":")
+    # Pixiecore percent-encodes nothing, but be forgiving about it anyway.
+    cleaned = cleaned.replace("%3a", ":")
+    if MAC_RE.match(cleaned):
+        return cleaned
+    return None
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    # Set by main(); class attributes so every thread sees the same values.
+    allowed = frozenset()
+    boot_json = {}
+    exit_after_serve = False
+
+    def log_message(self, fmt, *args):
+        sys.stderr.write(
+            "ghaf-netboot: %s - %s\n" % (self.address_string(), fmt % args)
+        )
+
+    def do_GET(self):
+        if self.path.startswith("/v1/boot/"):
+            return self.serve_boot_api(self.path[len("/v1/boot/") :])
+
+        result = super().do_GET()
+
+        # The image is the last and largest thing a client fetches, so a
+        # completed transfer of it means this install has what it needs. Shut
+        # down rather than sit on the LAN answering PXE for the rest of the day.
+        if type(self).exit_after_serve and self.path.endswith(".raw.zst"):
+            self.log_message("image served in full, shutting down")
+            # shutdown() blocks until serve_forever() returns, so it can never
+            # be called from a request thread -- hence the extra thread.
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+        return result
+
+    def serve_boot_api(self, raw_mac):
+        mac = normalise_mac(raw_mac)
+        if mac is None:
+            self.send_error(400, "malformed MAC")
+            return
+        if mac not in type(self).allowed:
+            # 404 is Pixiecore's "ignore this machine". This is the allowlist.
+            self.log_message("ignoring %s (not in allowlist)", mac)
+            self.send_error(404, "not allowlisted")
+            return
+
+        body = json.dumps(type(self).boot_json).encode()
+        self.log_message("booting %s", mac)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class Server(socketserver.ThreadingTCPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True, help="directory to serve")
+    ap.add_argument("--listen", required=True, help="address to bind")
+    ap.add_argument("--port", type=int, required=True)
+    ap.add_argument(
+        "--mac",
+        action="append",
+        default=[],
+        help="allowlisted client MAC; repeatable. No MACs means no machine boots.",
+    )
+    ap.add_argument("--cmdline", required=True, help="kernel command line")
+    ap.add_argument(
+        "--exit-after-serve",
+        action="store_true",
+        help="stop once the image has been fetched in full",
+    )
+    args = ap.parse_args()
+    Handler.exit_after_serve = args.exit_after_serve
+
+    base = f"http://{args.listen}:{args.port}"
+    Handler.boot_json = {
+        "kernel": f"{base}/boot/bzImage",
+        "initrd": [f"{base}/boot/initrd"],
+        "cmdline": args.cmdline,
+        "message": "Ghaf netboot installer",
+    }
+
+    macs = set()
+    for raw in args.mac:
+        mac = normalise_mac(raw)
+        if mac is None:
+            sys.exit(f"ghaf-netboot: not a MAC address: {raw}")
+        macs.add(mac)
+    Handler.allowed = frozenset(macs)
+    if not macs:
+        # Fail closed. An empty allowlist that silently served everyone would be
+        # the exact failure this component exists to prevent.
+        sys.exit("ghaf-netboot: refusing to start with an empty MAC allowlist")
+
+    os.chdir(args.root)
+    with Server((args.listen, args.port), Handler) as httpd:
+        print(
+            f"ghaf-netboot: HTTP on {base}, serving {args.root}, "
+            f"allowlist: {' '.join(sorted(macs))}",
+            file=sys.stderr,
+            flush=True,
+        )
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/pkgs-by-name/ghaf-netboot/ghaf-netboot.sh
+++ b/packages/pkgs-by-name/ghaf-netboot/ghaf-netboot.sh
@@ -32,19 +32,32 @@ Options:
       --secureboot         With --install-target: enroll Secure Boot keys
   -p, --port <PORT>        HTTP port (default 8080)
   -t, --timeout <MIN>      Exit after this long (default 60, 0 disables)
-      --exit-after-serve   Exit once the image has been fetched once
+      --exit-after-serve   Exit once the image has been fetched once. ON by
+                           default with --install-target: the installer reboots
+                           itself when it finishes, and a target with network
+                           boot ahead of its disk would land straight back in
+                           the installer and reinstall in a loop.
+      --no-exit-after-serve
+                           Keep serving after the image has been fetched. Only
+                           safe when the target boots from disk by preference.
       --force-interface    Skip the default-route / wireless refusals
       --open-firewall      Temporarily open 67/69/4011 and the HTTP ports in the
                            host firewall, and close them again on exit. Without
                            this, a host that filters inbound traffic drops every
                            PXE request before pixiecore sees it -- the server
                            looks healthy and the target times out.
-      --ipxe <FILE>        64-bit UEFI iPXE binary. Defaults to pixiecore's own
-                           embedded iPXE, which is the only build known to work
-                           with it. Only override this if pixiecore's iPXE has
-                           no driver for the NIC, and note that a stock iPXE
-                           will chainload-loop: it needs an embedded script
-                           that chains back to pixiecore.
+      --ipxe <FILE|builtin>
+                           64-bit UEFI iPXE binary. Defaults to the snponly.efi
+                           we build ourselves, which drives the NIC through the
+                           firmware's SNP driver; pixiecore's built-in iPXE uses
+                           its own native drivers and cannot receive broadcast
+                           DHCP on some adapters (the Lenovo dock among them),
+                           where it retries ten times and reboots forever.
+                           'builtin' falls back to pixiecore's, for a NIC the
+                           firmware's SNP does not cover. A *stock* iPXE is not
+                           a valid value: with no embedded script it identifies
+                           as user-class "iPXE", pixiecore reads that as plain
+                           UEFI firmware and re-serves the binary in a loop.
       --dry-run            Print what would run and exit
   -h, --help               This message
 
@@ -65,11 +78,15 @@ SECUREBOOT=false
 FORCE_IFACE=false
 OPEN_FIREWALL=false
 DRY_RUN=false
-EXIT_AFTER_SERVE=false
+# Deliberately tri-state: "" means "nobody asked", which resolves after argument
+# parsing to true for an unattended install and false otherwise.
+EXIT_AFTER_SERVE=""
 MACS=()
-# Empty by default, and package.nix deliberately does not set it: empty means
-# "let pixiecore use its own embedded iPXE". Only --ipxe fills this in.
-IPXE_EFI64="${IPXE_EFI64:-}"
+# package.nix exports GHAF_NETBOOT_IPXE as our snponly.efi on x86_64, and as the
+# empty string elsewhere (an aarch64 host can serve an x86_64 target, but cannot
+# build the binary natively). Empty means "let pixiecore use its own embedded
+# iPXE". An explicit IPXE_EFI64 in the environment still wins over both.
+IPXE_EFI64="${IPXE_EFI64:-${GHAF_NETBOOT_IPXE:-}}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -113,6 +130,10 @@ while [ $# -gt 0 ]; do
     EXIT_AFTER_SERVE=true
     shift
     ;;
+  --no-exit-after-serve)
+    EXIT_AFTER_SERVE=false
+    shift
+    ;;
   --force-interface)
     FORCE_IFACE=true
     shift
@@ -122,7 +143,14 @@ while [ $# -gt 0 ]; do
     shift
     ;;
   --ipxe)
-    IPXE_EFI64="$2"
+    # `builtin` is the escape hatch back to pixiecore's own iPXE, for a NIC the
+    # firmware's SNP driver does not cover. Spelt as a keyword rather than as
+    # --ipxe '' so it survives being quoted, logged and copied out of a runbook.
+    if [ "$2" = "builtin" ]; then
+      IPXE_EFI64=""
+    else
+      IPXE_EFI64="$2"
+    fi
     shift 2
     ;;
   --dry-run)
@@ -159,10 +187,11 @@ done
 [ -e "$IMAGE_DIR/ghaf-image.raw.zst" ] || die "$IMAGE_DIR/ghaf-image.raw.zst missing"
 [ -e "$IMAGE_DIR/ghaf-image.bmap" ] || die "$IMAGE_DIR/ghaf-image.bmap missing (needed to verify the image)"
 
-# Empty means "use pixiecore's own built-in iPXE", which is the right default.
-# Do NOT substitute a stock iPXE here: pixiecore's embedded build carries a
-# script that chains directly to pixiecore's HTTP endpoint, whereas a stock
-# iPXE finishes loading and simply re-runs DHCP.
+# Empty means "use pixiecore's own built-in iPXE" (--ipxe builtin, or a non-x86
+# build host). Do NOT substitute a *stock* iPXE here: our binary and pixiecore's
+# both carry an embedded script that identifies as user-class "pixiecore", which
+# is the only thing that stops pixiecore re-serving the binary in a loop. A
+# stock build has no such script and loops.
 [ -z "$IPXE_EFI64" ] || [ -e "$IPXE_EFI64" ] || die "no such iPXE binary: $IPXE_EFI64"
 
 # An unattended install wipes a disk with nobody watching. Allowlisting is not
@@ -170,6 +199,18 @@ done
 # machine" and "reinstall whichever machine happened to PXE boot".
 if [ -n "$INSTALL_TARGET" ]; then
   [[ $INSTALL_TARGET =~ ^/dev/[a-zA-Z0-9._-]+$ ]] || die "--install-target must look like /dev/nvme0n1"
+fi
+
+# An unattended install now ends with the installer rebooting itself, so a
+# server still answering PXE catches that reboot and reinstalls the machine --
+# an install loop, on the one operation where a loop is most expensive. Default
+# it on rather than leaving it to be remembered.
+if [ -z "$EXIT_AFTER_SERVE" ]; then
+  if [ -n "$INSTALL_TARGET" ]; then EXIT_AFTER_SERVE=true; else EXIT_AFTER_SERVE=false; fi
+fi
+if [ -n "$INSTALL_TARGET" ] && [ "$EXIT_AFTER_SERVE" = false ]; then
+  echo "ghaf-netboot: WARNING --no-exit-after-serve with --install-target: if this target" >&2
+  echo "ghaf-netboot:   prefers network boot it will reinstall itself on every reboot." >&2
 fi
 
 # --- interface guard rails ----------------------------------------------------
@@ -229,8 +270,17 @@ firewall_open() {
 
 firewall_close() {
   $FW_OPENED || return 0
-  nft delete element inet nixos-fw temp-ports "{ $FW_ELEMENTS }" 2>/dev/null ||
-    echo "ghaf-netboot: WARNING could not close firewall ports; check nixos-firewall-tool show" >&2
+  nft delete element inet nixos-fw temp-ports "{ $FW_ELEMENTS }" 2>/dev/null || true
+  # Assert on the resulting state, not on nft's exit status. Deleting the whole
+  # element list fails as a unit if any single element has already gone, so a
+  # delete that did close every port still reports failure -- observed on a real
+  # run, printing "could not close firewall ports" at a host whose ports were
+  # shut. A warning that sends the next person hunting a firewall that is
+  # already closed costs more than no warning at all.
+  local still
+  still=$(nft list set inet nixos-fw temp-ports 2>/dev/null | grep -cE 'udp \. (67|69|4011)' || true)
+  [ "$still" = 0 ] ||
+    echo "ghaf-netboot: WARNING firewall ports still open; check nixos-firewall-tool show" >&2
 }
 
 # Best-effort nudge when the ports are plainly going to be dropped. Deliberately
@@ -286,9 +336,10 @@ ghaf-netboot:
   netboot     $NETBOOT_DIR
   image       $IMAGE_DIR
   http        http://${LISTEN_IP}:${PORT}
-  ipxe        ${IPXE_EFI64:-pixiecore built-in (correct default; a stock iPXE loops)}
+  ipxe        ${IPXE_EFI64:-pixiecore built-in (native drivers; broadcast DHCP fails on some NICs)}
   cmdline     $CMDLINE
   mode        $(if [ -n "$INSTALL_TARGET" ]; then echo "UNATTENDED INSTALL to $INSTALL_TARGET (destructive)"; else echo "interactive TUI"; fi)
+  stop        $(if $EXIT_AFTER_SERVE; then echo "once the image has been served in full"; else echo "on timeout or signal only"; fi)
   timeout     $(if [ "$TIMEOUT_MIN" = 0 ]; then echo "none"; else echo "${TIMEOUT_MIN} min"; fi)
 EOF
 

--- a/packages/pkgs-by-name/ghaf-netboot/ghaf-netboot.sh
+++ b/packages/pkgs-by-name/ghaf-netboot/ghaf-netboot.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# ghaf-netboot - serve a Ghaf netboot install to one machine on one interface.
+#
+# Pixiecore answers PXE clients in ProxyDHCP mode (it never assigns addresses,
+# so it cannot disturb the lab's own DHCP), and asks our HTTP API what to do
+# with each machine. The API answers 404 for anything not in --mac, so exactly
+# the machine we were pointed at boots and nothing else does.
+#
+# Root is unavoidable: DHCP/PXE need :67, :69 and :4011, and a DHCP server must
+# answer clients that have no address yet. The effort therefore goes into
+# containment rather than into avoiding privilege.
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --interface <IFACE> --mac <MAC> --netboot <DIR> --image <DIR> [options]
+
+Serve a Ghaf netboot install. Requires root.
+
+Required:
+  -i, --interface <IFACE>  Interface facing the target. No default, deliberately.
+  -m, --mac <MAC>          Target's MAC. Repeatable. Only these machines boot.
+  -n, --netboot <DIR>      Result of .#<target>-netboot-installer
+  -g, --image <DIR>        Result of .#<target> (ghaf-image.raw.zst + .bmap)
+
+Options:
+      --install-target <D> Install unattended to <D> (e.g. /dev/nvme0n1).
+                           DESTRUCTIVE and requires --mac.
+      --encrypt            With --install-target: enable disk encryption
+      --secureboot         With --install-target: enroll Secure Boot keys
+  -p, --port <PORT>        HTTP port (default 8080)
+  -t, --timeout <MIN>      Exit after this long (default 60, 0 disables)
+      --exit-after-serve   Exit once the image has been fetched once
+      --force-interface    Skip the default-route / wireless refusals
+      --open-firewall      Temporarily open 67/69/4011 and the HTTP ports in the
+                           host firewall, and close them again on exit. Without
+                           this, a host that filters inbound traffic drops every
+                           PXE request before pixiecore sees it -- the server
+                           looks healthy and the target times out.
+      --ipxe <FILE>        64-bit UEFI iPXE binary. Defaults to pixiecore's own
+                           embedded iPXE, which is the only build known to work
+                           with it. Only override this if pixiecore's iPXE has
+                           no driver for the NIC, and note that a stock iPXE
+                           will chainload-loop: it needs an embedded script
+                           that chains back to pixiecore.
+      --dry-run            Print what would run and exit
+  -h, --help               This message
+
+The target must have Secure Boot OFF: the netboot chain is unsigned, exactly as
+the installer ISO is. That is the same precondition the ISO's Secure Boot
+enrollment already imposes, since enrollment needs firmware in Setup Mode.
+EOF
+}
+
+IFACE=""
+NETBOOT_DIR=""
+IMAGE_DIR=""
+PORT=8080
+TIMEOUT_MIN=60
+INSTALL_TARGET=""
+ENCRYPT=false
+SECUREBOOT=false
+FORCE_IFACE=false
+OPEN_FIREWALL=false
+DRY_RUN=false
+EXIT_AFTER_SERVE=false
+MACS=()
+# Empty by default, and package.nix deliberately does not set it: empty means
+# "let pixiecore use its own embedded iPXE". Only --ipxe fills this in.
+IPXE_EFI64="${IPXE_EFI64:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  -i | --interface)
+    IFACE="$2"
+    shift 2
+    ;;
+  -m | --mac)
+    MACS+=("$2")
+    shift 2
+    ;;
+  -n | --netboot)
+    NETBOOT_DIR="$2"
+    shift 2
+    ;;
+  -g | --image)
+    IMAGE_DIR="$2"
+    shift 2
+    ;;
+  --install-target)
+    INSTALL_TARGET="$2"
+    shift 2
+    ;;
+  --encrypt)
+    ENCRYPT=true
+    shift
+    ;;
+  --secureboot)
+    SECUREBOOT=true
+    shift
+    ;;
+  -p | --port)
+    PORT="$2"
+    shift 2
+    ;;
+  -t | --timeout)
+    TIMEOUT_MIN="$2"
+    shift 2
+    ;;
+  --exit-after-serve)
+    EXIT_AFTER_SERVE=true
+    shift
+    ;;
+  --force-interface)
+    FORCE_IFACE=true
+    shift
+    ;;
+  --open-firewall)
+    OPEN_FIREWALL=true
+    shift
+    ;;
+  --ipxe)
+    IPXE_EFI64="$2"
+    shift 2
+    ;;
+  --dry-run)
+    DRY_RUN=true
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+die() {
+  echo "ghaf-netboot: $*" >&2
+  exit 1
+}
+
+# --- G0: nothing is optional, and there is no autodetect -----------------------
+[ -n "$IFACE" ] || die "--interface is required (no default: picking the wrong NIC is the whole hazard)"
+[ ${#MACS[@]} -gt 0 ] || die "--mac is required; without an allowlist any PXE client on this LAN would be served"
+[ -n "$NETBOOT_DIR" ] || die "--netboot is required"
+[ -n "$IMAGE_DIR" ] || die "--image is required"
+
+[ -d "$NETBOOT_DIR" ] || die "no such directory: $NETBOOT_DIR"
+for f in bzImage initrd netboot.ipxe; do
+  [ -e "$NETBOOT_DIR/$f" ] || die "$NETBOOT_DIR/$f missing -- is that a *-netboot-installer result?"
+done
+[ -e "$IMAGE_DIR/ghaf-image.raw.zst" ] || die "$IMAGE_DIR/ghaf-image.raw.zst missing"
+[ -e "$IMAGE_DIR/ghaf-image.bmap" ] || die "$IMAGE_DIR/ghaf-image.bmap missing (needed to verify the image)"
+
+# Empty means "use pixiecore's own built-in iPXE", which is the right default.
+# Do NOT substitute a stock iPXE here: pixiecore's embedded build carries a
+# script that chains directly to pixiecore's HTTP endpoint, whereas a stock
+# iPXE finishes loading and simply re-runs DHCP.
+[ -z "$IPXE_EFI64" ] || [ -e "$IPXE_EFI64" ] || die "no such iPXE binary: $IPXE_EFI64"
+
+# An unattended install wipes a disk with nobody watching. Allowlisting is not
+# optional for that; it is the only thing standing between "reinstall the lab
+# machine" and "reinstall whichever machine happened to PXE boot".
+if [ -n "$INSTALL_TARGET" ]; then
+  [[ $INSTALL_TARGET =~ ^/dev/[a-zA-Z0-9._-]+$ ]] || die "--install-target must look like /dev/nvme0n1"
+fi
+
+# --- interface guard rails ----------------------------------------------------
+[ -e "/sys/class/net/$IFACE" ] || die "no such interface: $IFACE"
+
+# G1: the single check that prevents the classic disaster.
+default_iface=$(ip route show default 2>/dev/null | awk '/^default/ {print $5; exit}')
+if [ -n "$default_iface" ] && [ "$default_iface" = "$IFACE" ]; then
+  $FORCE_IFACE || die "$IFACE carries the default route; refusing (--force-interface to override)"
+  echo "ghaf-netboot: WARNING serving on the default-route interface because --force-interface was given" >&2
+fi
+
+# G2: a wireless NIC is always the wrong answer here, and usually a typo.
+if [ -d "/sys/class/net/$IFACE/wireless" ] || [ -e "/sys/class/net/$IFACE/phy80211" ]; then
+  $FORCE_IFACE || die "$IFACE is wireless; refusing (--force-interface to override)"
+fi
+
+# G3: no carrier means the cable is out and nothing will boot anyway.
+carrier=$(cat "/sys/class/net/$IFACE/carrier" 2>/dev/null || echo 0)
+[ "$carrier" = "1" ] || die "$IFACE has no carrier; check the cable"
+
+LISTEN_IP=$(ip -4 -br addr show "$IFACE" 2>/dev/null | awk '{print $3}' | cut -d/ -f1 | head -1)
+[ -n "$LISTEN_IP" ] || die "$IFACE has no IPv4 address; give it one first"
+
+# --- firewall ------------------------------------------------------------------
+# A host that filters inbound traffic drops PXE requests before pixiecore ever
+# sees them. Everything still *looks* right -- the ports are bound, the server
+# says "ready" -- while the target sits there timing out, so this is worth
+# handling rather than leaving as folklore.
+#
+# NixOS keeps a `temp-ports` set in its nixos-fw table for exactly this (it is
+# what nixos-firewall-tool drives). Adding elements to it is precise and
+# reversible; adding our own table would not work at all, because an `accept` in
+# one nftables base chain does not stop the packet traversing another base chain
+# at the same hook, so nixos-fw's `policy drop` still applies.
+FW_ELEMENTS="udp . 67, udp . 69, udp . 4011, tcp . ${PORT}, tcp . $((PORT + 1))"
+FW_OPENED=false
+
+firewall_has_nixos_fw() {
+  command -v nft >/dev/null 2>&1 &&
+    nft list set inet nixos-fw temp-ports >/dev/null 2>&1
+}
+
+firewall_open() {
+  firewall_has_nixos_fw || {
+    echo "ghaf-netboot: WARNING --open-firewall: no nixos-fw temp-ports set here;" >&2
+    echo "ghaf-netboot:   open $FW_ELEMENTS yourself if the target times out" >&2
+    return 0
+  }
+  nft add element inet nixos-fw temp-ports "{ $FW_ELEMENTS }" 2>/dev/null || {
+    echo "ghaf-netboot: WARNING could not open firewall ports" >&2
+    return 0
+  }
+  FW_OPENED=true
+  echo "ghaf-netboot: opened $FW_ELEMENTS (removed again on exit)" >&2
+}
+
+firewall_close() {
+  $FW_OPENED || return 0
+  nft delete element inet nixos-fw temp-ports "{ $FW_ELEMENTS }" 2>/dev/null ||
+    echo "ghaf-netboot: WARNING could not close firewall ports; check nixos-firewall-tool show" >&2
+}
+
+# Best-effort nudge when the ports are plainly going to be dropped. Deliberately
+# a warning and not a refusal: firewalls are too varied to detect reliably, and
+# refusing on a false positive would be worse than a noisy line.
+firewall_warn_if_closed() {
+  $OPEN_FIREWALL && return 0
+  command -v nft >/dev/null 2>&1 || return 0
+  nft list chain inet nixos-fw input 2>/dev/null | grep -q "policy drop" || return 0
+  nft list set inet nixos-fw temp-ports 2>/dev/null | grep -q "udp . 67" && return 0
+  echo "ghaf-netboot: WARNING this host's firewall input policy is 'drop' and udp/67" >&2
+  echo "ghaf-netboot:   is not open. PXE requests will be dropped before pixiecore" >&2
+  echo "ghaf-netboot:   sees them and the target will time out with nothing logged." >&2
+  echo "ghaf-netboot:   Re-run with --open-firewall." >&2
+}
+
+# --- assemble the kernel command line ----------------------------------------
+# The base cmdline MUST come from the builder's own netboot.ipxe, not be written
+# by hand here. It carries `init=/nix/store/...-nixos-system-.../init`, which is
+# how the initrd locates the closure to switch into, plus `root=fstab` and the
+# console/plymouth parameters. Passing only `ghaf.image_url=` boots a kernel that
+# mounts the store and then drops to an emergency shell with
+# "Failed to start Find NixOS closure" -- confirmed on hardware. The store path
+# changes with every rebuild, so it has to be read at run time.
+IPXE_SCRIPT="$NETBOOT_DIR/netboot.ipxe"
+BASE_CMDLINE=$(awk '/^kernel /{ sub(/^kernel[[:space:]]+[^[:space:]]+[[:space:]]*/, ""); print; exit }' "$IPXE_SCRIPT")
+[ -n "$BASE_CMDLINE" ] || die "could not read a 'kernel' line from $IPXE_SCRIPT"
+case "$BASE_CMDLINE" in
+*init=*) ;;
+*) die "no init= in $IPXE_SCRIPT; the target would drop to an emergency shell" ;;
+esac
+
+# Drop the iPXE-only placeholders and the builder's own image URL: that one is
+# templated on ${next-server} for a plain iPXE workflow, and we serve the image
+# ourselves, so ours has to win rather than appear alongside it.
+BASE_CMDLINE=$(
+  printf '%s\n' "$BASE_CMDLINE" |
+    sed -e 's/[$]{cmdline}//g' -e 's#ghaf[.]image_url=[^[:space:]]*##g' -e 's/[[:space:]]\+/ /g' -e 's/^ //' -e 's/ $//'
+)
+
+IMAGE_URL="http://${LISTEN_IP}:${PORT}/ghaf-image"
+CMDLINE="$BASE_CMDLINE ghaf.image_url=${IMAGE_URL}"
+if [ -n "$INSTALL_TARGET" ]; then
+  CMDLINE="$CMDLINE ghaf.install_target=${INSTALL_TARGET}"
+  $ENCRYPT && CMDLINE="$CMDLINE ghaf.install_encrypt"
+  $SECUREBOOT && CMDLINE="$CMDLINE ghaf.install_secureboot"
+fi
+
+cat >&2 <<EOF
+ghaf-netboot:
+  interface   $IFACE ($LISTEN_IP)
+  allowlist   ${MACS[*]}
+  netboot     $NETBOOT_DIR
+  image       $IMAGE_DIR
+  http        http://${LISTEN_IP}:${PORT}
+  ipxe        ${IPXE_EFI64:-pixiecore built-in (correct default; a stock iPXE loops)}
+  cmdline     $CMDLINE
+  mode        $(if [ -n "$INSTALL_TARGET" ]; then echo "UNATTENDED INSTALL to $INSTALL_TARGET (destructive)"; else echo "interactive TUI"; fi)
+  timeout     $(if [ "$TIMEOUT_MIN" = 0 ]; then echo "none"; else echo "${TIMEOUT_MIN} min"; fi)
+EOF
+
+firewall_warn_if_closed
+
+if $DRY_RUN; then
+  echo "ghaf-netboot: --dry-run, nothing started" >&2
+  exit 0
+fi
+
+[ "$EUID" -eq 0 ] || die "must run as root (DHCP/PXE need ports 67, 69 and 4011)"
+
+# --- serve --------------------------------------------------------------------
+# linkFarm results are symlinks into the store; deref them so the HTTP server
+# does not have to follow links out of its root.
+ROOT=$(mktemp -d)
+mkdir -p "$ROOT/boot" "$ROOT/ghaf-image"
+cp -L "$NETBOOT_DIR/bzImage" "$ROOT/boot/bzImage"
+cp -L "$NETBOOT_DIR/initrd" "$ROOT/boot/initrd"
+ln -s "$(readlink -f "$IMAGE_DIR/ghaf-image.raw.zst")" "$ROOT/ghaf-image/ghaf-image.raw.zst"
+ln -s "$(readlink -f "$IMAGE_DIR/ghaf-image.bmap")" "$ROOT/ghaf-image/ghaf-image.bmap"
+
+API_PID=""
+PIXIE_PID=""
+# Every step here is best-effort and MUST NOT be able to abort the ones after it.
+cleanup() {
+  [ -n "$API_PID" ] && kill "$API_PID" 2>/dev/null || true
+  [ -n "$PIXIE_PID" ] && kill "$PIXIE_PID" 2>/dev/null || true
+  firewall_close || true
+  rm -rf "$ROOT" || true
+  echo "ghaf-netboot: stopped" >&2
+}
+trap cleanup EXIT INT TERM
+
+$OPEN_FIREWALL && firewall_open
+
+mac_args=()
+for m in "${MACS[@]}"; do mac_args+=(--mac "$m"); done
+
+serve_args=()
+$EXIT_AFTER_SERVE && serve_args+=(--exit-after-serve)
+
+ghaf-netboot-api --root "$ROOT" --listen "$LISTEN_IP" --port "$PORT" \
+  --cmdline "$CMDLINE" "${mac_args[@]}" "${serve_args[@]+"${serve_args[@]}"}" &
+API_PID=$!
+sleep 1
+kill -0 "$API_PID" 2>/dev/null || die "HTTP server failed to start"
+
+# --debug and --log-timestamps are not optional niceties here. Without --debug,
+# pixiecore logs nothing at all for a DHCP client it does not end up booting
+ipxe_args=()
+[ -n "$IPXE_EFI64" ] && ipxe_args+=(--ipxe-efi64 "$IPXE_EFI64")
+
+pixiecore api "http://${LISTEN_IP}:${PORT}" \
+  --listen-addr "$LISTEN_IP" \
+  --port "$((PORT + 1))" \
+  "${ipxe_args[@]+"${ipxe_args[@]}"}" \
+  --debug --log-timestamps &
+PIXIE_PID=$!
+
+# G6: the realistic failure is not a misconfigured run, it is someone forgetting
+# to stop the server and carrying the laptop into a meeting.
+if [ "$TIMEOUT_MIN" != 0 ]; then
+  (
+    sleep $((TIMEOUT_MIN * 60))
+    echo "ghaf-netboot: ${TIMEOUT_MIN} minute timeout reached, stopping" >&2
+    kill -TERM $$ 2>/dev/null
+  ) &
+fi
+
+echo "ghaf-netboot: ready. Boot the target from the network." >&2
+wait -n "$API_PID" "$PIXIE_PID"

--- a/packages/pkgs-by-name/ghaf-netboot/package.nix
+++ b/packages/pkgs-by-name/ghaf-netboot/package.nix
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  coreutils,
+  ipxe,
+  iproute2,
+  lib,
+  nftables,
+  pixiecore,
+  python3,
+  writeShellApplication,
+}:
+let
+  # nixpkgs builds bin-x86_64-efi/snp.efi but not snponly.efi, so ask for it.
+  # Both land in the same output, which keeps `--ipxe <store>/snp.efi` available
+  # as a runtime fallback without another build.
+  ipxe' = ipxe.override {
+    additionalTargets = {
+      "bin-x86_64-efi/snponly.efi" = null;
+    };
+  };
+
+  # Kept as its own executable rather than a heredoc inside the shell script:
+  # writeShellApplication runs shellcheck over its text, and an embedded Python
+  # program is both unreadable there and invisible to any Python linting.
+  api = python3.pkgs.buildPythonApplication {
+    pname = "ghaf-netboot-api";
+    version = "0.1.0";
+    format = "other";
+    src = ./ghaf-netboot-api.py;
+    dontUnpack = true;
+    installPhase = ''
+      install -Dm755 $src $out/bin/ghaf-netboot-api
+      patchShebangs $out/bin/ghaf-netboot-api
+    '';
+  };
+in
+writeShellApplication {
+  name = "ghaf-netboot";
+  runtimeInputs = [
+    api
+    coreutils
+    iproute2 # ip route / ip addr, for the interface guard rails
+    nftables # --open-firewall; PXE is dropped outright without it
+    pixiecore # ProxyDHCP + TFTP; never assigns addresses
+  ];
+  text = builtins.readFile ./ghaf-netboot.sh;
+
+  # Deliberately NOT set: pixiecore uses its own embedded iPXE, and that is the
+  # only build that works with it.
+  # If this is ever set again, it must be runtimeEnv and not derivationArgs --
+  # derivationArgs sets the variable while the script is being *built*, where
+  # nothing reads it, leaving it unset at runtime.
+  passthru.ipxe = ipxe';
+
+  meta = {
+    description = "Serve a Ghaf netboot install to one machine on one interface";
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "ghaf-netboot";
+    license = lib.licenses.asl20;
+  };
+}

--- a/packages/pkgs-by-name/ghaf-netboot/package.nix
+++ b/packages/pkgs-by-name/ghaf-netboot/package.nix
@@ -2,24 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   coreutils,
-  ipxe,
   iproute2,
+  ipxe,
   lib,
   nftables,
   pixiecore,
   python3,
+  stdenv,
   writeShellApplication,
 }:
 let
-  # nixpkgs builds bin-x86_64-efi/snp.efi but not snponly.efi, so ask for it.
-  # Both land in the same output, which keeps `--ipxe <store>/snp.efi` available
-  # as a runtime fallback without another build.
-  ipxe' = ipxe.override {
-    additionalTargets = {
-      "bin-x86_64-efi/snponly.efi" = null;
-    };
-  };
-
   # Kept as its own executable rather than a heredoc inside the shell script:
   # writeShellApplication runs shellcheck over its text, and an embedded Python
   # program is both unreadable there and invisible to any Python linting.
@@ -34,6 +26,37 @@ let
       patchShebangs $out/bin/ghaf-netboot-api
     '';
   };
+
+  # The iPXE pixiecore embeds drives NICs with iPXE's own native drivers, which
+  # on the Lenovo USB-C dock cannot receive broadcast DHCP -- it retries ten
+  # times and reboots, and only unplugging the dock clears it. snponly.efi uses
+  # the firmware's SNP driver instead, i.e. the same one the firmware's PXE
+  # stack uses successfully throughout. See ./boot.ipxe for the other half.
+  ghafIpxe =
+    (ipxe.override {
+      embedScript = ./boot.ipxe;
+      # One target, not the usual dozen: this shortens a from-source build we
+      # cannot get from a cache, and it keeps the BIOS/ROM outputs we have no use
+      # for out of the closure.
+      enableDefaultPlatformTargets = false;
+      additionalTargets = {
+        "bin-x86_64-efi/snponly.efi" = null;
+      };
+      # Not cosmetic: the ipxe package asserts firmwareBinary is one of the
+      # binaries it actually built, and the "ipxe.efirom" default is no longer
+      # among them once the default targets are off.
+      firmwareBinary = "snponly.efi";
+    }).overrideAttrs
+      (_: {
+        # The ipxe package installs a compatibility symlink undionly.kpxe.0 ->
+        # undionly.kpxe on every x86 build, for dnsmasq setups that want the .0
+        # suffix. undionly.kpxe is a BIOS target we just switched off, so the
+        # link dangles -- and that fails the build outright in fixupPhase, where
+        # noBrokenSymlinks treats it as an error rather than a warning.
+        postInstall = "rm -f $out/undionly.kpxe.0";
+      });
+
+  defaultIpxe = lib.optionalString stdenv.hostPlatform.isx86_64 "${ghafIpxe}/snponly.efi";
 in
 writeShellApplication {
   name = "ghaf-netboot";
@@ -44,18 +67,17 @@ writeShellApplication {
     nftables # --open-firewall; PXE is dropped outright without it
     pixiecore # ProxyDHCP + TFTP; never assigns addresses
   ];
+  # runtimeEnv, not derivationArgs: the latter sets the variable while the
+  # script is *built*, where nothing reads it, and the script then runs with it
+  # unset.
+  runtimeEnv = {
+    GHAF_NETBOOT_IPXE = defaultIpxe;
+  };
   text = builtins.readFile ./ghaf-netboot.sh;
-
-  # Deliberately NOT set: pixiecore uses its own embedded iPXE, and that is the
-  # only build that works with it.
-  # If this is ever set again, it must be runtimeEnv and not derivationArgs --
-  # derivationArgs sets the variable while the script is being *built*, where
-  # nothing reads it, leaving it unset at runtime.
-  passthru.ipxe = ipxe';
 
   meta = {
     description = "Serve a Ghaf netboot install to one machine on one interface";
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.linux;
     mainProgram = "ghaf-netboot";
     license = lib.licenses.asl20;
   };

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -25,10 +25,6 @@ let
     extraModules = installerModules;
   };
 
-  # The same installer delivered over PXE instead of on an ISO. It takes the
-  # SAME installerModules, which is what guarantees the netboot installer keeps
-  # ghaf.host.secureboot.enable and the dev SSH keys -- i.e. that
-  # /etc/ghaf/secureboot/keys/*.auth are present for enrollment either way.
   ghaf-netboot-installer = self.builders.mkGhafNetbootInstaller {
     inherit self system;
     inherit (self) lib;
@@ -43,24 +39,25 @@ let
     self.nixosModules.profiles
   ];
 
-  installerModules = [
-    (
-      { config, ... }:
-      {
-        imports = [
-          self.nixosModules.common
-          self.nixosModules.givc
-          self.nixosModules.development
-          self.nixosModules.reference-personalize
-        ];
+  # Everything the installer environment needs beyond the boot medium: the dev
+  # SSH keys and the Secure Boot enrollment keys.
+  installerModule =
+    { config, ... }:
+    {
+      imports = [
+        self.nixosModules.common
+        self.nixosModules.givc
+        self.nixosModules.development
+        self.nixosModules.reference-personalize
+      ];
 
-        ghaf.host.secureboot.enable = true;
+      ghaf.host.secureboot.enable = true;
 
-        users.users.nixos.openssh.authorizedKeys.keys =
-          config.ghaf.reference.personalize.keys.authorizedSshKeys;
-      }
-    )
-  ];
+      users.users.nixos.openssh.authorizedKeys.keys =
+        config.ghaf.reference.personalize.keys.authorizedSshKeys;
+    };
+
+  installerModules = [ installerModule ];
 
   # All laptop configurations using mkGhafConfiguration
   target-configs = [
@@ -664,6 +661,10 @@ let
 in
 {
   flake = {
+    # So tests can build the installer the targets actually ship. See the
+    # comment on installerModule above.
+    nixosModules.laptop-installer = installerModule;
+
     nixosConfigurations = builtins.listToAttrs (
       map (t: lib.nameValuePair t.name t.hostConfiguration) config-targets
     );

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -25,6 +25,16 @@ let
     extraModules = installerModules;
   };
 
+  # The same installer delivered over PXE instead of on an ISO. It takes the
+  # SAME installerModules, which is what guarantees the netboot installer keeps
+  # ghaf.host.secureboot.enable and the dev SSH keys -- i.e. that
+  # /etc/ghaf/secureboot/keys/*.auth are present for enrollment either way.
+  ghaf-netboot-installer = self.builders.mkGhafNetbootInstaller {
+    inherit self system;
+    inherit (self) lib;
+    extraModules = installerModules;
+  };
+
   # Common modules shared across all laptop configurations
   commonModules = [
     self.nixosModules.disko-debug-partition
@@ -631,6 +641,11 @@ let
     }
   ) target-configs;
 
+  # Netboot counterparts. Unlike the ISOs these do NOT depend on the disk image
+  # -- it is fetched at install time -- so they are tiny and share one kernel
+  # and initrd across every target.
+  target-netboot-installers = map (t: ghaf-netboot-installer { inherit (t) name; }) target-configs;
+
   target-sysupdates = map (
     t:
     (t.extendHost [
@@ -644,7 +659,8 @@ let
   ) (builtins.filter (x: x.buildSysupdateImage) target-configs);
 
   config-targets = target-configs ++ target-sysupdates;
-  package-targets = target-configs ++ target-installers ++ target-sysupdates;
+  package-targets =
+    target-configs ++ target-installers ++ target-netboot-installers ++ target-sysupdates;
 in
 {
   flake = {

--- a/tests/flake-module.nix
+++ b/tests/flake-module.nix
@@ -13,6 +13,8 @@
         in
         {
           installer = pkgs.callPackage ./installer { inherit self; };
+          netboot-boot = pkgs.callPackage ./installer/netboot-boot.nix { inherit self; };
+          netboot-fetch = pkgs.callPackage ./installer/netboot-fetch.nix { inherit self; };
           # Fails after https://github.com/tiiuae/ghaf/commit/e45a8fc47dc82e37a0327bd794478277c5c7a043
           # firewall = pkgs.callPackage ./firewall { inherit self; };
           logging-fss = pkgs.callPackage ./logging { inherit self; };

--- a/tests/flake-module.nix
+++ b/tests/flake-module.nix
@@ -15,6 +15,7 @@
           installer = pkgs.callPackage ./installer { inherit self; };
           netboot-boot = pkgs.callPackage ./installer/netboot-boot.nix { inherit self; };
           netboot-fetch = pkgs.callPackage ./installer/netboot-fetch.nix { inherit self; };
+          netboot-server = pkgs.callPackage ./installer/netboot-server.nix { inherit self; };
           # Fails after https://github.com/tiiuae/ghaf/commit/e45a8fc47dc82e37a0327bd794478277c5c7a043
           # firewall = pkgs.callPackage ./firewall { inherit self; };
           logging-fss = pkgs.callPackage ./logging { inherit self; };

--- a/tests/installer/default.nix
+++ b/tests/installer/default.nix
@@ -52,6 +52,11 @@ pkgs.testers.nixosTest {
     def create_test_machine(
         oldmachine=None, **kwargs
     ):  # taken from <nixpkgs/nixos/tests/installer.nix>
+      # The default of None exists only to match the upstream signature; this
+      # helper cannot do anything without the installed machine's state dir.
+      # Asserting is also what satisfies the test driver's type checker, which
+      # otherwise rejects oldmachine.state_dir on `Unknown | None`.
+      assert oldmachine is not None, "create_test_machine requires oldmachine"
       # TODO: tpm2-abrmd.service fails to start. https://qemu-project.gitlab.io/qemu/specs/tpm.html
       start_command = [
           "${pkgs.qemu_test}/bin/qemu-kvm",

--- a/tests/installer/netboot-boot.nix
+++ b/tests/installer/netboot-boot.nix
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Boot the netboot installer over PXE and assert it actually reaches the
+# installer -- not merely that the artefacts were transferred.
+#
+# This test exists because of a real failure. The netboot server can serve every
+# artefact with a 200 and log a flawless sequence while the target sits in an
+# emergency shell: on 2026-08-01 an X1 did exactly that, because the kernel
+# command line was assembled by hand and omitted
+# `init=/nix/store/...-nixos-system-.../init`, so `initrd-find-nixos-closure`
+# had nothing to switch into. Nothing server-side could see it; it was caught by
+# someone photographing the screen.
+#
+# Hence the assertions below are deliberately about the *booted system*:
+#
+#   - ghaf-installer-tui.service is active   (only true if stage-2 was reached)
+#   - init= is on /proc/cmdline              (the specific regression)
+#   - ghaf.image_url= is on /proc/cmdline    (the installer knows where to fetch)
+#
+# Modelled on nixpkgs nixos/tests/boot.nix `makeNetbootTest`, which is the
+# working OVMF+iPXE reference: QEMU's user-mode network provides DHCP and TFTP,
+# `-boot order=n` boots from it, and the iPXE option ROM drives the UEFI path.
+{ pkgs, self }:
+let
+  inherit (self.inputs) nixpkgs;
+  system = "x86_64-linux";
+
+  netbootInstaller = self.builders.mkGhafNetbootInstaller {
+    inherit self system;
+    inherit (self) lib;
+    extraModules = [
+      self.nixosModules.laptop-installer
+      "${nixpkgs}/nixos/modules/testing/test-instrumentation.nix"
+      { key = "serial"; }
+    ];
+  };
+
+  # A literal URL rather than the default `http://${next-server}/...`: iPXE would
+  # expand that to QEMU's gateway, which is fine but makes the assertion depend
+  # on QEMU's addressing. Pinning it keeps the check about our plumbing.
+  imageUrl = "http://10.0.2.2:8080/ghaf-image";
+
+  # bzImage, initrd and netboot.ipxe -- exactly the layout a TFTP root needs, and
+  # exactly what ghaf-netboot serves.
+  tftpRoot =
+    (netbootInstaller {
+      name = "netboot-boot-test";
+      inherit imageUrl;
+    }).package;
+
+  startCommand = builtins.concatStringsSep " " [
+    "${pkgs.qemu_test}/bin/qemu-kvm"
+    "-cpu max"
+    # The initrd is ~637 MiB and is resident, with the store unpacked alongside
+    # it. Anything tight here fails as an opaque stage-1 OOM.
+    "-m 8192"
+    "-netdev user,id=net0,tftp=${tftpRoot},bootfile=netboot.ipxe"
+    "-device virtio-net-pci,netdev=net0,romfile=${pkgs.ipxe}/ipxe.efirom"
+    "-boot order=n"
+    # Secure Boot is off in these OVMF variables, which matches the documented
+    # precondition for netboot: the chain is unsigned, exactly as the ISO is.
+    "-drive if=pflash,format=raw,unit=0,readonly=on,file=${pkgs.OVMF.firmware}"
+    "-drive if=pflash,format=raw,unit=1,readonly=on,file=${pkgs.OVMF.variables}"
+  ];
+in
+pkgs.testers.nixosTest {
+  name = "netboot-boot-test";
+  nodes = { };
+
+  testScript = ''
+    machine = create_machine("${startCommand}")
+    machine.start()
+
+    machine.wait_for_unit("multi-user.target", timeout=500)
+
+    with subtest("the installer actually started"):
+        # The assertion that distinguishes a booted installer from an emergency
+        # shell. Everything below is detail; this is the test.
+        # Measured at 0.01 s once multi-user.target is up -- it is ordered after
+        # it -- so this timeout is pure headroom.
+        machine.wait_for_unit("ghaf-installer-tui.service", timeout=120)
+
+    with subtest("init= reached the kernel"):
+        # The 2026-08-01 regression, stated directly.
+        machine.succeed("grep -q 'init=/nix/store/' /proc/cmdline")
+
+    with subtest("the installer knows where to fetch the image"):
+        # Only the cmdline is asserted here. IMG_PATH comes from
+        # ghaf.installer.imageSource, a build-time default, and is *overridden*
+        # at runtime from ghaf.image_url by the installer scripts -- so checking
+        # the environment would be testing the wrong layer.
+        machine.succeed("grep -q 'ghaf.image_url=${imageUrl}' /proc/cmdline")
+
+    machine.shutdown()
+  '';
+}

--- a/tests/installer/netboot-fetch.nix
+++ b/tests/installer/netboot-fetch.nix
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install from an HTTP image source and boot the result.
+#
+# The ISO path (tests/installer/default.nix) reads the image from a local
+# directory. Netboot instead fetches it over HTTP at install time, which is the
+# whole reason the netboot artefacts are target-independent and ~650 MB rather
+# than ~7 GB. That fetch-and-write path is the risky part of the design, and
+# this test covers it without needing PXE, firmware or a network boot:
+#
+#   * IMG_PATH is a URL, so resolve_image_source() takes the http branch
+#   * the bmap is fetched -- and a missing bmap is fatal, never a silent dd
+#   * curl | zstdcat | pv | bmaptool copy writes to a real disk
+#   * bmaptool verifies per-range sha256 while copying, which is the only
+#     integrity check the image gets over plain HTTP
+#   * the written disk actually boots
+#
+# The last point matters most: `ghaf-installer` exiting 0 does not prove the
+# disk is bootable, in the same way that a netboot server logging 200 for every
+# artefact does not prove the target booted.
+{ pkgs, self }:
+let
+  testConfig = "lenovo-x1-carbon-gen11-debug";
+  expectedHostname = "ghaf-host";
+
+  cfg = self.nixosConfigurations.${testConfig};
+
+  testingConfig = cfg.extendModules {
+    modules = [
+      (cfg._module.specialArgs.modulesPath + "/testing/test-instrumentation.nix")
+      (cfg._module.specialArgs.modulesPath + "/profiles/qemu-guest.nix")
+      (_: {
+        testing.initrdBackdoor = true;
+        services.openssh.enable = true;
+      })
+    ];
+  };
+
+  imagePath = testingConfig.config.system.build.ghafImage;
+  targetPath = "/dev/vdb";
+  installerInput = pkgs.lib.strings.escapeNixString "${targetPath}\ny\ny\n";
+
+  # Matches what ghaf-netboot serves and what the ghaf.image_url= kernel
+  # parameter points at: a base URL with ghaf-image.raw.zst and
+  # ghaf-image.bmap directly beneath it.
+  imageUrl = "http://server/ghaf-image";
+in
+pkgs.testers.nixosTest {
+  name = "netboot-fetch-test";
+
+  nodes = {
+    # Stands in for ghaf-netboot's HTTP side. Only the layout matters, not the
+    # server: the installer sees a plain base URL either way.
+    server = _: {
+      networking.firewall.allowedTCPPorts = [ 80 ];
+      services.nginx = {
+        enable = true;
+        virtualHosts."server" = {
+          locations."/ghaf-image/".alias = "${imagePath}/";
+        };
+      };
+    };
+
+    machine = _: {
+      virtualisation.emptyDiskImages = [ (1024 * 256) ];
+      virtualisation.memorySize = 1024 * 16;
+
+      # The netboot equivalent of the ISO's local directory. This is the one
+      # thing that differs from tests/installer/default.nix.
+      environment.sessionVariables = {
+        IMG_PATH = imageUrl;
+      };
+
+      environment.systemPackages = [
+        self.packages.x86_64-linux.ghaf-installer
+        self.packages.x86_64-linux.hardware-scan
+      ];
+    };
+  };
+
+  testScript = ''
+    def create_test_machine(
+        oldmachine=None, **kwargs
+    ):  # taken from <nixpkgs/nixos/tests/installer.nix>
+      assert oldmachine is not None, "create_test_machine requires oldmachine"
+      start_command = [
+          "${pkgs.qemu_test}/bin/qemu-kvm",
+          "-cpu",
+          "max",
+          "-m",
+          "16384",
+          "-virtfs",
+          "local,path=/nix/store,security_model=none,mount_tag=nix-store",
+          "-drive",
+          f"file={oldmachine.state_dir}/empty0.qcow2,id=drive1,if=none,index=1,werror=report",
+          "-device",
+          "virtio-blk-pci,drive=drive1",
+          # UEFI support
+          "-drive",
+          "if=pflash,format=raw,unit=0,readonly=on,file=${pkgs.OVMF.firmware}",
+          "-drive",
+          "if=pflash,format=raw,unit=1,readonly=on,file=${pkgs.OVMF.variables}"
+      ]
+      machine = create_machine(start_command=" ".join(start_command), **kwargs)
+      driver.machines.append(machine)
+      return machine
+
+    start_all()
+    server.wait_for_unit("nginx.service")
+    server.wait_for_open_port(80)
+
+    with subtest("the image and its bmap are reachable over HTTP"):
+        # If this fails the rest is noise, so check it before the install.
+        machine.succeed("curl -sfI ${imageUrl}/ghaf-image.raw.zst >&2")
+        # A missing bmap must be fatal rather than degrade to an unverified dd,
+        # so its presence is part of the contract, not an optimisation.
+        machine.succeed("curl -sfI ${imageUrl}/ghaf-image.bmap >&2")
+
+    machine.succeed("lsblk >&2")
+    with subtest("install over HTTP"):
+        # bmaptool verifies each range's sha256 as it writes, so a corrupted or
+        # truncated transfer fails here rather than producing a silent bad disk.
+        #
+        # Measured at 110.7 s on a 128-core dev host with NVMe (whole test:
+        # 171.6 s). This step decompresses and writes several GB, so it is the
+        # one place where a slow or IO-constrained runner genuinely needs room --
+        # 900 s is ~8x measured. The ISO test next door still uses 3600 s, which
+        # predates any measurement; worth retuning it from its own log rather
+        # than copying either number forward on faith.
+        machine.succeed('printf ${installerInput} | ghaf-installer', timeout=900)
+
+    print("Shutting installer machine down")
+    machine.shutdown()
+
+    with subtest("the HTTP-installed disk boots"):
+        new_machine = create_test_machine(oldmachine=machine, name="after_install")
+        new_machine.start()
+        new_machine.switch_root()
+        new_machine.succeed("lsblk >&2")
+        name = new_machine.succeed("cat /proc/sys/kernel/hostname").strip()
+        assert name == "${expectedHostname}", f"expected hostname '${expectedHostname}', got {name}"
+        new_machine.shutdown()
+  '';
+}

--- a/tests/installer/netboot-fetch.nix
+++ b/tests/installer/netboot-fetch.nix
@@ -39,7 +39,6 @@ let
 
   imagePath = testingConfig.config.system.build.ghafImage;
   targetPath = "/dev/vdb";
-  installerInput = pkgs.lib.strings.escapeNixString "${targetPath}\ny\ny\n";
 
   # Matches what ghaf-netboot serves and what the ghaf.image_url= kernel
   # parameter points at: a base URL with ghaf-image.raw.zst and
@@ -66,11 +65,12 @@ pkgs.testers.nixosTest {
       virtualisation.emptyDiskImages = [ (1024 * 256) ];
       virtualisation.memorySize = 1024 * 16;
 
-      # The netboot equivalent of the ISO's local directory. This is the one
-      # thing that differs from tests/installer/default.nix.
-      environment.sessionVariables = {
-        IMG_PATH = imageUrl;
-      };
+      # Drive this the way netboot actually does: through the KERNEL COMMAND
+      # LINE, not an environment variable.
+      boot.kernelParams = [
+        "ghaf.image_url=${imageUrl}"
+        "ghaf.install_target=${targetPath}"
+      ];
 
       environment.systemPackages = [
         self.packages.x86_64-linux.ghaf-installer
@@ -118,17 +118,16 @@ pkgs.testers.nixosTest {
         machine.succeed("curl -sfI ${imageUrl}/ghaf-image.bmap >&2")
 
     machine.succeed("lsblk >&2")
+
+    with subtest("the kernel parameters reached the installer"):
+        machine.succeed("grep -q 'ghaf.image_url=${imageUrl}' /proc/cmdline")
+        machine.succeed("grep -q 'ghaf.install_target=${targetPath}' /proc/cmdline")
+
     with subtest("install over HTTP"):
         # bmaptool verifies each range's sha256 as it writes, so a corrupted or
         # truncated transfer fails here rather than producing a silent bad disk.
         #
-        # Measured at 110.7 s on a 128-core dev host with NVMe (whole test:
-        # 171.6 s). This step decompresses and writes several GB, so it is the
-        # one place where a slow or IO-constrained runner genuinely needs room --
-        # 900 s is ~8x measured. The ISO test next door still uses 3600 s, which
-        # predates any measurement; worth retuning it from its own log rather
-        # than copying either number forward on faith.
-        machine.succeed('printf ${installerInput} | ghaf-installer', timeout=900)
+        machine.succeed('ghaf-installer </dev/null', timeout=900)
 
     print("Shutting installer machine down")
     machine.shutdown()

--- a/tests/installer/netboot-server.nix
+++ b/tests/installer/netboot-server.nix
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Test ghaf-netboot itself -- the server wrapper, not the artefacts it serves.
+#
+# netboot-boot.nix and netboot-fetch.nix both bypass this script entirely: the
+# first boots the builder's artefacts through QEMU's own TFTP, the second serves
+# the image with nginx. So the code that actually broke on 2026-08-01 -- the
+# kernel command line ghaf-netboot.sh hands to pixiecore -- had no coverage at
+# all, and neither of those tests would have caught it.
+#
+# What is asserted here, in rough order of how badly it hurt when it was wrong:
+#
+#   1. the assembled cmdline carries init= from netboot.ipxe. Omitting it put a
+#      real machine into an emergency shell while every artefact was served 200.
+#   2. the cleanup trap runs to completion. Under `set -o errexit` a kill of an
+#      already-dead PID aborted the trap, leaving pixiecore running and the
+#      firewall open after --exit-after-serve -- i.e. a destructive netboot
+#      server still live on the LAN.
+#   3. the guard rails refuse rather than proceed. The allowlist is the only
+#      thing standing between "reinstall this machine" and "reinstall whichever
+#      machine happened to PXE boot".
+#   4. the iPXE binary we serve is our own snponly.efi and it carries the
+#      embedded script. Both halves are load-bearing and fail differently:
+#      pixiecore's built-in iPXE cannot get broadcast DHCP on the Lenovo dock
+#      (recoverable only by unplugging it), and a binary without the embedded
+#      "user-class pixiecore" line chainload-loops instead of booting.
+#
+# Deliberately fabricates its netboot/image directories: the point is to test
+# the script's behaviour, not to re-test the builder.
+{ pkgs, self }:
+let
+  # A recognisable stand-in for a real closure path, so the cmdline assertion
+  # can be exact rather than a substring match on "init=".
+  fakeInit = "/nix/store/0000000000000000000000000000000-nixos-system-fake/init";
+in
+pkgs.testers.nixosTest {
+  name = "netboot-server-test";
+
+  nodes.machine = {
+    environment.systemPackages = [
+      self.packages.x86_64-linux.ghaf-netboot
+      pkgs.curl
+      pkgs.file # identifying the iPXE binary as a real EFI application
+      pkgs.binutils # strings, for the embedded-script assertion
+    ];
+    # pixiecore wants :67/:69/:4011; the serve subtest below is the only part
+    # that needs them, and the VM is root anyway.
+    networking.firewall.enable = false;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # --- fixtures ---------------------------------------------------------
+    machine.succeed("mkdir -p /tmp/nb /tmp/img")
+    machine.succeed("echo fake-kernel > /tmp/nb/bzImage")
+    machine.succeed("echo fake-initrd > /tmp/nb/initrd")
+    # Shaped exactly like the builder's output, including the iPXE-only
+    # placeholders that must not survive into the kernel cmdline.
+    machine.succeed(
+        "printf '%s\\n' '#!ipxe' "
+        "'kernel bzImage init=${fakeInit} quiet root=fstab "
+        "ghaf.image_url=http://''${next-server}/ghaf-images/x ''${cmdline}' "
+        "'initrd initrd' 'boot' > /tmp/nb/netboot.ipxe"
+    )
+    machine.succeed("echo fake-image > /tmp/img/ghaf-image.raw.zst")
+    machine.succeed("echo fake-bmap  > /tmp/img/ghaf-image.bmap")
+
+    base = "ghaf-netboot -i eth1 -m aa:bb:cc:dd:ee:ff -n /tmp/nb -g /tmp/img --force-interface"
+
+    with subtest("the cmdline is taken from netboot.ipxe, not invented"):
+        # THE regression. Without init= the target boots into an emergency
+        # shell and nothing server-side can tell.
+        out = machine.succeed(f"{base} --dry-run 2>&1")
+        assert "init=${fakeInit}" in out, f"init= missing from cmdline:\n{out}"
+        # Carried over from the builder rather than re-guessed here.
+        assert "root=fstab" in out, f"root=fstab missing from cmdline:\n{out}"
+
+    with subtest("iPXE-only placeholders never reach the kernel"):
+        out = machine.succeed(f"{base} --dry-run 2>&1")
+        cmdline = [l for l in out.splitlines() if "cmdline" in l][0]
+        # The next-server and cmdline placeholders are expanded by iPXE, not by
+        # us. If they leak through, the kernel receives a literal dollar-brace
+        # string instead of a URL.
+        assert "next-server" not in cmdline, f"iPXE placeholder leaked:\n{cmdline}"
+        assert "''${cmdline}" not in cmdline, f"iPXE placeholder leaked:\n{cmdline}"
+        # Our URL must win over the builder's templated one.
+        assert cmdline.count("ghaf.image_url=") == 1, f"duplicate image_url:\n{cmdline}"
+
+    with subtest("a netboot dir without init= is refused, not served"):
+        machine.succeed("mkdir -p /tmp/bad && cp /tmp/nb/bzImage /tmp/nb/initrd /tmp/bad/")
+        machine.succeed(
+            "printf '%s\\n' '#!ipxe' 'kernel bzImage quiet' 'initrd initrd' 'boot'"
+            " > /tmp/bad/netboot.ipxe"
+        )
+        machine.fail(
+            "ghaf-netboot -i eth1 -m aa:bb:cc:dd:ee:ff -n /tmp/bad -g /tmp/img"
+            " --force-interface --dry-run"
+        )
+
+    with subtest("guard rails refuse rather than proceed"):
+        # No allowlist: every PXE client on the LAN would be served.
+        machine.fail("ghaf-netboot -i eth1 -n /tmp/nb -g /tmp/img --force-interface --dry-run")
+        # A missing bmap must be fatal -- it is the only integrity check the
+        # image gets over plain HTTP.
+        machine.succeed("mkdir -p /tmp/nobmap && cp /tmp/img/ghaf-image.raw.zst /tmp/nobmap/")
+        machine.fail(f"{base.replace('/tmp/img', '/tmp/nobmap')} --dry-run")
+        # A malformed install target is destructive if it is wrong.
+        machine.fail(f"{base} --install-target 'not-a-device' --dry-run")
+        # An interface that does not exist.
+        machine.fail("ghaf-netboot -i nosuchif0 -m aa:bb:cc:dd:ee:ff -n /tmp/nb -g /tmp/img --dry-run")
+        # Missing netboot.ipxe entirely.
+        machine.succeed("mkdir -p /tmp/noipxe && cp /tmp/nb/bzImage /tmp/nb/initrd /tmp/noipxe/")
+        machine.fail(f"{base.replace('/tmp/nb', '/tmp/noipxe')} --dry-run")
+
+    with subtest("the custom snponly.efi is the default, and it is real"):
+        # Pixiecore's own iPXE drives NICs with native drivers and cannot get
+        # broadcast DHCP on the Lenovo dock -- ten retries, then reboot, forever,
+        # clearable only by unplugging the dock. Ours goes through the firmware's
+        # SNP driver instead, so a silent regression back to the built-in would
+        # reintroduce a failure that needs physical access to recover from.
+        out = machine.succeed(f"{base} --dry-run 2>&1")
+        ipxe = [l for l in out.splitlines() if l.strip().startswith("ipxe")][0]
+        assert "snponly.efi" in ipxe, f"not defaulting to our iPXE:\n{ipxe}"
+        path = ipxe.split()[1]
+        machine.succeed(f"test -s {path}")
+        # A PE32+ EFI application, not an empty file or a leftover shell wrapper.
+        assert "PE32+" in machine.succeed(f"file -b {path}")
+        # THE contract with pixiecore: option 77 user-class "pixiecore" is the
+        # entire test it applies to decide it has already chainloaded a client
+        # (pixiecore/dhcp.go). Without it pixiecore re-serves the binary in an
+        # endless ~20 s chainload loop, which is how a stock iPXE fails here.
+        machine.succeed(f"strings -a {path} | grep -q 'set user-class pixiecore'")
+
+    with subtest("--ipxe builtin falls back, --ipxe <missing> refuses"):
+        # The escape hatch, for a NIC the firmware's SNP does not cover.
+        out = machine.succeed(f"{base} --ipxe builtin --dry-run 2>&1")
+        ipxe = [l for l in out.splitlines() if l.strip().startswith("ipxe")][0]
+        assert "snponly.efi" not in ipxe, f"--ipxe builtin ignored:\n{ipxe}"
+        assert "pixiecore built-in" in ipxe, f"--ipxe builtin ignored:\n{ipxe}"
+        # A typo'd path must not silently degrade to pixiecore's iPXE.
+        machine.fail(f"{base} --ipxe /nonexistent/snponly.efi --dry-run")
+
+    with subtest("--exit-after-serve defaults on for an unattended install"):
+        # The installer reboots itself when an unattended install finishes, and
+        # a netbooted target usually has network boot ahead of its disk -- so a
+        # server still answering PXE catches that reboot and reinstalls the
+        # machine, looping on the single most expensive operation there is.
+        out = machine.succeed(f"{base} --install-target /dev/nvme0n1 --dry-run 2>&1")
+        stop = [l for l in out.splitlines() if l.strip().startswith("stop")][0]
+        assert "served in full" in stop, f"not defaulting to --exit-after-serve:\n{stop}"
+
+        # Interactive runs must NOT inherit it. Nothing fetches the image, and
+        # an operator stepping through the TUI needs the server to stay up.
+        out = machine.succeed(f"{base} --dry-run 2>&1")
+        stop = [l for l in out.splitlines() if l.strip().startswith("stop")][0]
+        assert "timeout or signal" in stop, f"interactive must not exit after serve:\n{stop}"
+
+        # Opting out stays possible, but has to say what it costs.
+        out = machine.succeed(
+            f"{base} --install-target /dev/nvme0n1 --no-exit-after-serve --dry-run 2>&1"
+        )
+        assert "reinstall itself on every reboot" in out, f"loop hazard unflagged:\n{out}"
+
+    with subtest("--dry-run starts nothing"):
+        machine.succeed(f"{base} --dry-run")
+        machine.fail("pgrep -x pixiecore")
+
+    with subtest("--exit-after-serve stops the server AND cleans up"):
+        # The cleanup-trap bug: the API shuts itself down, so by the time the
+        # trap runs $API_PID is already dead; under errexit a bare `kill` of it
+        # aborted the trap and left pixiecore running with ports bound.
+        machine.succeed(f"{base} --exit-after-serve -t 5 >/tmp/srv.log 2>&1 &")
+        machine.wait_until_succeeds("grep -q 'ready. Boot the target' /tmp/srv.log", timeout=60)
+        machine.succeed("pgrep -x pixiecore")
+
+        ip = machine.succeed("ip -4 -br addr show eth1 | awk '{print $3}' | cut -d/ -f1").strip()
+        machine.succeed(f"curl -sf http://{ip}:8080/ghaf-image/ghaf-image.raw.zst -o /dev/null")
+
+        machine.wait_until_succeeds("grep -q 'image served in full' /tmp/srv.log", timeout=60)
+        # Everything below here is what the trap is for.
+        machine.wait_until_fails("pgrep -x pixiecore", timeout=60)
+        machine.wait_until_succeeds("grep -q 'ghaf-netboot: stopped' /tmp/srv.log", timeout=60)
+        machine.fail("ss -lnup | grep -E ':(67|69|4011)\\b'")
+  '';
+}


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Adds a **netboot (PXE) install path for x86_64**, so a machine can be installed over the network with no USB media.

Today an install means building a ~5.3 GB image, wrapping it in a ~7 GB installer ISO, and `dd`-ing that to a stick. Netboot drops the embedding: the installer boots over PXE (~650 MB) and fetches the image over HTTP at install time. The boot artefacts carry no image, so they are **target-independent** — one kernel and initrd for the whole fleet instead of ~20 per-target ISOs.

**What's here**

- `packages/pkgs-by-name/ghaf-netboot/` — the serving side: Pixiecore in ProxyDHCP mode (never assigns addresses) plus a small boot API that answers **only allowlisted MACs** (404 = "ignore this machine"). Guard rails refuse a default-route or wireless interface, an empty MAC allowlist, or a malformed `--install-target`; `--open-firewall` opens 67/69/4011 for the run and closes them again; `--exit-after-serve` stops the server once the image has gone out.
- Installer scripts now accept an **http(s) image source** as well as a directory, and write with `bmaptool`, which verifies a SHA-256 per range as it copies. `ghaf-installer` previously did a bare `zstdcat | dd` with no integrity check at all. A missing `.bmap` is fatal rather than degrading to an unverified copy.
- **Unattended installs**: `ghaf.install_target=` / `_encrypt` / `_secureboot` / `ghaf.image_url=` on the kernel command line.
- `ghaf-hw-test netboot` — pre-flight over ssh (reachable, Secure Boot off, network boot entry, BootOrder position) **before** anything reboots, then build → serve → reboot → verify.
- Docs: a netboot section in `installer.mdx`, and netboot as a third path in the `ghaf-deploy` skill.


Also: per-machine values (addresses, MACs, ssh identities, drive/serial nodes) move out of the shared `config.yaml` into a gitignored `config.local.yaml` (see `config.local.yaml.example`), so lab topology stays out of the repo.

**Known limitation:** on a Lenovo X1 with a USB-C dock, Pixiecore's built-in iPXE intermittently fails to obtain DHCP (its unicast TFTP works, broadcast replies never arrive) and loops. Unplugging the dock clears it; a laptop power cycle does not. The fix — an iPXE built with SNP support and an embedded script chaining to our own `netboot.ipxe` — is a follow-up, not in this PR.

### Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [x] Documentation
- [x] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

x86_64 only — the netboot chain is a 64-bit UEFI one, and `ghaf-netboot` is marked `meta.platforms = [ "x86_64-linux" ]`.

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other: this *is* an installation method. Nothing existing changes behaviour, but the two module changes (`efibootmgr` on the host PATH; NOPASSWD for `efibootmgr`/`systemctl reboot` on **debug** hosts only) need a rebuild or reflash before `ghaf-hw-test netboot` can set BootNext by itself.

### Test Steps To Verify:

**Preconditions.** Target has Secure Boot **off** (the chain is unsigned, exactly as the ISO is) and a firmware network boot entry. Build host and target must be on the same layer-2 network — PXE is broadcast. Not every USB-C adapter can PXE: the firmware needs its own UEFI driver for the chipset, and a vendor dock generally works where a generic adapter emits nothing.

Nothing below is destructive until step 5.

1. Build the artefacts:

   ```sh
   nix build .#intel-laptop-debug-netboot-installer -o result-netboot
   nix build .#intel-laptop-debug -o result
   ```

2. Check the plan without starting anything — this prints the exact kernel command line and exits:

   ```sh
   nix develop --command ghaf-netboot \
     --interface <build-host-nic> --mac <target-pxe-mac> \
     --netboot result-netboot --image result --dry-run
   ```

   Expect `init=/nix/store/…-nixos-system-ghaf-installer-kexec-…/init` in the cmdline. Without it the target reaches an emergency shell while the server logs a flawless transfer.

3. Serve it, and boot the target from the network:

   ```sh
   sudo ghaf-netboot --interface <nic> --mac <mac> \
     --netboot result-netboot --image result --open-firewall --exit-after-serve
   ```

   `--open-firewall` matters: a host that filters inbound traffic drops PXE **before** the server sees it, and the server still says `ready`. Add `--force-interface` if the NIC facing the target also carries the default route (normal on a shared lab LAN).

4. The interactive installer should come up on the target. Install to the target disk; confirm it reboots into Ghaf and reaches the desktop.

5. **Destructive** — unattended install, wipes the given disk with nobody at the console:

   ```sh
   sudo ghaf-netboot ... --install-target /dev/nvme0n1
   # or, with pre-flight and verification:
   ghaf-hw-test -y netboot --device <NAME> --install-target /dev/nvme0n1
   ```

   Confirm afterwards that the machine really reinstalled rather than merely answering ssh:

   ```sh
   ssh ghaf@<ip> ssh ghaf-host readlink /run/current-system   # matches what you built
   ssh ghaf@<ip> ssh ghaf-host cat /proc/sys/kernel/random/boot_id   # changed
   ```

6. Automated checks (no hardware needed):

   ```sh
   nix build .#checks.x86_64-linux.netboot-server   # ~18 s
   nix build .#checks.x86_64-linux.netboot-boot     # ~33 s
   nix build .#checks.x86_64-linux.netboot-fetch    # ~3 min
   nix build .#checks.x86_64-linux.installer        # ISO path, unchanged
   ```

7. Regression check that the ISO path still works: build and boot `.#intel-laptop-debug-installer` as before.
