### PR TITLE
feat(microvm): select Crosvm for AdminVM

### DIFF
--- a/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
@@ -15,12 +15,14 @@ Nevertheless, it may happen that some hypervisor options are not supported by mi
 QEMU and crosvm are VMMs (virtual machine monitors) running on top of KVM, not
 hypervisors themselves. Ghaf selects the system VM VMM through
 `ghaf.virtualization.vmConfig`. QEMU is the default for system VMs, while
-AdminVM uses crosvm on every target. Each system VM can override the default
+AdminVM uses crosvm when storage encryption is disabled. Encrypted AdminVMs
+remain on QEMU because the crosvm runner does not yet provide the TPM path used
+to seal their storage keys. Each system VM can override the default
 independently:
 
 ```nix
 vmConfig = {
-  defaultVmm = "qemu";
+  defaultSysVmVmm = "qemu";
   sysvms = {
     adminvm.vmm = "qemu"; # Optional AdminVM fallback
     netvm.vmm = "crosvm";
@@ -29,10 +31,13 @@ vmConfig = {
 ```
 
 System VM keys use unhyphenated names such as `adminvm`, `netvm`, and `guivm`.
-Profiles apply the selection when they extend each VM's evaluated configuration.
-This supports a mixed fleet during migration instead of requiring every VM on a
-target to use the same VMM. Note that microvm.nix names its own selector
-`microvm.hypervisor`; Ghaf maps `vmm` onto it.
+The selection takes effect only when the VM's evaluated configuration includes
+`lib.ghaf.vm.applyVmConfig`. Profiles and targets that construct an
+`evaluatedConfig` directly must include this helper; otherwise the default and
+per-VM settings are ignored. This supports a mixed fleet during migration
+instead of requiring every VM on a target to use the same VMM. Note that
+microvm.nix names its own selector `microvm.hypervisor`; Ghaf maps `vmm` onto
+it.
 
 AdminVM declares its vsock CID through the VMM-independent
 `microvm.vsock.cid` option. Both the QEMU fallback and the crosvm default

--- a/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
@@ -10,6 +10,55 @@ Update this section after the pull request https://github.com/tiiuae/ghaf/pull/9
 
 Nevertheless, it may happen that some hypervisor options are not supported by microvm. For example, adding specific devices. This document considers such cases.
 
