### PR TITLE
fix(orin): release unused passthrough memory

### DIFF
--- a/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_vm_display.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/nvidia_gpu_vm_display.mdx
@@ -192,6 +192,73 @@ the display engine's ISO/NISO SMMU streams.
   completions the guest can never receive (the awaken interrupt path does not
   cross the relay).
 
+### Host-Memory Footprint
+
+The identity mappings are removed from the host's normal RAM before Linux
+boots. Count them separately from each VM's ordinary QEMU RAM:
+
+| Mapping | Size | Accelerated | Split | Purpose |
+| --- | ---: | :---: | :---: | --- |
+| `vm_cma` | 768 MiB | yes | yes | GPU, NVMAP, and guest CMA heaps |
+| `vm_hs` | 64 MiB | yes | yes | host1x semaphore/syncpoint shim |
+| `scanout` | 128 MiB | yes | yes | 1:1 display scanout aperture |
+| `dispram_lo` | 736 MiB | no | yes | `disp-vm` kernel and working RAM |
+| `dispram_hi` | 416 MiB | no | yes | `disp-vm` display carveouts |
+| **Total** |  | **960 MiB** | **2112 MiB** |  |
+
+The former `vm_cma_vram` mapping reserved another 4 GiB at `0x100000000`, but
+no active guest heap used it after GPU allocations moved below 4 GiB. It is no
+longer present in the host overlay, guest memory node, QEMU VFIO arguments, or
+guest `reserved-memory`. The `disp-vm` banks are emitted only for the split
+topology; the combined `gui-vm` therefore releases a further 1152 MiB.
+
+On an AGX accelerated target, removing the split-only banks increased host
+`MemTotal` from 29,303,456 KiB to 30,483,120 KiB: exactly 1,179,664 KiB after
+kernel accounting, matching the 1152 MiB DT reservation. The host and
+`gui-vm` remained healthy, and the live host DT contained `vm_cma`, `vm_hs`,
+and `scanout`, but no old VRAM or `dispram` nodes.
+
+#### QEMU RAM Is a Separate Budget
+
+The fixed mappings above do not replace a graphics VM's ordinary
+`microvm.mem` allocation. QEMU exposes that allocation as a separate high
+guest memory bank. VFIO locks its address range, so lowering `microvm.mem`
+reduces the amount that can become unreclaimable on the host. Residency can be
+lazy: the complete range is locked even when not all pages are resident yet.
+
+Measurements from the accelerated targets on 2026-08-05 illustrate the
+difference:
+
+| Board | `gui-vm` QEMU RAM | Host `VmLck` | Host `VmRSS` | Guest used | Guest available |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| AGX | 6144 MiB | 6144 MiB | 6298 MiB | 1336 MiB | 4712 MiB |
+| NX 16 GB | 4096 MiB | 4096 MiB | 1845 MiB | 1255 MiB | 2723 MiB |
+
+All graphics system VMs already enable LZO-RLE zram at 25 percent of guest
+RAM with swappiness 10. Neither measured `gui-vm` was using zram. Zram can
+provide headroom after reducing QEMU RAM, but enabling or enlarging it alone
+does not release a host carveout or shrink the VFIO-locked range.
+
+Tune normal VM RAM independently for each topology and workload:
+
+- The AGX accelerated target can first test `gui-vm` at 4096 MiB, matching the
+  current NX allocation. This lowers the locked ceiling by 2 GiB.
+- On NX, test 3072 MiB before considering a smaller `gui-vm`; idle use does not
+  cover COSMIC login, application, graphics, and first-boot peaks.
+- In split mode, AGX defaults of 6000 MiB for `gpu-vm` and 4000 MiB for
+  `disp-vm` can be tested against the existing NX allocations of 2048 MiB and
+  1536 MiB. Validate `gpu-vm` with the intended CUDA or unified-memory workload.
+- Do not reduce the NX `net-vm` from 2048 MiB based on idle data. A 1024 MiB
+  configuration previously OOM-killed during the logging and networking
+  first-boot burst.
+
+For each step, cold boot the board, compare host `VmLck`/`VmRSS` and guest
+`MemAvailable`, then exercise modesets, COSMIC login, applications, and the
+intended GPU workload. Treat OOM events, sustained zram use, memory-pressure
+stalls, or GPU/DCE faults as a failed size. Guest kernel `mem=` limits,
+offlining, ballooning, and huge pages do not by themselves shrink these static
+VFIO mappings; change `microvm.mem` to reduce the host ceiling.
+
 ## Asynchronous events: hotplug and vblank
 
 The DCE pushes unsolicited notifications (channel type 3) for hotplug, vblank

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/tegra234-dispvm-memory.dtsi
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/disp-vm/tegra234-dispvm-memory.dtsi
@@ -11,8 +11,8 @@
 	// not reliably back the guest in this tegra passthrough setup (virt -m base !=
 	// DTB memory@), so RAM comes from a reserved host carveout mapped 1:1 via vfio
 	// mmio-base. 0xb8000000..0x100000000 sits between disp-vm's scanout (0xb0..0xb8)
