### PR TITLE
fix(pci-binder): detect passthrough devices when no ids are configured

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -354,8 +354,10 @@ let
         suspend)
           # Script to unbind PCI devices for suspend
           # For convenience, we pass IDs of all passthrough PCI devices,
-          # each guest will automatically determine the correct PCI devices
-          pci-binder unbind ${lib.concatStringsSep " " pciDevices}
+          # each guest will automatically determine the correct PCI devices.
+          # Boards that resolve passthrough dynamically in vhotplug populate no static ids
+          # (hardware-intel-laptop is one), so there the guest detects its own devices.
+          pci-binder unbind ${if pciDevices == [ ] then "--auto" else lib.concatStringsSep " " pciDevices}
           ;;
         *)
           echo "Usage: $0 (suspend|reboot|poweroff)"
@@ -719,12 +721,10 @@ in
 
         # Pre-suspend actions for the VM.
         #
-        # `pci-binder unbind` exits 1 with no device ids, and pciDevices is empty on any
-        # board whose ghaf.common.hardware.{nics,audio} carry no vendorId/productId
-        # (hardware-intel-laptop reports one NIC with both null). An ExecStartPre failure
-        # takes the whole unit down, so the guest never reaches guest-fake-suspend -- hence
-        # both the gate and the `-`.
-        ExecStartPre = optionals (cfg.vm.pciSuspend && pciDevices != [ ]) [
+        # `-` because an ExecStartPre failure takes the whole unit down, and losing the
+        # guest's fake suspend -- which is what stops its watchdogs firing on resume -- is
+        # far worse than a PCI device that did not reach low power.
+        ExecStartPre = optionals cfg.vm.pciSuspend [
           "-${getExe guest-power-actions} suspend"
         ];
       };

--- a/packages/pkgs-by-name/pci-binder/pci-binder.sh
+++ b/packages/pkgs-by-name/pci-binder/pci-binder.sh
@@ -7,6 +7,13 @@ declare -A PCI_DATA          # PCI data; associative array with key = PCI bus ID
 declare -a PCI_INPUT_DEVICES # Array to hold input PCI device identifiers
 declare ACTION_FLAG          # Action flag to determine whether to bind or unbind
 declare STATE_DIR=""
+declare AUTO_DETECT=0 # Detect this guest's passthrough devices instead of taking ids
+
+# Base PCI classes ghaf assigns to vfio-pci for passthrough (see extraVfioPciIds in the
+# hardware definitions): 0x02 network, 0x03 display, 0x04 multimedia.
+readonly PASSTHROUGH_CLASSES=(2 3 4)
+# Virtio. A guest's own virtio-net is class 0x02 and must never be unbound.
+readonly VIRTIO_VENDOR="0x1af4"
 
 # Helpers for clearer logging
 TAG="pci-binder"
