### PR TITLE
feat(orin/nx): three-vm split and accelerated gui-vm topologies

### DIFF
--- a/modules/reference/hardware/jetpack/agx/orin-agx.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx.nix
@@ -9,12 +9,8 @@
 
   imports = [
     ../../../../common/services/hwinfo
-    # DCE display-proxy HOST integration (AGX only). Keeps gpu_vm
-    # enabled, runs the host headless, force-loads tegra-dce so the host owns
-    # the real DCE R5, and builds + loads the dce-host-proxy .ko (with an
-    # injected nvidia,dce-host-proxy DT node) so the guest can drive the panel
-    # through the host-owned DCE. AGX-only on purpose -- do not hoist into a
-    # shared orin.nix.
+    # Host keeps the real DCE R5 and loads dce-host-proxy so the guest drives
+    # the panel through it. Shared by AGX and NX.
     ../nvidia-jetson-orin/virtualization/common/dce-virt-common/dce-probe-host.nix
   ];
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -296,6 +296,20 @@ let
         echo "QSPI-only mode: skipping ESP and root partition extraction."
       ''}
 
+      ${lib.optionalString config.ghaf.profiles.debug.enable ''
+        # NVIDIA's blkdiscard fallback dd-zeroes the whole partition at
+        # 512 bytes a write: hours on a 256GB NVMe. Wiping the head is enough
+        # to drop the old structures; the image write covers the rest. Blocks
+        # the sparse write skips keep old data -- debug only, never release.
+        eraser=tools/kernel_flash/l4t_flash_from_kernel.sh
+        if grep -q 'dd if=/dev/zero of=[^ ]* status=progress oflag=direct' "$eraser"; then
+          sed -i 's#dd if=/dev/zero of=\([^ ]*\) status=progress oflag=direct#dd if=/dev/zero of=\1 bs=4M count=8 conv=notrunc oflag=direct#g' "$eraser"
+          echo "Debug flash: capped erase-partition dd fallback to a 32MiB head wipe"
+        else
+          echo "WARNING: erase fallback pattern not found in $eraser; full-partition zeroing still active" >&2
+        fi
+      ''}
+
       echo ""
       echo "Ready to flash!"
       echo "============================================================"

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/dce-probe-host.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/dce-probe-host.nix
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# DCE display-proxy HOST integration (AGX only).
+# DCE display-proxy HOST integration.
 #
 # Companion to gpu-vm's guest overlay (../../passthrough/gpu-vm). Guest takes
 # display@13800000 and drives the panel via a synthetic DCE proxy; HOST keeps
@@ -14,7 +14,8 @@
 #     the guest's DCE IPC through it to the R5);
 #   - keep gpu_vm ENABLED (unlike the Phase-0 spike, which forced it off).
 #
-# AGX-only: imported from agx/orin-agx.nix, never hoisted into a shared orin.nix.
+# Shared by AGX and NX (both Tegra234 + host-owned DCE): imported from
+# agx/orin-agx.nix and nx/orin-nx.nix.
 {
   lib,
   pkgs,

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/default.nix
@@ -47,9 +47,14 @@ let
     "vfio-platform,host=${r.dev},mmio-base=${r.base}"
   ]) mappings;
 
-  inherit (import ../payload { inherit lib pkgs; }) capabilities mkPayload;
+  inherit (import ../payload { inherit lib pkgs; })
+    capabilities
+    mkPayload
+    boardFor
+    ;
   cap = capabilities.dispvm;
   payload = mkPayload cap;
+  board = boardFor config.ghaf.hardware.nvidia.orin.somType;
   _capOk =
     payload.needsDceBridge
     && payload.noSyncpointPatch
@@ -85,7 +90,7 @@ let
         };
       in
       ''