+### Selecting a System VM VMM
+
+QEMU and crosvm are VMMs (virtual machine monitors) running on top of KVM, not
+hypervisors themselves. Ghaf selects the system VM VMM through
+`ghaf.virtualization.vmConfig`. QEMU is the default for system VMs, while
+AdminVM uses crosvm on every target. Each system VM can override the default
+independently:
+
+```nix
+vmConfig = {
+  defaultVmm = "qemu";
+  sysvms = {
+    adminvm.vmm = "qemu"; # Optional AdminVM fallback
+    netvm.vmm = "crosvm";
+  };
+};
+```
+
+System VM keys use unhyphenated names such as `adminvm`, `netvm`, and `guivm`.
+Profiles apply the selection when they extend each VM's evaluated configuration.
+This supports a mixed fleet during migration instead of requiring every VM on a
+target to use the same VMM. Note that microvm.nix names its own selector
+`microvm.hypervisor`; Ghaf maps `vmm` onto it.
+
+AdminVM declares its vsock CID through the VMM-independent
+`microvm.vsock.cid` option. Both the QEMU fallback and the crosvm default
+therefore use the VM's configured network CID without raw QEMU arguments.
+
+#### crosvm Sandbox Boundary
+
+Ghaf runs VMM services as the unprivileged `microvm` user. crosvm's internal
+multiprocess minijail requires `CAP_SYS_ADMIN` to create PID and mount
+namespaces, which the service intentionally does not have. Ghaf consequently
+adds `--disable-sandbox` to crosvm VM runners by default.
+
+This keeps the VMM process behind the unprivileged systemd service boundary,
+but it disables crosvm's additional per-device-process isolation. Treat this as
+an explicit migration tradeoff until Ghaf provides capability-scoped namespace
+setup without granting the VMM broad host privileges.
+
+To inspect a deployed VM's selected VMM and generated command line, run
+(the file name comes from microvm.nix):
+
+```sh
+cat /var/lib/microvms/admin-vm/current/share/microvm/hypervisor
+admin_pid="$(systemctl show --property MainPID --value microvm@admin-vm)"
+tr '\0' ' ' <"/proc/${admin_pid}/cmdline"
+```
+
 ### Options Definitions
 
 A VM is defined under Ghaf’s subdirectory `microvmConfigurations/VM_NAME/default.nix`, for example:

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -122,7 +122,7 @@ its namespace setup requires `CAP_SYS_ADMIN`.
 
 ```nix
 vmConfig = {
-  defaultVmm = "qemu";
+  defaultSysVmVmm = "qemu";
 
   # System VMs, keyed by the unhyphenated name (guivm, netvm, audiovm,
   # adminvm, idsvm)

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -16,7 +16,7 @@ Creates a Ghaf configuration for any supported target type (laptop-x86, orin).
 - `variant`: String - Build variant, "debug" (default) or "release"
 - `extraModules`: List - Additional NixOS modules (default: [])
 - `extraConfig`: Attrs - Additional ghaf.* configuration (default: {})
-- `vmConfig`: Attrs - VM resource allocation and modules (default: {})
+- `vmConfig`: Attrs - VMM selection, VM resource allocation, and modules (default: {})
 
 **Returns:**
 - `name`: Full configuration name (e.g., "lenovo-x1-carbon-gen11-debug")
@@ -112,12 +112,18 @@ does not. So `inputs.ghaf.inputs` is missing exactly the key every ghaf module r
 }
 ```
 
-### Using vmConfig for Resource Allocation
+### Using vmConfig for VMM and Resource Configuration
 