-	// and gpu-vm's vram (0x100000000+), disjoint from every gpu-vm carveout. No GPU
-	// VRAM bank (no GPU here). Split: LOW bank (0xb8000000..0xe6000000, 736MB =
+	// and the 4GB boundary, disjoint from every gpu-vm carveout. Split: LOW bank
+	// (0xb8000000..0xe6000000, 736MB =
 	// 672MB normal + 64MB CMA) holds kernel/initrd + working set; HIGH bank
 	// (0x200000000..0x21a000000, 416MB) holds GPU-style carveouts (generic/vpr/fsi).
 	// DMA32 hole 0xe6000000..0x100000000 left to the host for PCIe MSI / WLAN.

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/default.nix
@@ -106,6 +106,8 @@ in
         dtsFile = ./gpu_passthrough_overlay.dts;
       }
     ];
+    # The split topology needs the fixed 1:1 RAM banks used by disp-vm.
+    hardware.deviceTree.dtboBuildExtraPreprocessorFlags = [ "-DGHAF_INCLUDE_DISPVM_RAM" ];
 
     ghaf.hardware.definition.gpuvm.extraModules = [
       (mkOrinGpuGuestModule {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/gpu_passthrough_overlay.dts
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/gpu_passthrough_overlay.dts
@@ -34,11 +34,8 @@
                     reg = <0x0 0x80000000 0x0 0x30000000>;				// 768MB
                     status = "okay";
                 };
-                // Reserved CMA for VM GPU VRAM
-                vm_cma_vram: vm_cma_vram@100000000 {
-                    compatible = "removed-dma-pool";
-                    reg = <0x01 0x00000000 0x01 0x00000000>;            // 4GB
-                };
+                // The active GPU/NVMAP heaps all live in vm_cma. Do not reserve
+                // the former 4GB vm_cma_vram bank: no guest consumer uses it.
                 // Reserved CMA for VM host1x sem-syncpt-shim
                 vm_hs: vm_hs@60000000 {
                     compatible = "removed-dma-pool";
@@ -75,14 +72,6 @@
                 compatible = "nvidia,dummy";
                 iommus = <&smmu_niso0 TEGRA234_SID_PASSTHROUGH>;
                 reg = <0x0 0x80000000 0x0 0x30000000>;              	// 768MB
-                dma-coherent;
-                status = "okay";
-            };
-
-            vm_cma_vram_p: vm_cma_vram_p@100000000 {
-                compatible = "nvidia,dummy";
-                iommus = <&smmu_niso0 TEGRA234_SID_PASSTHROUGH>;
-                reg = <0x01 0x00000000 0x01 0x00000000>;                // 4GB
                 dma-coherent;
                 status = "okay";
             };

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/gpu_passthrough_overlay.dts
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/gpu_passthrough_overlay.dts
@@ -49,6 +49,7 @@
                     reg = <0x0 0xB0000000 0x0 0x08000000>;				// 128MB
                     status = "okay";
                 };
+#ifdef GHAF_INCLUDE_DISPVM_RAM
                 // disp-vm guest RAM = SPLIT carveout (1:1 GPA=HPA). LOW bank:
                 // kernel/initrd + 672MB RAM + 64MB CMA (QEMU -M virt loads kernel
                 // low; all-high -> init killed; <672MB -> init SIGSEGV). HIGH bank
@@ -64,6 +65,7 @@
                     reg = <0x2 0x00000000 0x0 0x1A000000>;				// 416MB @ 8GB (0x200..0x21a)
                     status = "okay";
                 };
+#endif
             };
 
             // Bind the VM reserved-memory regions to a dummy driver so they can
@@ -93,6 +95,7 @@
                 dma-coherent;
                 status = "okay";
             };
+#ifdef GHAF_INCLUDE_DISPVM_RAM
             // disp-vm RAM carveout, 1:1 vfio (mmio-base=0x200000000).
             // GHAF_SID_DISPVM -> same IOMMU group as the other disp-vm wrappers,
             // disjoint from GPU.
@@ -110,6 +113,7 @@
                 dma-coherent;
                 status = "okay";
             };
+#endif
         };
     };
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/tegra234-gpuvm-memory.dtsi
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/gpu-vm/tegra234-gpuvm-memory.dtsi
@@ -10,13 +10,11 @@
 #ifdef EXP_SHRINK_BANK1
 		// Concurrent GPU VM (compute-with-host1x): bank1 ends at 0xb0000000, so
 		// the guest no longer spans the scanout carveout -> scanout_p is dropped
-		// and 0xb0000000 is released to the GUI VM. (bank2 GPU VRAM unchanged.)
-		reg = <0x00 0x80000000 0x00 0x30000000>,  // 0x80000000..0xb0000000 (no scanout tail)
-		      <0x01 0x00000000 0x01 0x00000000>;  // For GPU VRAM
+		// and 0xb0000000 is released to the GUI VM.
+		reg = <0x00 0x80000000 0x00 0x30000000>;  // 0x80000000..0xb0000000 (no scanout tail)
 #else
 		// Keep the scanout VFIO aperture outside System RAM.