-        $CC -E -nostdinc -undef -D__DTS__ -DEXP_DROP_HOST1X -DEXP_DROP_GPU -x assembler-with-cpp \
+        $CC -E -nostdinc -undef -D__DTS__ -DEXP_DROP_HOST1X -DEXP_DROP_GPU -DGHAF_DCB_DTSI='"${board.dcbDtsi}"' -x assembler-with-cpp \
           -I${mainInc} \
           -I${../gpu-vm/nv-dt-bindings} \
           -I${gpuvmDtsi} \

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/default.nix
@@ -12,15 +12,20 @@ let
 
   virt = config.ghaf.hardware.nvidia.virtualization;
 
-  inherit (import ../payload { inherit lib pkgs; }) capabilities mkPayload;
+  inherit (import ../payload { inherit lib pkgs; })
+    capabilities
+    mkPayload
+    boardFor
+    ;
   cap = capabilities.gpuvm;
   payload = mkPayload cap;
+  board = boardFor config.ghaf.hardware.nvidia.orin.somType;
 
   mkOrinGpuDtb = import ../payload/dtb.nix;
   mkOrinGpuGuestModule = import ../payload/guest-module.nix;
 
   gpuvm-dtb = mkOrinGpuDtb {
-    inherit lib pkgs;
+    inherit lib pkgs board;
     cap = capabilities.gpuvm;
     kernel = config.boot.kernelPackages.kernel;
   };

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/patches/0024-nvkms-keep-flip-completion-binding.patch
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/patches/0024-nvkms-keep-flip-completion-binding.patch
@@ -1,0 +1,74 @@
+--- a/nvdisplay/src/nvidia-modeset/src/nvkms-evo.c	2026-08-04 22:52:39.953301893 +0300
++++ b/nvdisplay/src/nvidia-modeset/src/nvkms-evo.c	2026-08-05 13:19:42.145888197 +0300
+@@ -4152,8 +4152,12 @@
+             nvRmApiFree(nvEvoGlobal.clientHandle,
+                         pChannel->pb.channel_handle,
+                         pChannel->completionNotifierEventHandle);
+-            nvFreeUnixRmHandle(&pDevEvo->handleAllocator,
+-                               pChannel->completionNotifierEventHandle);
++            /*
++             * Passthrough: never return the handle number to the allocator.
++             * The R5 unbinds asynchronously (posts for a freed handle arrive
++             * ~0.6s later), so a recycled number is torn down again right
++             * after the next registration.
++             */
+             pChannel->completionNotifierEventHandle = 0;
+             pChannel->completionNotifierEventRefPtr = NULL;
+         }
+@@ -4350,45 +4354,17 @@
+                                                    const NVEvoModesetUpdateState
+                                                        *pModesetUpdate)
+ {
+-    NVDevEvoRec *pDevEvo = pDispEvo->pDevEvo;
+-    NvU32 layer;
+-
+-    /* XXX NVKMS TODO: need disp-scope in event */
+-    if (pDispEvo->displayOwner != 0) {
+-        return;
+-    }
+-
+-    for (layer = 0; layer < pDevEvo->head[head].numLayers; layer++) {
+-        NVEvoChannelPtr pChannel = pDevEvo->head[head].layer[layer];
+-        const struct _NVEvoModesetUpdateStateOneLayer *pLayer =
+-             &pModesetUpdate->flipOccurredEvent[head].layer[layer];
+-
+-        if (!pLayer->changed ||
+-                (pLayer->ref_ptr != NULL) ||
+-                (pChannel->completionNotifierEventHandle == 0)) {
+-
+-            /*
+-             * If the flip occurred event of this layer is updated to get
+-             * enabled (pLayer->ref_ptr != NULL) then that update should have
+-             * been already processed by
+-             * nvEvoPreModesetRegisterFlipOccurredEvent() and
+-             * pChannel->completionNotifierEventRefPtr == pLayer->ref_ptr.
+-             */
+-            nvAssert(!pLayer->changed ||
+-                        (pChannel->completionNotifierEventHandle == 0) ||
+-                        (pChannel->completionNotifierEventRefPtr ==
+-                            pLayer->ref_ptr));
+-            continue;
+-        }
+-
+-        nvRmApiFree(nvEvoGlobal.clientHandle,
+-                    pChannel->pb.channel_handle,
+-                    pChannel->completionNotifierEventHandle);
+-        nvFreeUnixRmHandle(&pDevEvo->handleAllocator,
+-                           pChannel->completionNotifierEventHandle);
+-        pChannel->completionNotifierEventHandle = 0;
+-        pChannel->completionNotifierEventRefPtr = NULL;
+-    }
++    /*
++     * Passthrough: the DCE R5 binds a channel's flip-completion notifier once.
++     * Dropping the binding between modesets (greeter -> desktop session) left
++     * the re-registered event unbound: no completion ever arrived, the
++     * session's first atomic commit never retired and every later commit
++     * failed with EBUSY -- a lit but permanently black panel with the
++     * compositor spinning. The binding's event data (pDispEvo, apiHead,
++     * layer) is unchanged across the re-modeset, so keeping it is correct;
++     * ClearApiHeadState() still frees it on teardown.
++     */
++    return;
+ }
+ 
+ static void

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/tegra234-gpuvm-display.dtsi
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/tegra234-gpuvm-display.dtsi
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-only
 // SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 // nvdisplay node driven through the host-owned DCE R5 (see
