### PR TITLE
fix(logging): re-verify before believing a live-journal counter mismatch

### DIFF
--- a/modules/common/logging/fss-verify-classifier.sh
+++ b/modules/common/logging/fss-verify-classifier.sh
@@ -249,6 +249,33 @@ fss_clock_jump_stamp_state() {
   fi
 }
 
+# Counter mismatches are what a verifier sees when journald appends while it is
+# walking the file: it counts objects, then compares against header counters
+# that have moved since. systemd emits six variants of this
+# (journal-verify.c:1266-1315). On the LIVE journal it is an artefact of the
+# file being open for append, not evidence of tampering.
+fss_output_has_counter_mismatch() {
+  printf '%s\n' "$1" |
+    grep -qE '(Object|Entry|Data|Field|Tag|Entry array) number mismatch \([0-9]+ != [0-9]+\)'
+}
+
+# Signatures that mean the content itself is wrong. Never retried away.
+fss_output_has_tamper_signature() {
+  printf '%s\n' "$1" |
+    grep -qE 'Tag failed verification|Hash value mismatch|Older entry after newer tag|Epoch sequence|realtime timestamp out of synchronization'
+}
+
+# Whether an active-journal failure is worth re-verifying rather than believing
+# outright: a counter mismatch and nothing that indicts the content. A real
+# defect survives the re-verify; a live-write race does not.
+fss_active_failure_retryable() {
+  local output="$1" active_failures="$2"
+
+  [ -n "$active_failures" ] || return 1
+  fss_output_has_counter_mismatch "$output" || return 1
+  ! fss_output_has_tamper_signature "$output"
+}
+
 fss_path_list_contains() {
   local path_list="$1"
   local needle="$2"

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -1410,8 +1410,36 @@ let
               fi
             fi
 
-            VERIFY_EXIT=0
-            VERIFY_OUTPUT=$(journalctl --verify --verify-key="$VERIFY_KEY" 2>&1) || VERIFY_EXIT=$?
+            # journalctl walks the live journal while journald is still
+            # appending to it, so the object counts it accumulates can
+            # disagree with the header counters by the time it compares them.
+            # That surfaces as an active-system failure on a perfectly healthy
+            # machine -- observed on a freshly flashed device one second after
+            # setup's own probe passed the same file.
+            #
+            # --sync alone does not close it: the append continues for the
+            # duration of the walk. So re-verify, and only for that signature:
+            # anything that indicts the content (tag, hash, epoch) is believed
+            # on the first attempt, and a counter mismatch that survives every
+            # attempt is reported as a failure exactly as before.
+            attempt=1
+            while :; do
+              journalctl --sync 2>/dev/null || true
+              VERIFY_EXIT=0
+              VERIFY_OUTPUT=$(journalctl --verify --verify-key="$VERIFY_KEY" 2>&1) || VERIFY_EXIT=$?
+              fss_classify_verify_output "$VERIFY_OUTPUT"
+
+              if ! fss_active_failure_retryable "$VERIFY_OUTPUT" "$FSS_ACTIVE_SYSTEM_FAILURES"; then
+                break
+              fi
+              if [ "$attempt" -ge "${toString cfg.verifyRetries}" ]; then
+                fss_log warn "Active-journal counter mismatch persisted across ${toString cfg.verifyRetries} verifies; reporting it"
+                break
+              fi
+              fss_log info "Active-journal counter mismatch on attempt $attempt; journald was appending during the walk, re-verifying"
+              attempt=$((attempt + 1))
+              sleep 2
+            done
 
             # Content-bind lifecycle receipts to disk. Missing archives may be
             # journald retention, but an existing path with different content is
@@ -1799,6 +1827,25 @@ in
 
         Examples: "hourly", "daily", "weekly", "*:0/30" (every 30 min)
         See systemd.time(7) for full syntax.
+      '';
+    };
+
+    verifyRetries = mkOption {
+      type = types.ints.positive;
+      default = 3;
+      description = ''
+        How many times to verify before believing an active-journal counter
+        mismatch.
+
+        journalctl walks the live journal while journald appends to it, so the
+        object counts it accumulates can disagree with the header counters it
+        compares them against -- a failure on a healthy machine, and one that
+        --sync cannot prevent because the append continues for the duration of
+        the walk. Only that signature is retried; anything indicting the
+        content is believed on the first attempt, and a mismatch surviving
+        every attempt is still reported as a failure.
+
+        Set to 1 to disable retrying.
       '';
     };
   };