-The `vmConfig` parameter allows you to customize VM resource allocation per-target:
+The `vmConfig` parameter selects a default system-VM VMM and supports
+per-VM VMM and resource overrides. The default VMM is QEMU, while
+AdminVM defaults to crosvm on every target. crosvm VMs run as Ghaf's
+unprivileged `microvm` user with crosvm's internal minijail disabled, because
+its namespace setup requires `CAP_SYS_ADMIN`.
 
 ```nix
 vmConfig = {
+  defaultVmm = "qemu";
+
   # System VMs, keyed by the unhyphenated name (guivm, netvm, audiovm,
   # adminvm, idsvm)
   sysvms = {
@@ -132,6 +138,7 @@ vmConfig = {
     audiovm = {
       mem = 512;
     };
+    adminvm.vmm = "qemu"; # Optional AdminVM fallback
   };
 
   # App VMs
@@ -263,4 +270,5 @@ Key differences:
 - Named parameters instead of positional
 - `hardwareModule` separated from `extraModules`
 - `extraConfig` sets `ghaf.*` attributes directly
-- `vmConfig` for resource allocation (replaces `hardware.definition.<vm>.mem/vcpu`)
+- `vmConfig` for VMM selection and resource allocation (replaces
+  `hardware.definition.<vm>.mem/vcpu`)

--- a/lib/builders/mkGhafConfiguration.nix
+++ b/lib/builders/mkGhafConfiguration.nix
@@ -5,7 +5,8 @@
 #
 # Creates a Ghaf configuration for any supported target type.
 # This builder unifies mkLaptopConfiguration and mkOrinConfiguration into
-# a single, composable API with vmConfig support for resource allocation.
+# a single, composable API with vmConfig support for VMM selection and
+# resource allocation.
 #
 # Usage (inside ghaf, where self/inputs are ghaf's own):
 #   let
@@ -46,7 +47,8 @@
 #   variant        - Build variant: "debug" or "release" (default: "debug")
 #   extraModules   - Additional NixOS modules for the host (default: [])
 #   extraConfig    - Additional ghaf.* configuration (default: {})
-#   vmConfig       - VM resource allocation and modules (default: {})
+#   vmConfig       - VMM selection, resource allocation, and modules
+#                    (default: {})
 #                    Maps to ghaf.virtualization.vmConfig
 #   extraInputs    - Extra names merged into `inputs` (default: {}). Visible as
 #                    module arguments of the host and, because ghaf's profiles

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -858,7 +858,10 @@ rec {
         hwModules = hwDef.extraModules or [ ];
         vmConfigModules = vmCfg.extraModules or [ ];
         selectedVmm =
-          if (vmCfg.vmm or null) != null then vmCfg.vmm else config.ghaf.virtualization.vmConfig.defaultVmm;
+          if (vmCfg.vmm or null) != null then
+            vmCfg.vmm
+          else
+            config.ghaf.virtualization.vmConfig.defaultSysVmVmm;
 
         # VM settings module (applies the VMM and vmConfig.mem/vcpu)
         #
@@ -878,7 +881,9 @@ rec {
             # multiprocess minijail needs CAP_SYS_ADMIN to create PID and mount
             # namespaces, so retain the unprivileged service boundary and use
             # single-process mode until a capability-scoped sandbox is wired.
-            crosvm.extraArgs = lib.mkDefault [ "--disable-sandbox" ];
+            # This required runner argument must compose with device-specific
+            # crosvm arguments supplied by other modules.
+            crosvm.extraArgs = lib.mkBefore [ "--disable-sandbox" ];
           };
         };
       in

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -828,11 +828,11 @@ rec {
     # Build modules list with vmConfig applied
     #
     # This function collects modules from hardware.definition and vmConfig
-    # and builds a resource allocation module from vmConfig.mem/vcpu.
+    # and builds a VM settings module from the VMM and resource options.
     #
     # Module merge order (highest priority last):
     #   1. Base module (guivm-base.nix) - sets mkDefault values
-    #   2. resourceModule - applies vmConfig.mem/vcpu
+    #   2. vmSettingsModule - applies the VMM and vmConfig.mem/vcpu
     #   3. hwModules - hardware.definition.<vm>.extraModules
     #   4. vmConfigModules - vmConfig.sysvms.<vm>.extraModules (highest priority)
     #
@@ -857,19 +857,31 @@ rec {
 
         hwModules = hwDef.extraModules or [ ];
         vmConfigModules = vmCfg.extraModules or [ ];
+        selectedVmm =
+          if (vmCfg.vmm or null) != null then vmCfg.vmm else config.ghaf.virtualization.vmConfig.defaultVmm;
 
-        # Resource allocation module (applies vmConfig.mem/vcpu)
+        # VM settings module (applies the VMM and vmConfig.mem/vcpu)
         #
         # Merge inside `microvm`, not at the top level: `//` is a shallow
         # update, so combining { microvm.mem = ...; } with
         # { microvm.vcpu = ...; } would replace the whole microvm attrset and
         # silently drop mem whenever both are set.
-        resourceModule = {
-          microvm =
-            lib.optionalAttrs (vmCfg.mem or null != null) { inherit (vmCfg) mem; }
-            // lib.optionalAttrs (vmCfg.vcpu or null != null) { inherit (vmCfg) vcpu; };
+        vmSettingsModule = {
+          microvm = {
+            # microvm.nix calls its VMM selector `hypervisor`.
+            hypervisor = if (vmCfg.vmm or null) != null then selectedVmm else lib.mkDefault selectedVmm;
+          }
+          // lib.optionalAttrs (vmCfg.mem or null != null) { inherit (vmCfg) mem; }
+          // lib.optionalAttrs (vmCfg.vcpu or null != null) { inherit (vmCfg) vcpu; }
+          // lib.optionalAttrs (selectedVmm == "crosvm") {
+            # The host runs VMMs as the unprivileged `microvm` user. crosvm's
+            # multiprocess minijail needs CAP_SYS_ADMIN to create PID and mount
+            # namespaces, so retain the unprivileged service boundary and use
+            # single-process mode until a capability-scoped sandbox is wired.
+            crosvm.extraArgs = lib.mkDefault [ "--disable-sandbox" ];
+          };
         };
       in
