### PR TITLE
feat(fortivpn): integrate FortiSSLVPN profile management

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -109,6 +109,7 @@ export default defineConfig({
                         "ghaf/dev/ref/fleet",
                         "ghaf/dev/ref/memory-wipe",
                         "ghaf/dev/ref/kill_switch",
+                        "ghaf/dev/ref/fortinet-vpn",
                         "ghaf/dev/ref/wireguard-gui",
                         "ghaf/dev/ref/yubikey",
                         "ghaf/dev/ref/ssh",

--- a/docs/src/content/docs/ghaf/dev/ref/fortinet-vpn.mdx
+++ b/docs/src/content/docs/ghaf/dev/ref/fortinet-vpn.mdx
@@ -1,0 +1,129 @@
+---
+title: Fortinet SSL VPN
+description: Configure and use a Fortinet SSL VPN through NetworkManager.
+---
+{/*
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+*/}
+
+Ghaf supports Fortinet-compatible SSL VPN connections through the upstream NetworkManager
+FortiSSLVPN plugin and `openfortivpn`. The **Fortinet VPN** application creates the complete native
+NetworkManager profile, including optional certificate authentication. The profile then appears in
+**Network & Wireless → VPN** for normal connection management.
+
+The unprivileged COSMIC interface runs in `gui-vm`. NetworkManager, the VPN tunnel, profile
+creation, the stored account password, certificate validation, and protected certificate storage
+remain in `net-vm`.
+
+## Add a connection
+
+1. Open the application library and launch **Fortinet VPN**.
+2. Enter a connection name, gateway hostname, and port. Do not include `http://` or `https://` in
+   the gateway. For example, use `vpn.example.com` and port `443`.
+3. Enter the optional realm, username, and VPN account password.
+4. If the administrator supplied a trusted gateway certificate fingerprint, enter its 64-digit
+   SHA-256 value. Verify a fingerprint through a trusted administrative channel before using it.
+5. Select the required client-certificate mode:
+   - **No client certificate** for password-only authentication.
+   - **PKCS#12 / PFX bundle** for a `.p12` or `.pfx` file and its import password.
+   - **Certificate and private key** for a PEM or DER X.509 certificate and a PEM, DER, or PKCS#8
+     key. Enter the private-key password only when the key is encrypted.
+6. Optionally select a PEM or DER gateway CA certificate.
+7. Select **Add VPN**.
+
+The application validates the request in `net-vm` and creates a native, system-wide NetworkManager
+profile. No separate visit to **Advanced Network Configuration** is required. Open
+**Network & Wireless → VPN** to connect or disconnect it.
+
+### Password storage
+
+The VPN account password is stored by NetworkManager in its root-owned system connection in
+`net-vm`. It is never placed in a command line, environment variable, log, or application state
+file. This system-wide storage mode is required for activation from COSMIC in the split `gui-vm`
+and `net-vm` design, where no user-session NetworkManager SecretAgent runs beside the VPN backend.
+
+PKCS#12 passwords and private-key passphrases are used only during import and are discarded. Secret
+buffers owned by the application and backend are zeroized after use, although D-Bus and
+NetworkManager may create transient internal copies while serializing a request.
+
+## Certificate storage
+
+A client certificate is optional when the FortiGate permits password-only authentication. When
+certificate material is selected, the application reads bounded files in `gui-vm` and sends their
+contents through the filtered Ghaf D-Bus transport. The service in `net-vm` parses them with
+OpenSSL, verifies certificate validity and the client certificate/private-key match, and rejects
+invalid or oversized inputs before creating the profile.
+
+Profile creation is serialized. Before creating a profile, the service removes application-managed
+certificate directories whose NetworkManager connection no longer exists and counts all system
+FortiSSLVPN profiles. It rejects new profiles after the system-wide limit of 32 is reached. This
+bounds persistent certificate and NetworkManager state even if an authorized GUI process is
+compromised and repeatedly requests valid profiles.
+
+The service normalizes the client key to unencrypted PKCS#8 because `openfortivpn` must read it
+non-interactively during connection. The key is root-owned mode `0600`, and all imported files are
+stored below a root-only mode `0700` `/var/lib/ghaf/fortivpn/<profile-UUID>/` directory. Public
+certificate files carry the read bits required by the upstream FortiSSLVPN plugin.
+
+The upstream FortiSSLVPN editor version 1.4.0 can remove certificate paths when saving a profile.
+Avoid saving a certificate-backed profile through **Advanced Network Configuration**. Remove and
+recreate it with **Fortinet VPN** when its connection or certificate details must change.
+
+## Architecture and configuration
+
+The feature is enabled in the standard debug and release profiles. It can be assigned explicitly
+through the global feature configuration:
+
+```nix
+ghaf.global-config.features.fortivpn = {
+  enable = true;
+  targetVms = [
+    "gui-vm"
+    "net-vm"
+  ];
+};
+```
+
+Both VMs are required. `gui-vm` contains the unprivileged libcosmic application and the upstream
+profile editor plugin. `net-vm` contains the backend-only NetworkManager plugin and the sandboxed
+profile service. The service has no direct network access or Linux capabilities, and systemd limits
+its memory, tasks, and open file descriptors. Its system-bus policy permits only the exact profile
+creation method for local GUI users and the Ghaf cross-VM proxy identity required for the request
+path. Ghaf uses the existing filtered GIVC socket and the unmodified `dbus-proxy` package.
+
+The application source is maintained in
+[`tiiuae/ghaf-fortivpn`](https://github.com/tiiuae/ghaf-fortivpn). Reproducible Nix packaging and
+source pinning are maintained in [`tiiuae/ghafpkgs`](https://github.com/tiiuae/ghafpkgs). This Ghaf
+module owns the deployment policy and does not embed or independently fetch the application source.
+
+## Troubleshooting
+
+Inspect NetworkManager and the profile service from `net-vm`:
+
+```sh
+SYSTEMD_PAGER=cat systemctl status NetworkManager ghaf-fortivpn
+SYSTEMD_PAGER=cat journalctl -b -u NetworkManager -u ghaf-fortivpn
+nmcli -f NAME,UUID,TYPE connection show
+```
+
+Inspect both D-Bus proxies from `gui-vm`:
+
+```sh
+SYSTEMD_PAGER=cat systemctl status dbus-proxy-networkmanager dbus-proxy-fortivpn
+SYSTEMD_PAGER=cat journalctl -b -u dbus-proxy-networkmanager -u dbus-proxy-fortivpn
+busctl --system introspect org.ghaf.FortiVpn /org/ghaf/FortiVpn org.ghaf.FortiVpn1
+```
+
+For a certificate-backed profile, verify its non-secret paths from `net-vm` without printing the
+account password:
+
+```sh
+nmcli -f vpn.data connection show uuid <profile-UUID>
+```
+
+The output must contain `cert=`, `key=`, and, when configured, `ca=` paths below
+`/var/lib/ghaf/fortivpn/<profile-UUID>/`.
+
+If the FortiGate gateway certificate changes, obtain and verify its new fingerprint through a
+trusted administrative channel before recreating the profile.

--- a/flake.lock
+++ b/flake.lock
@@ -353,6 +353,23 @@
         "type": "github"
       }
     },
+    "ghaf-fortivpn": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787695055,
+        "narHash": "sha256-3Sdsac5uKb0Q/RFRtJM3JYBxe1ZjVHCfeum7m5+O1/Y=",
+        "owner": "tiiuae",
+        "repo": "ghaf-fortivpn",
+        "rev": "98d4359773c9ae3635ede828abd0b9534d339be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "repo": "ghaf-fortivpn",
+        "rev": "98d4359773c9ae3635ede828abd0b9534d339be8",
+        "type": "github"
+      }
+    },
     "ghafpkgs": {
       "inputs": {
         "crane": [

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -292,6 +292,20 @@ rec {
           };
         };
 
+        fortivpn = {
+          enable = mkEnableOption "Fortinet SSL VPN support" // {
+            default = true;
+          };
+          targetVms = mkOption {
+            type = types.listOf types.str;
+            default = [
+              "gui-vm"
+              "net-vm"
+            ];
+            description = "VMs that provide the Fortinet VPN UI and networking backend";
+          };
+        };
+
         # Hardware authentication services
         fprint = {
           enable = mkEnableOption "fingerprint authentication support" // {
@@ -476,6 +490,13 @@ rec {
 
       # Feature defaults for debug profile
       features = {
+        fortivpn = {
+          enable = true;
+          targetVms = [
+            "gui-vm"
+            "net-vm"
+          ];
+        };
         fprint = {
           enable = true;
           targetVms = [ "gui-vm" ];
@@ -583,6 +604,13 @@ rec {
 
       # Feature defaults for release profile
       features = {
+        fortivpn = {
+          enable = true;
+          targetVms = [
+            "gui-vm"
+            "net-vm"
+          ];
+        };
         fprint = {
           enable = true;
           targetVms = [ "gui-vm" ];
@@ -680,6 +708,10 @@ rec {
 
       # Feature defaults for minimal profile - all disabled
       features = {
+        fortivpn = {
+          enable = false;
+          targetVms = [ ];
+        };
         fprint = {
           enable = false;
           targetVms = [ ];

--- a/modules/common/services/default.nix
+++ b/modules/common/services/default.nix
@@ -10,6 +10,7 @@
     ./createFakeBattery.nix
     ./disks.nix
     ./firmware.nix
+    ./fortivpn.nix
     ./fprint.nix
     ./github.nix
     ./hwinfo

--- a/modules/common/services/fortivpn.nix
+++ b/modules/common/services/fortivpn.nix
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.services.fortivpn;
+  isGuiVm = config.networking.hostName == "gui-vm";
+  isNetVm = config.networking.hostName == "net-vm";
+  certificateDirectory = "/var/lib/ghaf/fortivpn";
+  backendPackage = pkgs.networkmanager-fortisslvpn.override { withGnome = false; };
+  editorPackage = pkgs.networkmanager-fortisslvpn;
+  busName = "org.ghaf.FortiVpn";
+  objectPath = "/org/ghaf/FortiVpn";
+  interfaceName = "org.ghaf.FortiVpn1";
+  createProfileMethod = "CreateProfile";
+  proxyUser = config.ghaf.users.proxyUser.name;
+  mkDbusPolicyPackage =
+    name: callerPolicy:
+    pkgs.writeTextFile {
+      inherit name;
+      destination = "/share/dbus-1/system.d/${name}.conf";
+      text = ''
+        <!DOCTYPE busconfig PUBLIC
+          "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+          "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+          <policy context="default">
+            <deny own="${busName}"/>
+            <deny send_destination="${busName}"/>
+          </policy>
+          <policy user="root">
+            <allow own="${busName}"/>
+            <allow send_destination="${busName}"/>
+          </policy>
+          ${callerPolicy}
+        </busconfig>
+      '';
+    };
+  serviceHardening = import ../systemd/hardened-configs/fortivpn.nix;
+in
+{
+  _file = ./fortivpn.nix;
+
+  options.ghaf.services.fortivpn.enable =
+    lib.mkEnableOption "Fortinet SSL VPN support in the GUI VM and Net VM";
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = isGuiVm || isNetVm;
+            message = "ghaf.services.fortivpn is supported only in gui-vm and net-vm";
+          }
+          {
+            assertion = config.ghaf.givc.enable;
+            message = "ghaf.services.fortivpn requires GIVC for GUI VM access to NetworkManager";
+          }
+          {
+            assertion = !isNetVm || config.ghaf.users.proxyUser.enable;
+            message = "ghaf.services.fortivpn requires the D-Bus proxy user in net-vm";
+          }
+        ];
+      }
+
+      (lib.mkIf isGuiVm {
+        environment.etc."NetworkManager/${editorPackage.networkManagerPlugin}".source =
+          "${editorPackage}/lib/NetworkManager/${editorPackage.networkManagerPlugin}";
+
+        environment.systemPackages = [
+          editorPackage
+          pkgs.ghaf-fortivpn
+          pkgs.networkmanager
+          pkgs.networkmanagerapplet
+        ];
+
+        services.dbus.packages = [
+          (mkDbusPolicyPackage "ghaf-fortivpn-gui" ''
+            <policy group="users">
+              <allow send_destination="${busName}" send_path="${objectPath}" send_interface="${interfaceName}" send_member="${createProfileMethod}"/>
+              <allow send_destination="${busName}" send_path="${objectPath}" send_interface="org.freedesktop.DBus.Introspectable" send_member="Introspect"/>
+            </policy>
+          '')
+        ];
+
+        systemd.services.dbus-proxy-fortivpn = {
+          description = "DBus proxy for the Fortinet VPN service in net-vm";
+          after = [ "givc-gui-vm.service" ];
+          requires = [ "givc-gui-vm.service" ];
+          wantedBy = [ "multi-user.target" ];
+          startLimitIntervalSec = 30;
+          startLimitBurst = 5;
+          serviceConfig = serviceHardening // {
+            Type = "simple";
+            Restart = "always";
+            RestartSec = "1s";
+            ExecStartPre = [
+              "${pkgs.coreutils}/bin/timeout 30 ${pkgs.bash}/bin/bash -c 'until [ -S /tmp/dbusproxy_net.sock ]; do sleep 0.5; done'"
+            ];
+            Environment = [
+              "DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/dbusproxy_net.sock"
+            ];
+            ExecStart = [
+              ''
+                ${lib.getExe pkgs.dbus-proxy} \
+                  --source-bus-name ${busName} \
+                  --source-object-path ${objectPath} \
+                  --proxy-bus-name ${busName} \
+                  --source-bus-type session \
+                  --target-bus-type system \
+                  --log-level error
+              ''
+            ];
+          };
+        };
+      })
+
+      (lib.mkIf isNetVm {
+        networking.networkmanager = {
+          enable = true;
+          plugins = [ backendPackage ];
+          unmanaged = [
+            config.ghaf.networking.hosts.${config.networking.hostName}.interfaceName
+          ];
+        };
+
+        givc.dbusproxy.system.policy.talk = [ busName ];
+
+        ghaf = {
+          storagevm.directories = lib.mkIf config.ghaf.storagevm.enable (
+            [ certificateDirectory ]
+            ++ lib.optional (!config.ghaf.services.wifi.enable) "/etc/NetworkManager/system-connections/"
+          );
+          security.audit.extraRules = [
+            "-w ${certificateDirectory}/ -p wa -k fortivpn-certificates"
+            "-w /etc/NetworkManager/system-connections/ -p wa -k networkmanager-connections"
+          ];
+        };
+
+        systemd.tmpfiles.rules = [ "d ${certificateDirectory} 0700 root root -" ];
+
+        services.dbus.packages = [
+          # dbus-proxy discovers the object tree by introspecting each ancestor from the root.
+          (mkDbusPolicyPackage "ghaf-fortivpn-service" ''
+            <policy user="${proxyUser}">
+              <allow send_destination="${busName}" send_path="${objectPath}" send_interface="${interfaceName}" send_member="${createProfileMethod}"/>
+              <allow send_destination="${busName}" send_path="/" send_interface="org.freedesktop.DBus.Introspectable" send_member="Introspect"/>
+              <allow send_destination="${busName}" send_path="/org" send_interface="org.freedesktop.DBus.Introspectable" send_member="Introspect"/>
+              <allow send_destination="${busName}" send_path="/org/ghaf" send_interface="org.freedesktop.DBus.Introspectable" send_member="Introspect"/>
+              <allow send_destination="${busName}" send_path="${objectPath}" send_interface="org.freedesktop.DBus.Introspectable" send_member="Introspect"/>
+            </policy>
+          '')
+        ];
+
+        systemd.services.ghaf-fortivpn = {
+          description = "Ghaf Fortinet VPN profile service";
+          after = [ "NetworkManager.service" ];
+          requires = [ "NetworkManager.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = serviceHardening // {
+            Type = "dbus";
+            BusName = busName;
+            ExecStart = lib.getExe pkgs.ghaf-fortivpn-service;
+            Environment = [ "GHAF_FORTIVPN_STATE_DIRECTORY=${certificateDirectory}" ];
+            Restart = "on-failure";
+            RestartSec = "1s";
+            StateDirectory = "ghaf/fortivpn";
+            StateDirectoryMode = "0700";
+            PrivateTmp = true;
+          };
+        };
+      })
+    ]
+  );
+}

--- a/modules/common/systemd/hardened-configs/fortivpn.nix
+++ b/modules/common/systemd/hardened-configs/fortivpn.nix
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  AmbientCapabilities = "";
+  CapabilityBoundingSet = "";
+  DevicePolicy = "closed";
+  LockPersonality = true;
+  LimitNOFILE = 128;
+  MemoryMax = "256M";
+  MemoryDenyWriteExecute = true;
+  NoNewPrivileges = true;
+  PrivateDevices = true;
+  PrivateNetwork = true;
+  ProcSubset = "pid";
+  ProtectClock = true;
+  ProtectControlGroups = true;
+  ProtectHome = true;
+  ProtectHostname = true;
+  ProtectKernelLogs = true;
+  ProtectKernelModules = true;
+  ProtectKernelTunables = true;
+  ProtectProc = "invisible";
+  ProtectSystem = "strict";
+  RemoveIPC = true;
+  RestrictAddressFamilies = [ "AF_UNIX" ];
+  RestrictNamespaces = true;
+  RestrictRealtime = true;
+  RestrictSUIDSGID = true;
+  SystemCallArchitectures = "native";
+  TasksMax = 64;
+  UMask = "0077";
+}

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -43,6 +43,7 @@ let
   fprintEnabled = lib.ghaf.features.isEnabledFor globalConfig "fprint" vmName;
   yubikeyEnabled = lib.ghaf.features.isEnabledFor globalConfig "yubikey" vmName;
   brightnessEnabled = lib.ghaf.features.isEnabledFor globalConfig "brightness" vmName;
+  fortivpnEnabled = lib.ghaf.features.isEnabledFor globalConfig "fortivpn" vmName;
   powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
   performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
   localeEnabled = lib.ghaf.features.isEnabledFor globalConfig "locale" vmName;
@@ -229,6 +230,7 @@ in
       fprint.enable = lib.mkDefault fprintEnabled;
       yubikey.enable = lib.mkDefault yubikeyEnabled;
       brightness.enable = lib.mkDefault brightnessEnabled;
+      fortivpn.enable = lib.mkDefault (fortivpnEnabled && (globalConfig.givc.enable or false));
 
       user-provisioning.enable = true;
 

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -28,6 +28,7 @@ let
   vmName = "net-vm";
   powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
   performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
+  fortivpnEnabled = lib.ghaf.features.isEnabledFor globalConfig "fortivpn" vmName;
   wifiEnabled = lib.ghaf.features.isEnabledFor globalConfig "wifi" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
   netVmAddress = hostConfig.networking.thisVm.ipv4 or "192.168.100.1";
@@ -141,6 +142,8 @@ in
       wifi.enable = lib.mkDefault wifiEnabled;
 
       firmware.enable = true;
+
+      fortivpn.enable = lib.mkDefault (fortivpnEnabled && (globalConfig.givc.enable or false));
 
       power-manager = {
         enable = lib.mkDefault powerManagerEnabled;


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

This PR integrates Fortinet SSL VPN profile management into Ghaf.

- Enables FortiSSLVPN support across `gui-vm` and `net-vm`.
- Installs and configures the NetworkManager FortiSSLVPN plugin.
- Configures GIVC D-Bus communication between the frontend and backend.
- Hardens the backend service and restricts access to its D-Bus interface.
- Persists and audits VPN profiles and certificate material.
- Exposes created profiles through COSMIC **Network & Wireless → VPN**.

This PR depends on [ghafpkgs PR #355](https://github.com/tiiuae/ghafpkgs/pull/355).

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->
https://jira.tii.ae/browse/SSRCSP-8767
## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Launch the Fortinet VPN application in `gui-vm`.
2. Enter a profile name, gateway, port, realm, username, and password. Optionally select a PKCS#12 bundle or separate certificate material. 
3. Add the profile and verify that the application reports success and clears the form.
4. Open COSMIC Network & Wireless → VPN and verify that the new profile is present.
5. Connect, disconnect, and reconnect using the native COSMIC VPN controls.
6. For the security review, please check the D-Bus interface, certificate validation, input limits, secret handling, and permissions applied to imported private keys.
