### PR TITLE
feat(gpuvm): integrate CDI and managed GPU partitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,10 @@ asking or guessing; if a field is null in both, ask once and offer to write it t
   exist but are no longer the default path.
 - **Jetson targets must be named `-from-x86_64` on an x86 build host.** The native aarch64
   attributes are not in `packages.x86_64-linux`, so the plain name resolves to nothing.
+- **JetPack-only packages cannot use `packages/pkgs-by-name/`.** That directory and
+  `packages/own-pkgs-overlay.nix` expose packages for every system, while the JetPack overlay
+  is applied only inside Jetson configurations. Use a relative-path `callPackage` from a
+  JetPack-configured module, as `gpu-vm-load` does, to avoid breaking x86_64 evaluation.
 - **The image you flash is always `result/ghaf-image.raw.zst`** (plus `ghaf-image.bmap`,
   used automatically). No target emits `result/<target>.img` any more.
 - **The test suite names the physical machine, not the image**: `robot-test -d` takes

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -188,6 +188,7 @@ export default defineConfig({
                                 "ghaf/dev/technologies/nvidia_uarti_net_vm",
                                 "ghaf/dev/technologies/nvidia_mgbe0_net_vm",
                                 "ghaf/dev/technologies/nvidia_gpu_vm",
+                                "ghaf/dev/technologies/nvidia_gpu_partitioning",
                                 "ghaf/dev/technologies/nvidia_gpu_vm_display",
                               ],
                             },

--- a/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_partitioning.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_partitioning.mdx
@@ -79,8 +79,10 @@ directory or install a privileged runtime discovery helper.
 
 ## Configure Ghaf
 
-Both features are opt-in. A downstream module enables them and supplies at
-least one trusted plugin:
+Both features are opt-in for general configurations. The existing NX debug
+target enables them with the manager repository's mock plugin so CI evaluates
+and builds the complete integration. A downstream module supplies real trusted
+plugins:
 
 ```nix
 ghaf.hardware.nvidia.passthroughs.gpu_vm = {
@@ -125,9 +127,17 @@ not apply to the combined accelerated `gui-vm` topology.
 
 ## Build and Deploy an Example
 
-The standard Ghaf AGX and NX targets leave both options disabled. Use a
-downstream configuration, or build the complete configurations maintained in
-the examples repository:
+The Ghaf NX debug target builds the manager, probe, plugin validation, and CDI
+generator with the manager-owned mock plugin. It is integration coverage, not a
+GPU workload example:
+
+```bash
+nix build .#nvidia-jetson-orin-nx-debug-from-x86_64
+```
+
+The AGX target and NX release target leave both options disabled. Use a
+downstream configuration for real workloads, or build the complete
+configurations maintained in the examples repository:
 
 <Tabs>
   <TabItem label="AGX">
@@ -257,11 +267,12 @@ cd ghaf-gpu-partition-manager
 nix build -L .#checks.x86_64-linux.tests
 ```
 
-The standard AGX and NX targets keep both integration options disabled. A
-downstream configuration must enable them and supply a trusted ABI plugin, then
-build that exact configuration to compile the manager and probe, validate the
-plugin contract, and generate both CDI devices. This integration build is not
-a replacement for hardware testing.
+The existing NX debug target enables both options with the manager-owned mock
+plugin. Building it compiles the manager and probe, validates the plugin
+contract, and generates both CDI devices. AGX, NX release, and other
+configurations remain opt-in. Downstream configurations replace the default
+mock plugin with trusted workload plugins. Integration builds are not a
+replacement for hardware testing.
 
 Before claiming support on a board, verify the queried split, direct and
 managed CDI paths, simultaneous managed jobs, cancellation, endurance, guest

