### PR TITLE
feat(appvm): select Crosvm by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Kernel patches contain whitespace-sensitive context lines that should not be
+# diagnosed as whitespace introduced into this repository.
+modules/microvm/sysvms/patches/chromiumos-virtio-tpm.patch -whitespace

--- a/docs/src/content/docs/ghaf/dev/architecture/vm-memory-management.mdx
+++ b/docs/src/content/docs/ghaf/dev/architecture/vm-memory-management.mdx
@@ -10,7 +10,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Ghaf VMs run with fixed memory allocations and, without swap, have no safety net for transient memory pressure. This is a problem during events like S3 (suspend-to-RAM) resume, where device drivers must reinitialize and temporarily allocate buffers, DMA regions, and firmware blobs. If the VM is already near its memory ceiling, these allocations can trigger OOM kills or kernel panics.
 
-Ghaf addresses this with a three-layer defense against OOM crashes: zram compressed swap inside every VM, virtio-balloon deflation for app VMs, and host-level disk swap that absorbs the resulting pressure.
+Ghaf addresses this with a layered defense against OOM crashes: zram compressed swap inside every VM, virtio-balloon deflation for App VMs, and host-level disk swap that absorbs the resulting pressure.
 
 ## Layer 1: zram Compressed Swap (All VMs)
 
@@ -26,24 +26,27 @@ With a typical 2.5x compression ratio, 25% of RAM as zram yields approximately 6
 
 ## Layer 2: Balloon deflateOnOOM (App VMs)
 
-App VMs use the [virtio-balloon](https://blog.pmhahn.de/virtio-balloon/) device for dynamic memory management. The host memory manager can inflate the balloon (reclaiming guest pages for the host) or the guest can deflate it (reclaiming pages back from the host).
+QEMU and crosvm App VMs use the [virtio-balloon](https://blog.pmhahn.de/virtio-balloon/) device for dynamic memory management. The host memory manager can inflate the balloon (reclaiming guest pages for the host) or the guest can deflate it (reclaiming pages back from the host).
 
 With `deflateOnOOM = true`, the guest kernel automatically deflates the balloon when an OOM condition is imminent. This reclaims pages that were previously loaned to the host, giving the guest more memory without any host intervention.
 
-For example, a 4 GB base app VM with `balloonRatio = 2` has a 12 GB QEMU allocation. If the balloon has inflated to 6 GB (guest sees approximately 6 GB), an OOM event causes the balloon to deflate, and the guest can reclaim up to the full 12 GB allocation.
+For example, a 4 GB base app VM with `balloonRatio = 2` has a 12 GB allocation. If the balloon has inflated to 6 GB (guest sees approximately 6 GB), an OOM event causes the balloon to deflate, and the guest can reclaim up to the full 12 GB allocation.
 
-System VMs (gui-vm, net-vm, audio-vm, admin-vm, ids-vm) do not use balloons, so this layer applies only to app VMs.
+System VMs (gui-vm, net-vm, audio-vm, admin-vm, ids-vm) do not use balloons.
+`ghaf-mem-manager` controls QEMU balloons through QMP and crosvm balloons
+through crosvm's control command. The crosvm backend converts Ghaf's desired
+guest-visible memory into the reclaimed byte count expected by crosvm.
 
 ## Layer 3: Host Disk Swap
 
-When app VM balloons deflate, the QEMU process on the host consumes more physical memory. The host has an 12 GB disk swap partition that absorbs this pressure. The host kernel can page out its own processes or inflate balloons on other idle VMs (via `ghaf-mem-manager`) to rebalance.
+When App VM balloons deflate, the VMM process on the host consumes more physical memory. The host has a 12 GB disk swap partition that absorbs this pressure. The host kernel can page out its own processes or inflate balloons on other idle App VMs (via `ghaf-mem-manager`) to rebalance.
 
 ## How the Layers Cascade During S3 Resume
 
-1. **Suspend**: The host enters S3 sleep. QEMU freezes VMs. RAM stays powered and contents are preserved.
-2. **Resume**: The host wakes. QEMU unfreezes VMs. Device drivers reinitialize, allocating temporary buffers.
+1. **Suspend**: The host enters S3 sleep. The VMM freezes VMs. RAM stays powered and contents are preserved.
+2. **Resume**: The host wakes. The VMM unfreezes VMs. Device drivers reinitialize, allocating temporary buffers.
 3. **zram absorbs the spike**: The kernel compresses idle pages into zram to make room for driver buffers (microsecond latency).
-4. **Balloon deflates if needed**: If more memory is required, the balloon shrinks and the guest reclaims pages from the host.
+4. **Balloon deflates if needed**: The balloon shrinks and the guest reclaims pages from the host.
 5. **Host swap absorbs the host-side impact**: The host uses its disk swap if balloon deflation increases host memory pressure.
 6. **Drivers initialize successfully**: Temporary buffers are freed and the system stabilizes.
 
@@ -61,7 +64,7 @@ All VM bases set this to `true`. To disable zram for a specific VM, override it 
 
 | Option | Description |
 |--------|-------------|
-| `balloonRatio` | Multiplier for QEMU memory allocation beyond base `mem`. A ratio of 2 means QEMU allocates `mem * (balloonRatio + 1)`. |
+| `balloonRatio` | Multiplier for VMM memory allocation beyond base `mem`. A ratio of 2 means the VMM allocates `mem * (balloonRatio + 1)`. |
 | `deflateOnOOM` | Set in `appvm-base.nix`. When `true`, the guest automatically reclaims ballooned pages on OOM. |
 
 ## Further Reading

--- a/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
@@ -15,12 +15,14 @@ Nevertheless, it may happen that some hypervisor options are not supported by mi
 QEMU and crosvm are VMMs (virtual machine monitors) running on top of KVM, not
 hypervisors themselves. Ghaf selects the system VM VMM through
 `ghaf.virtualization.vmConfig`. QEMU is the default for system VMs, while
-AdminVM uses crosvm on every target. Each system VM can override the default
+AdminVM uses crosvm when storage encryption is disabled. Encrypted AdminVMs
+remain on QEMU because the crosvm runner does not yet provide the TPM path used
+to seal their storage keys. Each system VM can override the default
 independently:
 
 ```nix
 vmConfig = {
-  defaultVmm = "qemu";
+  defaultSysVmVmm = "qemu";
   sysvms = {
     adminvm.vmm = "qemu"; # Optional AdminVM fallback
     netvm.vmm = "crosvm";
@@ -29,10 +31,13 @@ vmConfig = {
 ```
 
 System VM keys use unhyphenated names such as `adminvm`, `netvm`, and `guivm`.
-Profiles apply the selection when they extend each VM's evaluated configuration.
-This supports a mixed fleet during migration instead of requiring every VM on a
-target to use the same VMM. Note that microvm.nix names its own selector
-`microvm.hypervisor`; Ghaf maps `vmm` onto it.
+The selection takes effect only when the VM's evaluated configuration includes
+`lib.ghaf.vm.applyVmConfig`. Profiles and targets that construct an
+`evaluatedConfig` directly must include this helper; otherwise the default and
+per-VM settings are ignored. This supports a mixed fleet during migration
+instead of requiring every VM on a target to use the same VMM. Note that
+microvm.nix names its own selector `microvm.hypervisor`; Ghaf maps `vmm` onto
+it.
 
 AdminVM declares its vsock CID through the VMM-independent
 `microvm.vsock.cid` option. Both the QEMU fallback and the crosvm default

--- a/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
@@ -43,12 +43,47 @@ AdminVM declares its vsock CID through the VMM-independent
 `microvm.vsock.cid` option. Both the QEMU fallback and the crosvm default
 therefore use the VM's configured network CID without raw QEMU arguments.
 
-#### crosvm Sandbox Boundary
+### Selecting an App VM VMM
+
+App VMs use crosvm by default on both x86 and NVIDIA platforms. The default
+and individual App VMs can be overridden through the same
+`ghaf.virtualization.vmConfig` interface:
+
+```nix
+vmConfig = {
+  defaultAppVmVmm = "crosvm";
+  appvms = {
+    chrome.vmm = "qemu";
+    flatpak.vmm = "crosvm";
+  };
+};
+```
+
+App VM keys use their unhyphenated base names, such as `chrome`, `flatpak`, and
+`chromium`. Encrypted App VMs remain on the crosvm default. Ghaf's crosvm build
+connects its virtio TPM frontend to the same swtpm proxy socket as QEMU, and
+the App VM guest kernel includes ChromiumOS's virtio TPM transport driver when
+that crosvm App VM has a vTPM enabled. Applying this out-of-tree driver creates
+a separate guest-kernel derivation until that result is available from a binary
+cache.
+
+crosvm App VMs use the same `mem * (balloonRatio + 1)` allocation and
+virtio-balloon policy as QEMU App VMs. `ghaf-mem-manager` selects QEMU QMP or
+the crosvm control command from the VM's configured VMM. It also translates
+between QEMU's guest-visible memory value and crosvm's reclaimed-memory value.
+
+App VMs declare their vsock CID through `microvm.vsock.cid`, so QEMU and crosvm
+use the same configured CID. Runtime USB attachment through vhotplug is
+supported by crosvm. vhotplug records the crosvm guest port for each host USB
+device so identical devices can be detached independently and restored safely
+after daemon restarts. Runtime PCI attachment remains QEMU-only.
+
+### crosvm Sandbox Boundary
 
 Ghaf runs VMM services as the unprivileged `microvm` user. crosvm's internal
 multiprocess minijail requires `CAP_SYS_ADMIN` to create PID and mount
 namespaces, which the service intentionally does not have. Ghaf consequently
-adds `--disable-sandbox` to crosvm VM runners by default.
+adds `--disable-sandbox` to crosvm system VM and App VM runners by default.
 
 This keeps the VMM process behind the unprivileged systemd service boundary,
 but it disables crosvm's additional per-device-process isolation. Treat this as

--- a/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
@@ -10,6 +10,55 @@ Update this section after the pull request https://github.com/tiiuae/ghaf/pull/9
 
 Nevertheless, it may happen that some hypervisor options are not supported by microvm. For example, adding specific devices. This document considers such cases.
 
+### Selecting a System VM VMM
+
+QEMU and crosvm are VMMs (virtual machine monitors) running on top of KVM, not
+hypervisors themselves. Ghaf selects the system VM VMM through
+`ghaf.virtualization.vmConfig`. QEMU is the default for system VMs, while
+AdminVM uses crosvm on every target. Each system VM can override the default
+independently:
+
+```nix
+vmConfig = {
+  defaultVmm = "qemu";
+  sysvms = {
+    adminvm.vmm = "qemu"; # Optional AdminVM fallback
+    netvm.vmm = "crosvm";
+  };
+};
+```
+
+System VM keys use unhyphenated names such as `adminvm`, `netvm`, and `guivm`.
+Profiles apply the selection when they extend each VM's evaluated configuration.
+This supports a mixed fleet during migration instead of requiring every VM on a
+target to use the same VMM. Note that microvm.nix names its own selector
+`microvm.hypervisor`; Ghaf maps `vmm` onto it.
+
+AdminVM declares its vsock CID through the VMM-independent
+`microvm.vsock.cid` option. Both the QEMU fallback and the crosvm default
+therefore use the VM's configured network CID without raw QEMU arguments.
+
+#### crosvm Sandbox Boundary
+
+Ghaf runs VMM services as the unprivileged `microvm` user. crosvm's internal
+multiprocess minijail requires `CAP_SYS_ADMIN` to create PID and mount
+namespaces, which the service intentionally does not have. Ghaf consequently
+adds `--disable-sandbox` to crosvm VM runners by default.
+
+This keeps the VMM process behind the unprivileged systemd service boundary,
+but it disables crosvm's additional per-device-process isolation. Treat this as
+an explicit migration tradeoff until Ghaf provides capability-scoped namespace
+setup without granting the VMM broad host privileges.
+
+To inspect a deployed VM's selected VMM and generated command line, run
+(the file name comes from microvm.nix):
+
+```sh
+cat /var/lib/microvms/admin-vm/current/share/microvm/hypervisor
+admin_pid="$(systemctl show --property MainPID --value microvm@admin-vm)"
+tr '\0' ' ' <"/proc/${admin_pid}/cmdline"
+```
+
 ### Options Definitions
 
 A VM is defined under Ghaf’s subdirectory `microvmConfigurations/VM_NAME/default.nix`, for example:

--- a/flake.lock
+++ b/flake.lock
@@ -245,6 +245,24 @@
         "type": "github"
       }
     },
