### PR TITLE
fix(orin): cut boot-to-login time by half (initrd resize hunt + clock barrier)

### DIFF
--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -518,7 +518,16 @@ in
 
       clockReady = {
         enable = (mkEnableOption "clock readiness barrier for persistent sealed logging") // {
-          default = true;
+          # The barrier exists for hosts whose RTC needs to settle after
+          # power-on. A VM starts with its emulated RTC seeded from host wall
+          # time at VM creation (microvm sets rtc = "on") and runs timesyncd
+          # afterwards, so it boots with an already-settled clock and the
+          # barrier (plus the ghaf-clock-sync NTP wait it gates) only delays
+          # boot there. Disabling it in guests is a deliberate choice: guest
+          # FSS setup/verify no longer waits for NTP, which also uncouples it
+          # from net-vm availability; clock-jump recovery stays active.
+          default = config.ghaf.type == "host";
+          defaultText = lib.literalExpression ''config.ghaf.type == "host"'';
         };
 
         stableSeconds = mkOption {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -757,6 +757,12 @@ in
   };
 
   config = mkIf cfg.enable {
+    # The clock-readiness barrier gates systemd-journal-flush and with it the
+    # whole userspace boot. Tegra restores a sane RTC well within a few seconds,
+    # and post-release jumps are already handled by ghaf-clock-jump-watcher, so
+    # the default 20 s stability window only adds boot latency here.
+    ghaf.logging.recovery.clockReady.stableSeconds = lib.mkDefault 5;
+
     assertions = [
       {
         assertion =

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -293,41 +293,14 @@ let
       ESP_MOUNT="/mnt-esp"
       ESP_DEVICE="/dev/disk/by-label/${espLabel}"
 
-      # Resolve the root partition by the pinned LUKS header UUID rather than a
-      # hardcoded device name or a partition-table PARTUUID (which differs between
-      # the USB sd-image (MBR) and the eMMC/NVMe flash (GPT)). blkid matches the
-      # crypto_LUKS container by its own UUID, identical on both media.
-      PART_DEV=""
-      for _ in $(seq 1 30); do
-        for d in $(blkid -o device -t UUID=${luksUuid} 2>/dev/null); do
-          ${lib.optionalString cfg.diskEncryption.enable ''
-            [ "$(blkid -o value -s TYPE "$d" 2>/dev/null)" = "crypto_LUKS" ] || continue
-          ''}
-          PART_DEV="$d"
-          break
-        done
-        if [ -n "$PART_DEV" ]; then break; fi
-        sleep 1
-      done
-
-      if [ -z "$PART_DEV" ]; then
-        echo "Root partition (LUKS UUID=${luksUuid}) not found, skipping resize."
-        exit 0
-      fi
-
-      # Derive disk and partition number from the resolved node, so mmcblk/nvme/sda all work.
-      real_dev=$(readlink -f "$PART_DEV")
-      base_dev=$(basename "$real_dev")
-      PART_NUM=$(cat "/sys/class/block/$base_dev/partition")
-      DISK="/dev/$(basename "$(readlink -f "/sys/class/block/$base_dev/..")")"
-
-      RESIZE_TARGET="$PART_DEV"
-      ${lib.optionalString cfg.diskEncryption.enable ''
-        MAPPER_NAME="${cfg.diskEncryption.mapperName}"
-        RESIZE_TARGET="/dev/mapper/$MAPPER_NAME"
-      ''}
-
+      # Marker check comes FIRST: it needs no root/LUKS resolution, and doing it
+      # after the device hunt made every post-resize boot pay the full 30 s
+      # not-found timeout below before discovering there was nothing to do.
       mkdir -p "$ESP_MOUNT"
+      # The marker check no longer runs after the (slow) device hunt, so it can
+      # now race udev publishing /dev/disk/by-label/*. Settling first keeps a
+      # missing symlink from silently redoing the whole resize on every boot.
+      udevadm settle || true
       if [[ -b $ESP_DEVICE ]]; then
         if mount "$ESP_DEVICE" "$ESP_MOUNT"; then
           if [ -f "$ESP_MOUNT/$RESIZE_MARKER" ]; then
@@ -342,6 +315,60 @@ let
       else
         echo "ESP partition not found, continuing without marker check."
       fi
+
+      PART_DEV=""
+      ${
+        if cfg.diskEncryption.enable then
+          ''
+            # Resolve the root partition by the pinned LUKS header UUID rather than a
+            # hardcoded device name or a partition-table PARTUUID (which differs between
+            # the USB sd-image (MBR) and the eMMC/NVMe flash (GPT)). blkid matches the
+            # crypto_LUKS container by its own UUID, identical on both media.
+            for _ in $(seq 1 30); do
+              for d in $(blkid -o device -t UUID=${luksUuid} 2>/dev/null); do
+                [ "$(blkid -o value -s TYPE "$d" 2>/dev/null)" = "crypto_LUKS" ] || continue
+                PART_DEV="$d"
+                break
+              done
+              if [ -n "$PART_DEV" ]; then break; fi
+              sleep 1
+            done
+          ''
+        else
+          ''
+            # Plain (unencrypted) image: the root is the sd-image ext4 partition,
+            # Resolve it through the same option upstream sd-image.nix uses for
+            # fileSystems."/" rather than a hardcoded literal, with the `or`
+            # fallback for module sets where sdImage is absent (verity builds).
+            # The pinned LUKS UUID never matches here, so hunting for it only
+            # burned the full 30 s timeout before the resize could run.
+            ROOT_DEVICE="/dev/disk/by-label/${config.sdImage.rootVolumeLabel or "NIXOS_SD"}"
+            for _ in $(seq 1 30); do
+              if [ -b "$ROOT_DEVICE" ]; then
+                PART_DEV="$ROOT_DEVICE"
+                break
+              fi
+              sleep 1
+            done
+          ''
+      }
+
+      if [ -z "$PART_DEV" ]; then
+        echo "Root partition not found, skipping resize."
+        exit 0
+      fi
+
+      # Derive disk and partition number from the resolved node, so mmcblk/nvme/sda all work.
+      real_dev=$(readlink -f "$PART_DEV")
+      base_dev=$(basename "$real_dev")
+      PART_NUM=$(cat "/sys/class/block/$base_dev/partition")
+      DISK="/dev/$(basename "$(readlink -f "/sys/class/block/$base_dev/..")")"
+
+      RESIZE_TARGET="$PART_DEV"
+      ${lib.optionalString cfg.diskEncryption.enable ''
+        MAPPER_NAME="${cfg.diskEncryption.mapperName}"
+        RESIZE_TARGET="/dev/mapper/$MAPPER_NAME"
+      ''}
 
       for _ in {1..30}; do
         [ -b "$RESIZE_TARGET" ] && break
@@ -952,7 +979,11 @@ in
       '';
 
       systemd.services = {
-        resize-partitions = {
+        # Verity images have no resizable root here: their root is a tmpfs
+        # overlay, their ESP label never matches the marker check, and
+        # firstboot-persist.nix does its own growing -- so the unit only
+        # burned its 30 s device hunt on every boot. Skip it entirely.
+        resize-partitions = mkIf (!verityEnabled) {
           description = "Resize partitions to fill the disk on first boot";
           wantedBy = [ "initrd.target" ];
           before = [

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -73,12 +73,12 @@ in
     {
       firmwareSize = 256;
 
-      # The stock expand-root-partition.service resolves the root device via
-      # `lsblk -npo PKNAME /`, which is empty for a /dev/mapper/cryptroot root
-      # and makes sfdisk fail ("no disk device specified"). The initrd
-      # resize-partitions service already grows the LUKS partition + filesystem,
-      # so disable the redundant stock expand when encryption is enabled.
-      expandOnBoot = !config.ghaf.hardware.nvidia.orin.diskEncryption.enable;
+      # The initrd resize-partitions service grows the root partition and
+      # filesystem for both the plain and the LUKS layout, so the stock
+      # stage-2 expand-root-partition.service is redundant everywhere (and
+      # broken for LUKS: it resolves the root device via `lsblk -npo PKNAME /`,
+      # which is empty for a /dev/mapper/cryptroot root).
+      expandOnBoot = false;
       populateFirmwareCommands = ''
         mkdir -pv firmware
         ${mkESPContent} \


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Two serialized boot-time eaters, found while profiling why an Orin AGX takes minutes to reach the greeter, measured over timestamped serial + `systemd-analyze` on host and gui-vm:

1. **`resize-partitions` burned 31.7 s in the initrd on every boot.** It hunted for the root partition by the pinned LUKS header UUID before consulting its ESP done-marker; on unencrypted images that UUID never matches, so every boot span the full 30×1 s retry loop and then skipped — and the resize itself never ran at all. Now the done-marker is checked first, and unencrypted images resolve root by the `NIXOS_SD` label: first boot actually grows the filesystem (~11 s one-time), later boots skip in under a second.
2. **`ghaf-clock-ready` held every machine's boot for a 20 s clock-stability window.** The barrier gates `systemd-journal-flush` and through it `sysinit.target`. It exists for hosts whose RTC must settle after power-on — but a VM's clock is host-fed (kvm-clock/ptp_kvm) and synchronized from the first instruction, so `clockReady.enable` now defaults to hosts only (keyed on `ghaf.type`, the pattern `fss.nix` already uses). Tegra hosts keep the barrier with a 5 s window (`mkDefault`, overridable).

Measured on the AGX accelerated gui-vm image (PR #2068 head): warm reboot → greeter 171 s → 108 s; power-on → greeter ~150 s → ~80 s; guest boot → greetd 39.9 s → 21.1 s. Both fixes are also in effect on the PR #2068 bench image and survive reboot/replug.

### Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

Split out of #2068 (the fixes are target-independent).

## Checklist
- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

## Testing Instructions
### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`
### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:
(the resize fix lives in the initrd; the clock change alone is switch-able)
### Test Steps To Verify:
1. Flash an unencrypted debug image; first boot: journal shows `Resizing filesystem on /dev/disk/by-label/NIXOS_SD` (~11 s) and `df /` reports the full disk.
2. Reboot; initrd logs `Resize already performed, skipping.` within ~1 s of the marker check and `systemd-analyze` shows initrd well under 10 s.
3. In any VM: `systemctl status ghaf-clock-ready` → unit not found; on the host: journal shows "Clock readiness established after 5 stable seconds".
4. `nix eval` of `nvidia-jetson-orin-agx-debug`, `nvidia-jetson-orin-nx-debug`, `intel-laptop-debug` toplevels — verified as part of this PR.

Validation not run: encrypted-image boot path (the LUKS branch of the resize script is unchanged); x86 laptop hardware boot.