--- a/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_partitioning.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_partitioning.mdx
@@ -1,0 +1,278 @@
+---
+title: Managed GPU Partitions on NVIDIA Jetson Orin
+sidebar:
+  label: Managed GPU Partitions
+---
+
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
+
+Ghaf can divide the CUDA streaming multiprocessor (SM) resource in the split
+`gpu-vm` into two equal [CUDA Green Contexts][green-contexts]. A manager in
+`gpu-vm` owns the contexts and runs trusted, Nix-built workload plugins on
+their streams. Native processes and containers use the same local protocol.
+
+Ghaf owns the platform integration: NixOS options, service confinement,
+JetPack binding, and the Container Device Interface (CDI) specification. The
+[GPU partition manager repository][manager] owns the daemon, client, protocol,
+plugin SDK, and mock-CUDA tests. Workloads, OCI images, scenarios, and hardware
+measurements live in the downstream [examples repository][examples].
+
+This feature targets NVIDIA Jetson Orin AGX and Orin NX. The complete GA10B GPU
+remains assigned to one compute-only `gpu-vm`; `disp-vm` remains the display
+owner.
+
+<Aside type="caution">
+  Green Contexts provide cooperative SM placement, not security isolation,
+  fault containment, guaranteed concurrency, forward progress, or
+  memory-bandwidth isolation. An unrestricted CUDA process can interfere with
+  both managed slots.
+</Aside>
+
+## Architecture
+
+```text
+                         gpu-vm
+
+  native client                         managed container
+  gpu-partition-run                     gpu-partition-run
+           |                                   |
+           +------------- AF_UNIX -------------+
+                               |
+             /run/gpu-partition-manager/control.sock
+                               |
+                  gpu-partition-manager
+                    /                   \
+              slot 0 worker         slot 1 worker
+              Green Context         Green Context
+              half of SMs           half of SMs
+                    \                   /
+                     passed-through GA10B
+```
+
+At startup, the daemon queries CUDA device 0, requires two equal SM groups with
+no remainder, creates one Green Context and worker per group, loads only the
+configured immutable plugins, and then opens its group-restricted socket. It
+exits with `EX_CONFIG` (78) when the queried geometry cannot be divided as
+required; systemd does not restart that configuration failure.
+
+See the manager's [architecture][manager-architecture],
+[protocol][manager-protocol], [plugin API][manager-plugin-api], and
+[security model][manager-security] for the authoritative contracts.
+
+## CDI Devices
+
+The build-generated `/etc/cdi/nvidia.json` exposes these device names:
+
+| CDI device | GPU nodes | Manager socket | Purpose |
+| --- | --- | --- | --- |
+| `nvidia.com/gpu=all` | Complete JetPack set | No | Direct, unrestricted CUDA |
+| `nvidia.com/gpu=managed` | None | Yes | Jobs submitted through the manager |
+
+The unrestricted device preserves the existing `gpu=all` behavior. It also
+lets a process bypass the manager. The managed device injects the client and
+socket but no `/dev/nvgpu`, `/dev/nvhost-*`, `/dev/nvmap`, DRM render, or
+host1x-fence nodes.
+
+The CDI spec is immutable and generated at build time. Docker reads CDI specs
+only from `/etc/cdi`; Ghaf does not enable Docker's writable `/var/run/cdi`
+directory or install a privileged runtime discovery helper.
+
+## Configure Ghaf
+
+Both features are opt-in. A downstream module enables them and supplies at
+least one trusted plugin:
+
+```nix
+ghaf.hardware.nvidia.passthroughs.gpu_vm = {
+  containerRuntime.enable = true;
+  partitionManager = {
+    enable = true;
+    plugins = [ myWorkloadPlugin ];
+  };
+};
+```
+
+Each plugin package must:
+
+- expose `gpuPartitionPluginName`;
+- expose `requiredPluginAbiVersion` matching the manager ABI; and
+- install `lib/gpu-partition-manager/plugin.so`.
+
+Ghaf validates the metadata during evaluation and the shared-object path while
+building the VM closure. The manager repository exports the ABI-v1 SDK through
+`lib.mkSdk`; Ghaf also makes it available as
+`pkgs.gpu-vm-partition-manager-sdk` inside configured package sets.
+
+The runtime is rootful Docker. By default only root controls Docker. This
+optional setting adds `ghaf` to the `docker` group:
+
+```nix
+ghaf.hardware.nvidia.passthroughs.gpu_vm.containerRuntime = {
+  enable = true;
+  addGhafUserToDockerGroup = true;
+};
+```
+
+<Aside type="danger">
+  Membership in the `docker` group is root-equivalent inside `gpu-vm`: a user
+  can start a privileged container and mount the guest filesystem. Enable it
+  only when that matches the image's trust model.
+</Aside>
+
+These options have an effect only when the split
+`ghaf.hardware.nvidia.passthroughs.gpu_vm.enable` topology is selected. They do
+not apply to the combined accelerated `gui-vm` topology.
+
+## Build and Deploy an Example
+
+The standard Ghaf AGX and NX targets leave both options disabled. Use a
+downstream configuration, or build the complete configurations maintained in
+the examples repository:
+
+<Tabs>
+  <TabItem label="AGX">
+
+```bash
+git clone https://github.com/tiiuae/ghaf-gpu-partitioning-examples
+cd ghaf-gpu-partitioning-examples
+nix build .#nvidia-jetson-orin-agx-gpu-partitioning-example
+nix build .#nvidia-jetson-orin-agx-flash-script \
+  --max-jobs 8 -o result-flash
+```
+
+  </TabItem>
+  <TabItem label="NX">
+
+```bash
+git clone https://github.com/tiiuae/ghaf-gpu-partitioning-examples
+cd ghaf-gpu-partitioning-examples
+nix build .#nvidia-jetson-orin-nx-gpu-partitioning-example
+nix build .#nvidia-jetson-orin-nx-flash-script \
+  --max-jobs 8 -o result-flash
+```
+
+  </TabItem>
+</Tabs>
+
+Follow the examples repository's [user guide][examples-user-guide] for image
+selection, recovery-mode checks, flashing, and its reproducible scenarios.
+Flashing is destructive; verify the board and recovery USB identity before
+running a flash script.
+
+Connect using the configured VM hostname rather than a topology-dependent IP:
+
+```bash
+ssh ghaf@NET_VM_ADDRESS
+ssh ghaf@gpu-vm
+```
+
+## Operate the Manager
+
+The client uses `/run/gpu-partition-manager/control.sock` by default:
+
+```bash
+gpu-partition-run --help
+gpu-partition-run list
+gpu-partition-run status
+gpu-partition-run WORKLOAD [ARGS...]
+gpu-partition-run --slot 1 WORKLOAD [ARGS...]
+gpu-partition-run cancel JOB_ID
+```
+
+The scheduler runs one job per slot and queues bounded work per slot. Automatic
+placement selects the idle or shorter queue. Disconnecting a waiting client or
+sending `Ctrl+C` requests cancellation. Refer to the manager's protocol page
+for exact limits, status values, and compatibility rules.
+
+The Green Context geometry probe is installed only when
+`partitionManager.enable` is true:
+
+```bash
+gpu-vm-green-context-probe
+```
+
+It queries the real CUDA resource geometry independently of the manager and is
+useful for board bring-up. It does not prove concurrent execution or workload
+isolation.
+
+## Run Containers
+
+Use the managed device to submit a configured workload without granting the
+container direct GPU access:
+
+```bash
+docker run --rm --device nvidia.com/gpu=managed IMAGE \
+  /opt/ghaf/bin/gpu-partition-run WORKLOAD [ARGS...]
+```
+
+The v1 interface expects the process in the rootful container to run as root so
+it can connect to the group-restricted socket. The plugin executes inside the
+trusted manager process, not inside the container process.
+
+Use the unrestricted device for applications that initialize CUDA directly:
+
+```bash
+docker run --rm --device nvidia.com/gpu=all IMAGE
+```
+
+## Service and Troubleshooting
+
+```bash
+systemctl status gpu-partition-manager
+journalctl -u gpu-partition-manager -b
+gpu-partition-run status
+```
+
+The service runs as the dedicated `gpu-partition` user with `video` group
+access. Its systemd sandbox uses a private network namespace, permits only
+`AF_UNIX`, removes capabilities, and restricts namespaces, kernel controls,
+IPC, and writable filesystem access. Do not enable
+`MemoryDenyWriteExecute`; CUDA's PTX JIT needs executable mappings.
+
+- Exit status 78 means the runtime geometry is unsupported. Inspect the total
+  SM count, split, remainder, and Green Context readback.
+- For repeated failures, find the first CUDA or plugin error and inspect the
+  guest kernel log for `nvgpu` faults.
+- If a managed container cannot connect, check service readiness, socket group
+  access, and the managed entry in `/etc/cdi/nvidia.json`.
+- If a managed container contains GPU device nodes, stop the test and inspect
+  the CDI spec; the managed entry must contain mounts only.
+- Record any simultaneous `gpu=all` workload as unmanaged interference.
+
+## Development and Validation
+
+Keep ownership boundaries explicit:
+
+- Ghaf owns platform modules, service confinement, CDI generation, and target
+  integration.
+- The manager repository owns source, wire protocol, plugin ABI, constructors,
+  and mock-CUDA integration tests.
+- The examples repository owns plugins, images, scenarios, and measurements.
+
+Validate manager state-machine changes without hardware:
+
+```bash
+git clone https://github.com/tiiuae/ghaf-gpu-partition-manager
+cd ghaf-gpu-partition-manager
+nix build -L .#checks.x86_64-linux.tests
+```
+
+The standard AGX and NX targets keep both integration options disabled. A
+downstream configuration must enable them and supply a trusted ABI plugin, then
+build that exact configuration to compile the manager and probe, validate the
+plugin contract, and generate both CDI devices. This integration build is not
+a replacement for hardware testing.
+
+Before claiming support on a board, verify the queried split, direct and
+managed CDI paths, simultaneous managed jobs, cancellation, endurance, guest
+`nvgpu` errors, daemon restarts, and `gpu-vm` restarts. Report measurements as
+observations rather than isolation guarantees.
+
+[green-contexts]: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__GREEN__CONTEXTS.html
+[manager]: https://github.com/tiiuae/ghaf-gpu-partition-manager
+[manager-architecture]: https://github.com/tiiuae/ghaf-gpu-partition-manager/blob/main/docs/architecture.md
+[manager-protocol]: https://github.com/tiiuae/ghaf-gpu-partition-manager/blob/main/docs/protocol.md
+[manager-plugin-api]: https://github.com/tiiuae/ghaf-gpu-partition-manager/blob/main/docs/plugin-api.md
+[manager-security]: https://github.com/tiiuae/ghaf-gpu-partition-manager/blob/main/docs/security.md
+[examples]: https://github.com/tiiuae/ghaf-gpu-partitioning-examples
+[examples-user-guide]: https://github.com/tiiuae/ghaf-gpu-partitioning-examples/blob/main/docs/user-guide.md