+    "ghaf-crosvm": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786390562,
+        "narHash": "sha256-AENi4IrGdkTKLQdvUQ/SGN6H4SSixRlJgXISmu6nPEY=",
+        "ref": "refs/heads/main",
+        "rev": "fd3c2acf097f29eee479c95632b77144f20c2311",
+        "revCount": 11713,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/tiiuae/ghaf-crosvm"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/tiiuae/ghaf-crosvm"
+      }
+    },
     "ghafpkgs": {
       "inputs": {
         "crane": [
@@ -272,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785510724,
-        "narHash": "sha256-DYSllw9ibXiB1EJ0rwxh79+y3NqSkpWcn289FFc/Z9U=",
+        "lastModified": 1786479821,
+        "narHash": "sha256-IjlgULYzJHftvGTEap4vfpltBPN56f21aN0IpxeqpK8=",
         "owner": "tiiuae",
         "repo": "ghafpkgs",
-        "rev": "28877975035dce209ff46359e7fa5c4ddbefbc6d",
+        "rev": "ad9b7f3269b945b40ecb30fa3461fd8b798bce1a",
         "type": "github"
       },
       "original": {
@@ -594,6 +612,7 @@
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "flake-utils": "flake-utils",
+        "ghaf-crosvm": "ghaf-crosvm",
         "ghafpkgs": "ghafpkgs",
         "git-hooks-nix": "git-hooks-nix",
         "givc": "givc",
@@ -762,15 +781,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786115850,
-        "narHash": "sha256-GneU2FQUJxKsw620iyGVX+ysyXZP49rvF8/BoMPuu0A=",
-        "owner": "tiiuae",
+        "lastModified": 1786185853,
+        "narHash": "sha256-B+9Mt2aEYJowZ/A+BTPdrQ4+cmkmMPx0srXA9Yl96GM=",
+        "owner": "vadika",
         "repo": "vhotplug",
-        "rev": "3778838223d1402f1f0ca9e273ec2a5f5bc520ad",
+        "rev": "0f42be5226984203ba8bd5f4d2bc6cce9e4b8333",
         "type": "github"
       },
       "original": {
-        "owner": "tiiuae",
+        "owner": "vadika",
+        "ref": "fix/crosvm-usb-vhotplug",
         "repo": "vhotplug",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,13 @@
       };
     };
 
+    # Crosvm with Ghaf's swtpm backend. This is a non-flake source input
+    # because nixpkgs supplies the package expression and Rust dependencies.
+    ghaf-crosvm = {
+      url = "git+https://github.com/tiiuae/ghaf-crosvm?submodules=1";
+      flake = false;
+    };
+
     # To ensure that checks are run locally to enforce cleanliness
     git-hooks-nix = {
       url = "github:cachix/git-hooks.nix";
@@ -198,7 +205,8 @@
 
     # Hot-plugging USB devices into virtual machines
     vhotplug = {
-      url = "github:tiiuae/vhotplug";
+      # TODO: switch back to tiiuae/vhotplug after vhotplug#21 merges.
+      url = "github:vadika/vhotplug/fix/crosvm-usb-vhotplug";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -122,7 +122,7 @@ its namespace setup requires `CAP_SYS_ADMIN`.
 
 ```nix
 vmConfig = {
-  defaultVmm = "qemu";
+  defaultSysVmVmm = "qemu";
 
   # System VMs, keyed by the unhyphenated name (guivm, netvm, audiovm,
   # adminvm, idsvm)

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -16,7 +16,7 @@ Creates a Ghaf configuration for any supported target type (laptop-x86, orin).
 - `variant`: String - Build variant, "debug" (default) or "release"
 - `extraModules`: List - Additional NixOS modules (default: [])
 - `extraConfig`: Attrs - Additional ghaf.* configuration (default: {})
-- `vmConfig`: Attrs - VM resource allocation and modules (default: {})
+- `vmConfig`: Attrs - VMM selection, VM resource allocation, and modules (default: {})
 
 **Returns:**
 - `name`: Full configuration name (e.g., "lenovo-x1-carbon-gen11-debug")
@@ -112,12 +112,18 @@ does not. So `inputs.ghaf.inputs` is missing exactly the key every ghaf module r
 }
 ```
 
-### Using vmConfig for Resource Allocation
+### Using vmConfig for VMM and Resource Configuration
 
-The `vmConfig` parameter allows you to customize VM resource allocation per-target:
+The `vmConfig` parameter selects a default system-VM VMM and supports
+per-VM VMM and resource overrides. The default VMM is QEMU, while
+AdminVM defaults to crosvm on every target. crosvm VMs run as Ghaf's
+unprivileged `microvm` user with crosvm's internal minijail disabled, because
+its namespace setup requires `CAP_SYS_ADMIN`.
 
 ```nix
 vmConfig = {
+  defaultVmm = "qemu";
+
   # System VMs, keyed by the unhyphenated name (guivm, netvm, audiovm,
   # adminvm, idsvm)
   sysvms = {
@@ -132,6 +138,7 @@ vmConfig = {
     audiovm = {
       mem = 512;
     };
+    adminvm.vmm = "qemu"; # Optional AdminVM fallback
   };
 
   # App VMs
@@ -263,4 +270,5 @@ Key differences:
 - Named parameters instead of positional
 - `hardwareModule` separated from `extraModules`
 - `extraConfig` sets `ghaf.*` attributes directly
-- `vmConfig` for resource allocation (replaces `hardware.definition.<vm>.mem/vcpu`)
+- `vmConfig` for VMM selection and resource allocation (replaces
+  `hardware.definition.<vm>.mem/vcpu`)

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -116,7 +116,9 @@ does not. So `inputs.ghaf.inputs` is missing exactly the key every ghaf module r
 
 The `vmConfig` parameter selects a default system-VM VMM and supports
 per-VM VMM and resource overrides. The default VMM is QEMU, while
-AdminVM defaults to crosvm on every target. crosvm VMs run as Ghaf's
+AdminVM defaults to crosvm when storage encryption is disabled. Encrypted
+AdminVMs remain on QEMU until crosvm supports both TPM backends they require.
+crosvm VMs run as Ghaf's
 unprivileged `microvm` user with crosvm's internal minijail disabled, because
 its namespace setup requires `CAP_SYS_ADMIN`.
 
@@ -152,6 +154,21 @@ vmConfig = {
   };
 };
 ```
+
+### Resolving App VM Configuration
+
+Profiles that instantiate App VMs use
+`lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; }` before constructing
+the guest. The helper returns the effective VM definition after memory, vCPU,
+and balloon overrides, the selected VMM, and the App VM's additional modules:
+
+```nix
+resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+```
+
+Use `resolved.effectiveDef`, `resolved.selectedVmm`, and
+`resolved.extraModules` together so VMM and resource policy cannot drift
+between profiles.
 
 ### Extending Configurations
 

--- a/lib/builders/mkGhafConfiguration.nix
+++ b/lib/builders/mkGhafConfiguration.nix
@@ -5,7 +5,8 @@
 #
 # Creates a Ghaf configuration for any supported target type.
 # This builder unifies mkLaptopConfiguration and mkOrinConfiguration into
-# a single, composable API with vmConfig support for resource allocation.
+# a single, composable API with vmConfig support for VMM selection and
+# resource allocation.
 #
 # Usage (inside ghaf, where self/inputs are ghaf's own):
 #   let
@@ -46,7 +47,8 @@
 #   variant        - Build variant: "debug" or "release" (default: "debug")
 #   extraModules   - Additional NixOS modules for the host (default: [])
 #   extraConfig    - Additional ghaf.* configuration (default: {})
-#   vmConfig       - VM resource allocation and modules (default: {})
+#   vmConfig       - VMM selection, resource allocation, and modules
+#                    (default: {})
 #                    Maps to ghaf.virtualization.vmConfig
 #   extraInputs    - Extra names merged into `inputs` (default: {}). Visible as
 #                    module arguments of the host and, because ghaf's profiles

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -672,6 +672,7 @@ rec {
   #   lib.ghaf.vm.mkHostConfig  - Extract host config for VM specialArgs
   #   lib.ghaf.vm.getConfig     - Get inner NixOS config from microvm.vms entry
   #   lib.ghaf.vm.applyVmConfig - Build modules list with vmConfig applied
+  #   lib.ghaf.vm.resolveAppVmConfig - Resolve an App VM definition and policy
   #
   # Usage Example:
   #   guivmBase = lib.nixosSystem {
@@ -888,5 +889,48 @@ rec {
         };
       in
       [ vmSettingsModule ] ++ hwModules ++ vmConfigModules;
+
+    # Resolve an App VM definition against the host's vmConfig policy.
+    #
+    # Unlike singleton system VMs, App VMs are created by mkAppVm functions in
+    # multiple profiles. Keeping the resolution here prevents the laptop, Orin,
+    # and generic VM profiles from drifting apart.
+    #
+    # Arguments:
+    #   config - Host configuration containing virtualization.vmConfig
+    #   vmDef  - App VM definition with at least a name attribute
+    #
+    # Returns an attribute set containing:
+    #   effectiveDef - vmDef with mem, vcpu, and balloonRatio overrides applied
+    #   selectedVmm  - Per-VM override or defaultAppVmVmm
+    #   extraModules - Additional modules configured for this App VM
+    #
+    # Usage in profiles:
+    #   resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+    #   mkAppVm resolved.effectiveDef resolved.selectedVmm resolved.extraModules;
+    resolveAppVmConfig =
+      {
+        config,
+        vmDef,
+      }:
+      let
+        vmCfg = config.ghaf.virtualization.vmConfig.appvms.${vmDef.name} or { };
+        requestedVmm = vmCfg.vmm or null;
+        selectedVmm =
+          if requestedVmm != null then requestedVmm else config.ghaf.virtualization.vmConfig.defaultAppVmVmm;
+        configuredBalloonRatio =
+          if (vmCfg.balloonRatio or null) != null then vmCfg.balloonRatio else vmDef.balloonRatio or 2;
+        effectiveDef =
+          vmDef
+          // lib.optionalAttrs ((vmCfg.mem or null) != null) { inherit (vmCfg) mem; }
+          // lib.optionalAttrs ((vmCfg.vcpu or null) != null) { inherit (vmCfg) vcpu; }
+          // {
+            balloonRatio = configuredBalloonRatio;
+          };
+      in
+      {
+        inherit effectiveDef selectedVmm;
+        extraModules = vmCfg.extraModules or [ ];
+      };
   };
 }

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -858,7 +858,10 @@ rec {
         hwModules = hwDef.extraModules or [ ];
         vmConfigModules = vmCfg.extraModules or [ ];
         selectedVmm =
-          if (vmCfg.vmm or null) != null then vmCfg.vmm else config.ghaf.virtualization.vmConfig.defaultVmm;
+          if (vmCfg.vmm or null) != null then
+            vmCfg.vmm
+          else
+            config.ghaf.virtualization.vmConfig.defaultSysVmVmm;
 
         # VM settings module (applies the VMM and vmConfig.mem/vcpu)
         #
@@ -878,7 +881,9 @@ rec {
             # multiprocess minijail needs CAP_SYS_ADMIN to create PID and mount
             # namespaces, so retain the unprivileged service boundary and use
             # single-process mode until a capability-scoped sandbox is wired.
-            crosvm.extraArgs = lib.mkDefault [ "--disable-sandbox" ];
+            # This required runner argument must compose with device-specific
+            # crosvm arguments supplied by other modules.
+            crosvm.extraArgs = lib.mkBefore [ "--disable-sandbox" ];
           };
         };
       in

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -828,11 +828,11 @@ rec {
     # Build modules list with vmConfig applied
     #
     # This function collects modules from hardware.definition and vmConfig
-    # and builds a resource allocation module from vmConfig.mem/vcpu.
+    # and builds a VM settings module from the VMM and resource options.
     #
     # Module merge order (highest priority last):
     #   1. Base module (guivm-base.nix) - sets mkDefault values
-    #   2. resourceModule - applies vmConfig.mem/vcpu
+    #   2. vmSettingsModule - applies the VMM and vmConfig.mem/vcpu
     #   3. hwModules - hardware.definition.<vm>.extraModules
     #   4. vmConfigModules - vmConfig.sysvms.<vm>.extraModules (highest priority)
     #
@@ -857,19 +857,31 @@ rec {
 
         hwModules = hwDef.extraModules or [ ];
         vmConfigModules = vmCfg.extraModules or [ ];
+        selectedVmm =
+          if (vmCfg.vmm or null) != null then vmCfg.vmm else config.ghaf.virtualization.vmConfig.defaultVmm;
 
-        # Resource allocation module (applies vmConfig.mem/vcpu)
+        # VM settings module (applies the VMM and vmConfig.mem/vcpu)
         #
         # Merge inside `microvm`, not at the top level: `//` is a shallow
         # update, so combining { microvm.mem = ...; } with
         # { microvm.vcpu = ...; } would replace the whole microvm attrset and
         # silently drop mem whenever both are set.
-        resourceModule = {
-          microvm =
-            lib.optionalAttrs (vmCfg.mem or null != null) { inherit (vmCfg) mem; }
-            // lib.optionalAttrs (vmCfg.vcpu or null != null) { inherit (vmCfg) vcpu; };
+        vmSettingsModule = {
+          microvm = {
+            # microvm.nix calls its VMM selector `hypervisor`.
+            hypervisor = if (vmCfg.vmm or null) != null then selectedVmm else lib.mkDefault selectedVmm;
+          }
+          // lib.optionalAttrs (vmCfg.mem or null != null) { inherit (vmCfg) mem; }
+          // lib.optionalAttrs (vmCfg.vcpu or null != null) { inherit (vmCfg) vcpu; }
+          // lib.optionalAttrs (selectedVmm == "crosvm") {
+            # The host runs VMMs as the unprivileged `microvm` user. crosvm's
+            # multiprocess minijail needs CAP_SYS_ADMIN to create PID and mount
+            # namespaces, so retain the unprivileged service boundary and use
+            # single-process mode until a capability-scoped sandbox is wired.
+            crosvm.extraArgs = lib.mkDefault [ "--disable-sandbox" ];
+          };
         };
       in
-      [ resourceModule ] ++ hwModules ++ vmConfigModules;
+      [ vmSettingsModule ] ++ hwModules ++ vmConfigModules;
   };
 }

--- a/modules/hardware/passthrough/vhotplug.nix
+++ b/modules/hardware/passthrough/vhotplug.nix
@@ -176,6 +176,7 @@ in
         };
         modprobe = lib.getExe' pkgs.kmod "modprobe";
         modinfo = lib.getExe' pkgs.kmod "modinfo";