-      [ resourceModule ] ++ hwModules ++ vmConfigModules;
+      [ vmSettingsModule ] ++ hwModules ++ vmConfigModules;
   };
 }

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -212,15 +212,7 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 1024;
-    #TODO: Add back support cloud-hypervisor
-    #the system fails to switch root to the stage2 with cloud-hypervisor
-    hypervisor = "qemu";
-    qemu = {
-      extraArgs = [
-        "-device"
-        "vhost-vsock-pci,guest-cid=${toString (hostConfig.networking.thisVm.cid or 10)}"
-      ];
-    };
+    vsock.cid = hostConfig.networking.thisVm.cid or 10;
 
     shares = [
       {

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -208,8 +208,6 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 512;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/dispvm-base.nix
+++ b/modules/microvm/sysvms/dispvm-base.nix
@@ -148,8 +148,6 @@ in
     # display-only default, smaller than GPU VM's 6000.
     vcpu = 4;
     mem = lib.mkDefault 4000;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/gpuvm-base.nix
+++ b/modules/microvm/sysvms/gpuvm-base.nix
@@ -234,8 +234,6 @@ in
     # profile/vmConfig can shrink it.
     vcpu = 4;
     mem = lib.mkDefault 6000;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -375,8 +375,6 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 6;
     mem = lib.mkDefault 6144;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/idsvm/idsvm-base.nix
+++ b/modules/microvm/sysvms/idsvm/idsvm-base.nix
@@ -96,7 +96,6 @@ in
   ++ (lib.optional (globalConfig.debug.enable or false) pkgs.tcpdump);
 
   microvm = {
-    hypervisor = "qemu";
     optimize.enable = true;
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -239,8 +239,6 @@ in
     optimize.enable = false;
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 1024;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/vm-config.nix
+++ b/modules/microvm/vm-config.nix
@@ -3,11 +3,12 @@
 #
 # VM Configuration Module
 #
-# Provides ghaf.virtualization.vmConfig for resource allocation and
-# profile/downstream customization.
+# Provides ghaf.virtualization.vmConfig for VMM selection, resource
+# allocation, and profile/downstream customization.
 #
 # This is separate from hardware.definition which handles physical
 # hardware properties. vmConfig handles:
+# - VMM selection - QEMU by default, crosvm for AdminVM, and per-VM overrides
 # - Resource allocation (mem, vcpu) - varies by profile
 # - Profile-specific modules (apps, services)
 # - Downstream customizations
@@ -18,6 +19,7 @@
 #   └── extraModules: Hardware quirks ONLY (GPU passthrough, OVMF)
 #
 #   virtualization.vmConfig (VARIES by profile)
+#   ├── VMM selection: default plus per-system-VM overrides
 #   ├── Resource allocation: mem, vcpu
 #   └── extraModules: Profile apps, services, downstream config
 #
@@ -41,6 +43,21 @@ let
   # System VM configuration submodule (guivm, netvm, audiovm, adminvm, idsvm)
   systemVmConfigType = types.submodule {
     options = {
+      vmm = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "qemu"
+            "crosvm"
+          ]
+        );
+        default = null;
+        description = ''
+          VMM used for this system VM.
+          If null, uses ghaf.virtualization.vmConfig.defaultVmm.
+        '';
+        example = "crosvm";
+      };
+
       mem = mkOption {
         type = types.nullOr types.int;
         default = null;
@@ -119,6 +136,15 @@ in
   _file = ./vm-config.nix;
 
   options.ghaf.virtualization.vmConfig = {
+    defaultVmm = mkOption {
+      type = types.enum [
+        "qemu"
+        "crosvm"
+      ];
+      default = "qemu";
+      description = "Default VMM for system VMs without a per-VM override.";
+    };
+
     sysvms = mkOption {
       type = types.attrsOf systemVmConfigType;
       default = { };
@@ -129,6 +155,7 @@ in
       example = literalExpression ''
         {
           guivm = { mem = 16384; vcpu = 8; };
+          adminvm.vmm = "qemu"; # Optional AdminVM fallback
           netvm = { extraModules = [ ./my-net-config.nix ]; };
         }
       '';
@@ -149,6 +176,7 @@ in
     };
   };
 
-  # No config block - this is a pure options module
-  # Consumption happens in profiles via lib.ghaf.vm.applyVmConfig
+  # Keep QEMU as the system-wide default while migrating AdminVM to crosvm on
+  # every target. Targets and downstream configurations can still override it.
+  config.ghaf.virtualization.vmConfig.sysvms.adminvm.vmm = lib.mkDefault "crosvm";
 }

--- a/modules/microvm/vm-config.nix
+++ b/modules/microvm/vm-config.nix
@@ -30,6 +30,7 @@
 #   4. virtualization.vmConfig.sysvms.guivm.extraModules <- profile/downstream (highest priority)
 #
 {
+  config,
   lib,
   ...
 }:
@@ -53,7 +54,10 @@ let
         default = null;
         description = ''
           VMM used for this system VM.
-          If null, uses ghaf.virtualization.vmConfig.defaultVmm.
+          If null, uses ghaf.virtualization.vmConfig.defaultSysVmVmm.
+
+          This setting takes effect when the VM's evaluated configuration
+          includes lib.ghaf.vm.applyVmConfig.
         '';
         example = "crosvm";
       };
@@ -136,13 +140,20 @@ in
   _file = ./vm-config.nix;
 
   options.ghaf.virtualization.vmConfig = {
-    defaultVmm = mkOption {
+    defaultSysVmVmm = mkOption {
       type = types.enum [
         "qemu"
         "crosvm"
       ];
       default = "qemu";
-      description = "Default VMM for system VMs without a per-VM override.";
+      description = ''
+        Default VMM for system VMs without a per-VM override.
+
+        This setting takes effect when the VM's evaluated configuration
+        includes lib.ghaf.vm.applyVmConfig. Cloud Hypervisor is intentionally
+        not selectable because AdminVM does not switch root to stage 2 with it.
+      '';
+      example = "qemu";
     };
 
     sysvms = mkOption {
@@ -151,6 +162,9 @@ in
       description = ''
         Per-system-VM configuration. Keys should match system VM names
         (e.g., guivm, netvm, audiovm, adminvm, idsvm).
+
+        These settings take effect when the corresponding VM's evaluated
+        configuration includes lib.ghaf.vm.applyVmConfig.
       '';
       example = literalExpression ''
         {
@@ -176,7 +190,10 @@ in
     };
   };
 
-  # Keep QEMU as the system-wide default while migrating AdminVM to crosvm on
-  # every target. Targets and downstream configurations can still override it.
-  config.ghaf.virtualization.vmConfig.sysvms.adminvm.vmm = lib.mkDefault "crosvm";
+  # Keep QEMU as the system-wide default while migrating AdminVM to crosvm.
+  # Encrypted AdminVMs still need QEMU's TPM path until crosvm TPM support is
+  # wired. Targets and downstream configurations can override this selection.
+  config.ghaf.virtualization.vmConfig.sysvms.adminvm.vmm = lib.mkDefault (
+    if config.ghaf.global-config.storage.encryption.enable then "qemu" else "crosvm"
+  );
 }

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -305,7 +305,14 @@ in
 
           adminvm = {
             enable = true;
-            evaluatedConfig = lib.mkDefault cfg.adminvmBase;
+            evaluatedConfig = lib.mkDefault (
+              cfg.adminvmBase.extendModules {
+                modules = lib.ghaf.vm.applyVmConfig {
+                  inherit config;
+                  vmName = "adminvm";
+                };
+              }
+            );
           };
 
           idsvm = {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -376,8 +376,12 @@ in
 
           adminvm = {
             enable = true;
-            # Use evaluatedConfig pattern - common is passed via hostConfig
-            evaluatedConfig = cfg.adminvmBase;
+            evaluatedConfig = cfg.adminvmBase.extendModules {
+              modules = lib.ghaf.vm.applyVmConfig {
+                inherit config;
+                vmName = "adminvm";
+              };
+            };
           };
 
           # GPU VM: enable comes from the gpu-vm passthrough module

--- a/modules/reference/profiles/mvp-user-trial-extras.nix
+++ b/modules/reference/profiles/mvp-user-trial-extras.nix
@@ -42,7 +42,12 @@ in
           enable = lib.mkForce true;
           mitmproxy.enable = lib.mkForce true;
           # Use the new evaluatedConfig pattern from laptop-x86 profile
-          evaluatedConfig = config.ghaf.profiles.laptop-x86.idsvmBase;
+          evaluatedConfig = config.ghaf.profiles.laptop-x86.idsvmBase.extendModules {
+            modules = lib.ghaf.vm.applyVmConfig {
+              inherit config;
+              vmName = "idsvm";
+            };
+          };
         };
       };
 

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -104,7 +104,10 @@ let
 
               # Wire up netvm using inline netvmBase
               ghaf.virtualization.microvm.netvm.evaluatedConfig = netvmBase.extendModules {
-                modules = config.ghaf.hardware.definition.netvm.extraModules or [ ];
+                modules = lib.ghaf.vm.applyVmConfig {
+                  inherit config;
+                  vmName = "netvm";
+                };
               };
             }
           )

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -122,20 +122,37 @@ let
                     netvm = {
                       enable = true;
                       evaluatedConfig = vmProfile.netvmBase.extendModules {
-                        modules = [ netvmGivcModule ];
+                        modules = [
+                          netvmGivcModule
+                        ]
+                        ++ lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          vmName = "netvm";
+                        };
                       };
                     };
 
                     audiovm = {
                       enable = true;
                       evaluatedConfig = vmProfile.audiovmBase.extendModules {
-                        modules = [ audiovmGivcModule ];
+                        modules = [
+                          audiovmGivcModule
+                        ]
+                        ++ lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          vmName = "audiovm";
+                        };
                       };
                     };
 
                     adminvm = {
                       enable = true;
-                      evaluatedConfig = vmProfile.adminvmBase;
+                      evaluatedConfig = vmProfile.adminvmBase.extendModules {
+                        modules = lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          vmName = "adminvm";
+                        };
+                      };
                     };
 
                     # NOTE: GUI runs on host, not in a gui-vm


### PR DESCRIPTION
## Description of Changes

Add per-system-VM VMM selection with QEMU as the default, run AdminVM with Crosvm, and use the hypervisor-neutral vsock option. Keep the service unprivileged and retain `--disable-sandbox`; no `CAP_SYS_ADMIN` is added.

### Type of Change

- [x] New feature
- [x] Documentation

## Related Issues / Tickets

Prerequisite for #2123.

## Checklist

- [x] Clear summary
- [x] Signed-off conventional commit
- [x] Documentation updated
- [x] Ready for review

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop low-memory `x86_64`

### Installation Method

- [x] Can be updated with `nixos-rebuild ... switch`

### Test Steps To Verify

1. Confirm AdminVM selects `crosvm`.
2. Confirm another system VM retains `qemu`.
3. Verify the AdminVM service is active and uses a vsock CID.