--- a/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_vm.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_vm.mdx
@@ -1,10 +1,10 @@
 ---
-title: NVIDIA Jetson AGX Orin GPU Passthrough to gpu-vm
+title: NVIDIA Jetson Orin GPU Passthrough to gpu-vm
 sidebar:
   label: GPU Passthrough to gpu-vm
 ---
 
-The AGX Orin's integrated GPU (`ga10b`, `gpu@17000000`) and its host1x
+The Orin AGX or NX integrated GPU (`ga10b`, `gpu@17000000`) and its host1x
 multimedia engines are passed through to a dedicated `gpu-vm` microVM, so CUDA
 compute runs in an isolated guest instead of on the host. It coexists with the
 MGBE0 ethernet passthrough (`net-vm`), sharing the same BPMP-virtualisation and
@@ -13,10 +13,11 @@ MGBE0 ethernet passthrough (`net-vm`), sharing the same BPMP-virtualisation and
 import { Aside } from "@astrojs/starlight/components";
 
 <Aside>
-  Verified on the NVIDIA Jetson AGX Orin devkit. The guest binds `gk20a`,
+  Verified on the NVIDIA Jetson AGX Orin devkit; NX hardware validation is
+  pending. AGX and NX select their GPU payload from a build-time board table,
+  and the GPU is enabled per SoM, never in the shared `orin.nix`. The guest binds `gk20a`,
   creates `/dev/nvgpu/igpu0`, and CUDA `cuInit` succeeds —
-  `__nvcc_device_query` returns `87` (sm_87 / ga10b). AGX Orin only: the GPU is
-  enabled per-SoM, never in the shared `orin.nix`.
+  `__nvcc_device_query` returns `87` (sm_87 / ga10b).
 </Aside>
 
 <Aside>
@@ -118,10 +119,12 @@ is handed to vfio.
 
 ## Use
 
-### Enable (per-SoM, AGX only)
+For cooperative CUDA SM job placement and managed containers, see
+[Managed GPU Partitions](/ghaf/dev/technologies/nvidia_gpu_partitioning/).
 