@@ -31,11 +38,20 @@ log_debug() {
 usage() {
   if [[ $- == *i* ]]; then
     cat <<EOF
-Usage: $(basename "$0") [(-s|--state-dir) <state_directory>] (unbind [<pci_device> ...] | bind)
+Usage: $(basename "$0") [(-s|--state-dir) <state_directory>] (unbind (--auto | <pci_device> ...) | bind)
 
 Options:
   unbind
-    Unbind the drivers from the specified PCI devices. Requires at least one <pci_device> argument.
+    Unbind the drivers from the specified PCI devices. Requires at least one <pci_device>
+    argument, or --auto.
+
+  --auto
+    Detect the passthrough devices in this guest instead of being given their ids: every PCI
+    device whose base class is one of the classes ghaf assigns to vfio-pci (0x02 network,
+    0x03 display, 0x04 multimedia), excluding virtio (0x1af4) so the guest's own virtio-net
+    is never unbound. For boards whose passthrough is resolved dynamically by vhotplug there
+    is no static id list to pass. Detecting nothing is success, not an error -- a guest with
+    no passthrough PCI devices has nothing to unbind.
 
   bind
     Bind the previously unbound PCI devices to their drivers.
@@ -54,6 +70,7 @@ Examples:
   $(basename "$0") --state-dir /run/pci-binding bind
 
   $(basename "$0") unbind 8086:a7a1 8086:51f1
+  $(basename "$0") unbind --auto
 EOF
   fi
 }
@@ -131,6 +148,15 @@ parse_input() {
   # Validate the array of device identifiers
   if [[ $ACTION_FLAG == "unbind" ]]; then
 
+    if [[ ${1:-} == "--auto" ]]; then
+      AUTO_DETECT=1
+      shift 1
+      if [[ $# -ne 0 ]]; then
+        log_error_exit "--auto takes no device identifiers, but received: $*"
+      fi
+      return 0
+    fi
+
     if [[ $# -eq 0 ]]; then
       log_error_exit "No device identifiers found."
     fi
@@ -152,21 +178,58 @@ parse_input() {
   fi
 }
 
+# Detect this guest's passthrough devices by class, for boards where vhotplug resolves
+# passthrough dynamically and there is no static id list to pass.
+detect_passthrough_devices() {
+  local -n out=$1
+  local device_path class vendor base wanted
+
+  for device_path in /sys/bus/pci/devices/*; do
+    [ -r "$device_path/class" ] && [ -r "$device_path/vendor" ] || continue
+    class=$(cat "$device_path/class")
+    vendor=$(cat "$device_path/vendor")
+
+    [[ $vendor == "$VIRTIO_VENDOR" ]] && continue
+
+    base=$(((class >> 16) & 0xff))
+    for wanted in "${PASSTHROUGH_CLASSES[@]}"; do
+      if [[ $base -eq $wanted ]]; then
+        # No driver bound means nothing to unbind, not an error.
+        if [ -e "$device_path/driver" ]; then
+          out+=("$device_path")
+        else
+          log_debug "No driver bound to '$(basename "$device_path")', skipping..."
+        fi
+        break
+      fi
+    done
+  done
+}
+
 # Function to determine suitable devices and populate the PCI_DATA array
 init_pci_unbind() {
 
   # Add all PCI devices that are passed through to this guest
   declare -a pci_device_paths=()
 
-  for device in "${PCI_INPUT_DEVICES[@]}"; do
-    if guest_pci_id=$(lspci -n | grep -i "${device}" | awk '{print $1}'); then
-      pci_device_paths+=("/sys/bus/pci/devices/0000:$guest_pci_id")
-    else
-      log_debug "No matching PCI device '${device}', skipping..."
+  if [[ $AUTO_DETECT -eq 1 ]]; then
+    detect_passthrough_devices pci_device_paths
+    if [ ${#pci_device_paths[@]} -eq 0 ]; then
+      # A guest with no passthrough PCI devices -- an app VM, say -- has nothing to do.
+      log_info "No passthrough PCI devices detected, nothing to unbind."
+      return 0
     fi
-  done
-  if [ ${#pci_device_paths[@]} -eq 0 ]; then
-    log_error_exit "No PCI devices found to unbind."
+  else
+    for device in "${PCI_INPUT_DEVICES[@]}"; do
+      if guest_pci_id=$(lspci -n | grep -i "${device}" | awk '{print $1}'); then
+        pci_device_paths+=("/sys/bus/pci/devices/0000:$guest_pci_id")
+      else
+        log_debug "No matching PCI device '${device}', skipping..."
+      fi
+    done
+    if [ ${#pci_device_paths[@]} -eq 0 ]; then
+      log_error_exit "No PCI devices found to unbind."
+    fi
   fi
   log_info "Detected PCI device paths: ${pci_device_paths[*]}"
 


### PR DESCRIPTION
power.nix builds the guest's unbind list from ghaf.common.hardware.{nics,audio}, but boards that resolve passthrough dynamically in vhotplug populate no static ids -- hardware-intel-laptop declares one NIC with null vendorId/productId and no audio at all, by design ('detected dynamically in vhotplug'). On those boards the list is empty and guest-side PCI suspend never ran, so passed-through devices stayed bound to their guest drivers across a host suspend.

Add 'unbind --auto': the guest finds its own passthrough devices instead of being told. The rule mirrors the classes ghaf already assigns to vfio-pci in extraVfioPciIds -- base class 0x02 network, 0x03 display, 0x04 multimedia -- excluding virtio (0x1af4), because a guest's own virtio-net is class 0x02 and unbinding it would cut the VM off. Detecting nothing is success: an app VM with no passthrough PCI has nothing to unbind.

Verified on dell-ra13250 across a 415 s suspend:
  net-vm    Detected PCI device paths: 0000:01:00.0 0000:02:00.0
            Unbinding driver 'e1000e' from device '0000:02:00.0'
            Unbinding driver 'iwlwifi' from device '0000:01:00.0'
  audio-vm  Unbinding driver 'snd_hda_intel' from device '0000:02:00.0'
All three rebound on resume, both default routes came back, and no virtio device
was touched. Dry-run enumeration over all five VMs picked exactly the two NICs,
the audio codec and the GPU, and nothing in the VMs with no passthrough.

The ExecStartPre gate added with the empty-list fix is no longer needed and is dropped; the leading '-' stays, since losing the guest's fake suspend costs far more than a device that did not reach low power.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