+        crosvm = lib.getExe pkgs.crosvm;
         ovmfCode = "${pkgs.OVMF.fd}/FV/OVMF_CODE.fd";
         ovmfVars = "${pkgs.OVMF.fd}/FV/OVMF_VARS.fd";
       };

--- a/modules/microvm/common/vm-tpm.nix
+++ b/modules/microvm/common/vm-tpm.nix
@@ -8,6 +8,8 @@
 }:
 let
   cfg = config.ghaf.virtualization.microvm.tpm;
+  emulatedSocket =
+    if cfg.emulated.runInVM then "vtpm.sock" else "/var/lib/swtpm/${cfg.emulated.name}/sock";
   inherit (lib)
     types
     mkEnableOption
@@ -80,12 +82,10 @@ in
         machine = "q35";
       };
     })
-    (mkIf cfg.emulated.enable {
+    (mkIf (cfg.emulated.enable && config.microvm.hypervisor == "qemu") {
       microvm.qemu.extraArgs = [
         "-chardev"
-        "socket,id=chrtpm,path=${
-          if cfg.emulated.runInVM then "vtpm.sock" else "/var/lib/swtpm/${cfg.emulated.name}/sock"
-        }"
+        "socket,id=chrtpm,path=${emulatedSocket}"
         "-tpmdev"
         "emulator,id=tpm0,chardev=chrtpm"
         "-device"
@@ -93,6 +93,12 @@ in
         # sysbus variant tpm-tis-device (plain tpm-tis fails "not a valid
         # device model name" and the VM exits at startup).
         "${if pkgs.stdenv.isx86_64 then "tpm-tis" else "tpm-tis-device"},tpmdev=tpm0"
+      ];
+    })
+    (mkIf (cfg.emulated.enable && config.microvm.hypervisor == "crosvm") {
+      microvm.crosvm.extraArgs = lib.mkAfter [
+        "--swtpm"
+        emulatedSocket
       ];
     })
   ];