-Set in the AGX SoM files (`orin-agx.nix`, `orin-agx64.nix`,
-`orin-agx-industrial.nix`):
+### Enable per SoM
+
+Set in the AGX or NX SoM module:
 
 ```nix
 ghaf.hardware.nvidia.passthroughs.gpu_vm.enable = true;
@@ -149,7 +152,7 @@ nix build .#packages.aarch64-linux.nvidia-jetson-orin-agx-accelerated-guivm-debu
 
 ### Verify GPU compute
 
-From the host, reach the guest (`ssh ghaf@gpu-vm`, `192.168.100.3`):
+From the host, reach the guest by its configured hostname (`ssh ghaf@gpu-vm`):
 
 Run everything as the unprivileged `ghaf` user. Do **not** use `sudo`: the
 boot service group-grants the GPU nodes so no privilege is needed, and `sudo`

--- a/flake.lock
+++ b/flake.lock
@@ -385,6 +385,26 @@
         "type": "github"
       }
     },
+    "gpu-partition-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786134357,
+        "narHash": "sha256-lX4FYmO3obHgmEtrREXISFUYVdeobxvZH6Sy+wjRzTE=",
+        "owner": "tiiuae",
+        "repo": "ghaf-gpu-partition-manager",
+        "rev": "f79b6ffc6dd4bf731b1189deec94e9dc76999826",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "repo": "ghaf-gpu-partition-manager",
+        "type": "github"
+      }
+    },
     "jetpack-nixos": {
       "inputs": {
         "cuda-legacy": "cuda-legacy",
@@ -578,6 +598,7 @@
         "git-hooks-nix": "git-hooks-nix",
         "givc": "givc",
         "gp-gui": "gp-gui",
+        "gpu-partition-manager": "gpu-partition-manager",
         "jetpack-nixos": "jetpack-nixos",
         "microvm": "microvm",
         "nix-store-veritysetup-generator": "nix-store-veritysetup-generator",

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,12 @@
       };
     };
 
+    # Cooperative CUDA Green Context scheduler used by gpu-vm.
+    gpu-partition-manager = {
+      url = "github:tiiuae/ghaf-gpu-partition-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Nvidia Orin support for NixOS
     jetpack-nixos = {
       #url = "github:anduril/jetpack-nixos";

--- a/modules/common/users/admin.nix
+++ b/modules/common/users/admin.nix
@@ -79,6 +79,11 @@ in
       type = types.listOf types.str;
       default = [ ];
     };
+    addToDockerGroup = mkOption {
+      description = "Whether to add the admin user to the root-equivalent Docker group when Docker is enabled.";
+      type = types.bool;
+      default = true;
+    };
   };
 
   config = mkIf cfg.enable {
@@ -118,7 +123,7 @@ in
           ]
           ++ cfg.extraGroups
           ++ optionals config.security.tpm2.enable [ "tss" ]
-          ++ optionals config.virtualisation.docker.enable [ "docker" ];
+          ++ optionals (config.virtualisation.docker.enable && cfg.addToDockerGroup) [ "docker" ];
         };
       };
       groups = {

--- a/modules/microvm/sysvms/gpuvm-base.nix
+++ b/modules/microvm/sysvms/gpuvm-base.nix
@@ -30,6 +30,8 @@ in
     inputs.self.nixosModules.hardware-x86_64-guest-kernel
     inputs.self.nixosModules.vm-modules
     inputs.self.nixosModules.profiles
+    ./gpuvm-container-runtime.nix
+    ./gpuvm-partition-manager.nix
   ];
 
   ghaf = {
@@ -52,7 +54,11 @@ in
     # User configuration - from hostConfig
     users = {
       profile = hostConfig.users.profile or { };
-      admin = hostConfig.users.admin or { };
+      admin = (hostConfig.users.admin or { }) // {
+        # hostConfig is already evaluated, so preserve this copied default at
+        # default priority for the GPU-VM runtime's explicit policy override.
+        addToDockerGroup = lib.mkDefault (hostConfig.users.admin.addToDockerGroup or true);
+      };
       managed = hostConfig.users.managed or { };
     };
 
@@ -144,7 +150,7 @@ in
     ++ [
       pkgs.gcc
       # Prebuilt smoke test (driver API + embedded PTX, RPATH-wired to native
-      # libcuda), built at image time since the guest can't compile on-device.
+      # libcuda) so routine verification does not need an on-device build.
       (pkgs.callPackage ../../../packages/gpu-vm-load/package.nix {
         inherit (pkgs) nvidia-jetpack;
       })
@@ -163,10 +169,21 @@ in
       RemainAfterExit = true;
     };
     script = ''
+      for attempt in $(${pkgs.coreutils}/bin/seq 1 30); do
+        if [ -e /dev/nvgpu/igpu0/ctrl ]; then
+          break
+        fi
+        if [ "$attempt" -eq 30 ]; then
+          echo "GPU control node did not appear within 30 seconds" >&2
+          exit 1
+        fi
+        ${pkgs.coreutils}/bin/sleep 1
+      done
+
       for d in /dev/nvgpu /dev/nvhost-* /dev/nvmap; do
         [ -e "$d" ] || continue
-        chgrp -R video "$d" || true
-        chmod -R g+rw "$d" || true
+        chgrp -R video "$d"
+        chmod -R g+rw "$d"
       done
     '';
   };

--- a/modules/microvm/sysvms/gpuvm-container-runtime.nix
+++ b/modules/microvm/sysvms/gpuvm-container-runtime.nix
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.virtualization.gpuContainerRuntime;
+  partitionCfg = config.ghaf.virtualization.gpuPartitionManager;
+  partitionManager = inputs.gpu-partition-manager.lib.mkManager {
+    inherit pkgs;
+    cudaHeaders = pkgs.nvidia-jetpack.cudaPackages.cuda_cudart;
+    cudaDriver = pkgs.nvidia-jetpack.l4t-cuda;
+  };
+  partitionClient = pkgs.runCommand "gpu-partition-client" { } ''
+    install -Dm755 ${partitionManager}/bin/gpu-partition-run \
+      $out/bin/gpu-partition-run
+  '';
+  cudaClosureInfo = pkgs.closureInfo { rootPaths = [ pkgs.nvidia-jetpack.l4t-cuda ]; };
+  cudaLibPath = lib.makeLibraryPath [ pkgs.nvidia-jetpack.l4t-cuda ];
+  managedClosureInfo = pkgs.closureInfo { rootPaths = [ partitionClient ]; };
+  jqArgs = [
+    "--rawfile"
+    "paths"
+    "${cudaClosureInfo}/store-paths"
+  ]
+  ++ (
+    if partitionCfg.enable then
+      [
+        "--rawfile"
+        "managedPaths"
+        "${managedClosureInfo}/store-paths"
+        "--arg"
+        "client"
+        "${partitionClient}/bin/gpu-partition-run"
+      ]
+    else
+      [
+        "--arg"
+        "managedPaths"
+        ""
+        "--arg"
+        "client"
+        ""
+      ]
+  )
+  ++ [
+    "--arg"
+    "libPath"
+    cudaLibPath
+    "--arg"
+    "managed"
+    (lib.boolToString partitionCfg.enable)
+  ];
+
+  # The guest device layout is fixed by the passthrough DTS. Generate the CDI
+  # specification at build time so gpu-vm does not need a mutable toolkit or a
+  # privileged discovery helper at runtime.
+  nvidiaCdiSpec =
+    pkgs.runCommand "nvidia-cdi-spec" { nativeBuildInputs = [ pkgs.buildPackages.jq ]; }
+      ''
+        jq -n ${lib.escapeShellArgs jqArgs} \
+          '{
+            cdiVersion: "0.6.0",
+            kind: "nvidia.com/gpu",
+            devices: [
+              {
+                name: "all",
+                containerEdits: {
+                  # Hardware-enumerated set on JetPack r36. libcuda also needs
+                  # the DRM render node and host1x fence for initialization.
+                  deviceNodes: (
+                    [
+                      "/dev/nvhost-as-gpu",
+                      "/dev/nvhost-ctrl-gpu",
+                      "/dev/nvhost-ctxsw-gpu",
+                      "/dev/nvhost-dbg-gpu",
+                      "/dev/nvhost-gpu",
+                      "/dev/nvhost-nvsched-gpu",
+                      "/dev/nvhost-nvsched_ctrl_fifo-gpu",
+                      "/dev/nvhost-power-gpu",
+                      "/dev/nvhost-prof-ctx-gpu",
+                      "/dev/nvhost-prof-dev-gpu",
+                      "/dev/nvhost-prof-gpu",
+                      "/dev/nvhost-sched-gpu",
+                      "/dev/nvhost-tsg-gpu",
+                      "/dev/nvmap",
+                      "/dev/nvgpu/igpu0/as",
+                      "/dev/nvgpu/igpu0/channel",
+                      "/dev/nvgpu/igpu0/ctrl",
+                      "/dev/nvgpu/igpu0/ctxsw",
+                      "/dev/nvgpu/igpu0/dbg",
+                      "/dev/nvgpu/igpu0/nvsched",
+                      "/dev/nvgpu/igpu0/nvsched_ctrl_fifo",
+                      "/dev/nvgpu/igpu0/power",
+                      "/dev/nvgpu/igpu0/prof",
+                      "/dev/nvgpu/igpu0/prof-ctx",
+                      "/dev/nvgpu/igpu0/prof-dev",
+                      "/dev/nvgpu/igpu0/sched",
+                      "/dev/nvgpu/igpu0/tsg",
+                      "/dev/dri/renderD128",
+                      "/dev/host1x-fence"
+                    ] | map({ path: . })
+                  )
+                }
+              }
+            ] + (if $managed == "true" then [
+              {
+                name: "managed",
+                containerEdits: {
+                  env: [ "GPU_PARTITION_SOCKET=/run/gpu-partition-manager/control.sock" ],
+                  mounts: (
+                    ((($managedPaths | split("\n") | map(select(length > 0)))
+                      - ($paths | split("\n") | map(select(length > 0)))) | map({
+                      hostPath: .,
+                      containerPath: .,
+                      options: [ "ro", "bind", "nosuid", "nodev" ]
+                    })) + [
+                      {
+                        hostPath: $client,
+                        containerPath: "/opt/ghaf/bin/gpu-partition-run",
+                        options: [ "ro", "bind", "nosuid", "nodev" ]
+                      },
+                      {
+                        hostPath: "/run/gpu-partition-manager/control.sock",
+                        containerPath: "/run/gpu-partition-manager/control.sock",
+                        options: [ "bind", "nosuid", "nodev" ]
+                      }
+                    ]
+                  )
+                }
+              }
+            ] else [] end),
+            containerEdits: {
+              env: [ ("LD_LIBRARY_PATH=" + $libPath) ],
+              mounts: (
+                $paths | split("\n") | map(select(length > 0) | {
+                  hostPath: .,
+                  containerPath: .,
+                  options: [ "ro", "bind", "nosuid", "nodev" ]
+                })
+              )
+            }
+          }' > "$out"
+      '';
+in
+{
+  _file = ./gpuvm-container-runtime.nix;
+
+  options.ghaf.virtualization.gpuContainerRuntime = {
+    enable = lib.mkEnableOption "rootful Docker with NVIDIA CDI devices in gpu-vm";
+
+    addGhafUserToDockerGroup = lib.mkEnableOption ''
+      root-equivalent Docker access for the ghaf user in gpu-vm
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    ghaf.storagevm.directories = [
+      {
+        directory = "/var/lib/docker";
+        mode = "0710";
+      }
+    ];
+
+    ghaf.users.admin.addToDockerGroup = cfg.addGhafUserToDockerGroup;
+
+    virtualisation.docker = {
+      enable = true;
+      daemon.settings = {
+        features.cdi = true;
+        cdi-spec-dirs = [ "/etc/cdi" ];
+        no-new-privileges = true;
+      };
+    };
+
+    environment.etc."cdi/nvidia.json".source = nvidiaCdiSpec;
+  };
+}

--- a/modules/microvm/sysvms/gpuvm-partition-manager.nix
+++ b/modules/microvm/sysvms/gpuvm-partition-manager.nix
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.virtualization.gpuPartitionManager;
+  manager = inputs.gpu-partition-manager.lib.mkManager {
+    inherit pkgs;
+    cudaHeaders = pkgs.nvidia-jetpack.cudaPackages.cuda_cudart;
+    cudaDriver = pkgs.nvidia-jetpack.l4t-cuda;
+  };
+  probe = pkgs.callPackage ../../../packages/gpu-vm-green-context-probe/package.nix {
+    inherit (pkgs) nvidia-jetpack;
+  };
+  pluginLabel = plugin: plugin.pname or plugin.name or (toString plugin);
+  pluginsWithoutName = lib.filter (plugin: !(plugin ? gpuPartitionPluginName)) cfg.plugins;
+  pluginsWithWrongAbi = lib.filter (
+    plugin: (plugin.requiredPluginAbiVersion or null) != manager.pluginAbiVersion
+  ) cfg.plugins;
+  pluginNames = map (plugin: plugin.gpuPartitionPluginName or null) cfg.plugins;
+  duplicatePluginNames = lib.unique (
+    lib.filter (
+      name: name != null && lib.count (candidate: candidate == name) pluginNames > 1
+    ) pluginNames
+  );
+  validatedPlugins = pkgs.runCommand "gpu-partition-manager-plugins" { } ''
+    mkdir -p $out/lib/gpu-partition-manager
+    ${lib.concatMapStringsSep "\n" (plugin: ''
+      if [ ! -f ${plugin}/lib/gpu-partition-manager/plugin.so ]; then
+        echo "${pluginLabel plugin}: missing lib/gpu-partition-manager/plugin.so" >&2
+        exit 1
+      fi
+      ln -s ${plugin}/lib/gpu-partition-manager/plugin.so \
+        $out/lib/gpu-partition-manager/${plugin.gpuPartitionPluginName or "invalid"}.so
+    '') cfg.plugins}
+  '';
+  pluginArguments = lib.concatMap (plugin: [
+    "--plugin"
+    "${validatedPlugins}/lib/gpu-partition-manager/${plugin.gpuPartitionPluginName or "invalid"}.so"
+  ]) cfg.plugins;
+in
+{
+  _file = ./gpuvm-partition-manager.nix;
+
+  options.ghaf.virtualization.gpuPartitionManager = {
+    enable = lib.mkEnableOption "cooperative CUDA Green Context job manager";
+
+    plugins = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = ''
+        Trusted Nix packages implementing the gpu-partition-manager ABI.
+        Each package must expose gpuPartitionPluginName and
+        requiredPluginAbiVersion, and install its shared object at
+        lib/gpu-partition-manager/plugin.so.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.plugins != [ ];
+        message = "gpuPartitionManager requires at least one trusted plugin";
+      }
+      {
+        assertion = lib.all (plugin: plugin ? gpuPartitionPluginName) cfg.plugins;
+        message = "gpuPartitionManager plugins missing gpuPartitionPluginName: ${
+          lib.concatMapStringsSep ", " pluginLabel pluginsWithoutName
+        }";
+      }
+      {
+        assertion = pluginsWithWrongAbi == [ ];
+        message = "gpuPartitionManager plugins missing or not using manager ABI ${toString manager.pluginAbiVersion}: ${
+          lib.concatMapStringsSep ", " pluginLabel pluginsWithWrongAbi
+        }";
+      }
+      {
+        assertion = duplicatePluginNames == [ ];
+        message = "gpuPartitionManager plugin names must be unique; duplicated names: ${lib.concatStringsSep ", " duplicatePluginNames}";
+      }
+    ];
+
+    users.groups.gpu-partition = { };
+    users.users = {
+      gpu-partition = {
+        isSystemUser = true;
+        group = "gpu-partition";
+        extraGroups = [ "video" ];
+      };
+      ghaf.extraGroups = [ "gpu-partition" ];
+    };
+
+    environment.systemPackages = [
+      manager
+      probe
+    ];
+
+    systemd.services.gpu-partition-manager = {
+      description = "Managed CUDA Green Context jobs";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "gpu-vm-node-access.service" ];
+      after = [ "gpu-vm-node-access.service" ];
+      unitConfig = {
+        StartLimitIntervalSec = 300;
+        StartLimitBurst = 12;
+      };
+      serviceConfig = {
+        Type = "simple";
+        User = "gpu-partition";
+        Group = "gpu-partition";
+        RuntimeDirectory = "gpu-partition-manager";
+        RuntimeDirectoryMode = "0750";
+        UMask = "0007";
+        ExecStart = lib.escapeShellArgs ([ "${manager}/bin/gpu-partition-manager" ] ++ pluginArguments);
+        Restart = "on-failure";
+        RestartSec = 10;
+        # 78 = EX_CONFIG: the daemon exits with this when the GPU geometry
+        # cannot be split evenly. Never restart into an unsupported geometry.
+        RestartPreventExitStatus = 78;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateNetwork = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        CapabilityBoundingSet = [ "" ];
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        RemoveIPC = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        ProtectProc = "invisible";
+        SystemCallArchitectures = "native";
+        LockPersonality = true;
+      };
+    };
+  };
+}

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -146,7 +146,7 @@ let
       '';
 
   # preFlashCommands: Extract images from sdImage and patch flash.xml
-  preFlashScript = pkgs.writeShellApplication {
+  preFlashScript = pkgs.pkgsBuildBuild.writeShellApplication {
     name = "pre-flash-commands";
     runtimeInputs = [
       pkgs.pkgsBuildBuild.zstd

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/default.nix
@@ -33,10 +33,29 @@ in
 {
   _file = ./default.nix;
 
-  options.ghaf.hardware.nvidia.passthroughs.gpu_vm.enable = lib.mkOption {
-    type = lib.types.bool;
-    default = false;
-    description = "Pass the Tegra234 GPU and engines through to gpu-vm on NVIDIA Orin AGX";
+  options.ghaf.hardware.nvidia.passthroughs.gpu_vm = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Pass the Tegra234 GPU and engines through to gpu-vm on NVIDIA Orin AGX or NX";
+    };
+
+    containerRuntime = {
+      enable = lib.mkEnableOption "Docker with NVIDIA CDI devices in gpu-vm";
+      addGhafUserToDockerGroup = lib.mkEnableOption ''
+        root-equivalent Docker access for the ghaf user in gpu-vm
+      '';
+    };
+
+    partitionManager = {
+      enable = lib.mkEnableOption "the cooperative CUDA Green Context job manager in gpu-vm; a downstream configuration must also supply trusted workload plugins";
+
+      plugins = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [ ];
+        description = "Trusted Nix-built workload plugins loaded by gpu-partition-manager.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -117,6 +136,14 @@ in
         inherit (payload) vfioArgs;
         inherit (virt) sourcesPatch;
       })
+      {
+        ghaf.virtualization.gpuPartitionManager = {
+          inherit (cfg.partitionManager) enable plugins;
+        };
+        ghaf.virtualization.gpuContainerRuntime = {
+          inherit (cfg.containerRuntime) enable addGhafUserToDockerGroup;
+        };
+      }
     ];
   };
 }

--- a/packages/gpu-vm-green-context-probe/package.nix
+++ b/packages/gpu-vm-green-context-probe/package.nix
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deliberately not in packages/pkgs-by-name/ or packages/own-pkgs-overlay.nix:
+# both expose packages for every system, and nvidia-jetpack is absent from the
+# flake's perSystem pkgs. A CUDA package there breaks x86_64 evaluation. Reach
+# this package through a JetPack-configured relative-path callPackage instead.
+{
+  stdenv,
+  nvidia-jetpack,
+}:
+stdenv.mkDerivation {
+  pname = "gpu-vm-green-context-probe";
+  version = "1.0";
+  src = ./.;
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+    $CC -Wall -Wextra -Werror \
+      -I${nvidia-jetpack.cudaPackages.cuda_cudart}/include runner.c \
+      -o gpu-vm-green-context-probe \
+      -L${nvidia-jetpack.l4t-cuda}/lib -l:libcuda.so.1 \
+      -Wl,-rpath,${nvidia-jetpack.l4t-cuda}/lib
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 gpu-vm-green-context-probe \
+      $out/bin/gpu-vm-green-context-probe
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CUDA Green Context capability probe for gpu-vm";
+    platforms = [ "aarch64-linux" ];
+    mainProgram = "gpu-vm-green-context-probe";
+  };
+}

--- a/packages/gpu-vm-green-context-probe/runner.c
+++ b/packages/gpu-vm-green-context-probe/runner.c
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verify that the passed-through GPU supports two CUDA Green Context resource
+// groups. This diagnostic deliberately launches no workload kernels.
+#include <cuda.h>
+
+#include <errno.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct green_partition {
+  CUdevice device;
+  CUcontext primary;
+  bool primary_retained;
+  CUdevResource groups[2];
+  CUdevResource remainder;
+  CUdevResourceDesc descriptors[2];
+  CUgreenCtx contexts[2];
+  unsigned int group_count;
+};
+
+static void cuda_result(const char *call, CUresult result) {
+  const char *name = "unknown";
+  const char *description = "unknown";
+
+  (void)cuGetErrorName(result, &name);
+  (void)cuGetErrorString(result, &description);
+  printf("CUDA call=%s result=%d name=%s description=%s\n", call,
+         (int)result, name != NULL ? name : "unknown",
+         description != NULL ? description : "unknown");
+}
+
+#define PROBE_CALL(expression)                                                 \
+  do {                                                                         \
+    CUresult call_result = (expression);                                       \
+    cuda_result(#expression, call_result);                                     \
+    if (call_result == CUDA_ERROR_NOT_SUPPORTED) {                             \
+      fprintf(stderr,                                                          \
+              "GREEN_CONTEXT_UNSUPPORTED reason=cuda_api call=%s\n",         \
+              #expression);                                                    \
+      goto fail;                                                               \
+    }                                                                          \
+    if (call_result != CUDA_SUCCESS) {                                         \
+      fprintf(stderr, "GREEN_CONTEXT_FAIL reason=cuda_api call=%s\n",        \
+              #expression);                                                    \
+      goto fail;                                                               \
+    }                                                                          \
+  } while (0)
+
+static bool parse_unsigned(const char *text, unsigned int minimum,
+                           unsigned int maximum, unsigned int *value) {
+  char *end = NULL;
+  unsigned long parsed;
+
+  errno = 0;
+  parsed = strtoul(text, &end, 10);
+  if (errno != 0 || text[0] == '\0' || end == NULL || *end != '\0' ||
+      parsed < minimum || parsed > maximum)
+    return false;
+  *value = (unsigned int)parsed;
+  return true;
+}
+
+static void usage(FILE *stream, const char *program) {
+  fprintf(stream, "Usage: %s [--min-sm-count N]\n", program);
+}
+
+static bool parse_options(int argc, char **argv,
+                          unsigned int *min_sm_count) {
+  static const struct option long_options[] = {
+      {"min-sm-count", required_argument, NULL, 'm'},
+      {"help", no_argument, NULL, 'h'},
+      {NULL, 0, NULL, 0},
+  };
+  int option;
+
+  *min_sm_count = 4;
+  while ((option = getopt_long(argc, argv, "m:h", long_options, NULL)) != -1) {
+    switch (option) {
+    case 'm':
+      if (!parse_unsigned(optarg, 1, 1024, min_sm_count))
+        return false;
+      break;
+    case 'h':
+      usage(stdout, argv[0]);
+      exit(EXIT_SUCCESS);
+    default:
+      return false;
+    }
+  }
+  return optind == argc;
+}
+
+static void destroy_partition(struct green_partition *partition) {
+  for (int index = 1; index >= 0; index--) {
+    if (partition->contexts[index] != NULL) {
+      CUresult result = cuGreenCtxDestroy(partition->contexts[index]);
+      cuda_result("cuGreenCtxDestroy", result);
+      partition->contexts[index] = NULL;
+    }
+  }
+  if (partition->primary_retained) {
+    CUresult result = cuDevicePrimaryCtxRelease(partition->device);
+    cuda_result("cuDevicePrimaryCtxRelease", result);
+    partition->primary_retained = false;
+  }
+}
+
+static bool create_partition(struct green_partition *partition,
+                             unsigned int min_sm_count) {
+  CUdevResource device_resource = {0};
+  CUdevResource queried = {0};
+  unsigned int dry_run_groups = 2;
+  int driver_version = 0;
+  int device_count = 0;
+  int major = 0;
+  int minor = 0;
+  char device_name[256] = {0};
+
+  memset(partition, 0, sizeof(*partition));
+
+  PROBE_CALL(cuInit(0));
+  PROBE_CALL(cuDriverGetVersion(&driver_version));
+  PROBE_CALL(cuDeviceGetCount(&device_count));
+  if (device_count < 1) {
+    fprintf(stderr, "GREEN_CONTEXT_UNSUPPORTED reason=no_cuda_device\n");
+    goto fail;
+  }
+  PROBE_CALL(cuDeviceGet(&partition->device, 0));
+  PROBE_CALL(cuDeviceGetName(device_name, sizeof(device_name),
+                             partition->device));
+  PROBE_CALL(cuDeviceGetAttribute(
+      &major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, partition->device));
+  PROBE_CALL(cuDeviceGetAttribute(
+      &minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, partition->device));
+  printf("device=0 name=%s driver_version=%d compute_capability=sm_%d%d\n",
+         device_name, driver_version, major, minor);
+
+  PROBE_CALL(cuDevicePrimaryCtxRetain(&partition->primary,
+                                      partition->device));
+  partition->primary_retained = true;
+  PROBE_CALL(cuCtxSetCurrent(partition->primary));
+  PROBE_CALL(cuDeviceGetDevResource(partition->device, &device_resource,
+                                    CU_DEV_RESOURCE_TYPE_SM));
+  printf("device_sm_count=%u requested_groups=2 min_sm_count=%u\n",
+         device_resource.sm.smCount, min_sm_count);
+
+  PROBE_CALL(cuDevSmResourceSplitByCount(
+      NULL, &dry_run_groups, &device_resource, NULL, 0, min_sm_count));
+  printf("dry_run_group_count=%u\n", dry_run_groups);
+  if (dry_run_groups < 2) {
+    fprintf(stderr,
+            "GREEN_CONTEXT_UNSUPPORTED reason=insufficient_symmetric_groups "
+            "groups=%u\n",
+            dry_run_groups);
+    goto fail;
+  }
+
+  partition->group_count = 2;
+  PROBE_CALL(cuDevSmResourceSplitByCount(
+      partition->groups, &partition->group_count, &device_resource,
+      &partition->remainder, 0, min_sm_count));
+  if (partition->group_count != 2) {
+    fprintf(stderr,
+            "GREEN_CONTEXT_UNSUPPORTED reason=real_split_group_count "
+            "groups=%u\n",
+            partition->group_count);
+    goto fail;
+  }
+  printf("split group0_sm_count=%u group1_sm_count=%u remainder_sm_count=%u\n",
+         partition->groups[0].sm.smCount, partition->groups[1].sm.smCount,
+         partition->remainder.type == CU_DEV_RESOURCE_TYPE_SM
+             ? partition->remainder.sm.smCount
+             : 0);
+
+  for (unsigned int index = 0; index < partition->group_count; index++) {
+    PROBE_CALL(cuDevResourceGenerateDesc(&partition->descriptors[index],
+                                         &partition->groups[index], 1));
+    PROBE_CALL(cuGreenCtxCreate(&partition->contexts[index],
+                                partition->descriptors[index],
+                                partition->device,
+                                CU_GREEN_CTX_DEFAULT_STREAM));
+    PROBE_CALL(cuGreenCtxGetDevResource(partition->contexts[index], &queried,
+                                        CU_DEV_RESOURCE_TYPE_SM));
+    printf("green_context=%u requested_sm_count=%u queried_sm_count=%u\n",
+           index, partition->groups[index].sm.smCount, queried.sm.smCount);
+    if (queried.type != CU_DEV_RESOURCE_TYPE_SM ||
+        queried.sm.smCount != partition->groups[index].sm.smCount) {
+      fprintf(stderr,
+              "GREEN_CONTEXT_FAIL reason=resource_query_mismatch context=%u\n",
+              index);
+      goto fail;
+    }
+  }
+
+  PROBE_CALL(cuCtxSetCurrent(NULL));
+  printf("GREEN_CONTEXT_PROBE_OK groups=2\n");
+  return true;
+
+fail:
+  (void)cuCtxSetCurrent(NULL);
+  destroy_partition(partition);
+  return false;
+}
+
+int main(int argc, char **argv) {
+  struct green_partition partition;
+  unsigned int min_sm_count;
+
+  setvbuf(stdout, NULL, _IOLBF, 0);
+  if (!parse_options(argc, argv, &min_sm_count)) {
+    usage(stderr, argv[0]);
+    return 2;
+  }
+  if (!create_partition(&partition, min_sm_count))
+    return 1;
+  destroy_partition(&partition);
+  return 0;
+}

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
+{ inputs, ... }:
 {
   # keep-sorted start skip_lines=1
   flake.overlays.own-pkgs-overlay = final: _prev: {
@@ -23,6 +24,7 @@
     ghaf-qemu-bpmp = final.callPackage ./pkgs-by-name/ghaf-qemu-bpmp/package.nix { };
     ghaf-qemu-bpmp-gpu = final.callPackage ./pkgs-by-name/ghaf-qemu-bpmp-gpu/package.nix { };
     ghaf-vms = final.callPackage ./pkgs-by-name/ghaf-vms/package.nix { };
+    gpu-vm-partition-manager-sdk = inputs.gpu-partition-manager.lib.mkSdk { pkgs = final; };
     hardware-scan = final.callPackage ./pkgs-by-name/hardware-scan/package.nix { };
     make-checks = final.callPackage ./pkgs-by-name/make-checks/package.nix { };
     memsocket = final.callPackage ./pkgs-by-name/memsocket/package.nix { };

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -41,6 +41,59 @@ let
     self.nixosModules.profiles
   ];
 
+  # Exercise the complete manager/CDI integration in an existing CI-built
+  # image without making example workloads part of Ghaf. The manager-owned
+  # mock plugin is sufficient for build and boot validation; downstream
+  # configurations replace this default with real workload plugins.
+  nxGpuPartitioningDebugModule =
+    { pkgs, ... }:
+    let
+      managerSdk = inputs.gpu-partition-manager.lib.mkSdk { inherit pkgs; };
+      managerMockPlugin = pkgs.stdenv.mkDerivation {
+        pname = "gpu-partition-manager-mock-plugin";
+        version = "1.0";
+
+        dontUnpack = true;
+        dontConfigure = true;
+
+        buildPhase = ''
+          runHook preBuild
+          $CC -std=c11 -Wall -Wextra -Werror -fPIC -shared \
+            -I${managerSdk}/include \
+            -I${pkgs.nvidia-jetpack.cudaPackages.cuda_cudart}/include \
+            ${inputs.gpu-partition-manager}/tests/mock-plugin.c \
+            -o plugin.so
+          runHook postBuild
+        '';
+
+        installPhase = ''
+          runHook preInstall
+          install -Dm755 plugin.so \
+            $out/lib/gpu-partition-manager/plugin.so
+          runHook postInstall
+        '';
+
+        passthru = {
+          gpuPartitionPluginName = "mock";
+          requiredPluginAbiVersion = managerSdk.pluginAbiVersion;
+        };
+
+        meta = {
+          description = "Manager-owned mock plugin for NX debug integration validation";
+          platforms = [ "aarch64-linux" ];
+        };
+      };
+    in
+    {
+      ghaf.hardware.nvidia.passthroughs.gpu_vm = {
+        containerRuntime.enable = true;
+        partitionManager = {
+          enable = true;
+          plugins = lib.mkDefault [ managerMockPlugin ];
+        };
+      };
+    };
+
   # A/B verity boot targets: LVM-based A/B slots + UKI instead of the sd-card
   # format module
   orinVerityModules = [
@@ -179,7 +232,7 @@ let
       profile = "orin";
       hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-nx;
       variant = "debug";
-      extraModules = commonModules;
+      extraModules = commonModules ++ [ nxGpuPartitioningDebugModule ];
       extraConfig = {
         reference.profiles.mvp-orinuser-trial.enable = true;
         # Crucial for Orin devices to use the correct render device


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Integrate CUDA containers and cooperative CUDA Green Context partitions into
the existing split `gpu-vm` + `disp-vm` topology on NVIDIA Jetson Orin.

This PR is intentionally platform-only after the repository split:

- Ghaf owns Jetson/GPU-VM composition, rootful Docker, CDI, the systemd
  service, trusted plugin wiring, and the capability probe.
- [ghaf-gpu-partition-manager#1](https://github.com/tiiuae/ghaf-gpu-partition-manager/pull/1)
  is merged and owns the daemon, client, protocol, plugin ABI and SDK, generic
  Nix constructors, and mock-CUDA tests.
- [ghaf-gpu-partitioning-examples#1](https://github.com/tiiuae/ghaf-gpu-partitioning-examples/pull/1)
  is merged and owns burn, latency, and GEMM workloads; OCI examples; external
  CUDA/PyTorch qualification; operational scenarios; and research policy.

### GPU-VM Platform Integration

- Add an opt-in rootful Docker runtime in `gpu-vm`, with storage backed by
  storagevm. Membership of the root-equivalent `docker` group is a separate,
  disabled-by-default option.
- Generate a static NVIDIA CDI specification from the Nix-built L4T CUDA
  closure.
- Provide `nvidia.com/gpu=all` for unrestricted direct CUDA.
- Provide `nvidia.com/gpu=managed` with only the manager client and a hardened
  socket mount; it injects no direct GPU device nodes.
- Keep Docker-only configurations independent of the partition manager.
- Add an opt-in, systemd-hardened partition-manager service that binds the
  standalone manager to JetPack CUDA and accepts only trusted Nix-built ABI-v1
  plugins.
- Validate plugin shared objects during the Nix build and provide explicit
  module assertion diagnostics for invalid slot configuration.
- Re-export the external manager SDK through the Ghaf package set.
- Keep the local Green Context probe as a platform capability diagnostic, not
  an example workload.
- Keep all existing AGX/NX target names and deployable build variants unchanged;
  downstream products opt in and supply plugins.

CUDA Green Contexts provide cooperative SM placement. They are not a security
boundary and do not guarantee memory-bandwidth isolation, engine isolation,
real-time behavior, or concurrent progress. An unrestricted `gpu=all` process
can bypass the manager.

### Supporting Orin Fix

- Build cross-target pre-flash helpers for the build host, avoiding an AArch64
  interpreter in the x86 flash wrapper.

The earlier BPMP clock allowlist change has been removed from this PR and will
be handled independently.

### Type of Change

- [x] New feature
- [x] Bug fix
- [x] Documentation
- [x] Improvement / Refactor
- [ ] Infrastructure / CI/CD

## Validation

### Current Review-Fix Head

Validated before publishing this head:

- `nix fmt -- --fail-on-change`
- `nix develop --command reuse lint`
- `nix build .#checks.x86_64-linux.pre-commit`
- `nix build .#doc`
- `nix flake show --all-systems --accept-flake-config`
- focused AArch64 builds of the manager, capability probe, and CDI
  specification
