### PR TITLE
fix(chromecast): bound the externalNic wait so a wrong NIC fails visibly

### DIFF
--- a/modules/reference/services/nw-packet-forwarder/nw-packet-forwarder.nix
+++ b/modules/reference/services/nw-packet-forwarder/nw-packet-forwarder.nix
@@ -23,9 +23,20 @@ let
     --ccastvm-mac ${chromecastVmMac} \
     --ccastvm-ip ${chromecastVmIpAddr}/24
   '';
+  # Seconds to wait for externalNic before giving up. Bounded on purpose: an
+  # unbounded wait here logged "Waiting for IPv4 address on interface ..." every
+  # 10s forever while the unit reported "active". Failing loudly once is more useful than
+  # succeeding quietly at nothing.
+  externalNicTimeout = 60;
   nw-pckt-fwd-launcher = pkgs.writeShellScriptBin "nw-pckt-fwd" ''
     # Wait until the external interface has an IPv4 address (e.g. Wi-Fi connected).
+    deadline=$(( $(${pkgs.coreutils}/bin/date +%s) + ${toString externalNicTimeout} ))
     while [ -z "$(${pkgs.iproute2}/bin/ip -4 -o addr show dev ${cfg.externalNic} scope global 2>/dev/null)" ]; do
+      if [ "$(${pkgs.coreutils}/bin/date +%s)" -ge "$deadline" ]; then
+        echo "nw-pckt-fwd: '${cfg.externalNic}' has no global IPv4 address after ${toString externalNicTimeout}s - giving up." >&2
+        echo "nw-pckt-fwd: this NIC comes from ghaf.reference.services.chromecast.externalNic; it must name the interface that actually carries the LAN." >&2
+        exit 1
+      fi
       echo "Waiting for IPv4 address on interface ${cfg.externalNic}..."
       sleep 10
     done
@@ -111,6 +122,15 @@ in
 
     systemd.services."nw-packet-forwarder" = {
       description = "Network packet forwarder daemon";
+
+      # Restart=always below has no natural end, so bounding the wait in the
+      # launcher is not enough on its own -- without a start limit it would
+      # simply trade a 10s log-spam loop for a 75s restart loop. Give up after
+      # a few attempts so the unit lands in "failed" where it is visible.
+      unitConfig = {
+        StartLimitIntervalSec = 600;
+        StartLimitBurst = 3;
+      };
 
       bindsTo = [
         "sys-subsystem-net-devices-${cfg.externalNic}.device"

--- a/modules/reference/services/smcroute/smcroute.nix
+++ b/modules/reference/services/smcroute/smcroute.nix
@@ -8,6 +8,10 @@
 }:
 let
   cfg = config.services.smcroute;
+  # Seconds to wait for bindingNic to acquire an address before failing. Kept
+  # below the default TimeoutStartSec (90s) so our diagnostic is what gets
+  # logged, rather than systemd's generic "start-pre operation timed out".
+  bindingNicTimeout = 60;
 in
 {
   _file = ./smcroute.nix;
@@ -75,15 +79,34 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       requires = [ "network-online.target" ];
+      # Wait for the binding NIC to get an address, but bounded. This loop used
+      # to be unbounded, which turned "the interface never comes up" into a
+      # permanent restart loop: systemd killed preStart at TimeoutStartSec (90s),
+      # Restart=on-failure started it again, and round it went every ~95s
+      # forever.
       preStart = ''
-        # wait until ${cfg.bindingNic} has an ip
-        sleep 5
-        while [ -z "$ip" ]; do
-         ip=$(${pkgs.nettools}/bin/ifconfig ${cfg.bindingNic} | ${pkgs.gawk}/bin/awk '/inet / {print $2}')
-              [ -z "$ip" ] && ${pkgs.coreutils}/bin/sleep 1
+        deadline=$(( $(${pkgs.coreutils}/bin/date +%s) + ${toString bindingNicTimeout} ))
+        while :; do
+          if [ -n "$(${pkgs.iproute2}/bin/ip -4 -o addr show dev ${cfg.bindingNic} scope global 2>/dev/null)" ]; then
+            exit 0
+          fi
+          if [ "$(${pkgs.coreutils}/bin/date +%s)" -ge "$deadline" ]; then
+            echo "smcroute: '${cfg.bindingNic}' still has no global IPv4 address after ${toString bindingNicTimeout}s - giving up." >&2
+            echo "smcroute: this NIC comes from ghaf.reference.services.chromecast.externalNic; it must name the interface that actually carries the LAN." >&2
+            exit 1
+          fi
+          ${pkgs.coreutils}/bin/sleep 2
         done
-        exit 0
       '';
+
+      # Give up after a few attempts instead of restarting forever, so the unit
+      # lands in "failed" where `systemctl --failed` and the log collector can
+      # see it. Each attempt is bindingNicTimeout + RestartSec, so the interval
+      # has to be comfortably larger than burst * that.
+      unitConfig = {
+        StartLimitIntervalSec = 600;
+        StartLimitBurst = 3;
+      };
 
       serviceConfig = {
         Type = "simple";


### PR DESCRIPTION
smcroute and nw-packet-forwarder both wait for `externalNic` to acquire an IPv4 address before starting. Both waits were unbounded, and on any wired device that wait can never end.

`externalNic` is `(lib.head hardware.definition.network.pciDevices).name`. On the generic intel-laptop image that list holds exactly one hardcoded entry, `wlp0s5f0`, which exists only because these services need a static interface name -- see the TODO in intel-laptop.nix. A device on ethernet never associates that NIC, so:

  - smcroute's preStart looped forever, systemd killed it at TimeoutStartSec (90s), Restart=on-failure restarted it, and round it went every ~95s indefinitely.
  - nw-packet-forwarder looped inside ExecStart, logging "Waiting for IPv4 address on interface wlp0s5f0..." every 10s forever.

What made this expensive to find is that neither was visible. smcroute sat in "activating", never "failed", so `systemctl --failed` on net-vm reported the VM as completely clean while the unit had restarted 22 times; nw-packet-forwarder reported "active" while doing nothing at all. The Robot suite's "Check systemctl status in every VM" passed for the same reason. Observed on a Dell Latitude 7330 on wired ethernet.

Bound both waits to 60s -- under smcroute's 90s TimeoutStartSec, so our diagnostic is logged rather than systemd's generic "start-pre operation timed out" -- and name the offending interface and the option that set it. Add StartLimitIntervalSec/StartLimitBurst to both so they stop after three attempts and land in "failed". The start limit is not optional for nw-packet-forwarder: it uses Restart=always, so bounding the wait alone would only trade a 10s log-spam loop for a 75s restart loop.

This does not make Chromecast work on a wired device; the smcroute rules and iptables rules are still generated against the wrong interface. That needs the externalNic refactor the intel-laptop.nix TODO describes. This change only ensures the breakage announces itself instead of hiding.

Behaviour is otherwise unchanged: in both the old and new code the forwarder binary is never exec'd and smcrouted never starts when the NIC is absent, so only reporting differs.

Also switch smcroute's probe from `ifconfig | awk` to `ip -4 -o addr show`, dropping the nettools and gawk dependencies and matching what nw-packet-forwarder already used.

Verified on hardware after a netboot reinstall: both units reach `failed` with Result=start-limit-hit after 3 attempts, both appear in `systemctl --failed`, and the journal carries the diagnostic naming wlp0s5f0 and ghaf.reference.services.chromecast.externalNic.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