--- a/modules/microvm/host/mem-manager.nix
+++ b/modules/microvm/host/mem-manager.nix
@@ -33,6 +33,22 @@ in
             # Use enabledVms which has derived mem from evaluatedConfig
             vmBaseName = lib.removeSuffix "-vm" name;
             appvmConfig = config.ghaf.virtualization.microvm.appvm.enabledVms.${vmBaseName} or null;
+            crosvmArgs = lib.optionals (microvmConfig.hypervisor == "crosvm") [
+              "--hypervisor"
+              "crosvm"
+              "--crosvm-binary"
+              (lib.getExe microvmConfig.crosvm.package)
+            ];
+            managerArgs = [
+              (lib.getExe pkgs.ghaf-mem-manager)
+              "--socket"
+              "${name}.sock"
+              "--minimum"
+              (toString (appvmConfig.mem * 1024 * 1024))
+              "--maximum"
+              (toString (microvmConfig.mem * 1024 * 1024))
+            ]
+            ++ crosvmArgs;
           in
           lib.optionalAttrs (appvmConfig != null) {
             "ghaf-mem-manager-${name}" = {
@@ -42,9 +58,7 @@ in
               serviceConfig = {
                 Type = "simple";
                 WorkingDirectory = "${config.microvm.stateDir}/${name}";
-                ExecStart = "${pkgs.ghaf-mem-manager}/bin/ghaf-mem-manager -s ${name}.sock -m ${
-                  toString (appvmConfig.mem * 1024 * 1024)
-                } -M ${toString (microvmConfig.mem * 1024 * 1024)}";
+                ExecStart = lib.escapeShellArgs managerArgs;
               };
             };
           }

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -212,15 +212,7 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 1024;
-    #TODO: Add back support cloud-hypervisor
-    #the system fails to switch root to the stage2 with cloud-hypervisor
-    hypervisor = "qemu";
-    qemu = {
-      extraArgs = [
-        "-device"
-        "vhost-vsock-pci,guest-cid=${toString (hostConfig.networking.thisVm.cid or 10)}"
-      ];
-    };
+    vsock.cid = hostConfig.networking.thisVm.cid or 10;
 
     shares = [
       {

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -43,11 +43,15 @@ let
   # Get VM definition from hostConfig
   vm = hostConfig.appvm;
   vmName = "${vm.name}-vm";
+  vmm = hostConfig.appvmVmm or "qemu";
 
   # Helper to unwrap mkDefault values for use in lib.mkIf conditions
   # Values like `lib.mkDefault true` become { _type = "override"; content = true; priority = 1000; }
   # This extracts the actual boolean for use in conditionals
   unwrap = val: if val._type or null == "override" then val.content else val;
+
+  storageEncryption = globalConfig.storage.encryption.enable or false;
+  effectiveVtpm = (unwrap (vm.vtpm.enable or false)) || storageEncryption;
 
   # Base applications from hostConfig (defined in mkAppVm call)
   baseApplications = vm.applications or [ ];
@@ -172,8 +176,8 @@ in
       ghaf.appvm.vmDef = vm // {
         applications = allApplications;
         vtpm = {
-          enable = (unwrap (vm.vtpm.enable or false)) || (globalConfig.storage.encryption.enable or false);
-          runInVM = (unwrap (vm.vtpm.runInVM or false)) || (globalConfig.storage.encryption.enable or false);
+          enable = effectiveVtpm;
+          runInVM = effectiveVtpm && (unwrap (vm.vtpm.runInVM or false) || storageEncryption);
           basePort = vm.vtpm.basePort or null;
         };
       };
@@ -260,9 +264,11 @@ in
         };
         # vTPM support
         #
-        # App VMs use emulated TPM (swtpm) exclusively. Unlike system VMs (netvm, guivm,
-        # etc.) which can use hardware TPM passthrough on x86_64, app VMs rely on the
-        # admin-vm proxy chain: App VM (QEMU tpm-tis) → host swtpm-proxy-shim → admin-vm swtpm.
+        # App VMs use emulated TPM (swtpm) exclusively. Unlike system VMs
+        # (netvm, guivm, etc.) which can use hardware TPM passthrough on x86_64,
+        # App VMs rely on the admin-vm proxy chain: App VM TPM frontend → host
+        # swtpm-proxy-shim → admin-vm swtpm. QEMU uses tpm-tis while Crosvm
+        # exposes the ChromiumOS virtio TPM transport.
         #
         # When storage encryption is enabled globally, every app VM needs a TPM to satisfy
         # the storagevm assertion. We auto-enable emulated TPM here so downstream consumers
@@ -272,8 +278,8 @@ in
         # passthrough with per-VM NV indexes, or a TrustZone-based TA on aarch64), this
         # logic should be made platform-conditional, mirroring the pattern in netvm-base.nix.
         virtualization.microvm.tpm.emulated = {
-          enable = (unwrap (vm.vtpm.enable or false)) || (globalConfig.storage.encryption.enable or false);
-          runInVM = (unwrap (vm.vtpm.runInVM or false)) || (globalConfig.storage.encryption.enable or false);
+          enable = effectiveVtpm;
+          runInVM = effectiveVtpm && (unwrap (vm.vtpm.runInVM or false) || storageEncryption);
           inherit (vm) name;
         };
 
@@ -398,6 +404,17 @@ in
         ./idsvm/mitmproxy/mitmproxy-ca/mitmproxy-ca-cert.pem
       ];
 