- inspection of the generated managed CDI specification: no GPU device nodes,
  no manager daemon or SDK include paths, and a `nosuid,nodev` socket mount
- an ad hoc Docker-only target closure check proving it does not pull in the
  partition manager
- evaluation of the existing AGX/NX target set with no added target, check,
  image, or flash output
- downstream AGX and NX example target derivation evaluation with this Ghaf
  checkout supplied as the upstream input
- Docker group policy evaluation: the default GPU-VM user groups exclude
  `docker`; explicit `addGhafUserToDockerGroup` opt-in adds it

No image was flashed as part of the review-fix update.

### Dependency Chain

- standalone manager merged as `f79b6ffc6dd4bf731b1189deec94e9dc76999826`
  and pinned by `flake.lock`
- standalone manager `nix flake check -L`, mock-CUDA ASan/UBSan integration
  suite, and SDK build
- manager and examples REUSE, ShellCheck, clang-format, and Nix formatting
  checks
- examples source `a1771c31900e39f019fd595e7e717fa3ee6af2af`
  from merged PR `68d7ceec4abc7dba3702c390761d5f6a5fde4774`
- previously built downstream AGX image: 4,476,399,302 bytes compressed
- previously built downstream NX image: 4,302,857,629 bytes compressed

A supplemental whole-examples `nix flake check --no-build` was killed with
exit 137 after both target graphs had evaluated. It is not reported as passing;
the narrower checks and exact target builds above completed successfully.

