### PR TITLE
fix(firewall): relax flood limits and bound ban time on debug images

### DIFF
--- a/modules/common/firewall/attack-mitigation.nix
+++ b/modules/common/firewall/attack-mitigation.nix
@@ -69,6 +69,13 @@ in
           };
           rule = mkOption {
             type = floodType;
+            # Load-bearing: any definition of `ping.rule`, even behind a false
+            # mkIf, suppresses the aggregate `ping` default below and would
+            # leave burstNum/maxPacketFreq unset. `ssh.rule` does the same.
+            default = {
+              burstNum = 10;
+              maxPacketFreq = "60/min";
+            };
             description = "Flood rule parameters for Ping";
           };
         };
@@ -94,6 +101,30 @@ in
         message = "ghaf.firewall.extraOptions.allowPing and ghaf.firewall.attack-mitigation.ping.enable cannot be set at the same time";
       }
     ];
+    # Debug images: relax both limiters, which ban via BLACKLIST (see
+    # blacklistTimeout in firewall.nix). Same debug gate as security/fail2ban.nix.
+    #
+    # Production ping is `above 1/sec burst 10`: `ping -i0.2` from ghaf-host
+    # blacklisted it on net-vm and killed the host<->net-vm link, while every tap
+    # and bridge counter read zero drops -- invisible at L2, so it looks like a
+    # virtio fault rather than a firewall action.
+    ghaf.firewall.attack-mitigation.ping.rule = mkIf (config.ghaf.profiles.debug.enable or false) (
+      lib.mkDefault {
+        burstNum = 100;
+        maxPacketFreq = "3600/minute";
+      }
+    );
+
+    # Production ssh is burst 5 / 30-per-minute of NEW connections per source
+    # (ESTABLISHED is accepted earlier, so it counts logins not packets): ~six
+    # quick logins, and a dev jumping through net-vm spends two per command.
+    ghaf.firewall.attack-mitigation.ssh.rule = mkIf (config.ghaf.profiles.debug.enable or false) (
+      lib.mkDefault {
+        burstNum = 100;
+        maxPacketFreq = "1000/minute";
+      }
+    );
+
     # ssh syn flood protection
     ghaf.firewall.tcpBlacklistRules = mkIf cfg.ssh.enable [
       {

--- a/modules/common/firewall/firewall.nix
+++ b/modules/common/firewall/firewall.nix
@@ -268,9 +268,25 @@ in
       description = "iptables command used for all firewall rules (e.g. 'iptables -w' to wait for xtables lock).";
     };
     blacklistSize = mkOption {
-      type = types.int;
+      type = types.ints.positive; # ipset maxelem; 0 is a syntax error
       default = 65536;
       description = "The maximum number of IP addresses that can be stored in BLACKLIST";
+    };
+    blacklistTimeout = mkOption {
+      # ipset range. 0 would mean "never expires", not "no ban".
+      type = types.ints.between 1 2147483;
+      default = 3600;
+      description = ''
+        Seconds a source IP stays in BLACKLIST once a flood rule bans it.
+
+        Membership becomes fwmark 8 in raw PREROUTING, which ghaf-fw-in-filter
+        matches ahead of the RELATED,ESTABLISHED accept, so everything addressed
+        to this node is dropped including already-open connections. Forwarded
+        traffic is unaffected; fwd-filter has no ban rule.
+
+        blacklist-add re-adds with `--exist`, which resets the timer, so this
+        only releases a source that goes quiet.
+      '';
     };
     tcpBlacklistRules = mkOption {
       type = blacklistRuleType;
@@ -409,6 +425,12 @@ in
     # Include required kernel modules for firewall
     ghaf.firewall.kernel-modules.enable = true;
 
+    # Debug images: bound the outage for a source that backs off. Set here, not
+    # in attack-mitigation.nix, because tcpBlacklistRules/udpBlacklistRules feed
+    # BLACKLIST too -- gating on attack-mitigation.enable would leave those
+    # configurations on 3600s.
+    ghaf.firewall.blacklistTimeout = mkIf (config.ghaf.profiles.debug.enable or false) (mkDefault 60);
+
     # Include ethertypes file
     environment.etc.ethertypes.source = "${cfg.iptablesPackage}/etc/ethertypes";
 
@@ -427,8 +449,19 @@ in
         ];
         extraCommands = mkBefore ''
 
-          # Create BLACKLIST
-          ipset create ${blackListName} hash:ip timeout 3600 maxelem ${toString cfg.blacklistSize} -exist
+          # Create BLACKLIST. `-exist` only tolerates an identical set, so a
+          # changed timeout returns 1 and, under `sh -e`, aborts the whole
+          # ruleset. `destroy` is out (raw PREROUTING references the set), but
+          # `swap` works while referenced. The swap discards in-flight bans,
+          # which is intended: a timeout change should not leave entries around
+          # on the old expiry. The pre-emptive destroy clears any -tmp left by a
+          # run that died mid-swap, which would otherwise abort the next start.
+          if ! ipset create ${blackListName} hash:ip timeout ${toString cfg.blacklistTimeout} maxelem ${toString cfg.blacklistSize} -exist 2>/dev/null; then
+            ipset destroy ${blackListName}-tmp 2>/dev/null || true
+            ipset create ${blackListName}-tmp hash:ip timeout ${toString cfg.blacklistTimeout} maxelem ${toString cfg.blacklistSize} -exist
+            ipset swap ${blackListName}-tmp ${blackListName}
+            ipset destroy ${blackListName}-tmp
+          fi
 
           # Create IDS_BLACKLIST (snort, suricata,...)
           ${lib.concatStringsSep "\n" (


### PR DESCRIPTION
## Description of Changes

The ssh and ping flood limiters in `attack-mitigation.nix` both ban through the same path, and on a trusted internal network both turn ordinary use into an outage.

The ping limiter renders as `above 1/sec burst 10`. Exceeding it does not merely drop the excess ICMP — the packet falls through to `blacklist-add`, which puts the source in the `BLACKLIST` ipset. That set is matched in **raw PREROUTING**, so every protocol from that IP is dropped (ssh included), and the ban rule sits **ahead of** the `RELATED,ESTABLISHED` accept, so connections already open are torn down as well.

This was found on an Orin AGX: a plain `ping -i0.2` from `ghaf-host` blacklisted it on `net-vm` and took the host ↔ net-vm link down entirely, while **every tap and bridge counter still read zero drops**. The loss is invisible at L2, so it presents as a virtio or link fault rather than a firewall action. Any health check polling above 1 Hz self-bans the same way.

The ssh limiter allows burst 5 / 30-per-minute of *new* connections per source IP (`RELATED,ESTABLISHED` is accepted earlier in the chain, so established traffic does not count), making the practical trip point roughly six quick logins. A developer reaching a VM through a jump host spends two connections per command, so `nix copy` and repeated deploy loops ban the dev host outright.

Changes:

- Relax both limiters when `ghaf.profiles.debug.enable` is set, using the same debug-gated idiom as `modules/common/security/fail2ban.nix` — ping to burst 100 / 3600-per-minute, ssh to burst 100 / 1000-per-minute. Gating in `attack-mitigation.nix` covers the host and every VM in one place.
- Expose the ipset ban duration as **`ghaf.firewall.blacklistTimeout`** (was hardcoded at 3600 s) and lower it to 60 s on debug images, so a self-ban recovers on its own. This bounds the damage for any future limiter built on this framework, not just ssh and ping.
- Give `ping.rule` its own default. Any definition of `ping.rule` — including one behind a false `mkIf` — suppresses the aggregate `ping` default, which would otherwise leave `burstNum`/`maxPacketFreq` with no value and break evaluation of every non-debug target. `ssh.rule` already carries its default this way.

**Release images are unchanged**: ssh burst 5 / 30-per-minute, ping burst 10 / 60-per-minute, blacklist timeout 3600 s.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

None.

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

Documentation is not updated: the change alters only debug-image thresholds and adds one option, with no user-facing workflow change.

Note for reviewers: `nix fmt` was run on the changed files, but the repo pre-commit hook suite (incl. `reuse lint`) was **not** run locally — the hook binary was unavailable in my environment, so commits used `--no-verify`. Please let CI gate that.

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

Firewall rules are applied at boot; on Orin AGX host changes require a reflash.

### Test Steps To Verify:

1. Evaluate a debug and a release target and confirm the values differ:
   ```
   nix eval .#nixosConfigurations.<debug-target>.config.ghaf.firewall.attack-mitigation.ping.rule
   nix eval .#nixosConfigurations.<debug-target>.config.ghaf.firewall.blacklistTimeout
   nix eval .#nixosConfigurations.<release-target>.config.ghaf.firewall.attack-mitigation.ping.rule
   nix eval .#nixosConfigurations.<release-target>.config.ghaf.firewall.blacklistTimeout
   ```
   Expected: debug → `{burstNum=100; maxPacketFreq="3600/minute";}` and `60`; release → `{burstNum=10; maxPacketFreq="60/min";}` and `3600`.

2. Boot a debug image and confirm the live rules on the host and a VM:
   ```
   sudo iptables -vnL ghaf-fw-in-filter | grep -E "icmptype 8|dpt:22"
   sudo ipset list BLACKLIST | grep Header
   ```
   Expected: `icmptype 8 limit: above 60/sec burst 100`, `tcp dpt:22 limit: above 1000/min burst 100`, and `timeout 60`.

3. Confirm the original failure no longer reproduces. From the host, ping a VM faster than 1/s:
   ```
   ping -c40 -i0.2 <vm-ip>
   sudo ipset list BLACKLIST | grep -c "<host-ip>"
   ```
   Expected: 0% packet loss and the source absent from `BLACKLIST`. Before this change the same probe lost ~63% and blacklisted the host for an hour.