+      # Crosvm's TPM frontend uses ChromiumOS virtio device ID 62. The
+      # transport driver is not in mainline Linux, so add the current
+      # ChromiumOS driver to Crosvm App VM guest kernels.
+      boot.kernelPatches = lib.optionals (effectiveVtpm && vmm == "crosvm") [
+        {
+          name = "chromiumos-virtio-tpm";
+          patch = ./patches/chromiumos-virtio-tpm.patch;
+          structuredExtraConfig.TCG_VIRTIO_VTPM = lib.kernel.module;
+        }
+      ];
+
       microvm = {
         optimize.enable = false;
         # Sensible defaults based on vm definition - can be further overridden via vmConfig
@@ -405,7 +422,11 @@ in
         balloon = (vm.balloonRatio or 2) > 0;
         deflateOnOOM = true;
         vcpu = lib.mkDefault (vm.vcpu or 4);
-        hypervisor = "qemu";
+        hypervisor = vmm;
+        vsock.cid = hostConfig.networking.thisVm.cid or 100;
+        # Compose this required runner argument with device-specific arguments
+        # such as the swtpm socket from vm-tpm.nix.
+        crosvm.extraArgs = lib.mkBefore (lib.optionals (vmm == "crosvm") [ "--disable-sandbox" ]);
 
         shares = [
           {
@@ -451,8 +472,6 @@ in
               # rejects it ("Property 'virt-*-machine.sata' not found") and the
               # App VM exits at startup.
               "accel=kvm:tcg,mem-merge=on${lib.optionalString (effectiveMachine == "q35") ",sata=off"}"
-              "-device"
-              "vhost-vsock-pci,guest-cid=${toString (hostConfig.networking.thisVm.cid or 100)}"
             ]
             # qemu-xhci is a PCI device; not available on the microvm machine type
             ++ lib.optionals (!isMicrovm) [

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -208,8 +208,6 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 512;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/dispvm-base.nix
+++ b/modules/microvm/sysvms/dispvm-base.nix
@@ -148,8 +148,6 @@ in
     # display-only default, smaller than GPU VM's 6000.
     vcpu = 4;
     mem = lib.mkDefault 4000;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/gpuvm-base.nix
+++ b/modules/microvm/sysvms/gpuvm-base.nix
@@ -234,8 +234,6 @@ in
     # profile/vmConfig can shrink it.
     vcpu = 4;
     mem = lib.mkDefault 6000;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -375,8 +375,6 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 6;
     mem = lib.mkDefault 6144;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/idsvm/idsvm-base.nix
+++ b/modules/microvm/sysvms/idsvm/idsvm-base.nix
@@ -96,7 +96,6 @@ in
   ++ (lib.optional (globalConfig.debug.enable or false) pkgs.tcpdump);
 
   microvm = {
-    hypervisor = "qemu";
     optimize.enable = true;
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -239,8 +239,6 @@ in
     optimize.enable = false;
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 1024;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/patches/chromiumos-virtio-tpm.patch
+++ b/modules/microvm/sysvms/patches/chromiumos-virtio-tpm.patch
@@ -1,0 +1,531 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: vadik likholetov <vadikas@gmail.com>
+Date: Wed, 12 Aug 2026 00:00:00 +0300
+Subject: [PATCH] tpm: add ChromiumOS virtio transport for Ghaf guests
+
+The driver is based on ChromiumOS commit
+04fdb1751c20b807c81be7b43e2de7389e2b25ca, originally authored by
+David Tolnay. Regenerate the patch against Linux 7.1.7 so its context
+and index metadata detect future source drift.
+
+Ghaf-specific changes:
+- define ChromiumOS-private virtio device ID 62 locally;
+- support the tpm_class_ops.send API before and after Linux 6.17;
+- expose the complete TPM response buffer on the pre-6.17 ABI; and
+- reset the virtio device and detach its unused buffer before freeing
+  probe state after TPM startup failure.
+
+Signed-off-by: vadik likholetov <vadikas@gmail.com>
+---
+
+diff --git a/drivers/char/tpm/Kconfig b/drivers/char/tpm/Kconfig
+index 8a8f692b60880c1914d3d52c0256befbfd109b79..334766cdf78ad50c7e3e540606bf3f1d6c6cce49 100644
+--- a/drivers/char/tpm/Kconfig
++++ b/drivers/char/tpm/Kconfig
+@@ -254,5 +254,14 @@ config TCG_SVSM
+ 	  level (usually VMPL0).  To compile this driver as a module, choose M
+ 	  here; the module will be called tpm_svsm.
+ 
++config TCG_VIRTIO_VTPM
++	tristate "Virtio vTPM"
++	depends on TCG_TPM && VIRTIO
++	help
++	  This driver provides the guest kernel side of TPM over Virtio. If
++	  you are building Linux to run inside of a hypervisor that supports
++	  TPM over Virtio, say Yes and the virtualized TPM will be
++	  accessible from the guest.
++
+ source "drivers/char/tpm/st33zp24/Kconfig"
+ endif # TCG_TPM
+diff --git a/drivers/char/tpm/Makefile b/drivers/char/tpm/Makefile
+index 5b5cdc0d32e4e5ecf0803e785913f455d32fa1ff..5f5dad2ec800c22c5c01eb69c99de5360a0372dd 100644
+--- a/drivers/char/tpm/Makefile
++++ b/drivers/char/tpm/Makefile
+@@ -44,6 +44,7 @@ obj-$(CONFIG_TCG_XEN) += xen-tpmfront.o
+ obj-$(CONFIG_TCG_CRB) += tpm_crb.o
+ obj-$(CONFIG_TCG_ARM_CRB_FFA) += tpm_crb_ffa.o
+ obj-$(CONFIG_TCG_VTPM_PROXY) += tpm_vtpm_proxy.o
++obj-$(CONFIG_TCG_VIRTIO_VTPM) += tpm_virtio.o
+ obj-$(CONFIG_TCG_FTPM_TEE) += tpm_ftpm_tee.o
+ obj-$(CONFIG_TCG_SVSM) += tpm_svsm.o
+ obj-$(CONFIG_TCG_LOONGSON) += tpm_loongson.o
+diff --git a/drivers/char/tpm/tpm_virtio.c b/drivers/char/tpm/tpm_virtio.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..d086efb03c3d45ff355f6d4db27479eadfe696cf
+--- /dev/null
++++ b/drivers/char/tpm/tpm_virtio.c
+@@ -0,0 +1,474 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright 2019 Google Inc.
++ *
++ * Author: David Tolnay <dtolnay@gmail.com>
++ *
++ * ---
++ *
++ * Device driver for TPM over virtio.
++ *
++ * This driver employs a single virtio queue to handle both send and recv. TPM
++ * commands are sent over virtio to the hypervisor during a TPM send operation
++ * and responses are received over the same queue during a recv operation.
++ *
++ * The driver contains a single buffer that is the only buffer we ever place on
++ * the virtio queue. Commands are copied from the caller's command buffer into
++ * the driver's buffer before handing off to virtio, and responses are received
++ * into the driver's buffer then copied into the caller's response buffer. This
++ * allows us to be resilient to timeouts. When a send or recv operation times
++ * out, the caller is free to destroy their buffer; we don't want the hypervisor
++ * continuing to perform reads or writes against that destroyed buffer.
++ *
++ * This driver does not support concurrent send and recv operations. Mutual
++ * exclusion is upheld by the tpm_mutex lock held in tpm-interface.c around the
++ * calls to chip->ops->send and chip->ops->recv.
++ *
++ * The intended hypervisor-side implementation is as follows.
++ *
++ *     while true:
++ *         await next virtio buffer.
++ *         expect first descriptor in chain to be guest-to-host.
++ *         read tpm command from that buffer.
++ *         synchronously perform TPM work determined by the command.
++ *         expect second descriptor in chain to be host-to-guest.
++ *         write TPM response into that buffer.
++ *         place buffer on virtio used queue indicating how many bytes written.
++ */
++
++#include <linux/version.h>
++#include <linux/virtio_config.h>
++
++#define VIRTIO_ID_TPM 62
++
++#include "tpm.h"
++
++/*
++ * Timeout duration when waiting on the hypervisor to complete its end of the
++ * TPM operation. This timeout is relatively high because certain TPM operations
++ * can take dozens of seconds.
++ */
++#define TPM_VIRTIO_TIMEOUT (120 * HZ)
++
++struct vtpm_device {
++	/*
++	 * Data structure for integration with the common code of the TPM driver
++	 * in tpm-chip.c.
++	 */
++	struct tpm_chip *chip;
++
++	/*
++	 * Virtio queue for sending TPM commands out of the virtual machine and
++	 * receiving TPM responses back from the hypervisor.
++	 */
++	struct virtqueue *vq;
++
++	/*
++	 * Completion that is notified when a virtio operation has been
++	 * fulfilled by the hypervisor.
++	 */
++	struct completion complete;
++
++	/*
++	 * Whether driver currently holds ownership of the virtqueue buffer.
++	 * When false, the hypervisor is in the process of reading or writing
++	 * the buffer and the driver must not touch it.
++	 */
++	bool driver_has_buffer;
++
++	/*
++	 * Whether during the most recent TPM operation, a virtqueue_kick failed
++	 * or a wait timed out.
++	 *
++	 * The next send or recv operation will attempt a kick upon seeing this
++	 * status. That should clear up the queue in the case that the
++	 * hypervisor became temporarily nonresponsive, such as by resource
++	 * exhaustion on the host. The extra kick enables recovery from kicks
++	 * going unnoticed by the hypervisor as well as recovery from virtio
++	 * callbacks going unnoticed by the guest kernel.
++	 */
++	bool needs_kick;
++
++	/* Number of bytes available to read from the virtqueue buffer. */
++	unsigned int readable;
++
++	/*
++	 * Buffer in which all virtio transfers take place. Buffer size is the
++	 * maximum legal TPM command or response message size.
++	 */
++	u8 virtqueue_buffer[TPM_BUFSIZE];
++};
++
++/*
++ * Wait for ownership of the virtqueue buffer.
++ *
++ * The why-string should begin with "waiting to..." or "waiting for..." with no
++ * trailing newline. It will appear in log output.
++ *
++ * Returns zero for success, otherwise negative error.
++ */
++static int vtpm_wait_for_buffer(struct vtpm_device *dev, const char *why)
++{
++	int ret;
++	struct tpm_chip *chip = dev->chip;
++	unsigned long deadline = jiffies + TPM_VIRTIO_TIMEOUT;
++
++	/* Kick queue if needed. */
++	if (dev->needs_kick) {
++		bool did_kick = virtqueue_kick(dev->vq);
++		if (!did_kick) {
++			dev_notice(&chip->dev, "kick failed; will retry\n");
++			return -EBUSY;
++		}
++		dev->needs_kick = false;
++	}
++
++	while (!dev->driver_has_buffer) {
++		unsigned long now = jiffies;
++
++		/* Check timeout, otherwise `deadline - now` may underflow. */
++		if time_after_eq(now, deadline) {
++			dev_warn(&chip->dev, "timed out %s\n", why);
++			dev->needs_kick = true;
++			return -ETIMEDOUT;
++		}
++
++		/*
++		 * Wait to be signaled by virtio callback.
++		 *
++		 * Positive ret is jiffies remaining until timeout when the
++		 * completion occurred, which means successful completion. Zero
++		 * ret is timeout. Negative ret is error.
++		 */
++		ret = wait_for_completion_killable_timeout(
++				&dev->complete, deadline - now);
++
++		/* Log if completion did not occur. */
++		if (ret == -ERESTARTSYS) {
++			/* Not a warning if it was simply interrupted. */
++			dev_dbg(&chip->dev, "interrupted %s\n", why);
++		} else if (ret == 0) {
++			dev_warn(&chip->dev, "timed out %s\n", why);
++			ret = -ETIMEDOUT;
++		} else if (ret < 0) {
++			dev_warn(&chip->dev, "failed while %s: error %d\n",
++					why, -ret);
++		}
++
++		/*
++		 * Return error if completion did not occur. Schedule kick to be
++		 * retried at the start of the next send/recv to help unblock
++		 * the queue.
++		 */
++		if (ret < 0) {
++			dev->needs_kick = true;
++			return ret;
++		}
++
++		/* Completion occurred. Expect response buffer back. */
++		if (virtqueue_get_buf(dev->vq, &dev->readable)) {
++			dev->driver_has_buffer = true;
++
++			if (dev->readable > TPM_BUFSIZE) {
++				dev_crit(&chip->dev,
++						"hypervisor bug: response exceeds max size,"
++						" %u > %u\n",
++						dev->readable,
++						(unsigned int) TPM_BUFSIZE);
++				dev->readable = TPM_BUFSIZE;
++				return -EPROTO;
++			}
++		}
++	}
++
++	return 0;
++}
++
++static int vtpm_op_send(struct tpm_chip *chip, u8 *caller_buf, size_t bufsiz
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++			, size_t cmd_len
++#endif
++)
++{
++	int ret;
++	bool did_kick;
++	struct scatterlist sg_outbuf, sg_inbuf;
++	struct scatterlist *sgs[2] = { &sg_outbuf, &sg_inbuf };
++	struct vtpm_device *dev = dev_get_drvdata(&chip->dev);
++	u8 *virtqueue_buf = dev->virtqueue_buffer;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
++	size_t cmd_len = bufsiz;
++#endif
++
++	dev_dbg(&chip->dev, "vtpm_op_send %zu bytes\n", cmd_len);
++
++	if (cmd_len > TPM_BUFSIZE) {
++		dev_err(&chip->dev,
++				"command is too long, %zu > %zu\n",
++				cmd_len, (size_t) TPM_BUFSIZE);
++		return -EINVAL;
++	}
++
++	/*
++	 * Wait until hypervisor relinquishes ownership of the virtqueue buffer.
++	 *
++	 * This may block if the previous recv operation timed out in the guest
++	 * kernel but is still being processed by the hypervisor. Also may block
++	 * if send operations are performed back-to-back, such as if something
++	 * in the caller failed in between a send and recv.
++	 *
++	 * During normal operation absent of any errors or timeouts, this does
++	 * not block.
++	 */
++	ret = vtpm_wait_for_buffer(dev, "waiting to begin send");
++	if (ret) {
++		return ret;
++	}
++
++	/* Driver owns virtqueue buffer and may now write into it. */
++	memcpy(virtqueue_buf, caller_buf, cmd_len);
++
++	/*
++	 * Enqueue the virtqueue buffer once as outgoing virtio data (written by
++	 * the virtual machine and read by the hypervisor) and again as incoming
++	 * data (written by the hypervisor and read by the virtual machine).
++	 * This step moves ownership of the virtqueue buffer from driver to
++	 * hypervisor.
++	 *
++	 * Note that we don't know here how big of a buffer the caller will use
++	 * with their later call to recv. We allow the hypervisor to write up to
++	 * the TPM max message size. If the caller ends up using a smaller
++	 * buffer with recv that is too small to hold the entire response, the
++	 * recv will return an error. This conceivably breaks TPM
++	 * implementations that want to produce a different verbosity of
++	 * response depending on the receiver's buffer size.
++	 */
++	sg_init_one(&sg_outbuf, virtqueue_buf, cmd_len);
++	sg_init_one(&sg_inbuf, virtqueue_buf, TPM_BUFSIZE);
++	ret = virtqueue_add_sgs(dev->vq, sgs, 1, 1, virtqueue_buf, GFP_KERNEL);
++	if (ret) {
++		dev_err(&chip->dev, "failed virtqueue_add_sgs\n");
++		return ret;
++	}
++
++	/* Kick the other end of the virtqueue after having added a buffer. */
++	did_kick = virtqueue_kick(dev->vq);
++	if (!did_kick) {
++		dev->needs_kick = true;
++		dev_notice(&chip->dev, "kick failed; will retry\n");
++
++		/*
++		 * We return 0 anyway because what the caller doesn't know can't
++		 * hurt them. They can call recv and it will retry the kick. If
++		 * that works, everything is fine.
++		 *
++		 * If the retry in recv fails too, they will get -EBUSY from
++		 * recv.
++		 */
++	}
++
++	/*
++	 * Hypervisor is now processing the TPM command asynchronously. It will
++	 * read the command from the output buffer and write the response into
++	 * the input buffer (which are the same buffer). When done, it will send
++	 * back the buffers over virtio and the driver's virtio callback will
++	 * complete dev->complete so that we know the response is ready to be
++	 * read.
++	 *
++	 * It is important to have copied data out of the caller's buffer into
++	 * the driver's virtqueue buffer because the caller is free to destroy
++	 * their buffer when this call returns. We can't avoid copying by
++	 * waiting here for the hypervisor to finish reading, because if that
++	 * wait times out, we return and the caller may destroy their buffer
++	 * while the hypervisor is continuing to read from it.
++	 */
++	dev->driver_has_buffer = false;
++	return 0;
++}
++
++static int vtpm_op_recv(struct tpm_chip *chip, u8 *caller_buf, size_t len)
++{
++	int ret;
++	struct vtpm_device *dev = dev_get_drvdata(&chip->dev);
++	u8 *virtqueue_buf = dev->virtqueue_buffer;
++
++	dev_dbg(&chip->dev, "vtpm_op_recv\n");
++
++	/*
++	 * Wait until the virtqueue buffer is owned by the driver.
++	 *
++	 * This will usually block while the hypervisor finishes processing the
++	 * most recent TPM command.
++	 */
++	ret = vtpm_wait_for_buffer(dev, "waiting for TPM response");
++	if (ret) {
++		return ret;
++	}
++
++	dev_dbg(&chip->dev, "received %u bytes\n", dev->readable);
++
++	if (dev->readable > len) {
++		dev_notice(&chip->dev,
++				"TPM response is bigger than receiver's buffer:"
++				" %u > %zu\n",
++				dev->readable, len);
++		return -EINVAL;
++	}
++
++	/* Copy response over to the caller. */
++	memcpy(caller_buf, virtqueue_buf, dev->readable);
++
++	return dev->readable;
++}
++
++static void vtpm_op_cancel(struct tpm_chip *chip)
++{
++	/*
++	 * Cancel is not called in this driver's use of tpm-interface.c. It may
++	 * be triggered through tpm-sysfs but that can be implemented as needed.
++	 * Be aware that tpm-sysfs performs cancellation without holding the
++	 * tpm_mutex that protects our send and recv operations, so a future
++	 * implementation will need to consider thread safety of concurrent
++	 * send/recv and cancel.
++	 */
++	dev_notice(&chip->dev, "cancellation is not implemented\n");
++}
++
++static u8 vtpm_op_status(struct tpm_chip *chip)
++{
++	/*
++	 * Status is for TPM drivers that want tpm-interface.c to poll for
++	 * completion before calling recv. Usually this is when the hardware
++	 * needs to be polled i.e. there is no other way for recv to block on
++	 * the TPM command completion.
++	 *
++	 * Polling goes until `(status & complete_mask) == complete_val`. This
++	 * driver defines both complete_mask and complete_val as 0 and blocks on
++	 * our own completion object in recv instead.
++	 */
++	return 0;
++}
++
++static const struct tpm_class_ops vtpm_ops = {
++	.flags = TPM_OPS_AUTO_STARTUP,
++	.send = vtpm_op_send,
++	.recv = vtpm_op_recv,
++	.cancel = vtpm_op_cancel,
++	.status = vtpm_op_status,
++	.req_complete_mask = 0,
++	.req_complete_val = 0,
++};
++
++static void vtpm_virtio_complete(struct virtqueue *vq)
++{
++	struct virtio_device *vdev = vq->vdev;
++	struct vtpm_device *dev = vdev->priv;
++
++	complete(&dev->complete);
++}
++
++static int vtpm_probe(struct virtio_device *vdev)
++{
++	int err;
++	struct vtpm_device *dev;
++	struct virtqueue *vq;
++	struct tpm_chip *chip;
++
++	dev_dbg(&vdev->dev, "vtpm_probe\n");
++
++	dev = kzalloc(sizeof(struct vtpm_device), GFP_KERNEL);
++	if (!dev) {
++		err = -ENOMEM;
++		dev_err(&vdev->dev, "failed kzalloc\n");
++		goto err_dev_alloc;
++	}
++	vdev->priv = dev;
++
++	vq = virtio_find_single_vq(vdev, vtpm_virtio_complete, "vtpm");
++	if (IS_ERR(vq)) {
++		err = PTR_ERR(vq);
++		dev_err(&vdev->dev, "failed virtio_find_single_vq\n");
++		goto err_virtio_find;
++	}
++	dev->vq = vq;
++
++	chip = tpm_chip_alloc(&vdev->dev, &vtpm_ops);
++	if (IS_ERR(chip)) {
++		err = PTR_ERR(chip);
++		dev_err(&vdev->dev, "failed tpm_chip_alloc\n");
++		goto err_chip_alloc;
++	}
++	dev_set_drvdata(&chip->dev, dev);
++	chip->flags |= TPM_CHIP_FLAG_TPM2;
++	dev->chip = chip;
++
++	init_completion(&dev->complete);
++	dev->driver_has_buffer = true;
++	dev->needs_kick = false;
++	dev->readable = 0;
++
++	/*
++	 * Required in order to enable vq use in probe function for auto
++	 * startup.
++	 */
++	virtio_device_ready(vdev);
++
++	err = tpm_chip_register(dev->chip);
++	if (err) {
++		dev_err(&vdev->dev, "failed tpm_chip_register\n");
++		goto err_chip_register;
++	}
++
++	return 0;
++
++err_chip_register:
++	virtio_reset_device(vdev);
++	virtqueue_detach_unused_buf(dev->vq);
++	put_device(&dev->chip->dev);
++err_chip_alloc:
++	vdev->config->del_vqs(vdev);
++err_virtio_find:
++	kfree(dev);
++err_dev_alloc:
++	return err;
++}
++
++static void vtpm_remove(struct virtio_device *vdev)
++{
++	struct vtpm_device *dev = vdev->priv;
++
++	/* Undo tpm_chip_register. */
++	tpm_chip_unregister(dev->chip);
++
++	/* Undo tpm_chip_alloc. */
++	put_device(&dev->chip->dev);
++
++	vdev->config->reset(vdev);
++	vdev->config->del_vqs(vdev);
++
++	kfree(dev);
++}
++
++static struct virtio_device_id id_table[] = {
++	{
++		.device = VIRTIO_ID_TPM,
++		.vendor = VIRTIO_DEV_ANY_ID,
++	},
++	{},
++};
++MODULE_DEVICE_TABLE(virtio, id_table);
++
++static struct virtio_driver vtpm_driver = {
++	.driver.name = KBUILD_MODNAME,
++	.driver.owner = THIS_MODULE,
++	.id_table = id_table,
++	.probe = vtpm_probe,
++	.remove = vtpm_remove,
++};
++
++module_virtio_driver(vtpm_driver);
++
++MODULE_AUTHOR("David Tolnay (dtolnay@gmail.com)");
++MODULE_DESCRIPTION("Virtio vTPM Driver");
++MODULE_VERSION("1.0");
++MODULE_LICENSE("GPL");

--- a/modules/microvm/vm-config.nix
+++ b/modules/microvm/vm-config.nix
@@ -8,7 +8,8 @@
 #
 # This is separate from hardware.definition which handles physical
 # hardware properties. vmConfig handles:
-# - VMM selection - QEMU by default, crosvm for AdminVM, and per-VM overrides
+# - VMM selection - QEMU by default for system VMs, crosvm for AdminVM and
+#   AppVMs, and per-VM overrides
 # - Resource allocation (mem, vcpu) - varies by profile
 # - Profile-specific modules (apps, services)
 # - Downstream customizations
@@ -106,6 +107,21 @@ let
   # App VM configuration submodule (uses mem/vcpu for consistency with system VM definitions)
   appVmConfigType = types.submodule {
     options = {
+      vmm = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "qemu"
+            "crosvm"
+          ]
+        );
+        default = null;
+        description = ''
+          VMM used for this App VM.
+          If null, uses ghaf.virtualization.vmConfig.defaultAppVmVmm.
+        '';
+        example = "qemu";
+      };
+
       mem = mkOption {
         type = types.nullOr types.int;
         default = null;
@@ -122,9 +138,10 @@ let
         type = types.nullOr types.int;
         default = null;
         description = ''
-          Memory balloon ratio. The VM is allocated mem * (balloonRatio + 1)
-          bytes of memory, with ballooning enabled when balloonRatio > 0.
-          If null, uses the default from the VM definition (typically 2).
+          Memory balloon ratio. The VM is allocated
+          mem * (balloonRatio + 1) MB of memory, with ballooning enabled
+          when balloonRatio > 0. If null, uses the default from the VM
+          definition (typically 2).
         '';
       };
 
@@ -156,6 +173,18 @@ in
       example = "qemu";
     };
 
+    defaultAppVmVmm = mkOption {
+      type = types.enum [
+        "qemu"
+        "crosvm"
+      ];
+      default = "crosvm";
+      description = ''
+        Default VMM for App VMs without a per-VM override.
+      '';
+      example = "crosvm";
+    };
+
     sysvms = mkOption {
       type = types.attrsOf systemVmConfigType;
       default = { };
@@ -183,7 +212,7 @@ in
       '';
       example = literalExpression ''
         {
-          chromium = { mem = 8192; extraModules = [ ./chrome.nix ]; };
+          chromium = { vmm = "qemu"; mem = 8192; extraModules = [ ./chrome.nix ]; };
           comms = { mem = 4096; };
         }
       '';

--- a/modules/microvm/vm-config.nix
+++ b/modules/microvm/vm-config.nix
@@ -3,11 +3,12 @@
 #
 # VM Configuration Module
 #
-# Provides ghaf.virtualization.vmConfig for resource allocation and
-# profile/downstream customization.
+# Provides ghaf.virtualization.vmConfig for VMM selection, resource
+# allocation, and profile/downstream customization.
 #
 # This is separate from hardware.definition which handles physical
 # hardware properties. vmConfig handles:
+# - VMM selection - QEMU by default, crosvm for AdminVM, and per-VM overrides
 # - Resource allocation (mem, vcpu) - varies by profile
 # - Profile-specific modules (apps, services)
 # - Downstream customizations
@@ -18,6 +19,7 @@
 #   └── extraModules: Hardware quirks ONLY (GPU passthrough, OVMF)
 #
 #   virtualization.vmConfig (VARIES by profile)
+#   ├── VMM selection: default plus per-system-VM overrides
 #   ├── Resource allocation: mem, vcpu
 #   └── extraModules: Profile apps, services, downstream config
 #
@@ -41,6 +43,21 @@ let
   # System VM configuration submodule (guivm, netvm, audiovm, adminvm, idsvm)
   systemVmConfigType = types.submodule {
     options = {
+      vmm = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "qemu"
+            "crosvm"
+          ]
+        );
+        default = null;
+        description = ''
+          VMM used for this system VM.
+          If null, uses ghaf.virtualization.vmConfig.defaultVmm.
+        '';
+        example = "crosvm";
+      };
+
       mem = mkOption {
         type = types.nullOr types.int;
         default = null;
@@ -119,6 +136,15 @@ in
   _file = ./vm-config.nix;
 
   options.ghaf.virtualization.vmConfig = {
+    defaultVmm = mkOption {
+      type = types.enum [
+        "qemu"
+        "crosvm"
+      ];
+      default = "qemu";
+      description = "Default VMM for system VMs without a per-VM override.";
+    };
+
     sysvms = mkOption {
       type = types.attrsOf systemVmConfigType;
       default = { };
@@ -129,6 +155,7 @@ in
       example = literalExpression ''
         {
           guivm = { mem = 16384; vcpu = 8; };
+          adminvm.vmm = "qemu"; # Optional AdminVM fallback
           netvm = { extraModules = [ ./my-net-config.nix ]; };
         }
       '';
@@ -149,6 +176,7 @@ in
     };
   };
 
-  # No config block - this is a pure options module
-  # Consumption happens in profiles via lib.ghaf.vm.applyVmConfig
+  # Keep QEMU as the system-wide default while migrating AdminVM to crosvm on
+  # every target. Targets and downstream configurations can still override it.
+  config.ghaf.virtualization.vmConfig.sysvms.adminvm.vmm = lib.mkDefault "crosvm";
 }

--- a/modules/microvm/vm-config.nix
+++ b/modules/microvm/vm-config.nix
@@ -30,6 +30,7 @@
 #   4. virtualization.vmConfig.sysvms.guivm.extraModules <- profile/downstream (highest priority)
 #
 {
+  config,
   lib,
   ...
 }:
@@ -53,7 +54,10 @@ let
         default = null;
         description = ''
           VMM used for this system VM.
-          If null, uses ghaf.virtualization.vmConfig.defaultVmm.
+          If null, uses ghaf.virtualization.vmConfig.defaultSysVmVmm.
+
+          This setting takes effect when the VM's evaluated configuration
+          includes lib.ghaf.vm.applyVmConfig.
         '';
         example = "crosvm";
       };
@@ -136,13 +140,20 @@ in
   _file = ./vm-config.nix;
 
   options.ghaf.virtualization.vmConfig = {
-    defaultVmm = mkOption {
+    defaultSysVmVmm = mkOption {
       type = types.enum [
         "qemu"
         "crosvm"
       ];
       default = "qemu";
-      description = "Default VMM for system VMs without a per-VM override.";
+      description = ''
+        Default VMM for system VMs without a per-VM override.
+
+        This setting takes effect when the VM's evaluated configuration
+        includes lib.ghaf.vm.applyVmConfig. Cloud Hypervisor is intentionally
+        not selectable because AdminVM does not switch root to stage 2 with it.
+      '';
+      example = "qemu";
     };
 
     sysvms = mkOption {
@@ -151,6 +162,9 @@ in
       description = ''
         Per-system-VM configuration. Keys should match system VM names
         (e.g., guivm, netvm, audiovm, adminvm, idsvm).
+
+        These settings take effect when the corresponding VM's evaluated
+        configuration includes lib.ghaf.vm.applyVmConfig.
       '';
       example = literalExpression ''
         {
@@ -176,7 +190,10 @@ in
     };
   };
 
-  # Keep QEMU as the system-wide default while migrating AdminVM to crosvm on
-  # every target. Targets and downstream configurations can still override it.
-  config.ghaf.virtualization.vmConfig.sysvms.adminvm.vmm = lib.mkDefault "crosvm";
+  # Keep QEMU as the system-wide default while migrating AdminVM to crosvm.
+  # Encrypted AdminVMs still need QEMU's TPM path until crosvm TPM support is
+  # wired. Targets and downstream configurations can override this selection.
+  config.ghaf.virtualization.vmConfig.sysvms.adminvm.vmm = lib.mkDefault (
+    if config.ghaf.global-config.storage.encryption.enable then "qemu" else "crosvm"
+  );
 }

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -305,7 +305,14 @@ in
 
           adminvm = {
             enable = true;
-            evaluatedConfig = lib.mkDefault cfg.adminvmBase;
+            evaluatedConfig = lib.mkDefault (
+              cfg.adminvmBase.extendModules {
+                modules = lib.ghaf.vm.applyVmConfig {
+                  inherit config;
+                  vmName = "adminvm";
+                };
+              }
+            );
           };
 
           idsvm = {

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -214,13 +214,8 @@ in
         mkAppVm =
           vmDef:
           let
-            # Apply vmConfig.appvms overrides (mem, vcpu)
-            vmCfg = config.ghaf.virtualization.vmConfig.appvms.${vmDef.name} or { };
-            effectiveDef =
-              vmDef
-              // lib.optionalAttrs ((vmCfg.mem or null) != null) { inherit (vmCfg) mem; }
-              // lib.optionalAttrs ((vmCfg.vcpu or null) != null) { inherit (vmCfg) vcpu; }
-              // lib.optionalAttrs ((vmCfg.balloonRatio or null) != null) { inherit (vmCfg) balloonRatio; };
+            resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+            inherit (resolved) effectiveDef selectedVmm;
           in
           lib.nixosSystem {
             modules = [
@@ -235,7 +230,7 @@ in
                 };
               }
             ]
-            ++ (vmCfg.extraModules or [ ]);
+            ++ resolved.extraModules;
             specialArgs = lib.ghaf.vm.mkSpecialArgs {
               inherit lib inputs;
               globalConfig = hostGlobalConfig;
@@ -247,6 +242,7 @@ in
                 // {
                   # App VM-specific hostConfig fields
                   appvm = effectiveDef;
+                  appvmVmm = selectedVmm;
                   # Pass shared directory config for storage
                   sharedVmDirectory =
                     config.ghaf.virtualization.microvm-host.sharedVmDirectory or {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -258,12 +258,8 @@ in
         orin.mkAppVm =
           vmDef:
           let
-            vmCfg = config.ghaf.virtualization.vmConfig.appvms.${vmDef.name} or { };
-            effectiveDef =
-              vmDef
-              // lib.optionalAttrs ((vmCfg.mem or null) != null) { inherit (vmCfg) mem; }
-              // lib.optionalAttrs ((vmCfg.vcpu or null) != null) { inherit (vmCfg) vcpu; }
-              // lib.optionalAttrs ((vmCfg.balloonRatio or null) != null) { inherit (vmCfg) balloonRatio; };
+            resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+            inherit (resolved) effectiveDef selectedVmm;
           in
           lib.nixosSystem {
             modules = [
@@ -277,7 +273,7 @@ in
                 };
               }
             ]
-            ++ (vmCfg.extraModules or [ ]);
+            ++ resolved.extraModules;
             specialArgs = lib.ghaf.vm.mkSpecialArgs {
               inherit lib inputs;
               globalConfig = hostGlobalConfig;
@@ -288,6 +284,7 @@ in
                 }
                 // {
                   appvm = effectiveDef;
+                  appvmVmm = selectedVmm;
                   sharedVmDirectory =
                     config.ghaf.virtualization.microvm-host.sharedVmDirectory or {
                       enable = false;

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -376,8 +376,12 @@ in
 
           adminvm = {
             enable = true;
-            # Use evaluatedConfig pattern - common is passed via hostConfig
-            evaluatedConfig = cfg.adminvmBase;
+            evaluatedConfig = cfg.adminvmBase.extendModules {
+              modules = lib.ghaf.vm.applyVmConfig {
+                inherit config;
+                vmName = "adminvm";
+              };
+            };
           };
 
           # GPU VM: enable comes from the gpu-vm passthrough module

--- a/modules/profiles/vm.nix
+++ b/modules/profiles/vm.nix
@@ -138,6 +138,10 @@ in
       # Pure function - extensions are applied via extendModules in appvm.nix
       mkAppVm =
         vmDef:
+        let
+          resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+          inherit (resolved) effectiveDef selectedVmm;
+        in
         lib.nixosSystem {
           modules = [
             inputs.microvm.nixosModules.microvm
@@ -149,18 +153,20 @@ in
                 inherit (config.nixpkgs) config;
               };
             }
-          ];
+          ]
+          ++ resolved.extraModules;
           specialArgs = lib.ghaf.vm.mkSpecialArgs {
             inherit lib inputs;
             globalConfig = hostGlobalConfig;
             hostConfig =
               lib.ghaf.vm.mkHostConfig {
                 inherit config;
-                vmName = "${vmDef.name}-vm";
+                vmName = "${effectiveDef.name}-vm";
               }
               // {
                 # App VM-specific hostConfig fields
-                appvm = vmDef;
+                appvm = effectiveDef;
+                appvmVmm = selectedVmm;
                 sharedVmDirectory =
                   config.ghaf.virtualization.microvm-host.sharedVmDirectory or {
                     enable = false;

--- a/modules/reference/profiles/mvp-user-trial-extras.nix
+++ b/modules/reference/profiles/mvp-user-trial-extras.nix
@@ -42,7 +42,12 @@ in
           enable = lib.mkForce true;
           mitmproxy.enable = lib.mkForce true;
           # Use the new evaluatedConfig pattern from laptop-x86 profile
-          evaluatedConfig = config.ghaf.profiles.laptop-x86.idsvmBase;
+          evaluatedConfig = config.ghaf.profiles.laptop-x86.idsvmBase.extendModules {
+            modules = lib.ghaf.vm.applyVmConfig {
+              inherit config;
+              vmName = "idsvm";
+            };
+          };
         };
       };
 

--- a/overlays/flake-module.nix
+++ b/overlays/flake-module.nix
@@ -10,6 +10,17 @@
   flake.overlays = {
     cross-compilation = import ./cross-compilation;
     custom-packages = import ./custom-packages;
+    crosvm = _final: prev: {
+      crosvm = prev.crosvm.overrideAttrs (old: {
+        src = inputs.ghaf-crosvm;
+        cargoDeps = prev.rustPlatform.fetchCargoVendor {
+          src = inputs.ghaf-crosvm;
+          hash = "sha256-lU30pTzJ1hYyHcpFKemZou9d2ZqSlFu4JC+IUe2Gm5A=";
+        };
+        cargoBuildFeatures = (old.cargoBuildFeatures or (old.buildFeatures or [ ])) ++ [ "vtpm" ];
+        buildInputs = (old.buildInputs or [ ]) ++ [ prev.dbus ];
+      });
+    };
 
     # Jetson-only Python fixes for the EDK2/UEFI firmware build. Deliberately
     # excluded from `default`: it rewrites pythonPackagesExtensions globally.
@@ -26,6 +37,7 @@
       #internal overlays
       inputs.self.overlays.own-pkgs-overlay
       inputs.self.overlays.custom-packages
+      inputs.self.overlays.crosvm
       #external overlays that we use
       inputs.ghafpkgs.overlays.default
       inputs.ctrl-panel.overlays.default

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -104,7 +104,10 @@ let
 
               # Wire up netvm using inline netvmBase
               ghaf.virtualization.microvm.netvm.evaluatedConfig = netvmBase.extendModules {
-                modules = config.ghaf.hardware.definition.netvm.extraModules or [ ];
+                modules = lib.ghaf.vm.applyVmConfig {
+                  inherit config;
+                  vmName = "netvm";
+                };
               };
             }
           )

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -122,20 +122,37 @@ let
                     netvm = {
                       enable = true;
                       evaluatedConfig = vmProfile.netvmBase.extendModules {
-                        modules = [ netvmGivcModule ];
+                        modules = [
+                          netvmGivcModule
+                        ]
+                        ++ lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          vmName = "netvm";
+                        };
                       };
                     };
 
                     audiovm = {
                       enable = true;
                       evaluatedConfig = vmProfile.audiovmBase.extendModules {
-                        modules = [ audiovmGivcModule ];
+                        modules = [
+                          audiovmGivcModule
+                        ]
+                        ++ lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          vmName = "audiovm";
+                        };
                       };
                     };
 
                     adminvm = {
                       enable = true;
-                      evaluatedConfig = vmProfile.adminvmBase;
+                      evaluatedConfig = vmProfile.adminvmBase.extendModules {
+                        modules = lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          vmName = "adminvm";
+                        };
+                      };
                     };
 
                     # NOTE: GUI runs on host, not in a gui-vm


### PR DESCRIPTION
## Description of Changes

Run AppVMs with Crosvm by default while preserving per-AppVM overrides. Add swtpm-backed virtio TPM, balloon control, runtime USB hotplug, neutral vsock configuration, and the guest TPM transport.

### Type of Change

- [x] New feature
- [x] Documentation

## Related Issues / Tickets

- Depends on #2106
- Depends on tiiuae/ghaf-crosvm#1
- Depends on tiiuae/vhotplug#21

## Checklist

- [x] Clear summary
- [x] Signed-off conventional commit
- [x] Commits squashed
- [x] Documentation updated
- [x] Review threads resolved

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] VM targets

### Installation Method

- [x] Requires a full installation for encrypted storage validation

### Test Steps To Verify

1. Boot an encrypted AppVM configuration.
2. Verify AppVM services use Crosvm and expose TPM devices.
3. Exercise USB attach/detach and balloon target changes.
4. Reboot and confirm existing storage still unlocks.

### Validation

- Ghaf formatting, REUSE, evaluation, pre-commit, and installer builds passed
- live x86 and AGX guests completed TPM commands
- live x86 laptop booted the Crosvm AppVM configuration without changing TPM or LUKS state