### AGX Hardware

The extracted dependency chain before the review-fix update was flashed to a
P3701-0000 AGX and passed:

- runtime discovery of 16 SMs and two 8-SM manager slots;
- exact `--min-sm-count 8` capability probe with no remainder;
- direct and managed CDI smoke tests, including absence of direct GPU nodes in
  the managed container;
- concurrent slots, FIFO queue release, and cancellation;
- managed-versus-unmanaged interference observation; and
- a 30-minute dual-slot run with 11,137 validated iterations per slot.

Manager and GPU-VM restart counts remained zero, GPU-VM had no failed units,
and no relevant nvgpu fault, timeout, or Xid was observed. NetVM remained
reachable at 1 Gbps/full duplex. The host retained an unrelated failed fTPM
module unit; this work did not change or diagnose host fTPM configuration.

The current head was source- and configuration-validated as described above.
It was not re-flashed because the review update addresses configuration,
service hardening, diagnostics, and documentation rather than the validated GPU
partitioning mechanism.

### Orin NX

NX evaluation and the previously recorded full downstream image build pass.
Live NX hardware validation remains pending and is documented as such.

## Testing Instructions

1. Build and flash an AGX or NX downstream configuration that enables
   `containerRuntime` and `partitionManager` and supplies at least one ABI-v1
   plugin.
2. Connect to `gpu-vm` through NetVM.
3. Check `systemctl status gpu-partition-manager`,
   `gpu-partition-run list`, and `gpu-partition-run status`.
4. On AGX, run `gpu-vm-green-context-probe --min-sm-count 8`; on NX, use
   `--min-sm-count 4`. Confirm two equal groups, no remainder, and matching
   manager slots.
5. Use the downstream examples repository for direct/managed CDI,
   queue/cancellation, endurance, GEMM, external-container qualification, and
   interference scenarios.

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`

## Checklist

- [x] Ownership and trust boundaries documented
- [x] Signed-off, logically scoped commits
- [x] Existing target set preserved without adding CI targets
- [x] Source, docs, and downstream AGX/NX evaluations validated
- [x] Extracted-chain AGX hardware rerun
- [ ] Live NX hardware validation
- [ ] Reviewer approval