--- a/tests/logging/test_scripts/fss-classifier-cases.nix
+++ b/tests/logging/test_scripts/fss-classifier-cases.nix
@@ -492,6 +492,44 @@ writeShellApplication {
     [ "$(fss_clock_jump_stamp_state "	$CURBOOT	e" "$CURBOOT" "$NOW" "$TTL")" = malformed ]
     [ "$(fss_clock_jump_stamp_state "-5	$CURBOOT	e" "$CURBOOT" "$NOW" "$TTL")" = malformed ]
 
+    # Live-write race vs real defect. Only the counter-mismatch family is
+    # retryable, and only when nothing indicts the content.
+    ACT="$FSS_ACTIVE_SYSTEM_FAILURES"
+    assert_verdict fail "FAIL: $ACTIVE (Bad message)"
+    ACT="$FSS_ACTIVE_SYSTEM_FAILURES"
+    [ -n "$ACT" ]
+
+    # All six variants systemd emits (journal-verify.c:1266-1315).
+    for kind in Object Entry Data Field Tag "Entry array"; do
+      fss_output_has_counter_mismatch "0000d0: $kind number mismatch (208 != 207)" \
+        || { echo "counter mismatch not recognised: $kind" >&2; exit 1; }
+      fss_active_failure_retryable "0000d0: $kind number mismatch (208 != 207)" "$ACT" \
+        || { echo "should be retryable: $kind" >&2; exit 1; }
+    done
+
+    # The exact output observed on hardware.
+    OBSERVED="$(printf '%s\n%s\n%s' \
+      "0000d0: Data number mismatch (208 != 207)" \
+      "File corruption detected at /var/log/journal/mid/system.journal:2997544 (of 8388608 bytes, 35%)." \
+      "FAIL: $ACTIVE (Bad message)")"
+    fss_active_failure_retryable "$OBSERVED" "$ACT"
+
+    # Nothing else is retryable: no counter mismatch, no active failure, or a
+    # signature that indicts the content.
+    refute fss_output_has_counter_mismatch "FAIL: $ACTIVE (Bad message)"
+    refute fss_active_failure_retryable "FAIL: $ACTIVE (Bad message)" "$ACT"
+    refute fss_active_failure_retryable "0000d0: Data number mismatch (208 != 207)" ""
+    for bad in "2cb2e0: Tag failed verification" \
+               "0000d0: Hash value mismatch in hash entry 3 of 9" \
+               "0002a8: Older entry after newer tag (1 < 2)" \
+               "352a58: Epoch sequence not continuous (0 vs 0)" \
+               "0002a8: tag/entry realtime timestamp out of synchronization (5 >= 4)"; do
+      fss_output_has_tamper_signature "$bad" \
+        || { echo "tamper signature not recognised: $bad" >&2; exit 1; }
+      refute fss_active_failure_retryable \
+        "$(printf '%s\n%s' "0000d0: Data number mismatch (208 != 207)" "$bad")" "$ACT"
+    done
+
     echo "fss-classifier-cases: all cases passed against $CLASSIFIER"
   '';
 }


### PR DESCRIPTION
journal-fss-verify fails at boot on a healthy machine. Reproduced on a freshly flashed Orin AGX: one second after journal-fss-setup logged "Confirmed active system journal verifies after FSS activation", the verify unit reported

  0000d0: Data number mismatch (208 != 207)
  File corruption detected at .../system.journal:2997544 (of 8388608 bytes, 35%)
  FAIL: .../system.journal (Bad message)

Re-running the unit once the boot settled gave PASS on the same file. It is not corruption: journalctl walks the live journal counting objects while journald is still appending, then compares its count against header counters that have moved since. systemd emits six variants of that comparison (journal-verify.c:1266-1315 -- Object, Entry, Data, Field, Tag and Entry array); we happened to hit one. Because an active-system failure is fatal by design, a healthy busy boot reports a critical integrity failure.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