-// docs: nvidia_gpu_vm_display). DCB payload is included from
-// generated/agx-p3737-p3701-dcb.dtsi and hash-verified at build.
+// docs: nvidia_gpu_vm_display). DCB payload is included from the
+// board-selected generated/<board>-dcb.dtsi (payload/default.nix
+// boards.<key>.dcbDtsi) and hash-verified at build.
 
 / {
 	platform-bus@70000000 {
@@ -168,7 +169,8 @@
 			//iommus = <&smmu_iso TEGRA234_SID_ISO_NVDISPLAY>;
 			non-coherent;
 
-#include "generated/agx-p3737-p3701-dcb.dtsi"
+/* Board DCB selected at build time (payload/default.nix boards.<key>.dcbDtsi). */
+#include GHAF_DCB_DTSI
 
 			/* nvdisplay RM requires this child at probe or it bails
 			 * with "no nvdisplay-niso child node" -> no crtc/format.

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gui-vm/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gui-vm/default.nix
@@ -12,15 +12,20 @@ let
 
   virt = config.ghaf.hardware.nvidia.virtualization;
 
-  inherit (import ../payload { inherit lib pkgs; }) capabilities mkPayload;
+  inherit (import ../payload { inherit lib pkgs; })
+    capabilities
+    mkPayload
+    boardFor
+    ;
   cap = capabilities.guivm;
   payload = mkPayload cap;
+  board = boardFor config.ghaf.hardware.nvidia.orin.somType;
 
   mkOrinGpuDtb = import ../payload/dtb.nix;
   mkOrinGpuGuestModule = import ../payload/guest-module.nix;
 
   guivm-dtb = mkOrinGpuDtb {
-    inherit lib pkgs;
+    inherit lib pkgs board;
     cap = capabilities.guivm;
     kernel = config.boot.kernelPackages.kernel;
   };

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/default.nix
@@ -127,7 +127,26 @@ let
       needsDceBridge = cap.display;
       noSyncpointPatch = cap.noSyncpointDisplay;
     };
+
+  # The DCB image is the only board-specific piece; the rest is SoC-level.
+  agxBoard = {
+    dcbDtsi = "generated/agx-p3737-p3701-dcb.dtsi";
+    dcbSha256 = "e0d92e6dbf1ffef266cfd2e192847e76f8d88c19c55430f2f5d4aaf69494a2fc";
+    dcbBytes = "8407";
+  };
+  boards = {
+    agx = agxBoard;
+    # Stock L4T r36.5 ships one DCB for both devkits (verified against the
+    # NX host DTB), so nx aliases agx: one pin to update on a DCB bump.
+    nx = agxBoard;
+  };
+  boardFor = somType: if somType == "nx" then boards.nx else boards.agx;
 in
 {
-  inherit capabilities mkPayload;
+  inherit
+    capabilities
+    mkPayload
+    boards
+    boardFor
+    ;
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/dtb.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/dtb.nix
@@ -5,6 +5,7 @@
   lib,
   pkgs,
   cap,
+  board,
   kernel,
   dtsDir ? ../gpu-vm,
 }:
@@ -35,12 +36,10 @@ pkgs.stdenv.mkDerivation {
   buildPhase =
     let
       mainInc = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
-      # Stock R36.5 P3737/P3701 AGX DCB payload.
-      dcbSha256 = "e0d92e6dbf1ffef266cfd2e192847e76f8d88c19c55430f2f5d4aaf69494a2fc";
-      dcbBytes = "8407";
+      inherit (board) dcbSha256 dcbBytes;
     in
     ''
-      $CC -E -nostdinc -undef -D__DTS__ ${expDtDefines}-x assembler-with-cpp \
+      $CC -E -nostdinc -undef -D__DTS__ ${expDtDefines}-DGHAF_DCB_DTSI='"${board.dcbDtsi}"' -x assembler-with-cpp \
         -I${mainInc} \
         -I${dtsDir + "/nv-dt-bindings"} \
         -I. \

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/guest-module.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/guest-module.nix
@@ -131,6 +131,9 @@ in
               (srcDir + "/patches/0020-synthesize-boot-hotplug-long-pulse.patch")
               # Keep the stock R5 FLIP_OCCURRED path as the sole completion owner.
               (srcDir + "/patches/0011-window-notifier-plain-write.patch")
+              # Keep the R5's flip-completion binding across modesets, or the
+              # desktop session after the greeter never sees a completion.
+              (srcDir + "/patches/0024-nvkms-keep-flip-completion-binding.patch")
             ]
             # disp-vm has no guest-owned host1x syncpoints.
             ++ lib.optional payload.noSyncpointPatch (

--- a/modules/reference/hardware/jetpack/nx/orin-nx.nix
+++ b/modules/reference/hardware/jetpack/nx/orin-nx.nix
@@ -11,7 +11,12 @@
 {
   _file = ./orin-nx.nix;
 
-  imports = [ ../../../../common/services/hwinfo ];
+  imports = [
+    ../../../../common/services/hwinfo
+    # Host keeps the real DCE R5 and loads dce-host-proxy so the guest drives
+    # the panel through it. Shared by AGX and NX.
+    ../nvidia-jetson-orin/virtualization/common/dce-virt-common/dce-probe-host.nix
+  ];
 
   ghaf = {
     # Enable hardware info generation on host
@@ -27,14 +32,18 @@
         somType = "nx";
         nx.enableNetvmEthernetPCIPassthrough = true;
         carrierBoard = "xavierNxDevkit";
-        # Orin NX p3768 devkit boots rootfs from NVMe and USB (no eMMC on this SoM);
-        # Default is set to USB
+        # No eMMC on this SoM; jetpack flashes the QSPI+NVMe layout below.
         flashScriptOverrides = {
-          deviceDisk = "sda";
-          deviceDiskEspPartition = "sda1";
-          deviceDiskRootfsPartition = "sda2";
+          deviceDisk = "nvme0n1";
+          deviceDiskEspPartition = "nvme0n1p1";
+          deviceDiskRootfsPartition = "nvme0n1p2";
         };
       };
+
+      # Split topology, as on AGX. The accelerated-guivm target variant
+      # forces these off and enables gui_vm instead.
+      nvidia.passthroughs.gpu_vm.enable = true;
+      nvidia.passthroughs.disp_vm.enable = true;
 
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
@@ -116,5 +125,12 @@
         ];
       };
     };
+  };
+
+  # 16GB SoM: VM RAM is memfd shmem and host RAM after the carveouts is
+  # thin; without zram a spike OOM-kills a qemu.
+  zramSwap = {
+    enable = true;
+    memoryPercent = 50;
   };
 }

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -71,6 +71,47 @@ let
     }
   ];
 
+  # Shared by the AGX and NX accelerated-guivm variants.
+  acceleratedGuivmUsbRules = [
+
+    {
+      description = "USB Devices for GUIVM";
+      targetVm = "gui-vm";
+      allow = [
+        {
+          interfaceClass = 3;
+          interfaceProtocol = 1;
+          description = "HID Keyboard";
+        }
+        {
+          interfaceClass = 3;
+          interfaceProtocol = 2;
+          description = "HID Mouse";
+        }
+        {
+          interfaceClass = 11;
+          description = "Chip/SmartCard (e.g. YubiKey)";
+        }
+        {
+          interfaceClass = 8;
+          interfaceSubclass = 6;
+          description = "Mass Storage - SCSI (USB drives)";
+        }
+        {
+          interfaceClass = 17;
+          description = "USB-C alternate modes supported by device";
+        }
+      ];
+      deny = [
+        {
+          vendorId = "046d";
+          productId = "c52b";
+          description = "Logitech Unifying Receiver: evdev-only on Orin (usb-host interrupt-IN broken)";
+        }
+      ];
+    }
+  ];
+
   # Non-verity Orin configurations using mkGhafConfiguration
   target-configs = [
     # ============================================================
@@ -104,44 +145,7 @@ let
         hardware.nvidia.passthroughs.disp_vm.enable = lib.mkForce false;
 
         # Keep the Unifying receiver on the working evdev path.
-        hardware.passthrough.usb.guivmRules = lib.mkForce [
-          {
-            description = "USB Devices for GUIVM";
-            targetVm = "gui-vm";
-            allow = [
-              {
-                interfaceClass = 3;
-                interfaceProtocol = 1;
-                description = "HID Keyboard";
-              }
-              {
-                interfaceClass = 3;
-                interfaceProtocol = 2;
-                description = "HID Mouse";
-              }
-              {
-                interfaceClass = 11;
-                description = "Chip/SmartCard (e.g. YubiKey)";
-              }
-              {
-                interfaceClass = 8;
-                interfaceSubclass = 6;
-                description = "Mass Storage - SCSI (USB drives)";
-              }
-              {
-                interfaceClass = 17;
-                description = "USB-C alternate modes supported by device";
-              }
-            ];
-            deny = [
-              {
-                vendorId = "046d";
-                productId = "c52b";
-                description = "Logitech Unifying Receiver: evdev-only on Orin (usb-host interrupt-IN broken)";
-              }
-            ];
-          }
-        ];
+        hardware.passthrough.usb.guivmRules = lib.mkForce acceleratedGuivmUsbRules;
       };
     })
 
@@ -197,6 +201,52 @@ let
           # then evicts page cache backing the USB-eth driver and the dongle
           # disconnects, killing sshd on the test-net IP.
           mem = 2048;
+        };
+        # The carveouts (~6.1GB) come out of the 16GB, leaving ~9.5GB for
+        # host + all QEMU RAM. Keep the VM total at or under 7GB: 10.1GB
+        # OOM-killed a VM and hung PID 1 on every boot.
+        sysvms.gpuvm = {
+          mem = 2048;
+        };
+        # disp-vm runs on the 1:1 dispram carveout; -m only backs the
+        # machine's default RAM window.
+        sysvms.dispvm = {
+          mem = 1536;
+        };
+      };
+    })
+
+    (ghaf-configuration {
+      name = "nvidia-jetson-orin-nx-accelerated-guivm";
+      inherit system;
+      profile = "orin";
+      hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-nx;
+      variant = "debug";
+      extraModules = commonModules;
+      extraConfig = {
+        reference.profiles.mvp-orinuser-trial.enable = true;
+        # Accelerated topology has one combined GPU/display owner.
+        hardware.nvidia.passthroughs.gui_vm.enable = true;
+        hardware.nvidia.passthroughs.gpu_vm.enable = lib.mkForce false;
+        hardware.nvidia.passthroughs.disp_vm.enable = lib.mkForce false;
+
+        # Pin APP so the flash script carries no embedded image: every flash
+        # supplies one with -s, which also keeps the script buildable without
+        # the image.
+        hardware.nvidia.orin.flashScriptOverrides.appPartitionSizeBytes = 34359738368;
+
+        # Keep the Unifying receiver on the working evdev path.
+        hardware.passthrough.usb.guivmRules = lib.mkForce acceleratedGuivmUsbRules;
+      };
+      vmConfig = {
+        sysvms.netvm = {
+          vcpu = 4;
+          mem = 2048;
+        };
+        # VFIO pins all guest RAM up front, so 4096 only fits alongside the
+        # host zram in orin-nx.nix; without it this OOM-crash-looped.
+        sysvms.guivm = {
+          mem = 4096;
         };
       };
     })


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Ports the Orin three-VM composition to the Orin NX 16GB p3768 devkit, in both topologies: split (compute `gpu-vm` + display-only `disp-vm`, the NX default) and combined accelerated `gui-vm`.

- **DCB per board** — the DCB image is the only board-specific piece of the composition; it moves into a `boards` attrset selected by `somType` and reaches both guest DTB derivations through a cpp define. Stock L4T r36.5 ships the same DCB for p3737 and p3768, so `nx` aliases `agx`. AGX guest DTBs are byte-identical before and after.
- **NX topologies** — split enabled by default in the hardware module, plus an `accelerated-guivm` target variant. Rootfs flashes to NVMe (no eMMC on this SoM); the accelerated variant pins a static 32 GiB APP so its flash script does not depend on the cross image build, which is supplied with `-s` at flash time. Memory is refitted for 16 GB: the DT carveouts take ~6.1 GB of physical RAM and VFIO pins all guest RAM, so the AGX sizing oversubscribed the board — gpu-vm 2048, disp-vm 1536, gui-vm 4096, plus host zram.
- **Flip-completion binding** — the DCE R5 binds a channel's flip-completion notifier once, but NVKMS frees and re-registers it on every modeset; in passthrough the rebind stayed unbound, so after the greeter handed over to the session no completion arrived, the first atomic commit never retired, and every later commit failed with `EBUSY` (lit panel, black output). Fixed by keeping the binding across modesets and never recycling completion-notifier handle numbers.
- **Flash erase** — NVIDIA's `blkdiscard` fallback dd-zeroes a whole partition at 512 bytes a write (hours on a 256 GB NVMe); debug flashes now wipe only the head.

#2068 is merged; these 4 commits apply directly to main.

### Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

Follows #2068 (merged).

## Checklist
- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions
### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`
### Installation Method
- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:
### Test Steps To Verify:
1. AGX unchanged: the `gpuvm-dtb` / `dispvm-dtb` requisites of `nvidia-jetson-orin-agx-debug-from-x86_64` are the same derivations as on the base branch.
2. Split: flash `nvidia-jetson-orin-nx-debug-from-x86_64`; all microVMs reach `microvms.target`; in disp-vm, `modetest -M nvidia-drm -s <conn>@<crtc>:1920x1080` puts a test pattern on the panel. Use the DP port next to the USB-C connector — the other one is not in the DCB routing.
3. Accelerated: build `packages.aarch64-linux.nvidia-jetson-orin-nx-accelerated-guivm-debug` natively, flash it with `-s <image>`; the COSMIC greeter appears, and logging in brings up the desktop.

Validated on an Orin NX 16GB p3768 devkit. Known gaps: the GPU-less disp-vm has no KMS holder (`kms-owner` needs EGL), and cold boots occasionally hang in OP-TEE before the console — both pre-existing and shared with AGX.
