### PR TITLE
fix(orin): stop resize-partitions burning 30 s in initrd on every boot

### DIFF
--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -313,25 +313,71 @@ let
       ESP_MOUNT="/mnt-esp"
       ESP_DEVICE="/dev/disk/by-label/${espLabel}"
 
-      # Resolve the root partition by the pinned LUKS header UUID rather than a
-      # hardcoded device name or a partition-table PARTUUID (which differs between
-      # the USB sd-image (MBR) and the eMMC/NVMe flash (GPT)). blkid matches the
-      # crypto_LUKS container by its own UUID, identical on both media.
-      PART_DEV=""
-      for _ in $(seq 1 30); do
-        for d in $(blkid -o device -t UUID=${luksUuid} 2>/dev/null); do
-          ${lib.optionalString cfg.diskEncryption.enable ''
-            [ "$(blkid -o value -s TYPE "$d" 2>/dev/null)" = "crypto_LUKS" ] || continue
-          ''}
-          PART_DEV="$d"
-          break
-        done
-        if [ -n "$PART_DEV" ]; then break; fi
-        sleep 1
-      done
+      # Marker check comes FIRST: it needs no root/LUKS resolution, and doing it
+      # after the device hunt made every post-resize boot pay a not-found
+      # timeout before discovering there was nothing to do. The unit orders
+      # after initrd-root-device.target (and cryptsetup.target), so the disk is
+      # present; `udevadm settle` only drains the by-label symlink queue and
+      # adds no fixed delay. Exits the script when the marker is found.
+      check_resize_marker() {
+        mkdir -p "$ESP_MOUNT"
+        udevadm settle || true
+        if [[ ! -b $ESP_DEVICE ]]; then
+          echo "ESP partition not found, continuing without marker check."
+          return 0
+        fi
+        if ! mount "$ESP_DEVICE" "$ESP_MOUNT"; then
+          echo "Failed to mount ESP $ESP_DEVICE, continuing without marker check."
+          return 0
+        fi
+        if [ -f "$ESP_MOUNT/$RESIZE_MARKER" ]; then
+          echo "Resize already performed, skipping."
+          umount "$ESP_MOUNT"
+          exit 0
+        fi
+        umount "$ESP_MOUNT"
+      }
+
+      # No retry loop: the settle in check_resize_marker plus the unit ordering
+      # guarantee the device links are as ready as they will ever be, and a
+      # missing device means "skip resize", not "wait for it".
+      set_part_dev() {
+        PART_DEV=""
+        ${
+          if cfg.diskEncryption.enable then
+            ''
+              # Resolve the root partition by the pinned LUKS header UUID rather than a
+              # hardcoded device name or a partition-table PARTUUID (which differs between
+              # the USB sd-image (MBR) and the eMMC/NVMe flash (GPT)). blkid matches the
+              # crypto_LUKS container by its own UUID, identical on both media.
+              local d
+              for d in $(blkid -o device -t UUID=${luksUuid} 2>/dev/null); do
+                [ "$(blkid -o value -s TYPE "$d" 2>/dev/null)" = "crypto_LUKS" ] || continue
+                PART_DEV="$d"
+                break
+              done
+            ''
+          else
+            ''
+              # Plain (unencrypted) image: the root is the sd-image ext4 partition.
+              # Resolve it through the same option upstream sd-image.nix uses for
+              # fileSystems."/" rather than a hardcoded literal, with the `or`
+              # fallback for module sets where sdImage is absent (verity builds).
+              # The pinned LUKS UUID never matches here, which is why this arm
+              # exists at all.
+              local root_device="/dev/disk/by-label/${config.sdImage.rootVolumeLabel or "NIXOS_SD"}"
+              if [ -b "$root_device" ]; then
+                PART_DEV="$root_device"
+              fi
+            ''
+        }
+      }
+
+      check_resize_marker
+      set_part_dev
 
       if [ -z "$PART_DEV" ]; then