-		reg = <0x00 0x80000000 0x00 0x30000000>,  // CMA/carveouts; ends before scanout
-		      <0x01 0x00000000 0x01 0x00000000>;  // For GPU VRAM
+		reg = <0x00 0x80000000 0x00 0x30000000>;  // CMA/carveouts; ends before scanout
 #endif
 		device_type = "memory";
 	};
@@ -66,16 +64,8 @@
 		// to the in-frame offset -> white screen + smmu_iso faults).
 		// 0xA0000000..0xB0000000 is plain guest RAM, 1:1 vfio-backed by
 		// vm_cma_p and already inside the anchor's ISO hi map.
-		// The 4GB VFIO-backed region must STAY reserved even without the
-		// nvmap compatible: it is declared in the memory node, and without
-		// a no-map cover the kernel allocates from it at early boot and
-		// hangs before the console (learned the hard way, twice).
-		vram_reserved: vram_reserved@100000000 {
-			reg = <0x01 0x00000000 0x01 0x00000000>; // 4GB
-			no-map;
-			status = "okay";
-		};
-
+		// The former 4GB bank at 0x100000000 had no remaining consumer after
+		// this move, so it is no longer declared as guest memory or reserved.
 		// (0xA0000000 attempt hung the guest silently; 0xB2000000 sits in
 		// the scanout vfio region, untouched by the loader.)
 		generic_reserved: generic_carveout {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/default.nix
@@ -55,10 +55,6 @@ let
             dev = "80000000.vm_cma_p";
             base = "0x80000000";
           }
-          {
-            dev = "100000000.vm_cma_vram_p";
-            base = "0x100000000";
-          }
         ]
         ++ lib.optional (!computeWithHost1x) {
           dev = "b0000000.scanout_p";

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -202,9 +202,10 @@ let
           # disconnects, killing sshd on the test-net IP.
           mem = 2048;
         };
-        # The carveouts (~6.1GB) come out of the 16GB, leaving ~9.5GB for
-        # host + all QEMU RAM. Keep the VM total at or under 7GB: 10.1GB
-        # OOM-killed a VM and hung PID 1 on every boot.
+        # The split topology reserves ~2.1GiB after dropping the old 4GiB VRAM
+        # bank. Keep the VM total at or under 7GiB until this reduced layout is
+        # validated on NX; 10.1GiB under the former ~6.1GiB layout OOM-killed a
+        # VM and hung PID 1 on every boot.
         sysvms.gpuvm = {
           mem = 2048;
         };


### PR DESCRIPTION
## Description of Changes


Orin GPU/display passthrough reserved fixed identity-mapped RAM for regions
that the selected topology did not use:

- Remove the obsolete 4 GiB `vm_cma_vram` bank from the host DT overlay, guest
  DT memory/reservation nodes, VFIO device list, and QEMU arguments. The active
  GPU and NVMAP heaps already live in the 768 MiB `vm_cma` bank.
- Emit the 736 MiB low and 416 MiB high `disp-vm` RAM banks only for the split
  `gpu-vm` plus `disp-vm` topology. The accelerated `gui-vm` does not instantiate
  `disp-vm` and no longer removes those banks from host RAM.
- Document fixed-carveout accounting, live AGX/NX measurements, the separate
  QEMU RAM budget, and bounded guest-memory tuning guidance.

The resulting fixed reservation is 960 MiB for accelerated `gui-vm` and
2112 MiB for the split topology. This releases 5.125 GiB in accelerated mode
and 4 GiB in split mode relative to the former layout.

On the flashed AGX accelerated target, the topology-specific change increased
host `MemTotal` from 29,303,456 KiB to 30,483,120 KiB, an exact 1,179,664 KiB
increase matching the removed 1152 MiB DT reservation. The live DT retained
`vm_cma`, `vm_hs`, and `scanout`, with no old VRAM or `dispram` nodes.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [x] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

- Follow-up to #2100 (merged)

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

The split topology still receives both `dispram` banks by construction, but it
has not been reflashed after this change. The NX measurements in the
documentation were collected from its previous layout and are used only for
QEMU/guest-RAM analysis.

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify

1. Build and flash `nvidia-jetson-orin-agx-accelerated-guivm-debug`.
2. On the host, verify `MemTotal` and inspect `/proc/device-tree/reserved-memory`.
   The accelerated topology must contain `vm_cma`, `vm_hs`, and `scanout`, but
   no `vm_cma_vram`, `dispram_lo`, or `dispram_hi`.
3. Verify `microvm@net-vm.service` and `microvm@gui-vm.service` are active and
   that the GUI guest reaches its login session.
4. For the split target, verify both `dispram` nodes remain present and boot
   `gpu-vm` plus `disp-vm` before marking this PR ready.

Checks completed:

- `git range-diff` reports all three commits patch-identical across the rebase
- `nix fmt -- --fail-on-change`
- `nix develop --command reuse lint`
- `nix build .#doc --no-link`
- Evaluation of AGX and NX accelerated and split debug configurations
- AGX accelerated image build, flash, host/DT inspection, and GUI guest boot