-        echo "Root partition (LUKS UUID=${luksUuid}) not found, skipping resize."
+        echo "Root partition not found, skipping resize."
         exit 0
       fi
 
@@ -347,27 +393,8 @@ let
         RESIZE_TARGET="/dev/mapper/$MAPPER_NAME"
       ''}
 
-      mkdir -p "$ESP_MOUNT"
-      if [[ -b $ESP_DEVICE ]]; then
-        if mount "$ESP_DEVICE" "$ESP_MOUNT"; then
-          if [ -f "$ESP_MOUNT/$RESIZE_MARKER" ]; then
-            echo "Resize already performed, skipping."
-            umount "$ESP_MOUNT"
-            exit 0
-          fi
-          umount "$ESP_MOUNT"
-        else
-          echo "Failed to mount ESP $ESP_DEVICE, continuing without marker check."
-        fi
-      else
-        echo "ESP partition not found, continuing without marker check."
-      fi
-
-      for _ in {1..30}; do
-        [ -b "$RESIZE_TARGET" ] && break
-        sleep 1
-      done
-
+      # No retry loop: cryptsetup.target ordering means the mapper is either
+      # open by now or not coming.
       if [ ! -b "$RESIZE_TARGET" ]; then
         echo "Target device $RESIZE_TARGET not found, skipping."
         exit 0
@@ -972,7 +999,11 @@ in
       '';
 
       systemd.services = {
-        resize-partitions = {
+        # Verity images have no resizable root here: their root is a tmpfs
+        # overlay, their ESP label never matches the marker check, and
+        # firstboot-persist.nix does its own growing -- so the unit only
+        # burned its 30 s device hunt on every boot. Skip it entirely.
+        resize-partitions = mkIf (!verityEnabled) {
           description = "Resize partitions to fill the disk on first boot";
           wantedBy = [ "initrd.target" ];
           before = [

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -73,12 +73,12 @@ in
     {
       firmwareSize = 256;
 
-      # The stock expand-root-partition.service resolves the root device via
-      # `lsblk -npo PKNAME /`, which is empty for a /dev/mapper/cryptroot root
-      # and makes sfdisk fail ("no disk device specified"). The initrd
-      # resize-partitions service already grows the LUKS partition + filesystem,
-      # so disable the redundant stock expand when encryption is enabled.
-      expandOnBoot = !config.ghaf.hardware.nvidia.orin.diskEncryption.enable;
+      # The initrd resize-partitions service grows the root partition and
+      # filesystem for both the plain and the LUKS layout, so the stock
+      # stage-2 expand-root-partition.service is redundant everywhere (and
+      # broken for LUKS: it resolves the root device via `lsblk -npo PKNAME /`,
+      # which is empty for a /dev/mapper/cryptroot root).
+      expandOnBoot = false;
       populateFirmwareCommands = ''
         mkdir -pv firmware
         ${mkESPContent} \


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Resize half of the approved-then-reverted #2098 (clock half + FSS fix: #2103). All #2098 review feedback included.

The initrd resize hunted a LUKS UUID that never matches on unencrypted images: 30 s burned every boot, and the initrd resize never ran (upstream's stage-2 unit grew the root instead). Now: ESP done-marker first (after `udevadm settle`), unencrypted root via `sdImage.rootVolumeLabel`, verity targets skip the unit, redundant stage-2 `expandOnBoot` dropped (broken for LUKS anyway).

Measured on an AGX devkit: host initrd 40 s → 9 s; first boot resizes once (~11 s), later boots skip in under a second.

### Type of Change
- [x] Bug fix

## Related Issues / Tickets
#2098 (reverted in 64fd16fb), #2103.

## Checklist
- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

## Testing Instructions
### Applicable Targets
- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
### Installation Method
- [x] Requires full re-installation
### Test Steps To Verify:
1. Flash unencrypted debug image; first boot resizes (`df /` shows full disk).
2. Reboot: `Resize already performed, skipping.` within ~1 s; initrd < 10 s.
3. Evals: agx-debug, agx-verity-debug, nx-debug, intel-laptop-debug.