### PR TITLE
feat(targets): enable Crosvm for generic Intel laptops

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 # Kernel patches contain whitespace-sensitive context lines that should not be
 # diagnosed as whitespace introduced into this repository.
 modules/microvm/sysvms/patches/chromiumos-virtio-tpm.patch -whitespace
+overlays/patches/ghaf-mem-manager-no-syslog.patch -whitespace
+overlays/patches/ghaf-usb-applet-log-level.patch -whitespace

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Kernel patches contain whitespace-sensitive context lines that should not be
+# diagnosed as whitespace introduced into this repository.
+modules/microvm/sysvms/patches/chromiumos-virtio-tpm.patch -whitespace

--- a/docs/src/content/docs/ghaf/dev/architecture/vm-memory-management.mdx
+++ b/docs/src/content/docs/ghaf/dev/architecture/vm-memory-management.mdx
@@ -10,7 +10,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Ghaf VMs run with fixed memory allocations and, without swap, have no safety net for transient memory pressure. This is a problem during events like S3 (suspend-to-RAM) resume, where device drivers must reinitialize and temporarily allocate buffers, DMA regions, and firmware blobs. If the VM is already near its memory ceiling, these allocations can trigger OOM kills or kernel panics.
 
-Ghaf addresses this with a three-layer defense against OOM crashes: zram compressed swap inside every VM, virtio-balloon deflation for app VMs, and host-level disk swap that absorbs the resulting pressure.
+Ghaf addresses this with a layered defense against OOM crashes: zram compressed swap inside every VM, virtio-balloon deflation for App VMs, and host-level disk swap that absorbs the resulting pressure.
 
 ## Layer 1: zram Compressed Swap (All VMs)
 
@@ -26,24 +26,27 @@ With a typical 2.5x compression ratio, 25% of RAM as zram yields approximately 6
 
 ## Layer 2: Balloon deflateOnOOM (App VMs)
 
-App VMs use the [virtio-balloon](https://blog.pmhahn.de/virtio-balloon/) device for dynamic memory management. The host memory manager can inflate the balloon (reclaiming guest pages for the host) or the guest can deflate it (reclaiming pages back from the host).
+QEMU and crosvm App VMs use the [virtio-balloon](https://blog.pmhahn.de/virtio-balloon/) device for dynamic memory management. The host memory manager can inflate the balloon (reclaiming guest pages for the host) or the guest can deflate it (reclaiming pages back from the host).
 
 With `deflateOnOOM = true`, the guest kernel automatically deflates the balloon when an OOM condition is imminent. This reclaims pages that were previously loaned to the host, giving the guest more memory without any host intervention.
 
-For example, a 4 GB base app VM with `balloonRatio = 2` has a 12 GB QEMU allocation. If the balloon has inflated to 6 GB (guest sees approximately 6 GB), an OOM event causes the balloon to deflate, and the guest can reclaim up to the full 12 GB allocation.
+For example, a 4 GB base app VM with `balloonRatio = 2` has a 12 GB allocation. If the balloon has inflated to 6 GB (guest sees approximately 6 GB), an OOM event causes the balloon to deflate, and the guest can reclaim up to the full 12 GB allocation.
 
-System VMs (gui-vm, net-vm, audio-vm, admin-vm, ids-vm) do not use balloons, so this layer applies only to app VMs.
+System VMs (gui-vm, net-vm, audio-vm, admin-vm, ids-vm) do not use balloons.
+`ghaf-mem-manager` controls QEMU balloons through QMP and crosvm balloons
+through crosvm's control command. The crosvm backend converts Ghaf's desired
+guest-visible memory into the reclaimed byte count expected by crosvm.
 
 ## Layer 3: Host Disk Swap
 
-When app VM balloons deflate, the QEMU process on the host consumes more physical memory. The host has an 12 GB disk swap partition that absorbs this pressure. The host kernel can page out its own processes or inflate balloons on other idle VMs (via `ghaf-mem-manager`) to rebalance.
+When App VM balloons deflate, the VMM process on the host consumes more physical memory. The host has a 12 GB disk swap partition that absorbs this pressure. The host kernel can page out its own processes or inflate balloons on other idle App VMs (via `ghaf-mem-manager`) to rebalance.
 
 ## How the Layers Cascade During S3 Resume
 
-1. **Suspend**: The host enters S3 sleep. QEMU freezes VMs. RAM stays powered and contents are preserved.
-2. **Resume**: The host wakes. QEMU unfreezes VMs. Device drivers reinitialize, allocating temporary buffers.
+1. **Suspend**: The host enters S3 sleep. The VMM freezes VMs. RAM stays powered and contents are preserved.
+2. **Resume**: The host wakes. The VMM unfreezes VMs. Device drivers reinitialize, allocating temporary buffers.
 3. **zram absorbs the spike**: The kernel compresses idle pages into zram to make room for driver buffers (microsecond latency).
-4. **Balloon deflates if needed**: If more memory is required, the balloon shrinks and the guest reclaims pages from the host.
+4. **Balloon deflates if needed**: The balloon shrinks and the guest reclaims pages from the host.
 5. **Host swap absorbs the host-side impact**: The host uses its disk swap if balloon deflation increases host memory pressure.
 6. **Drivers initialize successfully**: Temporary buffers are freed and the system stabilizes.
 
@@ -61,7 +64,7 @@ All VM bases set this to `true`. To disable zram for a specific VM, override it 
 
 | Option | Description |
 |--------|-------------|
-| `balloonRatio` | Multiplier for QEMU memory allocation beyond base `mem`. A ratio of 2 means QEMU allocates `mem * (balloonRatio + 1)`. |
+| `balloonRatio` | Multiplier for VMM memory allocation beyond base `mem`. A ratio of 2 means the VMM allocates `mem * (balloonRatio + 1)`. |
 | `deflateOnOOM` | Set in `appvm-base.nix`. When `true`, the guest automatically reclaims ballooned pages on OOM. |
 
 ## Further Reading

--- a/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
@@ -18,10 +18,9 @@ hypervisors themselves. Ghaf selects the system VM VMM through
 profile keeps that default, but every generic `intel-laptop` target selects
 crosvm for all system VMs. This includes debug, release, low-memory, and
 store-disk variants. Machine-specific x86, aarch64, and generic VM targets keep
-their existing selections. AdminVM normally uses crosvm only when storage
-encryption is disabled; generic Intel laptop targets also select crosvm for the
-encrypted AdminVM and use crosvm's TPM passthrough path. Each system VM can
-override the target default independently:
+their existing selections. Generic Intel laptop targets also select crosvm for
+encrypted AdminVM variants and use crosvm's TPM passthrough path. Each system
+VM can override the target default independently:
 
 ```nix
 vmConfig = {
@@ -48,9 +47,10 @@ therefore use the VM's configured network CID without raw QEMU arguments.
 
 ### Selecting an App VM VMM
 
-App VMs use crosvm by default on both x86 and NVIDIA platforms. The default
-and individual App VMs can be overridden through the same
-`ghaf.virtualization.vmConfig` interface:
+App VMs use QEMU by default. Generic `intel-laptop` targets select crosvm for
+their App VMs; machine-specific x86, aarch64, and generic VM targets retain
+QEMU. The target default and individual App VMs can be overridden through the
+same `ghaf.virtualization.vmConfig` interface:
 
 ```nix
 vmConfig = {

--- a/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
+++ b/docs/src/content/docs/ghaf/dev/technologies/hypervisor_options.mdx
@@ -10,6 +10,100 @@ Update this section after the pull request https://github.com/tiiuae/ghaf/pull/9
 
 Nevertheless, it may happen that some hypervisor options are not supported by microvm. For example, adding specific devices. This document considers such cases.
 
+### Selecting a System VM VMM
+
+QEMU and crosvm are VMMs (virtual machine monitors) running on top of KVM, not
+hypervisors themselves. Ghaf selects the system VM VMM through
+`ghaf.virtualization.vmConfig`. QEMU is the system-wide default. The x86 laptop
+profile keeps that default, but every generic `intel-laptop` target selects
+crosvm for all system VMs. This includes debug, release, low-memory, and
+store-disk variants. Machine-specific x86, aarch64, and generic VM targets keep
+their existing selections. AdminVM normally uses crosvm only when storage
+encryption is disabled; generic Intel laptop targets also select crosvm for the
+encrypted AdminVM and use crosvm's TPM passthrough path. Each system VM can
+override the target default independently:
+
+```nix
+vmConfig = {
+  defaultSysVmVmm = "qemu";
+  sysvms = {
+    adminvm.vmm = "qemu"; # Optional AdminVM fallback
+    netvm.vmm = "qemu"; # Optional x86 laptop rollback
+  };
+};
+```
+
+System VM keys use unhyphenated names such as `adminvm`, `netvm`, and `guivm`.
+The selection takes effect only when the VM's evaluated configuration includes
+`lib.ghaf.vm.applyVmConfig`. Profiles and targets that construct an
+`evaluatedConfig` directly must include this helper; otherwise the default and
+per-VM settings are ignored. This supports a mixed fleet during migration
+instead of requiring every VM on a target to use the same VMM. Note that
+microvm.nix names its own selector `microvm.hypervisor`; Ghaf maps `vmm` onto
+it.
+
+AdminVM declares its vsock CID through the VMM-independent
+`microvm.vsock.cid` option. Both the QEMU fallback and the crosvm default
+therefore use the VM's configured network CID without raw QEMU arguments.
+
+### Selecting an App VM VMM
+
+App VMs use crosvm by default on both x86 and NVIDIA platforms. The default
+and individual App VMs can be overridden through the same
+`ghaf.virtualization.vmConfig` interface:
+
+```nix
+vmConfig = {
+  defaultAppVmVmm = "crosvm";
+  appvms = {
+    chrome.vmm = "qemu";
+    flatpak.vmm = "crosvm";
+  };
+};
+```
+
+App VM keys use their unhyphenated base names, such as `chrome`, `flatpak`, and
+`chromium`. Encrypted App VMs remain on the crosvm default. Ghaf's crosvm build
+connects its virtio TPM frontend to the same swtpm proxy socket as QEMU, and
+the App VM guest kernel includes ChromiumOS's virtio TPM transport driver when
+that crosvm App VM has a vTPM enabled. Applying this out-of-tree driver creates
+a separate guest-kernel derivation until that result is available from a binary
+cache.
+
+crosvm App VMs use the same `mem * (balloonRatio + 1)` allocation and
+virtio-balloon policy as QEMU App VMs. `ghaf-mem-manager` selects QEMU QMP or
+the crosvm control command from the VM's configured VMM. It also translates
+between QEMU's guest-visible memory value and crosvm's reclaimed-memory value.
+
+App VMs declare their vsock CID through `microvm.vsock.cid`, so QEMU and crosvm
+use the same configured CID. Runtime USB attachment through vhotplug is
+supported by crosvm. vhotplug records the crosvm guest port for each host USB
+device so identical devices can be detached independently and restored safely
+after daemon restarts. x86 laptop system VMs also resolve their configured PCI
+devices through vhotplug at startup and support runtime PCI attachment with
+crosvm's removable VFIO slots.
+
+### crosvm Sandbox Boundary
+
+Ghaf runs VMM services as the unprivileged `microvm` user. crosvm's internal
+multiprocess minijail requires `CAP_SYS_ADMIN` to create PID and mount
+namespaces, which the service intentionally does not have. Ghaf consequently
+adds `--disable-sandbox` to crosvm system VM and App VM runners by default.
+
+This keeps the VMM process behind the unprivileged systemd service boundary,
+but it disables crosvm's additional per-device-process isolation. Treat this as
+an explicit migration tradeoff until Ghaf provides capability-scoped namespace
+setup without granting the VMM broad host privileges.
+
+To inspect a deployed VM's selected VMM and generated command line, run
+(the file name comes from microvm.nix):
+
+```sh
+cat /var/lib/microvms/admin-vm/current/share/microvm/hypervisor
+admin_pid="$(systemctl show --property MainPID --value microvm@admin-vm)"
+tr '\0' ' ' <"/proc/${admin_pid}/cmdline"
+```
+
 ### Options Definitions
 
 A VM is defined under Ghaf’s subdirectory `microvmConfigurations/VM_NAME/default.nix`, for example:

--- a/flake.lock
+++ b/flake.lock
@@ -248,16 +248,17 @@
     "ghaf-crosvm": {
       "flake": false,
       "locked": {
-        "lastModified": 1786390562,
-        "narHash": "sha256-AENi4IrGdkTKLQdvUQ/SGN6H4SSixRlJgXISmu6nPEY=",
-        "ref": "refs/heads/main",
-        "rev": "fd3c2acf097f29eee479c95632b77144f20c2311",
-        "revCount": 11713,
+        "lastModified": 1786723319,
+        "narHash": "sha256-xIQMyjH6P6vDEAwwnttnlK5sZSH0Qe8xu6e2c+/VO2o=",
+        "ref": "fix/usb-isochronous-out",
+        "rev": "8123d5ed83323603b81acfaf6762a75c438c28d9",
+        "revCount": 11731,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/tiiuae/ghaf-crosvm"
       },
       "original": {
+        "ref": "fix/usb-isochronous-out",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/tiiuae/ghaf-crosvm"

--- a/flake.lock
+++ b/flake.lock
@@ -245,6 +245,24 @@
         "type": "github"
       }
     },
+    "ghaf-crosvm": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786390562,
+        "narHash": "sha256-AENi4IrGdkTKLQdvUQ/SGN6H4SSixRlJgXISmu6nPEY=",
+        "ref": "refs/heads/main",
+        "rev": "fd3c2acf097f29eee479c95632b77144f20c2311",
+        "revCount": 11713,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/tiiuae/ghaf-crosvm"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/tiiuae/ghaf-crosvm"
+      }
+    },
     "ghafpkgs": {
       "inputs": {
         "crane": [
@@ -593,6 +611,7 @@
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "flake-utils": "flake-utils",
+        "ghaf-crosvm": "ghaf-crosvm",
         "ghafpkgs": "ghafpkgs",
         "git-hooks-nix": "git-hooks-nix",
         "givc": "givc",
@@ -761,15 +780,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786994697,
-        "narHash": "sha256-3Xa86R12YJ1kP/Xx6Ol3yaZuacVv5H/4+CUvJB/zCfw=",
-        "owner": "tiiuae",
+        "lastModified": 1786564420,
+        "narHash": "sha256-f9j+gadZqEoy/gPkRD1erY0Abur1OTplRlDlV6zRPOQ=",
+        "owner": "vadika",
         "repo": "vhotplug",
-        "rev": "51286cf26629d17722fdbf371f54883a6f1f44a4",
+        "rev": "be231fde59bd766428e2cbfe4ffb62fbf7c59458",
         "type": "github"
       },
       "original": {
-        "owner": "tiiuae",
+        "owner": "vadika",
+        "ref": "feat/crosvm-pci-hotplug",
         "repo": "vhotplug",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -270,15 +270,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786986574,
-        "narHash": "sha256-gBgPng2X2Dj8af9v2e+oWXlUdjhiElwDRi1OR/8bpnQ=",
+        "lastModified": 1787052754,
+        "narHash": "sha256-oKYwwMY63lbrgWy45flMfSxBGtLYdO7GJ+Cspo36h1M=",
         "owner": "tiiuae",
         "repo": "ghaf-device-manager",
-        "rev": "02687265b0f15f4ae2d48103b81b5da428e4b7af",
+        "rev": "b93dbc5c32689da179822231089593613c534133",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
+        "ref": "fix/suppress-noop-notifications",
         "repo": "ghaf-device-manager",
         "type": "github"
       }
@@ -310,11 +311,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786614244,
-        "narHash": "sha256-EJ/RmSLQtHHxvE2PwakawcmDaVB6ebDiY29AdUuT2q4=",
+        "lastModified": 1787052754,
+        "narHash": "sha256-qcUNHT7UjOHu1qGdcDgRvoLQzcbDWfB+W+vi1I8OvFk=",
         "owner": "vadika",
         "repo": "ghafpkgs",
-        "rev": "a6e6c383c24f3a87fe77df10f1f33411c3c60fa8",
+        "rev": "4f181fe02222f9f7ef74ebb230f23f67b028714a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -271,16 +271,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1786986140,
+        "lastModified": 1786986574,
         "narHash": "sha256-gBgPng2X2Dj8af9v2e+oWXlUdjhiElwDRi1OR/8bpnQ=",
         "owner": "tiiuae",
         "repo": "ghaf-device-manager",
-        "rev": "72ce5394f773a23d82a7c12343bd6726fa9ee36a",
+        "rev": "02687265b0f15f4ae2d48103b81b5da428e4b7af",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
-        "ref": "fix/crosvm-runtime-reliability",
         "repo": "ghaf-device-manager",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -264,6 +264,27 @@
         "url": "https://github.com/tiiuae/ghaf-crosvm"
       }
     },
+    "ghaf-device-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786644911,
+        "narHash": "sha256-7l/aoKlOQUDJ0GkMlSn5vkOuDyingaHaKNEgMvDMedM=",
+        "owner": "tiiuae",
+        "repo": "ghaf-device-manager",
+        "rev": "09fa325f266667b9a0480e1d65d4569797815420",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "ref": "fix/crosvm-runtime-reliability",
+        "repo": "ghaf-device-manager",
+        "type": "github"
+      }
+    },
     "ghafpkgs": {
       "inputs": {
         "crane": [
@@ -291,15 +312,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786479821,
-        "narHash": "sha256-IjlgULYzJHftvGTEap4vfpltBPN56f21aN0IpxeqpK8=",
-        "owner": "tiiuae",
+        "lastModified": 1786614244,
+        "narHash": "sha256-EJ/RmSLQtHHxvE2PwakawcmDaVB6ebDiY29AdUuT2q4=",
+        "owner": "vadika",
         "repo": "ghafpkgs",
-        "rev": "ad9b7f3269b945b40ecb30fa3461fd8b798bce1a",
+        "rev": "a6e6c383c24f3a87fe77df10f1f33411c3c60fa8",
         "type": "github"
       },
       "original": {
-        "owner": "tiiuae",
+        "owner": "vadika",
+        "ref": "fix/crosvm-cli-log-spam",
         "repo": "ghafpkgs",
         "type": "github"
       }
@@ -613,6 +635,7 @@
         "flake-root": "flake-root",
         "flake-utils": "flake-utils",
         "ghaf-crosvm": "ghaf-crosvm",
+        "ghaf-device-manager": "ghaf-device-manager",
         "ghafpkgs": "ghafpkgs",
         "git-hooks-nix": "git-hooks-nix",
         "givc": "givc",
@@ -781,11 +804,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786564420,
-        "narHash": "sha256-f9j+gadZqEoy/gPkRD1erY0Abur1OTplRlDlV6zRPOQ=",
+        "lastModified": 1786614239,
+        "narHash": "sha256-jh4QOHemA1WMFLWS06uIHv56sjX0UwaD7NQP701HAOw=",
         "owner": "vadika",
         "repo": "vhotplug",
-        "rev": "be231fde59bd766428e2cbfe4ffb62fbf7c59458",
+        "rev": "123ea2d56380a1353d671fa1f88b241d08dcffe1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786644911,
-        "narHash": "sha256-7l/aoKlOQUDJ0GkMlSn5vkOuDyingaHaKNEgMvDMedM=",
+        "lastModified": 1786986140,
+        "narHash": "sha256-gBgPng2X2Dj8af9v2e+oWXlUdjhiElwDRi1OR/8bpnQ=",
         "owner": "tiiuae",
         "repo": "ghaf-device-manager",
-        "rev": "09fa325f266667b9a0480e1d65d4569797815420",
+        "rev": "72ce5394f773a23d82a7c12343bd6726fa9ee36a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -248,17 +248,16 @@
     "ghaf-crosvm": {
       "flake": false,
       "locked": {
-        "lastModified": 1786723319,
-        "narHash": "sha256-xIQMyjH6P6vDEAwwnttnlK5sZSH0Qe8xu6e2c+/VO2o=",
-        "ref": "fix/usb-isochronous-out",
-        "rev": "8123d5ed83323603b81acfaf6762a75c438c28d9",
-        "revCount": 11731,
+        "lastModified": 1786989044,
+        "narHash": "sha256-t0LiFIh1wNKIozQpdOuFIfuorirb3yOWiT58VtOK8/A=",
+        "ref": "refs/heads/main",
+        "rev": "767f265b3edbb65ab0d69a79023ca0a57e66a256",
+        "revCount": 11722,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/tiiuae/ghaf-crosvm"
       },
       "original": {
-        "ref": "fix/usb-isochronous-out",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/tiiuae/ghaf-crosvm"

--- a/flake.lock
+++ b/flake.lock
@@ -258,6 +258,7 @@
         "url": "https://github.com/tiiuae/ghaf-crosvm"
       },
       "original": {
+        "rev": "767f265b3edbb65ab0d69a79023ca0a57e66a256",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/tiiuae/ghaf-crosvm"
@@ -311,16 +312,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1787052754,
-        "narHash": "sha256-qcUNHT7UjOHu1qGdcDgRvoLQzcbDWfB+W+vi1I8OvFk=",
-        "owner": "vadika",
+        "lastModified": 1786479821,
+        "narHash": "sha256-IjlgULYzJHftvGTEap4vfpltBPN56f21aN0IpxeqpK8=",
+        "owner": "tiiuae",
         "repo": "ghafpkgs",
-        "rev": "4f181fe02222f9f7ef74ebb230f23f67b028714a",
+        "rev": "ad9b7f3269b945b40ecb30fa3461fd8b798bce1a",
         "type": "github"
       },
       "original": {
-        "owner": "vadika",
-        "ref": "fix/crosvm-cli-log-spam",
+        "owner": "tiiuae",
         "repo": "ghafpkgs",
         "type": "github"
       }
@@ -803,16 +803,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1786614239,
-        "narHash": "sha256-jh4QOHemA1WMFLWS06uIHv56sjX0UwaD7NQP701HAOw=",
-        "owner": "vadika",
+        "lastModified": 1786994697,
+        "narHash": "sha256-3Xa86R12YJ1kP/Xx6Ol3yaZuacVv5H/4+CUvJB/zCfw=",
+        "owner": "tiiuae",
         "repo": "vhotplug",
-        "rev": "123ea2d56380a1353d671fa1f88b241d08dcffe1",
+        "rev": "51286cf26629d17722fdbf371f54883a6f1f44a4",
         "type": "github"
       },
       "original": {
-        "owner": "vadika",
-        "ref": "feat/crosvm-pci-hotplug",
+        "owner": "tiiuae",
         "repo": "vhotplug",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -271,16 +271,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1787052754,
-        "narHash": "sha256-oKYwwMY63lbrgWy45flMfSxBGtLYdO7GJ+Cspo36h1M=",
+        "lastModified": 1787330506,
+        "narHash": "sha256-V5WAMGcAO5qPeMMKv1ZPtsVakuxypA2hCyzwMOxoq+Q=",
         "owner": "tiiuae",
         "repo": "ghaf-device-manager",
-        "rev": "b93dbc5c32689da179822231089593613c534133",
+        "rev": "02d4cafd8769652969cdcecbeab9095a688af948",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
-        "ref": "fix/suppress-noop-notifications",
         "repo": "ghaf-device-manager",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -96,8 +96,7 @@
     # Crosvm with Ghaf's swtpm backend. This is a non-flake source input
     # because nixpkgs supplies the package expression and Rust dependencies.
     ghaf-crosvm = {
-      # TODO: switch back to main after ghaf-crosvm#6 and #7 merge.
-      url = "git+https://github.com/tiiuae/ghaf-crosvm?ref=fix/usb-isochronous-out&submodules=1";
+      url = "git+https://github.com/tiiuae/ghaf-crosvm?submodules=1";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -80,8 +80,7 @@
 
     # A set of useful nix packages and utilities for ghaf
     ghafpkgs = {
-      # TODO: switch back to tiiuae/ghafpkgs after ghafpkgs#362 merges.
-      url = "github:vadika/ghafpkgs/fix/crosvm-cli-log-spam";
+      url = "github:tiiuae/ghafpkgs";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";
@@ -96,7 +95,7 @@
     # Crosvm with Ghaf's swtpm backend. This is a non-flake source input
     # because nixpkgs supplies the package expression and Rust dependencies.
     ghaf-crosvm = {
-      url = "git+https://github.com/tiiuae/ghaf-crosvm?submodules=1";
+      url = "git+https://github.com/tiiuae/ghaf-crosvm?rev=767f265b3edbb65ab0d69a79023ca0a57e66a256&submodules=1";
       flake = false;
     };
 
@@ -214,8 +213,7 @@
 
     # Hot-plugging devices into QEMU virtual machines
     vhotplug = {
-      # TODO: switch back to tiiuae/vhotplug after vhotplug#22 merges.
-      url = "github:vadika/vhotplug/feat/crosvm-pci-hotplug";
+      url = "github:tiiuae/vhotplug";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,8 @@
     # Crosvm with Ghaf's swtpm backend. This is a non-flake source input
     # because nixpkgs supplies the package expression and Rust dependencies.
     ghaf-crosvm = {
-      url = "git+https://github.com/tiiuae/ghaf-crosvm?submodules=1";
+      # TODO: switch back to main after ghaf-crosvm#6 and #7 merge.
+      url = "git+https://github.com/tiiuae/ghaf-crosvm?ref=fix/usb-isochronous-out&submodules=1";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -206,8 +206,7 @@
 
     # Hot-plugging USB and PCI devices into Crosvm virtual machines
     ghaf-device-manager = {
-      # TODO: switch back to mainline after the notification suppression fix merges.
-      url = "github:tiiuae/ghaf-device-manager/fix/suppress-noop-notifications";
+      url = "github:tiiuae/ghaf-device-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -207,7 +207,8 @@
 
     # Hot-plugging USB and PCI devices into Crosvm virtual machines
     ghaf-device-manager = {
-      url = "github:tiiuae/ghaf-device-manager";
+      # TODO: switch back to mainline after the notification suppression fix merges.
+      url = "github:tiiuae/ghaf-device-manager/fix/suppress-noop-notifications";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -208,7 +208,7 @@
 
     # Hot-plugging USB and PCI devices into Crosvm virtual machines
     ghaf-device-manager = {
-      url = "github:tiiuae/ghaf-device-manager/fix/crosvm-runtime-reliability";
+      url = "github:tiiuae/ghaf-device-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,13 @@
       };
     };
 
+    # Crosvm with Ghaf's swtpm backend. This is a non-flake source input
+    # because nixpkgs supplies the package expression and Rust dependencies.
+    ghaf-crosvm = {
+      url = "git+https://github.com/tiiuae/ghaf-crosvm?submodules=1";
+      flake = false;
+    };
+
     # To ensure that checks are run locally to enforce cleanliness
     git-hooks-nix = {
       url = "github:cachix/git-hooks.nix";
@@ -199,7 +206,8 @@
 
     # Hot-plugging USB devices into virtual machines
     vhotplug = {
-      url = "github:tiiuae/vhotplug";
+      # TODO: switch back to tiiuae/vhotplug after vhotplug#22 merges.
+      url = "github:vadika/vhotplug/feat/crosvm-pci-hotplug";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,8 @@
 
     # A set of useful nix packages and utilities for ghaf
     ghafpkgs = {
-      url = "github:tiiuae/ghafpkgs";
+      # TODO: switch back to tiiuae/ghafpkgs after ghafpkgs#362 merges.
+      url = "github:vadika/ghafpkgs/fix/crosvm-cli-log-spam";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";
@@ -205,7 +206,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Hot-plugging USB devices into virtual machines
+    # Hot-plugging USB and PCI devices into Crosvm virtual machines
+    ghaf-device-manager = {
+      url = "github:tiiuae/ghaf-device-manager/fix/crosvm-runtime-reliability";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # Hot-plugging devices into QEMU virtual machines
     vhotplug = {
       # TODO: switch back to tiiuae/vhotplug after vhotplug#22 merges.
       url = "github:vadika/vhotplug/feat/crosvm-pci-hotplug";

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -16,7 +16,7 @@ Creates a Ghaf configuration for any supported target type (laptop-x86, orin).
 - `variant`: String - Build variant, "debug" (default) or "release"
 - `extraModules`: List - Additional NixOS modules (default: [])
 - `extraConfig`: Attrs - Additional ghaf.* configuration (default: {})
-- `vmConfig`: Attrs - VM resource allocation and modules (default: {})
+- `vmConfig`: Attrs - VMM selection, VM resource allocation, and modules (default: {})
 
 **Returns:**
 - `name`: Full configuration name (e.g., "intel-laptop-debug")
@@ -112,12 +112,24 @@ does not. So `inputs.ghaf.inputs` is missing exactly the key every ghaf module r
 }
 ```
 
-### Using vmConfig for Resource Allocation
+### Using vmConfig for VMM and Resource Configuration
 
-The `vmConfig` parameter allows you to customize VM resource allocation per-target:
+The `vmConfig` parameter selects separate defaults for system VMs and App VMs,
+and supports per-VM VMM and resource overrides. The system-wide default is
+QEMU. Every generic `intel-laptop` target selects crosvm for all system VMs,
+including debug, release, low-memory, and store-disk variants. Machine-specific
+x86, generic VM, and aarch64 targets keep their existing selections. AdminVM
+normally defaults to crosvm only when storage encryption is disabled; generic
+Intel laptop targets also select crosvm for the encrypted AdminVM and use
+crosvm's TPM passthrough path. App VMs default to crosvm. crosvm VMs run as Ghaf's
+unprivileged `microvm` user with crosvm's internal minijail disabled, because
+its namespace setup requires `CAP_SYS_ADMIN`.
 
 ```nix
 vmConfig = {
+  defaultSysVmVmm = "qemu";
+  defaultAppVmVmm = "crosvm";
+
   # System VMs, keyed by the unhyphenated name (guivm, netvm, audiovm,
   # adminvm, idsvm)
   sysvms = {
@@ -128,10 +140,12 @@ vmConfig = {
     };
     netvm = {
       mem = 1024;
+      vmm = "qemu";       # Optional x86 laptop rollback
     };
     audiovm = {
       mem = 512;
     };
+    adminvm.vmm = "qemu"; # Optional AdminVM fallback
   };
 
   # App VMs
@@ -145,6 +159,21 @@ vmConfig = {
   };
 };
 ```
+
+### Resolving App VM Configuration
+
+Profiles that instantiate App VMs use
+`lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; }` before constructing
+the guest. The helper returns the effective VM definition after memory, vCPU,
+and balloon overrides, the selected VMM, and the App VM's additional modules:
+
+```nix
+resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+```
+
+Use `resolved.effectiveDef`, `resolved.selectedVmm`, and
+`resolved.extraModules` together so VMM and resource policy cannot drift
+between profiles.
 
 ### Extending Configurations
 
@@ -263,4 +292,5 @@ Key differences:
 - Named parameters instead of positional
 - `hardwareModule` separated from `extraModules`
 - `extraConfig` sets `ghaf.*` attributes directly
-- `vmConfig` for resource allocation (replaces `hardware.definition.<vm>.mem/vcpu`)
+- `vmConfig` for VMM selection and resource allocation (replaces
+  `hardware.definition.<vm>.mem/vcpu`)

--- a/lib/builders/README.md
+++ b/lib/builders/README.md
@@ -118,17 +118,17 @@ The `vmConfig` parameter selects separate defaults for system VMs and App VMs,
 and supports per-VM VMM and resource overrides. The system-wide default is
 QEMU. Every generic `intel-laptop` target selects crosvm for all system VMs,
 including debug, release, low-memory, and store-disk variants. Machine-specific
-x86, generic VM, and aarch64 targets keep their existing selections. AdminVM
-normally defaults to crosvm only when storage encryption is disabled; generic
-Intel laptop targets also select crosvm for the encrypted AdminVM and use
-crosvm's TPM passthrough path. App VMs default to crosvm. crosvm VMs run as Ghaf's
-unprivileged `microvm` user with crosvm's internal minijail disabled, because
-its namespace setup requires `CAP_SYS_ADMIN`.
+x86, generic VM, and aarch64 targets keep their existing selections. Generic
+Intel laptop targets also select crosvm for encrypted AdminVM variants and use
+crosvm's TPM passthrough path. App VMs default to QEMU system-wide and to crosvm
+on generic Intel laptop targets. crosvm VMs run as Ghaf's unprivileged
+`microvm` user with crosvm's internal minijail disabled, because its namespace
+setup requires `CAP_SYS_ADMIN`.
 
 ```nix
 vmConfig = {
   defaultSysVmVmm = "qemu";
-  defaultAppVmVmm = "crosvm";
+  defaultAppVmVmm = "qemu";
 
   # System VMs, keyed by the unhyphenated name (guivm, netvm, audiovm,
   # adminvm, idsvm)

--- a/lib/builders/mkGhafConfiguration.nix
+++ b/lib/builders/mkGhafConfiguration.nix
@@ -5,7 +5,8 @@
 #
 # Creates a Ghaf configuration for any supported target type.
 # This builder unifies mkLaptopConfiguration and mkOrinConfiguration into
-# a single, composable API with vmConfig support for resource allocation.
+# a single, composable API with vmConfig support for VMM selection and
+# resource allocation.
 #
 # Usage (inside ghaf, where self/inputs are ghaf's own):
 #   let
@@ -46,7 +47,8 @@
 #   variant        - Build variant: "debug" or "release" (default: "debug")
 #   extraModules   - Additional NixOS modules for the host (default: [])
 #   extraConfig    - Additional ghaf.* configuration (default: {})
-#   vmConfig       - VM resource allocation and modules (default: {})
+#   vmConfig       - VMM selection, resource allocation, and modules
+#                    (default: {})
 #                    Maps to ghaf.virtualization.vmConfig
 #   extraInputs    - Extra names merged into `inputs` (default: {}). Visible as
 #                    module arguments of the host and, because ghaf's profiles

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -788,6 +788,7 @@ rec {
 
         # Hardware passthrough settings
         passthrough = {
+          deviceManagerBackend = config.ghaf.hardware.passthrough.deviceManager.backend;
           qemuExtraArgs = config.ghaf.hardware.passthrough.qemuExtraArgs.${vmName} or [ ];
           vmUdevExtraRules =
             let
@@ -882,7 +883,6 @@ rec {
     #
     # Arguments:
     #   config - Host configuration (with ghaf.hardware.definition and ghaf.virtualization.vmConfig)
-    #   hostPkgs - Host package set used by generated host-side runner commands
     #   vmName - VM name without -vm suffix (e.g., "guivm", "netvm")
     #
     # Returns: List of modules to add via extendModules
@@ -894,7 +894,6 @@ rec {
     applyVmConfig =
       {
         config,
-        hostPkgs ? null,
         vmName,
       }:
       let
@@ -967,8 +966,8 @@ rec {
             assertions =
               lib.optionals usesPciVhotplug [
                 {
-                  assertion = vhotplugEnabled && hostPkgs != null && config.microvm.socket != null;
-                  message = "Crosvm PCI passthrough for ${vhotplugVmName} requires a device manager, a host package set, and a control socket";
+                  assertion = vhotplugEnabled && config.microvm.socket != null;
+                  message = "Crosvm PCI passthrough for ${vhotplugVmName} requires a device manager and a control socket";
                 }
               ]
               ++ lib.optionals (selectedVmm == "crosvm") [

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -720,6 +720,7 @@ rec {
   #   lib.ghaf.vm.mkHostConfig  - Extract host config for VM specialArgs
   #   lib.ghaf.vm.getConfig     - Get inner NixOS config from microvm.vms entry
   #   lib.ghaf.vm.applyVmConfig - Build modules list with vmConfig applied
+  #   lib.ghaf.vm.resolveAppVmConfig - Resolve an App VM definition and policy
   #
   # Usage Example:
   #   guivmBase = lib.nixosSystem {
@@ -871,16 +872,17 @@ rec {
     # Build modules list with vmConfig applied
     #
     # This function collects modules from hardware.definition and vmConfig
-    # and builds a resource allocation module from vmConfig.mem/vcpu.
+    # and builds a VM settings module from the VMM and resource options.
     #
     # Module merge order (highest priority last):
     #   1. Base module (guivm-base.nix) - sets mkDefault values
-    #   2. resourceModule - applies vmConfig.mem/vcpu
+    #   2. vmSettingsModule - applies the VMM and vmConfig.mem/vcpu
     #   3. hwModules - hardware.definition.<vm>.extraModules
     #   4. vmConfigModules - vmConfig.sysvms.<vm>.extraModules (highest priority)
     #
     # Arguments:
     #   config - Host configuration (with ghaf.hardware.definition and ghaf.virtualization.vmConfig)
+    #   hostPkgs - Host package set used by generated host-side runner commands
     #   vmName - VM name without -vm suffix (e.g., "guivm", "netvm")
     #
     # Returns: List of modules to add via extendModules
@@ -892,6 +894,7 @@ rec {
     applyVmConfig =
       {
         config,
+        hostPkgs ? null,
         vmName,
       }:
       let
@@ -900,19 +903,143 @@ rec {
 
         hwModules = hwDef.extraModules or [ ];
         vmConfigModules = vmCfg.extraModules or [ ];
+        selectedVmm =
+          if (vmCfg.vmm or null) != null then
+            vmCfg.vmm
+          else
+            config.ghaf.virtualization.vmConfig.defaultSysVmVmm;
+        # System VM registry keys consistently drop the hyphen from the unit
+        # name (for example, `audiovm` -> `audio-vm`). Derive the unit name from
+        # that convention instead of maintaining another per-VM lookup table.
+        vhotplugVmName = "${lib.removeSuffix "vm" vmName}-vm";
+        pciRules = config.ghaf.hardware.passthrough.vhotplug.pciRules or [ ];
+        usesPciVhotplug =
+          selectedVmm == "crosvm" && lib.any (rule: (rule.targetVm or null) == vhotplugVmName) pciRules;
+        vhotplugEnabled = config.ghaf.hardware.passthrough.vhotplug.enable or false;
+        pciBusPrefix = config.ghaf.hardware.passthrough.pciPorts.pcieBusPrefix;
+        vhotplugArgs = lib.escapeShellArgs (
+          [
+            (lib.getExe' hostPkgs.vhotplug "vhotplugcli")
+            "vmm"
+            "args"
+            "--vm"
+            vhotplugVmName
+            "--qemu-bus-start-index"
+            "1"
+            "--timeout"
+            "30"
+            "--require-pci"
+          ]
+          ++ lib.optionals (pciBusPrefix != null) [
+            "--qemu-bus-prefix"
+            pciBusPrefix
+          ]
+        );
 
-        # Resource allocation module (applies vmConfig.mem/vcpu)
+        # VM settings module (applies the VMM and vmConfig.mem/vcpu)
         #
         # Merge inside `microvm`, not at the top level: `//` is a shallow
         # update, so combining { microvm.mem = ...; } with
         # { microvm.vcpu = ...; } would replace the whole microvm attrset and
         # silently drop mem whenever both are set.
-        resourceModule = {
-          microvm =
-            lib.optionalAttrs (vmCfg.mem or null != null) { inherit (vmCfg) mem; }
-            // lib.optionalAttrs (vmCfg.vcpu or null != null) { inherit (vmCfg) vcpu; };
-        };
+        vmSettingsModule =
+          { config, ... }:
+          {
+            microvm = {
+              # microvm.nix calls its VMM selector `hypervisor`.
+              hypervisor = if (vmCfg.vmm or null) != null then selectedVmm else lib.mkDefault selectedVmm;
+            }
+            // lib.optionalAttrs (vmCfg.mem or null != null) { inherit (vmCfg) mem; }
+            // lib.optionalAttrs (vmCfg.vcpu or null != null) { inherit (vmCfg) vcpu; }
+            // lib.optionalAttrs (selectedVmm == "crosvm") {
+              # The host runs VMMs as the unprivileged `microvm` user. crosvm's
+              # multiprocess minijail needs CAP_SYS_ADMIN to create PID and mount
+              # namespaces, so retain the unprivileged service boundary and use
+              # single-process mode until a capability-scoped sandbox is wired.
+              crosvm.extraArgs = lib.mkBefore [ "--disable-sandbox" ];
+            }
+            // lib.optionalAttrs usesPciVhotplug {
+              devices = lib.mkForce [ ];
+              extraArgsScript = lib.mkForce vhotplugArgs;
+              # microvm.nix currently marks Crosvm runners Type=simple. The
+              # host overrides PCI-backed system VMs to Type=notify, so signal
+              # readiness only after Crosvm has created its control socket.
+              preStart = lib.mkAfter ''
+                (
+                  attempt=0
+                  while [ "$attempt" -lt 300 ]; do
+                    if [ -S ${lib.escapeShellArg config.microvm.socket} ]; then
+                      ${config.microvm.vmHostPackages.systemd}/bin/systemd-notify \
+                        --ready --status='Crosvm control socket is ready'
+                      exit 0
+                    fi
+                    attempt=$((attempt + 1))
+                    ${config.microvm.vmHostPackages.coreutils}/bin/sleep 0.1
+                  done
+                  ${config.microvm.vmHostPackages.systemd}/bin/systemd-notify \
+                    --status='Crosvm control socket did not become ready'
+                ) &
+              '';
+            };
+
+            assertions =
+              lib.optionals usesPciVhotplug [
+                {
+                  assertion = vhotplugEnabled && hostPkgs != null && config.microvm.socket != null;
+                  message = "Crosvm PCI passthrough for ${vhotplugVmName} requires vhotplug, a host package set, and a control socket";
+                }
+              ]
+              ++ lib.optionals (selectedVmm == "crosvm") [
+                {
+                  assertion = (config.microvm.qemu.extraArgs or [ ]) == [ ];
+                  message = "Crosvm system VMs cannot contain QEMU-only extra arguments";
+                }
+              ];
+          };
       in
-      [ resourceModule ] ++ hwModules ++ vmConfigModules;
+      [ vmSettingsModule ] ++ hwModules ++ vmConfigModules;
+
+    # Resolve an App VM definition against the host's vmConfig policy.
+    #
+    # Unlike singleton system VMs, App VMs are created by mkAppVm functions in
+    # multiple profiles. Keeping the resolution here prevents the laptop, Orin,
+    # and generic VM profiles from drifting apart.
+    #
+    # Arguments:
+    #   config - Host configuration containing virtualization.vmConfig
+    #   vmDef  - App VM definition with at least a name attribute
+    #
+    # Returns an attribute set containing:
+    #   effectiveDef - vmDef with mem, vcpu, and balloonRatio overrides applied
+    #   selectedVmm  - Per-VM override or defaultAppVmVmm
+    #   extraModules - Additional modules configured for this App VM
+    #
+    # Usage in profiles:
+    #   resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+    #   mkAppVm resolved.effectiveDef resolved.selectedVmm resolved.extraModules;
+    resolveAppVmConfig =
+      {
+        config,
+        vmDef,
+      }:
+      let
+        vmCfg = config.ghaf.virtualization.vmConfig.appvms.${vmDef.name} or { };
+        requestedVmm = vmCfg.vmm or null;
+        selectedVmm =
+          if requestedVmm != null then requestedVmm else config.ghaf.virtualization.vmConfig.defaultAppVmVmm;
+        configuredBalloonRatio =
+          if (vmCfg.balloonRatio or null) != null then vmCfg.balloonRatio else vmDef.balloonRatio or 2;
+        effectiveDef =
+          vmDef
+          // lib.optionalAttrs ((vmCfg.mem or null) != null) { inherit (vmCfg) mem; }
+          // lib.optionalAttrs ((vmCfg.vcpu or null) != null) { inherit (vmCfg) vcpu; }
+          // {
+            balloonRatio = configuredBalloonRatio;
+          };
+      in
+      {
+        inherit effectiveDef selectedVmm;
+        extraModules = vmCfg.extraModules or [ ];
+      };
   };
 }

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -917,9 +917,10 @@ rec {
           selectedVmm == "crosvm" && lib.any (rule: (rule.targetVm or null) == vhotplugVmName) pciRules;
         vhotplugEnabled = config.ghaf.hardware.passthrough.vhotplug.enable or false;
         pciBusPrefix = config.ghaf.hardware.passthrough.pciPorts.pcieBusPrefix;
+        deviceManagerPackage = config.ghaf.hardware.passthrough.deviceManager.package;
         vhotplugArgs = lib.escapeShellArgs (
           [
-            (lib.getExe' hostPkgs.vhotplug "vhotplugcli")
+            (lib.getExe' deviceManagerPackage "vhotplugcli")
             "vmm"
             "args"
             "--vm"
@@ -961,32 +962,13 @@ rec {
             // lib.optionalAttrs usesPciVhotplug {
               devices = lib.mkForce [ ];
               extraArgsScript = lib.mkForce vhotplugArgs;
-              # microvm.nix currently marks Crosvm runners Type=simple. The
-              # host overrides PCI-backed system VMs to Type=notify, so signal
-              # readiness only after Crosvm has created its control socket.
-              preStart = lib.mkAfter ''
-                (
-                  attempt=0
-                  while [ "$attempt" -lt 300 ]; do
-                    if [ -S ${lib.escapeShellArg config.microvm.socket} ]; then
-                      ${config.microvm.vmHostPackages.systemd}/bin/systemd-notify \
-                        --ready --status='Crosvm control socket is ready'
-                      exit 0
-                    fi
-                    attempt=$((attempt + 1))
-                    ${config.microvm.vmHostPackages.coreutils}/bin/sleep 0.1
-                  done
-                  ${config.microvm.vmHostPackages.systemd}/bin/systemd-notify \
-                    --status='Crosvm control socket did not become ready'
-                ) &
-              '';
             };
 
             assertions =
               lib.optionals usesPciVhotplug [
                 {
                   assertion = vhotplugEnabled && hostPkgs != null && config.microvm.socket != null;
-                  message = "Crosvm PCI passthrough for ${vhotplugVmName} requires vhotplug, a host package set, and a control socket";
+                  message = "Crosvm PCI passthrough for ${vhotplugVmName} requires a device manager, a host package set, and a control socket";
                 }
               ]
               ++ lib.optionals (selectedVmm == "crosvm") [

--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -184,11 +184,14 @@ let
   # to ghaf-wait-time-sync, whose literal "synchronised" SPIRE gates on.
   ghafClockSync = pkgs.writeShellApplication {
     name = "ghaf-clock-sync";
-    runtimeInputs = with pkgs; [
-      coreutils
-      gawk
-      systemd
-    ];
+    runtimeInputs =
+      with pkgs;
+      [
+        coreutils
+        gawk
+        systemd
+      ]
+      ++ lib.optional config.services.chrony.enable config.services.chrony.package;
     text = ''
       sync_wait_seconds="${toString effectiveSyncWaitSeconds}"
       sync_state_file="/run/ghaf-clock-sync-state"
@@ -213,10 +216,22 @@ let
 
       if [ "$sync_wait_seconds" -le 0 ]; then
         sync_result="disabled"
-      elif command -v timedatectl >/dev/null 2>&1; then
+      elif command -v ${
+        if config.services.chrony.enable then "chronyc" else "timedatectl"
+      } >/dev/null 2>&1; then
         sync_start_up="$(uptime_seconds)"
         while true; do
-          sync_value="$(timedatectl show -p NTPSynchronized --value 2>/dev/null || true)"
+          if ${
+            if config.services.chrony.enable then
+              "chronyc waitsync 1 0 0 0.1 >/dev/null 2>&1"
+            else
+              ''[ "$(timedatectl show -p NTPSynchronized --value 2>/dev/null || true)" = "yes" ]''
+          }; then
+            sync_value="yes"
+          else
+            sync_value="no"
+          fi
+
           if [ "$sync_value" = "yes" ]; then
             sync_result="synchronized"
             echo "Clock sync observed system time synchronization"
@@ -233,8 +248,10 @@ let
           sleep 1
         done
       else
-        sync_result="timedatectl-unavailable"
-        echo "Clock sync could not check time synchronization: timedatectl unavailable"
+        sync_result="sync-tool-unavailable"
+        echo "Clock sync could not check time synchronization: ${
+          if config.services.chrony.enable then "chronyc" else "timedatectl"
+        } unavailable"
       fi
 
       write_sync_state

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -1576,7 +1576,7 @@ in
         default = 120;
         description = ''
           Maximum number of seconds to wait for system time synchronization
-          (timedatectl NTPSynchronized) after local clock readiness before
+          (reported by the configured time daemon) after local clock readiness before
           activating FSS sealing.
 
           This is a best-effort soft gate, not a hard requirement: on an offline

--- a/modules/common/networking/uplink-resolver.nix
+++ b/modules/common/networking/uplink-resolver.nix
@@ -30,6 +30,7 @@ let
 
   stateFile = "/run/ghaf-uplink-state";
   readyFlag = "/run/ghaf-uplink-ready";
+  changedFlag = "/run/ghaf-uplink-changed";
 
   resolver = pkgs.writeShellApplication {
     name = "ghaf-resolve-uplink";
@@ -80,6 +81,14 @@ let
         printf 'uplink_reason=%s\n' "$reason"
       } >"$tmp"
       chmod 0644 "$tmp"
+
+      # NetworkManager can emit several dispatcher events for one transition
+      # (up, DHCP change and connectivity change). Preserve a pending change
+      # marker across an interrupted resolver run, but do not restart consumers
+      # again when the resolved state is identical.
+      if [ ! -r ${stateFile} ] || [ "$(cat ${stateFile})" != "$(cat "$tmp")" ]; then
+        : >${changedFlag}
+      fi
       mv -f "$tmp" ${stateFile}
 
       if [ "$state" = resolved ]; then
@@ -219,7 +228,12 @@ in
         # uplink goes away the flag is gone, so the start half is skipped by
         # ConditionPathExists and the unit correctly ends up stopped.
         # --no-block avoids deadlocking against the resolver they depend on.
-        ExecStartPost = "${pkgs.systemd}/bin/systemctl restart --no-block ${lib.escapeShellArgs cfg.dependentUnits}";
+        ExecStartPost = pkgs.writeShellScript "ghaf-restart-uplink-dependents" ''
+          if [ -e ${changedFlag} ]; then
+            rm -f ${changedFlag}
+            ${pkgs.systemd}/bin/systemctl restart --no-block ${lib.escapeShellArgs cfg.dependentUnits}
+          fi
+        '';
       };
     };
 

--- a/modules/common/services/bluetooth.nix
+++ b/modules/common/services/bluetooth.nix
@@ -156,6 +156,7 @@ in
         for _ in $(seq 1 30); do
           if bluetoothctl show | grep -q "Powered: yes"; then
             powered=true
+            break
           else
             powered=false
             bluetoothctl power on || true

--- a/modules/common/services/bluetooth.nix
+++ b/modules/common/services/bluetooth.nix
@@ -99,6 +99,9 @@ in
       KERNEL=="rfkill", SUBSYSTEM=="misc", GROUP="${bluetoothUser}"
       KERNEL=="uinput", SUBSYSTEM=="misc", GROUP="${bluetoothUser}"
       KERNEL=="uhid", GROUP="${bluetoothUser}" MODE="0660"
+    ''
+    + lib.optionalString cfg.powerOnBoot ''
+      ACTION=="add", SUBSYSTEM=="bluetooth", KERNEL=="hci[0-9]*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="bluetooth-power-on.service"
     '';
 
     # Dbus policy updates
@@ -150,28 +153,49 @@ in
         "bluetooth.service"
         "bluetooth.target"
       ];
-      path = [ pkgs.bluez ];
+      path = [
+        pkgs.bluez
+        pkgs.gawk
+      ];
       script = ''
-        powered=false
-        for _ in $(seq 1 30); do
-          if bluetoothctl show | grep -q "Powered: yes"; then
-            powered=true
-            break
-          else
-            powered=false
-            bluetoothctl power on || true
-          fi
-          sleep 1
-        done
+        controllers=()
+        while IFS= read -r controller; do
+          controllers+=("$controller")
+        done < <(bluetoothctl list | awk '$1 == "Controller" { print $2 }')
 
-        if "$powered"; then
+        # Passthrough adapters normally appear after bluetoothd. Their udev add
+        # event starts this unit again, so an empty controller list is not an
+        # error and must not delay or fail AudioVM boot.
+        if [ "''${#controllers[@]}" -eq 0 ]; then
+          echo "No Bluetooth adapter is currently available"
           exit 0
         fi
-        exit 1
+
+        failed=false
+        for controller in "''${controllers[@]}"; do
+          powered=false
+          for _ in $(seq 1 30); do
+            if bluetoothctl show "$controller" | grep -q "Powered: yes"; then
+              powered=true
+              break
+            fi
+            bluetoothctl select "$controller" >/dev/null || true
+            bluetoothctl power on || true
+            sleep 1
+          done
+
+          if ! "$powered"; then
+            echo "Failed to power on Bluetooth adapter $controller" >&2
+            failed=true
+          fi
+        done
+
+        if "$failed"; then
+          exit 1
+        fi
       '';
       serviceConfig = {
         Type = "oneshot";
-        RemainAfterExit = true;
       };
     };
 

--- a/modules/common/services/bluetooth.nix
+++ b/modules/common/services/bluetooth.nix
@@ -39,14 +39,24 @@ in
       '';
     };
 
+    powerOnBoot = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Automatically power on Bluetooth adapters when they appear.
+
+        This also applies when an adapter is reattached after suspend or a
+        hardware kill-switch cycle.
+      '';
+    };
+
   };
   config = mkIf cfg.enable {
 
     # Enable bluetooth
     hardware.bluetooth = {
       enable = true;
-      # Save battery by disabling bluetooth on boot
-      powerOnBoot = false;
+      inherit (cfg) powerOnBoot;
       # https://github.com/bluez/bluez/blob/master/src/main.conf full list of options
       settings = {
         General = {
@@ -122,6 +132,46 @@ in
     systemd.services.bluetooth.serviceConfig = {
       User = "${bluetoothUser}";
       Group = "${bluetoothUser}";
+    };
+
+    # BlueZ AutoEnable is not sufficient when a passthrough adapter is
+    # detached and reattached while bluetoothd is being restarted. Explicitly
+    # restore the powered state after both service restarts and adapter
+    # reappearance.
+    systemd.services.bluetooth-power-on = mkIf cfg.powerOnBoot {
+      description = "Power on Bluetooth adapters";
+      wantedBy = [
+        "bluetooth.service"
+        "bluetooth.target"
+      ];
+      after = [ "bluetooth.service" ];
+      requires = [ "bluetooth.service" ];
+      partOf = [
+        "bluetooth.service"
+        "bluetooth.target"
+      ];
+      path = [ pkgs.bluez ];
+      script = ''
+        powered=false
+        for _ in $(seq 1 30); do
+          if bluetoothctl show | grep -q "Powered: yes"; then
+            powered=true
+          else
+            powered=false
+            bluetoothctl power on || true
+          fi
+          sleep 1
+        done
+
+        if "$powered"; then
+          exit 0
+        fi
+        exit 1
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
     };
 
     # Add blueman-mechanism helper

--- a/modules/common/services/killswitch.nix
+++ b/modules/common/services/killswitch.nix
@@ -12,6 +12,19 @@ let
     mkIf
     ;
   cfg = config.ghaf.services.kill-switch;
+  deviceManagerPackage =
+    lib.attrByPath
+      [
+        "ghaf"
+        "hardware"
+        "passthrough"
+        "deviceManager"
+        "package"
+      ]
+      (
+        if (config.microvm.hypervisor or null) == "crosvm" then pkgs.ghaf-device-manager else pkgs.vhotplug
+      )
+      config;
 
   supportedDevices = [
     "mic"
@@ -66,9 +79,9 @@ let
 
   ghaf-killswitch = pkgs.writeShellApplication {
     name = "ghaf-killswitch";
-    runtimeInputs = with pkgs; [
-      coreutils
-      vhotplug
+    runtimeInputs = [
+      pkgs.coreutils
+      deviceManagerPackage
     ];
 
     text = ''

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -899,10 +899,15 @@ in
           resume-actions = {
             description = "Resume Actions";
             # QEMU stops sleep.target on wake, which runs ExecStop below.
-            # Crosvm wakes the guest kernel directly, so the host starts this
-            # otherwise-unneeded service explicitly after confirming wake.
-            wantedBy = optionals (config.microvm.hypervisor != "crosvm") [ "sleep.target" ];
-            before = optionals (config.microvm.hypervisor != "crosvm") [ "sleep.target" ];
+            # With Crosvm GPU suspend, the host instead starts this service
+            # explicitly after confirming wake. Crosvm without GPU suspend
+            # still needs the normal sleep.target lifecycle.
+            wantedBy = optionals (!(config.microvm.hypervisor == "crosvm" && cfg.gui.gpuSuspend)) [
+              "sleep.target"
+            ];
+            before = optionals (!(config.microvm.hypervisor == "crosvm" && cfg.gui.gpuSuspend)) [
+              "sleep.target"
+            ];
             unitConfig = {
               DefaultDependencies = false;
               StopWhenUnneeded = true;

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -9,6 +9,19 @@
   ...
 }:
 let
+  deviceManagerPackage =
+    lib.attrByPath
+      [
+        "ghaf"
+        "hardware"
+        "passthrough"
+        "deviceManager"
+        "package"
+      ]
+      (
+        if (config.microvm.hypervisor or null) == "crosvm" then pkgs.ghaf-device-manager else pkgs.vhotplug
+      )
+      config;
   cfg = config.ghaf.services.power-manager;
   inherit (lib)
     concatMapStringsSep
@@ -148,6 +161,30 @@ let
     in
     vmConfig != null && vmConfig.microvm.hypervisor == "crosvm"
   ) gpuSuspendVms;
+  crosvmGpuResumeCases = concatMapStringsSep "\n" (
+    vmName:
+    let
+      vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${vmName};
+      controlSocket =
+        if vmConfig != null && (vmConfig.microvm.socket or null) != null then
+          "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
+        else
+          "";
+      crosvmPackage = vmConfig.microvm.crosvm.package;
+    in
+    ''
+      ${lib.escapeShellArg vmName})
+        control_socket=${lib.escapeShellArg controlSocket}
+        if [ -z "$control_socket" ] || [ ! -S "$control_socket" ]; then
+          echo "Crosvm control socket $control_socket does not exist for $vm_name" >&2
+        elif ${crosvmPackage}/bin/crosvm --no-syslog resume "$control_socket"; then
+          resume_signal_sent=1
+        else
+          echo "Crosvm resume command failed for $vm_name" >&2
+        fi
+        ;;
+    ''
+  ) crosvmGpuSuspendVms;
 
   # Host suspend actions
   host-suspend-actions = pkgs.writeShellApplication {
@@ -159,7 +196,7 @@ let
       pkgs.grpcurl
       pkgs.jq
       pkgs.socat
-      pkgs.vhotplug
+      deviceManagerPackage
       pkgs.wait-for-unit
     ];
     text = ''
@@ -256,8 +293,15 @@ let
                   exit 1
                 fi
 
-                echo "Crosvm VM $vm_name will resume after its kernel fallback timeout (${toString cfg.gui.gpuSuspendDuration}s)"
-                sleep ${toString cfg.gui.gpuSuspendDuration}
+                resume_signal_sent=0
+                case "$vm_name" in
+                  ${crosvmGpuResumeCases}
+                esac
+
+                if [ "$resume_signal_sent" != 1 ]; then
+                  echo "Crosvm VM $vm_name will resume after its kernel fallback timeout (${toString cfg.gui.gpuSuspendDuration}s)"
+                  sleep ${toString cfg.gui.gpuSuspendDuration}
+                fi
 
                 deadline=$((SECONDS + 10))
                 resumed=0
@@ -948,6 +992,18 @@ in
           ];
     })
 
+    (optionalAttrs (options ? microvm && options.microvm ? crosvm) {
+      # Crosvm can inject the ACPI wake event directly over its control socket.
+      # Keep the guest kernel timer as a fallback if that command is unavailable.
+      microvm.crosvm.extraArgs = mkIf (
+        cfg.gui.enable
+        && cfg.vm.enable
+        && cfg.gui.gpuSuspend
+        && pkgs.stdenv.hostPlatform.isx86_64
+        && config.microvm.hypervisor == "crosvm"
+      ) [ "--s2idle" ];
+    })
+
     # Host power management
     (mkIf cfg.host.enable {
       # Host still handles power buttons in most situations
@@ -1057,7 +1113,7 @@ in
                 before = [ "sleep.target" ];
                 serviceConfig = {
                   Type = "oneshot";
-                  ExecStart = "${getExe' pkgs.vhotplug "vhotplugcli"} usb suspend";
+                  ExecStart = "${getExe' deviceManagerPackage "vhotplugcli"} usb suspend";
                 };
               };
 
@@ -1068,7 +1124,7 @@ in
                 after = [ "suspend.target" ];
                 serviceConfig = {
                   Type = "oneshot";
-                  ExecStart = "${getExe' pkgs.vhotplug "vhotplugcli"} usb resume";
+                  ExecStart = "${getExe' deviceManagerPackage "vhotplugcli"} usb resume";
                 };
               };
             }
@@ -1235,6 +1291,7 @@ in
                           "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
                         else
                           "";
+                      crosvmPackage = vmConfig.microvm.crosvm.package;
                       crosvmAcpiGraceSec = 15;
                       crosvmStopDeadlineSec = 25;
                       crosvm-stop = pkgs.writeShellScript "crosvm-stop" ''
@@ -1245,12 +1302,11 @@ in
                           exit 0
                         fi
 
-                        shutdown_script='${config.microvm.stateDir}/${vmName}/booted/bin/microvm-shutdown'
-                        if [ -n '${controlSocket}' ] && [ -S '${controlSocket}' ] && [ -x "$shutdown_script" ]; then
+                        if [ -n '${controlSocket}' ] && [ -S '${controlSocket}' ]; then
                           echo "Crosvm powerbtn -> '${vmName}' (${controlSocket})"
-                          # Use the runner from the booted generation so its control
-                          # protocol always matches the running Crosvm process.
-                          if ! "$shutdown_script"; then
+                          # Use the package from this VM's evaluated configuration
+                          # so the control protocol matches the running process.
+                          if ! ${crosvmPackage}/bin/crosvm --no-syslog powerbtn '${controlSocket}'; then
                             echo "WARN: Crosvm powerbtn for '${vmName}' failed; sending SIGTERM" >&2
                             kill -15 "$pid" 2>/dev/null || true
                           fi

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -852,10 +852,12 @@ in
         );
       };
 
-      # Allow the host power manager to trigger kernel GPU suspend in the GUI VM
-      givc.sysvm.capabilities.services = optionals (cfg.vm.enable && useGivc && cfg.gui.gpuSuspend) [
-        "gpu-suspend.service"
-      ];
+      # Allow the host power manager to stop the GUI VM gracefully through GIVC.
+      # Unlike the other system VMs, GUI VM ignores the ACPI power button and
+      # therefore cannot use the host's QMP system_powerdown path.
+      givc.sysvm.capabilities.services = optionals (cfg.vm.enable && useGivc) (
+        [ "poweroff.target" ] ++ optionals cfg.gui.gpuSuspend [ "gpu-suspend.service" ]
+      );
 
       # Override systemd actions for suspend, poweroff, and reboot
       systemd.services = optionalAttrs (cfg.vm.enable && useGivc) (

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -110,6 +110,19 @@ let
         vmConfig = lib.ghaf.vm.getConfig vm;
       in
       vmConfig != null
+      && vmConfig.microvm.hypervisor == "qemu"
+      && !(vmConfig.ghaf.services.power-manager.enable && vmConfig.ghaf.services.power-manager.gui.enable)
+    ) config.microvm.vms
+  );
+
+  crosvmShutdownVms = lib.attrNames (
+    filterAttrs (
+      _: vm:
+      let
+        vmConfig = lib.ghaf.vm.getConfig vm;
+      in
+      vmConfig != null
+      && vmConfig.microvm.hypervisor == "crosvm"
       && !(vmConfig.ghaf.services.power-manager.enable && vmConfig.ghaf.services.power-manager.gui.enable)
     ) config.microvm.vms
   );
@@ -128,6 +141,13 @@ let
       && vmConfig.ghaf.services.power-manager.gui.gpuSuspend
     ) config.microvm.vms
   );
+  crosvmGpuSuspendVms = lib.filter (
+    vmName:
+    let
+      vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${vmName};
+    in
+    vmConfig != null && vmConfig.microvm.hypervisor == "crosvm"
+  ) gpuSuspendVms;
 
   # Host suspend actions
   host-suspend-actions = pkgs.writeShellApplication {
@@ -137,6 +157,7 @@ let
       pkgs.systemd
       pkgs.coreutils
       pkgs.grpcurl
+      pkgs.jq
       pkgs.socat
       pkgs.vhotplug
       pkgs.wait-for-unit
@@ -230,10 +251,41 @@ let
               wake_socket="${config.microvm.stateDir}/$vm_name/vm-wake.sock"
               echo "Signaling kernel GPU resume to $vm_name..."
               if [ ! -S "$wake_socket" ]; then
-                echo "Wake socket $wake_socket does not exist, $vm_name will resume after fallback timeout (${toString cfg.gui.gpuSuspendDuration}s)"
-                exit 1
+                if [[ " ${lib.concatStringsSep " " crosvmGpuSuspendVms} " != *" $vm_name "* ]]; then
+                  echo "Wake socket $wake_socket does not exist for QEMU VM $vm_name" >&2
+                  exit 1
+                fi
+
+                echo "Crosvm VM $vm_name will resume after its kernel fallback timeout (${toString cfg.gui.gpuSuspendDuration}s)"
+                sleep ${toString cfg.gui.gpuSuspendDuration}
+
+                deadline=$((SECONDS + 10))
+                resumed=0
+                while [ "$SECONDS" -lt "$deadline" ]; do
+                  if status_response=$(grpcurl \
+                    -cacert /etc/givc/ca-cert.pem \
+                    -cert /etc/givc/cert.pem \
+                    -key /etc/givc/key.pem \
+                    -d "{\"VmName\":\"$vm_name\",\"UnitName\":\"gpu-suspend.service\"}" \
+                    '${config.ghaf.networking.hosts.admin-vm.ipv4}:9001' \
+                    admin.AdminService.GetUnitStatus 2>/dev/null); then
+                    active_state=$(jq -r '.ActiveState // "unknown"' <<<"$status_response")
+                    sub_state=$(jq -r '.SubState // "unknown"' <<<"$status_response")
+                    if [ "$active_state" = "inactive" ] && [ "$sub_state" = "dead" ]; then
+                      resumed=1
+                      break
+                    fi
+                  fi
+                  sleep 1
+                done
+                if [ "$resumed" != 1 ]; then
+                  echo "Crosvm VM $vm_name did not confirm GPU resume within 10s" >&2
+                  exit 1
+                fi
+                echo "Crosvm VM $vm_name confirmed GPU resume"
+              else
+                printf 'resume\n' | socat -u - "UNIX-CONNECT:$wake_socket"
               fi
-              printf 'resume\n' | socat -u - "UNIX-CONNECT:$wake_socket"
               ;;
             *)
               echo "Invalid action: $action"
@@ -880,7 +932,14 @@ in
       # rejects it and the VM fails to start, so gate the wake device on x86. On
       # aarch64 the guest resumes via the fallback timeout (see gpuSuspendDuration).
       microvm.qemu.extraArgs =
-        mkIf (cfg.gui.enable && cfg.vm.enable && cfg.gui.gpuSuspend && pkgs.stdenv.hostPlatform.isx86_64)
+        mkIf
+          (
+            cfg.gui.enable
+            && cfg.vm.enable
+            && cfg.gui.gpuSuspend
+            && pkgs.stdenv.hostPlatform.isx86_64
+            && config.microvm.hypervisor == "qemu"
+          )
           [
             "-chardev"
             "socket,id=wake0,path=vm-wake.sock,server=on,wait=off"
@@ -971,7 +1030,11 @@ in
                       description = "post-resume ${suspendAction} action for '%i'";
                       partOf = [ "post-resume-actions.target" ];
                       after = [ "suspend.target" ];
-                      before = optionals (suspendAction == "pci-suspend") [ "post-resume-fake-suspend@%i.service" ];
+                      # Reattach PCI before waking guest services so drivers and
+                      # NetworkManager never race a still-detached VFIO device.
+                      before = optionals (suspendAction == "pci-suspend") [
+                        "post-resume-fake-suspend@%i.service"
+                      ];
                       serviceConfig = {
                         Type = "oneshot";
                         ExecStart = "${getExe host-suspend-actions} %i ${suspendAction} resume";
@@ -1155,6 +1218,72 @@ in
                 };
               }
             ) qmpShutdownVms
+          ))
+          # Crosvm guests use the same ACPI power-button path, delivered through
+          # the Crosvm control socket instead of QMP.
+          (lib.listToAttrs (
+            map (
+              vmName:
+              nameValuePair "microvm@${vmName}" {
+                serviceConfig = {
+                  TimeoutStopSec = lib.mkDefault "30";
+                  ExecStop =
+                    let
+                      vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${vmName};
+                      controlSocket =
+                        if vmConfig != null && (vmConfig.microvm.socket or null) != null then
+                          "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
+                        else
+                          "";
+                      crosvmAcpiGraceSec = 15;
+                      crosvmStopDeadlineSec = 25;
+                      crosvm-stop = pkgs.writeShellScript "crosvm-stop" ''
+                        set -u
+                        pid="''${MAINPID:-}"
+                        if [ -z "$pid" ]; then
+                          echo "Crosvm '${vmName}' has no MAINPID; nothing to stop"
+                          exit 0
+                        fi
+
+                        shutdown_script='${config.microvm.stateDir}/${vmName}/booted/bin/microvm-shutdown'
+                        if [ -n '${controlSocket}' ] && [ -S '${controlSocket}' ] && [ -x "$shutdown_script" ]; then
+                          echo "Crosvm powerbtn -> '${vmName}' (${controlSocket})"
+                          # Use the runner from the booted generation so its control
+                          # protocol always matches the running Crosvm process.
+                          if ! "$shutdown_script"; then
+                            echo "WARN: Crosvm powerbtn for '${vmName}' failed; sending SIGTERM" >&2
+                            kill -15 "$pid" 2>/dev/null || true
+                          fi
+                        else
+                          echo "WARN: no Crosvm control socket for '${vmName}'; SIGTERM fallback" >&2
+                          kill -15 "$pid" 2>/dev/null || true
+                        fi
+
+                        echo "Waiting for Crosvm '${vmName}' with PID=$pid to stop"
+                        waited=0
+                        grace_logged=0
+                        while kill -0 "$pid" 2>/dev/null; do
+                          sleep 1
+                          waited=$((waited + 1))
+                          if [ "$grace_logged" = 0 ] && [ "$waited" -ge ${toString crosvmAcpiGraceSec} ]; then
+                            grace_logged=1
+                            echo "WARN: guest '${vmName}' has not stopped after ''${waited}s; systemd will force it at the stop timeout" >&2
+                          fi
+                          if [ "$waited" -ge ${toString crosvmStopDeadlineSec} ]; then
+                            echo "ERROR: Crosvm '${vmName}' with PID=$pid did not stop within ''${waited}s" >&2
+                            exit 1
+                          fi
+                        done
+                        echo "Crosvm '${vmName}' with PID=$pid stopped"
+                      '';
+                    in
+                    [
+                      ""
+                      "+${crosvm-stop}"
+                    ];
+                };
+              }
+            ) crosvmShutdownVms
           ))
           # Handle VMs with shutdownLast enabled
           (lib.listToAttrs (

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -795,6 +795,8 @@ in
               systemctl start ${service}
             '') cfg.vm.pciSuspendServices
           )
+          # The GUI profile runs these from resume-actions.service below.
+          # Running them here too races two copies of every resume hook.
           + optionalString (cfg.suspend.extraResumeCommands != "" && !cfg.gui.enable) ''
             # config.ghaf.services.power-manager.suspend.extraResumeCommands
             ${cfg.suspend.extraResumeCommands}

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -287,12 +287,7 @@ let
             resume)
               wake_socket="${config.microvm.stateDir}/$vm_name/vm-wake.sock"
               echo "Signaling kernel GPU resume to $vm_name..."
-              if [ ! -S "$wake_socket" ]; then
-                if [[ " ${lib.concatStringsSep " " crosvmGpuSuspendVms} " != *" $vm_name "* ]]; then
-                  echo "Wake socket $wake_socket does not exist for QEMU VM $vm_name" >&2
-                  exit 1
-                fi
-
+              if [[ " ${lib.concatStringsSep " " crosvmGpuSuspendVms} " == *" $vm_name "* ]]; then
                 resume_signal_sent=0
                 case "$vm_name" in
                   ${crosvmGpuResumeCases}
@@ -327,7 +322,20 @@ let
                   exit 1
                 fi
                 echo "Crosvm VM $vm_name confirmed GPU resume"
+
+                # Crosvm wakes the guest kernel directly, so the guest's
+                # sleep.target is not stopped and its ExecStop-based resume
+                # hook does not run automatically as it does with QEMU.
+                echo "Running resume actions in $vm_name..."
+                if ! ${givc-cli} start service --vm "$vm_name" resume-actions.service; then
+                  echo "Failed to start resume actions in Crosvm VM $vm_name" >&2
+                  exit 1
+                fi
               else
+                if [ ! -S "$wake_socket" ]; then
+                  echo "Wake socket $wake_socket does not exist for QEMU VM $vm_name" >&2
+                  exit 1
+                fi
                 printf 'resume\n' | socat -u - "UNIX-CONNECT:$wake_socket"
               fi
               ;;
@@ -856,7 +864,11 @@ in
       # Unlike the other system VMs, GUI VM ignores the ACPI power button and
       # therefore cannot use the host's QMP system_powerdown path.
       givc.sysvm.capabilities.services = optionals (cfg.vm.enable && useGivc) (
-        [ "poweroff.target" ] ++ optionals cfg.gui.gpuSuspend [ "gpu-suspend.service" ]
+        [ "poweroff.target" ]
+        ++ optionals cfg.gui.gpuSuspend [
+          "gpu-suspend.service"
+          "resume-actions.service"
+        ]
       );
 
       # Override systemd actions for suspend, poweroff, and reboot
@@ -886,12 +898,11 @@ in
 
           resume-actions = {
             description = "Resume Actions";
-            wantedBy = [
-              "sleep.target"
-            ];
-            before = [
-              "sleep.target"
-            ];
+            # QEMU stops sleep.target on wake, which runs ExecStop below.
+            # Crosvm wakes the guest kernel directly, so the host starts this
+            # otherwise-unneeded service explicitly after confirming wake.
+            wantedBy = optionals (config.microvm.hypervisor != "crosvm") [ "sleep.target" ];
+            before = optionals (config.microvm.hypervisor != "crosvm") [ "sleep.target" ];
             unitConfig = {
               DefaultDependencies = false;
               StopWhenUnneeded = true;
@@ -1303,6 +1314,20 @@ in
                         pid="''${MAINPID:-}"
                         if [ -z "$pid" ]; then
                           echo "Crosvm '${vmName}' has no MAINPID; nothing to stop"
+                          exit 0
+                        fi
+
+                        # Keep host activation bounded: switch-to-configuration
+                        # restarts changed units synchronously, so graceful guest
+                        # shutdown here would serialize up to 25 seconds per VM.
+                        jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
+                        if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
+                          && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
+                          echo "switch-to-configuration activation in progress, SIGTERM '${vmName}'"
+                          kill -15 "$pid" 2>/dev/null || true
+                          while kill -0 "$pid" 2>/dev/null; do
+                            sleep 1
+                          done
                           exit 0
                         fi
 

--- a/modules/common/time/default.nix
+++ b/modules/common/time/default.nix
@@ -204,13 +204,13 @@ in
           # first accepted reply only at 127s. Keeping the ceiling next to the
           # floor roughly halves that.
           #
-          # 16s/17s is as tight as systemd allows: PollIntervalMinSec must not be
-          # smaller than 16s, and PollIntervalMaxSec must be strictly larger than
-          # PollIntervalMinSec (timesyncd.conf(5)).
+          # Keep both limits at 16s. timesyncd doubles the current interval before
+          # checking it against the maximum, so a 16s/17s range actually retries
+          # after 32s. Equal limits are accepted and prevent that overshoot.
           settings.Time = {
             RootDistanceMaxSec = "30s";
             PollIntervalMinSec = "16s";
-            PollIntervalMaxSec = "17s";
+            PollIntervalMaxSec = "16s";
             ConnectionRetrySec = "5s";
           };
         };

--- a/modules/common/time/default.nix
+++ b/modules/common/time/default.nix
@@ -124,11 +124,14 @@ in
             ExecStart = lib.getExe (
               pkgs.writeShellApplication {
                 name = "ghaf-wait-time-sync";
-                runtimeInputs = with pkgs; [
-                  coreutils
-                  gawk
-                  systemd
-                ];
+                runtimeInputs =
+                  with pkgs;
+                  [
+                    coreutils
+                    gawk
+                    systemd
+                  ]
+                  ++ lib.optional cfg.server.enable config.services.chrony.package;
                 # The bounded-wait branch is emitted only when requireSync is
                 # false. Declaring its state unconditionally would leave unused
                 # variables in the requireSync case, and writeShellApplication
@@ -146,8 +149,12 @@ in
                   ''}
 
                   while true; do
-                    value="$(timedatectl show -p NTPSynchronized --value 2>/dev/null || true)"
-                    if [ "$value" = "yes" ]; then
+                    if ${
+                      if cfg.server.enable then
+                        "chronyc waitsync 1 0 0 0.1 >/dev/null 2>&1"
+                      else
+                        ''[ "$(timedatectl show -p NTPSynchronized --value 2>/dev/null || true)" = "yes" ]''
+                    }; then
                       echo "Clock synchronised; realtime is $(date -u -Is)"
                       printf 'synchronised\n' > "$synced_file"
                       break

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -442,6 +442,9 @@ in
         # The NetworkManager D-Bus proxy and forwarded PipeWire core recover
         # asynchronously after net-vm and audio-vm resume. Restarting the panel
         # before they accept requests leaves their applets permanently empty.
+        network_wait_pid=""
+        pipewire_wait_pid=""
+        bluetooth_wait_pid=""
         if systemctl -q is-enabled dbus-proxy-networkmanager.service; then
           ${lib.getExe' pkgs.coreutils "timeout"} 30 ${lib.getExe pkgs.bash} -c '
             until ${lib.getExe' pkgs.systemd "busctl"} --system get-property \
@@ -450,7 +453,8 @@ in
               org.freedesktop.NetworkManager State >/dev/null 2>&1; do
               ${lib.getExe' pkgs.coreutils "sleep"} 0.5
             done
-          ' || echo "NetworkManager proxy did not recover before the panel restart"
+          ' &
+          network_wait_pid=$!
         fi
 
         if [ -S /tmp/pipewire-0 ]; then
@@ -459,7 +463,84 @@ in
               ${lib.getExe' pkgs.wireplumber "wpctl"} status >/dev/null 2>&1; do
               ${lib.getExe' pkgs.coreutils "sleep"} 0.5
             done
-          ' || echo "PipeWire control did not recover before the panel restart"
+          ' &
+          pipewire_wait_pid=$!
+        fi
+
+        ${lib.optionalString graphicsProfileCfg.bluetooth.applet.enable ''
+          if systemctl -q is-enabled dbus-proxy-bluetooth.service; then
+            # Stop clients before replacing the proxy. Otherwise they can
+            # retain stale BlueZ objects or race adapter power restoration.
+            while read -r user_id _; do
+              ${lib.getExe' pkgs.systemd "systemctl"} --user \
+                --machine="$user_id@.host" stop blueman-applet.service \
+                || echo "Blueman applet did not stop for user $user_id"
+            done < <(${lib.getExe' pkgs.systemd "loginctl"} list-users --no-legend)
+
+            while read -r manager_pid; do
+              if [ -n "$manager_pid" ]; then
+                ${lib.getExe' pkgs.busybox "kill"} "$manager_pid" || true
+              fi
+            done < <(${lib.getExe' pkgs.busybox "pgrep"} -x blueman-manager || true)
+
+            # The GIVC socket may reappear before BlueZ is ready. Wait for the
+            # source adapter, then rebuild the proxy so it does not retain the
+            # stale pre-suspend object map.
+            ${lib.getExe' pkgs.coreutils "timeout"} 30 ${lib.getExe pkgs.bash} -c '
+              stable_powered=0
+              until [ "$stable_powered" -ge 3 ]; do
+                if [ "$(
+                  ${lib.getExe' pkgs.coreutils "timeout"} 2 \
+                    ${lib.getExe' pkgs.systemd "busctl"} --address=unix:path=/tmp/dbusproxy_snd.sock \
+                      get-property org.bluez /org/bluez/hci0 org.bluez.Adapter1 Powered \
+                      2>/dev/null
+                )" = "b true" ]; then
+                  stable_powered=$((stable_powered + 1))
+                else
+                  stable_powered=0
+                fi
+                ${lib.getExe' pkgs.coreutils "sleep"} 0.5
+              done
+
+              ${lib.getExe' pkgs.systemd "systemctl"} restart dbus-proxy-bluetooth.service
+
+              until ${lib.getExe' pkgs.coreutils "timeout"} 2 \
+                ${lib.getExe' pkgs.systemd "busctl"} --system get-property \
+                  org.bluez /org/bluez/hci0 org.bluez.Adapter1 Powered \
+                  >/dev/null 2>&1; do
+                ${lib.getExe' pkgs.coreutils "sleep"} 0.5
+              done
+
+              ${lib.getExe' pkgs.systemd "busctl"} --system set-property \
+                org.bluez /org/bluez/hci0 org.bluez.Adapter1 Powered b true
+
+              until [ "$(
+                ${lib.getExe' pkgs.systemd "busctl"} --system get-property \
+                  org.bluez /org/bluez/hci0 org.bluez.Adapter1 Powered \
+                  2>/dev/null
+              )" = "b true" ]; do
+                ${lib.getExe' pkgs.coreutils "sleep"} 0.5
+              done
+            ' &
+            bluetooth_wait_pid=$!
+          fi
+        ''}
+
+        if [ -n "$network_wait_pid" ]; then
+          wait "$network_wait_pid" || echo "NetworkManager proxy did not recover before the panel restart"
+        fi
+        if [ -n "$pipewire_wait_pid" ]; then
+          wait "$pipewire_wait_pid" || echo "PipeWire control did not recover before the panel restart"
+        fi
+        if [ -n "$bluetooth_wait_pid" ]; then
+          if ! wait "$bluetooth_wait_pid"; then
+            echo "Bluetooth proxy did not recover before the applet restart"
+          fi
+          while read -r user_id _; do
+            ${lib.getExe' pkgs.systemd "systemctl"} --user \
+              --machine="$user_id@.host" start blueman-applet.service \
+              || echo "Blueman applet did not start for user $user_id"
+          done < <(${lib.getExe' pkgs.systemd "loginctl"} list-users --no-legend)
         fi
 
         pid=$(${lib.getExe' pkgs.busybox "pgrep"} -f "cosmic-panel" | ${lib.getExe' pkgs.busybox "head"} -n1)

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -439,6 +439,29 @@ in
       # Workaround for https://github.com/pop-os/cosmic-applets/issues/1390
       # TODO: Remove when upstream issue is fixed
       ''
+        # The NetworkManager D-Bus proxy and forwarded PipeWire core recover
+        # asynchronously after net-vm and audio-vm resume. Restarting the panel
+        # before they accept requests leaves their applets permanently empty.
+        if systemctl -q is-enabled dbus-proxy-networkmanager.service; then
+          ${lib.getExe' pkgs.coreutils "timeout"} 30 ${lib.getExe pkgs.bash} -c '
+            until ${lib.getExe' pkgs.systemd "busctl"} --system get-property \
+              org.freedesktop.NetworkManager \
+              /org/freedesktop/NetworkManager \
+              org.freedesktop.NetworkManager State >/dev/null 2>&1; do
+              ${lib.getExe' pkgs.coreutils "sleep"} 0.5
+            done
+          ' || echo "NetworkManager proxy did not recover before the panel restart"
+        fi
+
+        if [ -S /tmp/pipewire-0 ]; then
+          ${lib.getExe' pkgs.coreutils "timeout"} 30 ${lib.getExe pkgs.bash} -c '
+            until PIPEWIRE_RUNTIME_DIR=/tmp ${lib.getExe' pkgs.coreutils "timeout"} 2 \
+              ${lib.getExe' pkgs.wireplumber "wpctl"} status >/dev/null 2>&1; do
+              ${lib.getExe' pkgs.coreutils "sleep"} 0.5
+            done
+          ' || echo "PipeWire control did not recover before the panel restart"
+        fi
+
         pid=$(${lib.getExe' pkgs.busybox "pgrep"} -f "cosmic-panel" | ${lib.getExe' pkgs.busybox "head"} -n1)
         if [ -n "$pid" ]; then
           ${lib.getExe' pkgs.busybox "kill"} "$pid" || true

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -486,13 +486,23 @@ in
             # The GIVC socket may reappear before BlueZ is ready. Wait for the
             # source adapter, then rebuild the proxy so it does not retain the
             # stale pre-suspend object map.
-            ${lib.getExe' pkgs.coreutils "timeout"} 30 ${lib.getExe pkgs.bash} -c '
+            (
               stable_powered=0
-              until [ "$stable_powered" -ge 3 ]; do
-                if [ "$(
+              source_deadline=$((SECONDS + 15))
+              while [ "$SECONDS" -lt "$source_deadline" ] && [ "$stable_powered" -lt 3 ]; do
+                source_adapter=$(
                   ${lib.getExe' pkgs.coreutils "timeout"} 2 \
                     ${lib.getExe' pkgs.systemd "busctl"} --address=unix:path=/tmp/dbusproxy_snd.sock \
-                      get-property org.bluez /org/bluez/hci0 org.bluez.Adapter1 Powered \
+                      --json=short call org.bluez / org.freedesktop.DBus.ObjectManager GetManagedObjects \
+                      2>/dev/null \
+                    | ${lib.getExe pkgs.jq} -r \
+                      ".data[0] | to_entries[] | select(.value | has(\"org.bluez.Adapter1\")) | .key" \
+                    | ${lib.getExe' pkgs.coreutils "head"} -n1
+                )
+                if [ -n "$source_adapter" ] && [ "$(
+                  ${lib.getExe' pkgs.coreutils "timeout"} 2 \
+                    ${lib.getExe' pkgs.systemd "busctl"} --address=unix:path=/tmp/dbusproxy_snd.sock \
+                      get-property org.bluez "$source_adapter" org.bluez.Adapter1 Powered \
                       2>/dev/null
                 )" = "b true" ]; then
                   stable_powered=$((stable_powered + 1))
@@ -502,26 +512,55 @@ in
                 ${lib.getExe' pkgs.coreutils "sleep"} 0.5
               done
 
+              if [ "$stable_powered" -lt 3 ]; then
+                echo "Source Bluetooth adapter did not stabilize before proxy restart" >&2
+                exit 1
+              fi
+
               ${lib.getExe' pkgs.systemd "systemctl"} restart dbus-proxy-bluetooth.service
 
-              until ${lib.getExe' pkgs.coreutils "timeout"} 2 \
-                ${lib.getExe' pkgs.systemd "busctl"} --system get-property \
-                  org.bluez /org/bluez/hci0 org.bluez.Adapter1 Powered \
-                  >/dev/null 2>&1; do
+              proxy_adapter=""
+              proxy_deadline=$((SECONDS + 5))
+              while [ "$SECONDS" -lt "$proxy_deadline" ] && [ -z "$proxy_adapter" ]; do
+                proxy_adapter=$(
+                  ${lib.getExe' pkgs.coreutils "timeout"} 2 \
+                    ${lib.getExe' pkgs.systemd "busctl"} --system --json=short \
+                      call org.bluez / org.freedesktop.DBus.ObjectManager GetManagedObjects \
+                      2>/dev/null \
+                    | ${lib.getExe pkgs.jq} -r \
+                      ".data[0] | to_entries[] | select(.value | has(\"org.bluez.Adapter1\")) | .key" \
+                    | ${lib.getExe' pkgs.coreutils "head"} -n1
+                )
+                [ -n "$proxy_adapter" ] && break
                 ${lib.getExe' pkgs.coreutils "sleep"} 0.5
               done
 
-              ${lib.getExe' pkgs.systemd "busctl"} --system set-property \
-                org.bluez /org/bluez/hci0 org.bluez.Adapter1 Powered b true
+              if [ -z "$proxy_adapter" ]; then
+                echo "Bluetooth adapter did not appear through the rebuilt proxy" >&2
+                exit 1
+              fi
 
-              until [ "$(
-                ${lib.getExe' pkgs.systemd "busctl"} --system get-property \
-                  org.bluez /org/bluez/hci0 org.bluez.Adapter1 Powered \
-                  2>/dev/null
-              )" = "b true" ]; do
+              # Give property restoration its own budget. Unlike one timeout
+              # around the whole sequence, this cannot terminate after the
+              # proxy restart but before the power-on attempt.
+              power_deadline=$((SECONDS + 8))
+              while [ "$SECONDS" -lt "$power_deadline" ]; do
+                ${lib.getExe' pkgs.systemd "busctl"} --system set-property \
+                  org.bluez "$proxy_adapter" org.bluez.Adapter1 Powered b true \
+                  >/dev/null 2>&1 || true
+                if [ "$(
+                  ${lib.getExe' pkgs.systemd "busctl"} --system get-property \
+                    org.bluez "$proxy_adapter" org.bluez.Adapter1 Powered \
+                    2>/dev/null
+                )" = "b true" ]; then
+                  exit 0
+                fi
                 ${lib.getExe' pkgs.coreutils "sleep"} 0.5
               done
-            ' &
+
+              echo "Bluetooth adapter $proxy_adapter did not power on" >&2
+              exit 1
+            ) &
             bluetooth_wait_pid=$!
           fi
         ''}

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -50,6 +50,13 @@ in
               Device additional arguments (optional)
             '';
           };
+          crosvm.useRootBus = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Attach the device directly to the Crosvm PCI root bus
+            '';
+          };
         };
       };
 

--- a/modules/hardware/passthrough/evdev-rules.nix
+++ b/modules/hardware/passthrough/evdev-rules.nix
@@ -37,6 +37,10 @@ let
           value = "1";
         }
         {
+          description = "Laptop lid switch";
+          name = "^Lid Switch$";
+        }
+        {
           description = "ThinkPad Extra Buttons";
           pathTag = "platform-thinkpad_acpi";
         }

--- a/modules/hardware/passthrough/pci-rules.nix
+++ b/modules/hardware/passthrough/pci-rules.nix
@@ -4,7 +4,6 @@
 {
   config,
   lib,
-  pkgs,
   options,
   ...
 }:
@@ -174,9 +173,10 @@ let
   ];
 
   busPrefix = config.ghaf.hardware.passthrough.pciPorts.pcieBusPrefix;
+  deviceManagerPackage = config.ghaf.hardware.passthrough.deviceManager.package;
   hwDetectModule = vm: [
     {
-      microvm.extraArgsScript = "${lib.getExe' pkgs.vhotplug "vhotplugcli"} vmm args --vm ${vm} --qemu-bus-prefix ${busPrefix} --qemu-bus-start-index 1";
+      microvm.extraArgsScript = "${lib.getExe' deviceManagerPackage "vhotplugcli"} vmm args --vm ${vm} --qemu-bus-prefix ${busPrefix} --qemu-bus-start-index 1";
     }
   ];
 

--- a/modules/hardware/passthrough/pci-rules.nix
+++ b/modules/hardware/passthrough/pci-rules.nix
@@ -22,19 +22,49 @@ let
   # Check if hardware.definition option exists
   hasHardwareDefinition = options ? ghaf.hardware.definition;
 
+  isIntelIntegratedGpu =
+    device:
+    device.path == "0000:00:02.0" && device.vendorId != null && lib.toLower device.vendorId == "8086";
+
+  isIntelGscProxy =
+    device:
+    device.path == "0000:00:16.0" && device.vendorId != null && lib.toLower device.vendorId == "8086";
+
+  isIntelGuiRootBusDevice = device: isIntelIntegratedGpu device || isIntelGscProxy device;
+
+  hasIntelIntegratedGpu =
+    hasHardwareDefinition
+    && lib.any isIntelIntegratedGpu config.ghaf.hardware.definition.gpu.pciDevices;
+
+  hasIntelGscProxy =
+    hasHardwareDefinition && lib.any isIntelGscProxy config.ghaf.hardware.definition.gpu.pciDevices;
+
+  guiVmConfig = config.ghaf.virtualization.vmConfig.sysvms.guivm or { };
+  guiVmVmm =
+    if (guiVmConfig.vmm or null) != null then
+      guiVmConfig.vmm
+    else
+      config.ghaf.virtualization.vmConfig.defaultSysVmVmm;
+
   defaultGuivmPciRules =
-    optionals hasHardwareDefinition [
-      {
-        description = "Static PCI Devices for GUIVM";
+    optionals hasHardwareDefinition (
+      map (d: {
+        description = "Static PCI Device ${d.path} for GUIVM";
         targetVm = "gui-vm";
         skipOnSuspend = true;
-        allow = map (d: {
-          address = d.path;
-          deviceId = d.productId;
-          inherit (d) vendorId;
-        }) config.ghaf.hardware.definition.gpu.pciDevices;
-      }
-    ]
+        # Intel integrated graphics must remain on the guest PCI root bus for
+        # IGD OpRegion and GSC proxy discovery. Keep the per-device override
+        # for other hardware that has the same Crosvm requirement.
+        crosvmUseRootBus = d.crosvm.useRootBus || isIntelGuiRootBusDevice d;
+        allow = [
+          {
+            address = d.path;
+            deviceId = d.productId;
+            inherit (d) vendorId;
+          }
+        ];
+      }) config.ghaf.hardware.definition.gpu.pciDevices
+    )
     ++ optionals cfg.autoDetectGpu [
       {
         description = "Auto-detected PCI Devices for GUIVM";
@@ -43,6 +73,7 @@ let
         pciIommuAddAll = true;
         autoOvmf = true;
         qemuUseRootBus = true;
+        crosvmUseRootBus = true;
         allow = [
           {
             deviceClass = 3;
@@ -50,7 +81,25 @@ let
           }
         ];
       }
-    ];
+    ]
+    ++
+      optionals
+        (guiVmVmm == "crosvm" && !hasIntelGscProxy && (cfg.autoDetectGpu || hasIntelIntegratedGpu))
+        [
+          {
+            description = "Intel GSC proxy CSME HECI for GUIVM";
+            targetVm = "gui-vm";
+            skipOnSuspend = true;
+            crosvmUseRootBus = true;
+            allow = [
+              {
+                # Intel exposes the CSME HECI endpoint used by the graphics GSC
+                # proxy at this stable PCI function across supported laptops.
+                address = "0000:00:16.0";
+              }
+            ];
+          }
+        ];
 
   defaultNetvmPciRules =
     optionals hasHardwareDefinition [

--- a/modules/hardware/passthrough/usb-rules.nix
+++ b/modules/hardware/passthrough/usb-rules.nix
@@ -55,6 +55,11 @@ let
           description = "Communications - Ethernet Networking";
         }
         {
+          interfaceClass = 2;
+          interfaceSubclass = 13;
+          description = "Communications - Network Control Model";
+        }
+        {
           driverPath = ".*/kernel/drivers/net/usb/.*";
           description = "USB network devices that do not report their class or interfaces";
         }

--- a/modules/hardware/passthrough/vhotplug.nix
+++ b/modules/hardware/passthrough/vhotplug.nix
@@ -29,6 +29,12 @@ let
       }";
     }
   ) config.microvm.vms;
+  crosvmPciVms = lib.filter (
+    vm: vm.type == "crosvm" && lib.any (rule: (rule.targetVm or null) == vm.name) cfg.pciRules
+  ) cfg.vms;
+  disableRunnerGlobbing = pkgs.writeText "disable-crosvm-runner-globbing" ''
+    set -f
+  '';
 in
 {
   _file = ./vhotplug.nix;
@@ -155,7 +161,7 @@ in
     services.udev.extraRules = ''
       SUBSYSTEM=="usb", GROUP="kvm"
       KERNEL=="event*", GROUP="kvm"
-      SUBSYSTEM=="vfio",GROUP="kvm"
+      SUBSYSTEM=="vfio", GROUP="kvm", MODE="0660"
     '';
 
     environment.etc."vhotplug.conf".text = builtins.toJSON {
@@ -176,25 +182,45 @@ in
         };
         modprobe = lib.getExe' pkgs.kmod "modprobe";
         modinfo = lib.getExe' pkgs.kmod "modinfo";
+        crosvm = lib.getExe pkgs.crosvm;
         ovmfCode = "${pkgs.OVMF.fd}/FV/OVMF_CODE.fd";
         ovmfVars = "${pkgs.OVMF.fd}/FV/OVMF_VARS.fd";
       };
     };
 
-    systemd.services.vhotplug = {
-      enable = true;
-      description = "vhotplug";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "local-fs.target" ];
-      before = [ "microvm@.service" ];
-      serviceConfig = {
-        Type = "simple";
-        Restart = "always";
-        RestartSec = "1";
-        ExecStart = "${getExe pkgs.vhotplug} -a -c /etc/vhotplug.conf";
+    systemd.services = {
+      vhotplug = {
+        enable = true;
+        description = "vhotplug";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "local-fs.target" ];
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "1";
+          ExecStart = "${getExe pkgs.vhotplug} -a -c /etc/vhotplug.conf";
+        };
+        startLimitIntervalSec = 0;
       };
-      startLimitIntervalSec = 0;
-    };
+    }
+    // builtins.listToAttrs (
+      map (vm: {
+        name = "microvm@${vm.name}";
+        value = {
+          requires = [ "vhotplug.service" ];
+          after = [ "vhotplug.service" ];
+          serviceConfig = {
+            Type = lib.mkForce "notify";
+            NotifyAccess = "all";
+            TimeoutStartSec = "45";
+            # microvm.nix expands extraArgsScript output as shell words. The
+            # vhotplug CLI rejects whitespace inside arguments; disabling glob
+            # expansion completes the safe one-word-per-argument contract.
+            Environment = "BASH_ENV=${disableRunnerGlobbing}";
+          };
+        };
+      }) crosvmPciVms
+    );
 
     environment.systemPackages = [ pkgs.vhotplug ];
   };

--- a/modules/hardware/passthrough/vhotplug.nix
+++ b/modules/hardware/passthrough/vhotplug.nix
@@ -8,6 +8,7 @@
 }:
 let
   cfg = config.ghaf.hardware.passthrough.vhotplug;
+  managerCfg = config.ghaf.hardware.passthrough.deviceManager;
   inherit (lib)
     mkEnableOption
     mkOption
@@ -35,9 +36,53 @@ let
   disableRunnerGlobbing = pkgs.writeText "disable-crosvm-runner-globbing" ''
     set -f
   '';
+  waitForCrosvmSocket = pkgs.writeShellApplication {
+    name = "wait-for-crosvm-socket";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = ''
+      if [ "$#" -ne 2 ]; then
+        echo "Usage: wait-for-crosvm-socket SOCKET MAIN_PID" >&2
+        exit 2
+      fi
+
+      socket=$1
+      main_pid=$2
+      while [ ! -S "$socket" ]; do
+        if ! kill -0 "$main_pid" 2>/dev/null; then
+          echo "Crosvm process $main_pid exited before creating $socket" >&2
+          exit 1
+        fi
+        sleep 0.1
+      done
+    '';
+  };
+  managerService =
+    if managerCfg.backend == "ghaf-device-manager" then "ghaf-device-manager" else "vhotplug";
 in
 {
   _file = ./vhotplug.nix;
+
+  options.ghaf.hardware.passthrough.deviceManager = {
+    backend = mkOption {
+      type = types.enum [
+        "vhotplug"
+        "ghaf-device-manager"
+      ];
+      default = "vhotplug";
+      description = ''
+        Device manager used by this image. Select ghaf-device-manager only
+        when every dynamically managed VM uses Crosvm.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      readOnly = true;
+      default =
+        if managerCfg.backend == "ghaf-device-manager" then pkgs.ghaf-device-manager else pkgs.vhotplug;
+      description = "Package providing the selected daemon and the vhotplugcli compatibility command.";
+    };
+  };
 
   options.ghaf.hardware.passthrough.vhotplug = {
     enable = mkEnableOption "the hot plugging of USB devices";
@@ -158,6 +203,14 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          managerCfg.backend != "ghaf-device-manager" || lib.all (vm: vm.type == "crosvm") cfg.vms;
+        message = "ghaf-device-manager requires every dynamically managed VM to use Crosvm";
+      }
+    ];
+
     services.udev.extraRules = ''
       SUBSYSTEM=="usb", GROUP="kvm"
       KERNEL=="event*", GROUP="kvm"
@@ -189,7 +242,7 @@ in
     };
 
     systemd.services = {
-      vhotplug = {
+      vhotplug = mkIf (managerCfg.backend == "vhotplug") {
         enable = true;
         description = "vhotplug";
         wantedBy = [ "multi-user.target" ];
@@ -202,17 +255,41 @@ in
         };
         startLimitIntervalSec = 0;
       };
+
+      ghaf-device-manager = mkIf (managerCfg.backend == "ghaf-device-manager") {
+        enable = true;
+        description = "Ghaf Crosvm device manager";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "local-fs.target" ];
+        conflicts = [ "vhotplug.service" ];
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "1";
+          ExecStart = "${getExe managerCfg.package} -a -c /etc/vhotplug.conf";
+        };
+        startLimitIntervalSec = 0;
+      };
     }
     // builtins.listToAttrs (
       map (vm: {
         name = "microvm@${vm.name}";
         value = {
-          requires = [ "vhotplug.service" ];
-          after = [ "vhotplug.service" ];
+          requires = [ "${managerService}.service" ];
+          after = [ "${managerService}.service" ];
           serviceConfig = {
-            Type = lib.mkForce "notify";
-            NotifyAccess = "all";
-            TimeoutStartSec = "45";
+            # Keep the service activating until Crosvm has created its control
+            # socket. ExecStartPost runs alongside the runner's volume setup
+            # and bounded device discovery, unlike microvm.preStart which runs
+            # before both and can expire before Crosvm is launched.
+            Type = lib.mkForce "exec";
+            TimeoutStartSec = "10min";
+            ExecStartPre = lib.mkBefore [
+              "${pkgs.coreutils}/bin/rm -f ${lib.escapeShellArg vm.socket}"
+            ];
+            ExecStartPost = lib.mkBefore [
+              "${lib.getExe waitForCrosvmSocket} ${lib.escapeShellArg vm.socket} $MAINPID"
+            ];
             # microvm.nix expands extraArgsScript output as shell words. The
             # vhotplug CLI rejects whitespace inside arguments; disabling glob
             # expansion completes the safe one-word-per-argument contract.
@@ -222,6 +299,6 @@ in
       }) crosvmPciVms
     );
 
-    environment.systemPackages = [ pkgs.vhotplug ];
+    environment.systemPackages = [ managerCfg.package ];
   };
 }

--- a/modules/hardware/passthrough/vhotplug.nix
+++ b/modules/hardware/passthrough/vhotplug.nix
@@ -293,6 +293,8 @@ in
             # microvm.nix expands extraArgsScript output as shell words. The
             # vhotplug CLI rejects whitespace inside arguments; disabling glob
             # expansion completes the safe one-word-per-argument contract.
+            # TODO: remove this process-wide workaround after microvm.nix
+            # quotes each generated argument in its Crosvm runner.
             Environment = "BASH_ENV=${disableRunnerGlobbing}";
           };
         };

--- a/modules/hardware/x86_64-generic/kernel/guest/default.nix
+++ b/modules/hardware/x86_64-generic/kernel/guest/default.nix
@@ -16,6 +16,29 @@ let
   };
 
   cfg = config.ghaf.guest.kernel.hardening;
+  baseKernelPackages =
+    if cfg.enable then pkgs.linuxPackagesFor guest_hardened_kernel else pkgs.linuxPackages_latest;
+  needsKernelBootAlias =
+    (config.microvm.hypervisor or null) == "crosvm"
+    && lib.versionAtLeast baseKernelPackages.kernel.version "7.2";
+  kernelPackages =
+    if needsKernelBootAlias then
+      baseKernelPackages.extend (
+        _final: prev: {
+          # Linux 7.2 installs rebuilt x86 kernels as vmlinuz while nixpkgs
+          # still advertises bzImage as the kernel target. Keep that declared
+          # target usable instead of overriding the bootloader globally.
+          kernel = prev.kernel.overrideAttrs (oldAttrs: {
+            postInstall = (oldAttrs.postInstall or "") + ''
+              if [ -e "$out/vmlinuz" ] && [ ! -e "$out/${prev.kernel.target}" ]; then
+                ln -s vmlinuz "$out/${prev.kernel.target}"
+              fi
+            '';
+          });
+        }
+      )
+    else
+      baseKernelPackages;
   gpuSuspend =
     (config.ghaf.services.power-manager.gui.enable or false)
     && (config.ghaf.services.power-manager.gui.gpuSuspend or false);
@@ -36,8 +59,7 @@ in
   };
 
   config = lib.mkIf pkgs.stdenv.hostPlatform.isx86_64 {
-    boot.kernelPackages =
-      if cfg.enable then pkgs.linuxPackagesFor guest_hardened_kernel else pkgs.linuxPackages_latest;
+    boot.kernelPackages = kernelPackages;
 
     boot.kernelPatches = lib.optionals gpuSuspend [
       {

--- a/modules/microvm/audiovm-features/bluetooth.nix
+++ b/modules/microvm/audiovm-features/bluetooth.nix
@@ -22,6 +22,17 @@ in
   _file = ./bluetooth.nix;
 
   config = lib.mkIf bluetoothEnabled {
-    ghaf.services.bluetooth.enable = true;
+    ghaf.services.bluetooth = {
+      enable = true;
+      # The adapter is intentionally removed by the hardware kill switch and
+      # during host suspend. Restore it to a usable state when it reappears.
+      powerOnBoot = true;
+    };
+
+    # USB passthrough controls whether AudioVM owns the adapter. Persisting
+    # rfkill state inside the guest races adapter hotplug and can leave
+    # systemd-rfkill waiting indefinitely on /dev/rfkill.
+    systemd.services.systemd-rfkill.enable = false;
+    systemd.sockets.systemd-rfkill.enable = false;
   };
 }

--- a/modules/microvm/audiovm-features/hardware-passthrough.nix
+++ b/modules/microvm/audiovm-features/hardware-passthrough.nix
@@ -14,6 +14,7 @@
 # Auto-enables when: hostConfig has audio hardware devices
 #
 {
+  config,
   lib,
   hostConfig,
   ...
@@ -28,6 +29,7 @@ let
   # Get kernel/qemu configs (can be null)
   kernelConfig = hostConfig.kernel or null;
   qemuConfig = hostConfig.qemu or null;
+  isQemu = config.microvm.hypervisor == "qemu";
 in
 {
   _file = ./hardware-passthrough.nix;
@@ -38,6 +40,6 @@ in
     # Kernel configuration from host (if defined)
     ++ lib.optional (kernelConfig != null) kernelConfig
     # QEMU configuration from host (if defined)
-    ++ lib.optional (qemuConfig != null) qemuConfig
+    ++ lib.optional (qemuConfig != null) (lib.mkIf isQemu qemuConfig)
   );
 }

--- a/modules/microvm/audiovm-features/hardware-passthrough.nix
+++ b/modules/microvm/audiovm-features/hardware-passthrough.nix
@@ -29,7 +29,7 @@ let
   # Get kernel/qemu configs (can be null)
   kernelConfig = hostConfig.kernel or null;
   qemuConfig = hostConfig.qemu or null;
-  isQemu = config.microvm.hypervisor == "qemu";
+  isCrosvm = config.microvm.hypervisor == "crosvm";
 in
 {
   _file = ./hardware-passthrough.nix;
@@ -40,6 +40,6 @@ in
     # Kernel configuration from host (if defined)
     ++ lib.optional (kernelConfig != null) kernelConfig
     # QEMU configuration from host (if defined)
-    ++ lib.optional (qemuConfig != null) (lib.mkIf isQemu qemuConfig)
+    ++ lib.optional (qemuConfig != null) (lib.mkIf (!isCrosvm) qemuConfig)
   );
 }

--- a/modules/microvm/common/microvm-nix-crosvm-store-disk-overlay.nix
+++ b/modules/microvm/common/microvm-nix-crosvm-store-disk-overlay.nix
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  ...
+}:
+let
+  needsStoreDiskFix = config.microvm.hypervisor == "crosvm" && config.microvm.storeOnDisk;
+  storeDisk = toString config.microvm.storeDisk;
+in
+{
+  # TODO: Remove after https://github.com/microvm-nix/microvm.nix/pull/584
+  # is merged and the microvm input is updated. Crosvm's -r option both
+  # attaches a disk and injects root=/dev/vda, so the Nix store image must be
+  # attached as a normal read-only block device instead.
+  microvm.declaredRunner = lib.mkIf needsStoreDiskFix (
+    config.microvm.runner.crosvm.overrideAttrs (oldAttrs: {
+      buildCommand = oldAttrs.buildCommand + ''
+        runner="$out/bin/microvm-run"
+        cp --dereference "$runner" "$runner.fixed"
+        rm "$runner"
+        mv "$runner.fixed" "$runner"
+        chmod +x "$runner"
+        substituteInPlace "$runner" \
+          --replace-fail "-r ${storeDisk}" "--block ${storeDisk},ro=true"
+      '';
+    })
+  );
+}

--- a/modules/microvm/common/storagevm.nix
+++ b/modules/microvm/common/storagevm.nix
@@ -163,7 +163,9 @@ in
             };
             requires = [
               "${utils.escapeSystemdPath drivePath}.device"
+              "dev-tpmrm0.device"
             ];
+            after = [ "dev-tpmrm0.device" ];
             wantedBy = [ "multi-user.target" ];
           };
       }

--- a/modules/microvm/common/vm-crosvm.nix
+++ b/modules/microvm/common/vm-crosvm.nix
@@ -12,6 +12,11 @@ in
 {
   _file = ./vm-crosvm.nix;
 
+  # Crosvm's serial console makes systemd's per-unit shutdown status output
+  # expensive. The messages remain available in the guest journal; suppressing
+  # only their console rendering avoids adding seconds to every guest shutdown.
+  systemd.settings.Manager.ShowStatus = lib.mkIf isCrosvm false;
+
   # Crosvm's virtual IOMMU must be available before PCI enumeration.  Loading
   # it as a module lets passthrough drivers race ahead of the IOMMU supplier;
   # the late registration then leaves those devices without an IOMMU group and

--- a/modules/microvm/common/vm-crosvm.nix
+++ b/modules/microvm/common/vm-crosvm.nix
@@ -6,6 +6,9 @@
   pkgs,
   ...
 }:
+let
+  isCrosvm = config.microvm.hypervisor == "crosvm";
+in
 {
   _file = ./vm-crosvm.nix;
 
@@ -13,17 +16,15 @@
   # it as a module lets passthrough drivers race ahead of the IOMMU supplier;
   # the late registration then leaves those devices without an IOMMU group and
   # DMA-backed drivers cannot probe reliably.
-  boot.kernelPatches =
-    lib.optionals (config.microvm.hypervisor == "crosvm" && pkgs.stdenv.hostPlatform.isx86_64)
-      [
-        {
-          name = "crosvm-virtio-iommu-builtin";
-          patch = null;
-          structuredExtraConfig = with lib.kernel; {
-            VIRTIO = yes;
-            VIRTIO_PCI = yes;
-            VIRTIO_IOMMU = yes;
-          };
-        }
-      ];
+  boot.kernelPatches = lib.optionals (isCrosvm && pkgs.stdenv.hostPlatform.isx86_64) [
+    {
+      name = "crosvm-virtio-iommu-builtin";
+      patch = null;
+      structuredExtraConfig = with lib.kernel; {
+        VIRTIO = yes;
+        VIRTIO_PCI = yes;
+        VIRTIO_IOMMU = yes;
+      };
+    }
+  ];
 }

--- a/modules/microvm/common/vm-crosvm.nix
+++ b/modules/microvm/common/vm-crosvm.nix
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  _file = ./vm-crosvm.nix;
+
+  # Crosvm's virtual IOMMU must be available before PCI enumeration.  Loading
+  # it as a module lets passthrough drivers race ahead of the IOMMU supplier;
+  # the late registration then leaves those devices without an IOMMU group and
+  # DMA-backed drivers cannot probe reliably.
+  boot.kernelPatches =
+    lib.optionals (config.microvm.hypervisor == "crosvm" && pkgs.stdenv.hostPlatform.isx86_64)
+      [
+        {
+          name = "crosvm-virtio-iommu-builtin";
+          patch = null;
+          structuredExtraConfig = with lib.kernel; {
+            VIRTIO = yes;
+            VIRTIO_PCI = yes;
+            VIRTIO_IOMMU = yes;
+          };
+        }
+      ];
+}

--- a/modules/microvm/common/vm-tpm.nix
+++ b/modules/microvm/common/vm-tpm.nix
@@ -69,6 +69,11 @@ in
           structuredExtraConfig.TCG_VIRTIO_VTPM = lib.kernel.module;
         }
       ];
+
+      # Encrypted VM storage is unlocked in initrd. Crosvm's TPM frontend uses
+      # the virtio transport, so loading this only in stage 2 makes first-boot
+      # enrollment succeed but leaves the next boot unable to unlock vmdata.
+      boot.initrd.kernelModules = lib.optionals (vmm == "crosvm") [ "tpm_virtio" ];
     })
     (mkIf cfg.passthrough.enable {
       assertions = [

--- a/modules/microvm/common/vm-tpm.nix
+++ b/modules/microvm/common/vm-tpm.nix
@@ -8,6 +8,9 @@
 }:
 let
   cfg = config.ghaf.virtualization.microvm.tpm;
+  vmm = config.microvm.hypervisor;
+  emulatedSocket =
+    if cfg.emulated.runInVM then "vtpm.sock" else "/var/lib/swtpm/${cfg.emulated.name}/sock";
   inherit (lib)
     types
     mkEnableOption
@@ -58,6 +61,14 @@ in
         config.ghaf.security.tpm2.pkcs11
         pkgs.tpm2-openssl
       ];
+
+      boot.kernelPatches = lib.optionals (vmm == "crosvm") [
+        {
+          name = "chromiumos-virtio-tpm";
+          patch = ../sysvms/patches/chromiumos-virtio-tpm.patch;
+          structuredExtraConfig.TCG_VIRTIO_VTPM = lib.kernel.module;
+        }
+      ];
     })
     (mkIf cfg.passthrough.enable {
       assertions = [
@@ -67,7 +78,7 @@ in
         }
       ];
 
-      microvm.qemu = {
+      microvm.qemu = mkIf (vmm == "qemu") {
         extraArgs = [
           "-tpmdev"
           "passthrough,id=tpmrm0,path=/dev/tpmrm0,cancel-path=/tmp/cancel"
@@ -79,13 +90,17 @@ in
         #   tpm_tis MSFT0101:00: [Firmware Bug]: failed to get TPM2 ACPI table
         machine = "q35";
       };
+      microvm.crosvm.extraArgs = lib.mkIf (vmm == "crosvm") (
+        lib.mkAfter [
+          "--tpm-device"
+          "/dev/tpmrm0"
+        ]
+      );
     })
-    (mkIf cfg.emulated.enable {
+    (mkIf (cfg.emulated.enable && config.microvm.hypervisor == "qemu") {
       microvm.qemu.extraArgs = [
         "-chardev"
-        "socket,id=chrtpm,path=${
-          if cfg.emulated.runInVM then "vtpm.sock" else "/var/lib/swtpm/${cfg.emulated.name}/sock"
-        }"
+        "socket,id=chrtpm,path=${emulatedSocket}"
         "-tpmdev"
         "emulator,id=tpm0,chardev=chrtpm"
         "-device"
@@ -93,6 +108,12 @@ in
         # sysbus variant tpm-tis-device (plain tpm-tis fails "not a valid
         # device model name" and the VM exits at startup).
         "${if pkgs.stdenv.isx86_64 then "tpm-tis" else "tpm-tis-device"},tpmdev=tpm0"
+      ];
+    })
+    (mkIf (cfg.emulated.enable && config.microvm.hypervisor == "crosvm") {
+      microvm.crosvm.extraArgs = lib.mkAfter [
+        "--swtpm"
+        emulatedSocket
       ];
     })
   ];

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -5,10 +5,17 @@
 #
 # Note: Modules receive `inputs` via specialArgs from mkLaptopConfiguration.
 # This eliminates the need for the `{ inputs }:` wrapper anti-pattern.
-_: {
+{ inputs, ... }:
+{
   _file = ./flake-module.nix;
 
   flake.nixosModules = {
+    # Overlay temporary upstream fixes without pinning Ghaf to a fork.
+    microvm-nix.imports = [
+      inputs.microvm.nixosModules.microvm
+      ./common/microvm-nix-crosvm-store-disk-overlay.nix
+    ];
+
     microvm.imports = [
       ./host/microvm-host.nix
       ./sysvms/netvm.nix

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -32,6 +32,7 @@ _: {
       ./common/microvm-store-mode.nix
       ./common/shared-directory.nix
       ./common/storagevm.nix
+      ./common/vm-crosvm.nix
       ./common/vm-networking.nix
       ./common/vm-qemu.nix
       ./common/vm-swap.nix

--- a/modules/microvm/guivm-features/hardware-passthrough.nix
+++ b/modules/microvm/guivm-features/hardware-passthrough.nix
@@ -34,7 +34,7 @@ let
   # Get kernel/qemu configs (can be null)
   kernelConfig = hostConfig.kernel or null;
   qemuConfig = hostConfig.qemu or null;
-  isQemu = config.microvm.hypervisor == "qemu";
+  isCrosvm = config.microvm.hypervisor == "crosvm";
 in
 {
   _file = ./hardware-passthrough.nix;
@@ -43,10 +43,10 @@ in
     # Import GPU device passthrough config from host
     lib.optional hasGpuDevices gpuDevicesConfig
     # Import input device passthrough config from host
-    ++ lib.optional hasEvdevDevices (lib.mkIf isQemu evdevDevicesConfig)
+    ++ lib.optional hasEvdevDevices (lib.mkIf (!isCrosvm) evdevDevicesConfig)
     # Kernel configuration from host (if defined)
     ++ lib.optional (kernelConfig != null) kernelConfig
     # QEMU configuration from host (if defined)
-    ++ lib.optional (qemuConfig != null) (lib.mkIf isQemu qemuConfig)
+    ++ lib.optional (qemuConfig != null) (lib.mkIf (!isCrosvm) qemuConfig)
   );
 }

--- a/modules/microvm/guivm-features/hardware-passthrough.nix
+++ b/modules/microvm/guivm-features/hardware-passthrough.nix
@@ -15,6 +15,7 @@
 # Auto-enables when: hostConfig has GPU hardware devices
 #
 {
+  config,
   lib,
   hostConfig,
   ...
@@ -33,6 +34,7 @@ let
   # Get kernel/qemu configs (can be null)
   kernelConfig = hostConfig.kernel or null;
   qemuConfig = hostConfig.qemu or null;
+  isQemu = config.microvm.hypervisor == "qemu";
 in
 {
   _file = ./hardware-passthrough.nix;
@@ -41,10 +43,10 @@ in
     # Import GPU device passthrough config from host
     lib.optional hasGpuDevices gpuDevicesConfig
     # Import input device passthrough config from host
-    ++ lib.optional hasEvdevDevices evdevDevicesConfig
+    ++ lib.optional hasEvdevDevices (lib.mkIf isQemu evdevDevicesConfig)
     # Kernel configuration from host (if defined)
     ++ lib.optional (kernelConfig != null) kernelConfig
     # QEMU configuration from host (if defined)
-    ++ lib.optional (qemuConfig != null) qemuConfig
+    ++ lib.optional (qemuConfig != null) (lib.mkIf isQemu qemuConfig)
   );
 }

--- a/modules/microvm/host/boot.nix
+++ b/modules/microvm/host/boot.nix
@@ -111,7 +111,7 @@ in
 
   options.ghaf.microvm-boot = {
     enable = mkEnableOption "ghaf-specific microvm boot order";
-    debug = mkEnableOption "resource tracing of the ghaf-specific microvm boot order";
+    bootchart.enable = mkEnableOption "systemd-bootchart tracing of the microVM boot sequence";
     uiEnabled = mkOption {
       type = types.bool;
       default = config.ghaf.virtualization.microvm.guivm.enable && config.ghaf.givc.enable;
@@ -201,8 +201,7 @@ in
       # See: modules/desktop/guivm/boot-ui.nix
     })
 
-    # Enable systemd-bootchart if debug is enabled
-    (mkIf cfg.debug {
+    (mkIf cfg.bootchart.enable {
       systemd.services.systemd-bootchart = {
         description = "Trace microvm boot with systemd-bootchart";
         wantedBy = [ "local-fs.target" ];

--- a/modules/microvm/host/mem-manager.nix
+++ b/modules/microvm/host/mem-manager.nix
@@ -33,6 +33,22 @@ in
             # Use enabledVms which has derived mem from evaluatedConfig
             vmBaseName = lib.removeSuffix "-vm" name;
             appvmConfig = config.ghaf.virtualization.microvm.appvm.enabledVms.${vmBaseName} or null;
+            crosvmArgs = lib.optionals (microvmConfig.hypervisor == "crosvm") [
+              "--hypervisor"
+              "crosvm"
+              "--crosvm-binary"
+              (lib.getExe microvmConfig.crosvm.package)
+            ];
+            managerArgs = [
+              (lib.getExe pkgs.ghaf-mem-manager)
+              "--socket"
+              "${name}.sock"
+              "--minimum"
+              (toString (appvmConfig.mem * 1024 * 1024))
+              "--maximum"
+              (toString (microvmConfig.mem * 1024 * 1024))
+            ]
+            ++ crosvmArgs;
           in
           lib.optionalAttrs (appvmConfig != null) {
             "ghaf-mem-manager-${name}" = {
@@ -42,9 +58,7 @@ in
               serviceConfig = {
                 Type = "simple";
                 WorkingDirectory = "${config.microvm.stateDir}/${name}";
-                ExecStart = "${pkgs.ghaf-mem-manager}/bin/ghaf-mem-manager -s ${name}.sock -m ${
-                  toString (appvmConfig.mem * 1024 * 1024)
-                } -M ${toString (microvmConfig.mem * 1024 * 1024)}";
+                ExecStart = lib.escapeShellArgs managerArgs;
               };
             };
           }

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -112,7 +112,6 @@ in
         type = "host";
         microvm-boot = {
           inherit (config.ghaf.virtualization.microvm.guivm) enable;
-          debug = config.ghaf.profiles.debug.enable;
         };
         systemd = {
           withName = "host-systemd";

--- a/modules/microvm/netvm-features/hardware-passthrough.nix
+++ b/modules/microvm/netvm-features/hardware-passthrough.nix
@@ -27,7 +27,7 @@ let
   # Get kernel/qemu configs (can be null)
   kernelConfig = hostConfig.kernel or null;
   qemuConfig = hostConfig.qemu or null;
-  isQemu = config.microvm.hypervisor == "qemu";
+  isCrosvm = config.microvm.hypervisor == "crosvm";
 in
 {
   _file = ./hardware-passthrough.nix;
@@ -38,6 +38,6 @@ in
     # Kernel configuration from host (if defined)
     ++ lib.optional (kernelConfig != null) kernelConfig
     # QEMU configuration from host (if defined)
-    ++ lib.optional (qemuConfig != null) (lib.mkIf isQemu qemuConfig)
+    ++ lib.optional (qemuConfig != null) (lib.mkIf (!isCrosvm) qemuConfig)
   );
 }

--- a/modules/microvm/netvm-features/hardware-passthrough.nix
+++ b/modules/microvm/netvm-features/hardware-passthrough.nix
@@ -12,6 +12,7 @@
 # Auto-enables when: hostConfig has network hardware devices
 #
 {
+  config,
   lib,
   hostConfig,
   ...
@@ -26,6 +27,7 @@ let
   # Get kernel/qemu configs (can be null)
   kernelConfig = hostConfig.kernel or null;
   qemuConfig = hostConfig.qemu or null;
+  isQemu = config.microvm.hypervisor == "qemu";
 in
 {
   _file = ./hardware-passthrough.nix;
@@ -36,6 +38,6 @@ in
     # Kernel configuration from host (if defined)
     ++ lib.optional (kernelConfig != null) kernelConfig
     # QEMU configuration from host (if defined)
-    ++ lib.optional (qemuConfig != null) qemuConfig
+    ++ lib.optional (qemuConfig != null) (lib.mkIf isQemu qemuConfig)
   );
 }

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -226,15 +226,7 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 1024;
-    #TODO: Add back support cloud-hypervisor
-    #the system fails to switch root to the stage2 with cloud-hypervisor
-    hypervisor = "qemu";
-    qemu = {
-      extraArgs = [
-        "-device"
-        "vhost-vsock-pci,guest-cid=${toString (hostConfig.networking.thisVm.cid or 10)}"
-      ];
-    };
+    vsock.cid = hostConfig.networking.thisVm.cid or 10;
 
     shares = [
       {

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -43,11 +43,15 @@ let
   # Get VM definition from hostConfig
   vm = hostConfig.appvm;
   vmName = "${vm.name}-vm";
+  vmm = hostConfig.appvmVmm or "qemu";
 
   # Helper to unwrap mkDefault values for use in lib.mkIf conditions
   # Values like `lib.mkDefault true` become { _type = "override"; content = true; priority = 1000; }
   # This extracts the actual boolean for use in conditionals
   unwrap = val: if val._type or null == "override" then val.content else val;
+
+  storageEncryption = globalConfig.storage.encryption.enable or false;
+  effectiveVtpm = (unwrap (vm.vtpm.enable or false)) || storageEncryption;
 
   # Base applications from hostConfig (defined in mkAppVm call)
   baseApplications = vm.applications or [ ];
@@ -172,8 +176,8 @@ in
       ghaf.appvm.vmDef = vm // {
         applications = allApplications;
         vtpm = {
-          enable = (unwrap (vm.vtpm.enable or false)) || (globalConfig.storage.encryption.enable or false);
-          runInVM = (unwrap (vm.vtpm.runInVM or false)) || (globalConfig.storage.encryption.enable or false);
+          enable = effectiveVtpm;
+          runInVM = effectiveVtpm && (unwrap (vm.vtpm.runInVM or false) || storageEncryption);
           basePort = vm.vtpm.basePort or null;
         };
       };
@@ -259,9 +263,11 @@ in
         };
         # vTPM support
         #
-        # App VMs use emulated TPM (swtpm) exclusively. Unlike system VMs (netvm, guivm,
-        # etc.) which can use hardware TPM passthrough on x86_64, app VMs rely on the
-        # admin-vm proxy chain: App VM (QEMU tpm-tis) → host swtpm-proxy-shim → admin-vm swtpm.
+        # App VMs use emulated TPM (swtpm) exclusively. Unlike system VMs
+        # (netvm, guivm, etc.) which can use hardware TPM passthrough on x86_64,
+        # App VMs rely on the admin-vm proxy chain: App VM TPM frontend → host
+        # swtpm-proxy-shim → admin-vm swtpm. QEMU uses tpm-tis while Crosvm
+        # exposes the ChromiumOS virtio TPM transport.
         #
         # When storage encryption is enabled globally, every app VM needs a TPM to satisfy
         # the storagevm assertion. We auto-enable emulated TPM here so downstream consumers
@@ -271,8 +277,8 @@ in
         # passthrough with per-VM NV indexes, or a TrustZone-based TA on aarch64), this
         # logic should be made platform-conditional, mirroring the pattern in netvm-base.nix.
         virtualization.microvm.tpm.emulated = {
-          enable = (unwrap (vm.vtpm.enable or false)) || (globalConfig.storage.encryption.enable or false);
-          runInVM = (unwrap (vm.vtpm.runInVM or false)) || (globalConfig.storage.encryption.enable or false);
+          enable = effectiveVtpm;
+          runInVM = effectiveVtpm && (unwrap (vm.vtpm.runInVM or false) || storageEncryption);
           inherit (vm) name;
         };
 
@@ -421,7 +427,11 @@ in
         balloon = (vm.balloonRatio or 2) > 0;
         deflateOnOOM = true;
         vcpu = lib.mkDefault (vm.vcpu or 4);
-        hypervisor = "qemu";
+        hypervisor = vmm;
+        vsock.cid = hostConfig.networking.thisVm.cid or 100;
+        # Compose this required runner argument with device-specific arguments
+        # such as the swtpm socket from vm-tpm.nix.
+        crosvm.extraArgs = lib.mkBefore (lib.optionals (vmm == "crosvm") [ "--disable-sandbox" ]);
 
         shares = [
           {
@@ -467,8 +477,6 @@ in
               # rejects it ("Property 'virt-*-machine.sata' not found") and the
               # App VM exits at startup.
               "accel=kvm:tcg,mem-merge=on${lib.optionalString (effectiveMachine == "q35") ",sata=off"}"
-              "-device"
-              "vhost-vsock-pci,guest-cid=${toString (hostConfig.networking.thisVm.cid or 100)}"
             ]
             # qemu-xhci is a PCI device; not available on the microvm machine type
             ++ lib.optionals (!isMicrovm) [

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -31,6 +31,7 @@ let
   powerManagerEnabled = lib.ghaf.features.isEnabledFor globalConfig "power-manager" vmName;
   performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+  isCrosvm = config.microvm.hypervisor == "crosvm";
 in
 {
   _file = ./audiovm-base.nix;
@@ -210,6 +211,17 @@ in
     ++ lib.optional (config.ghaf.development.debug.tools.enable or false) pkgs.alsa-utils;
   };
 
+  boot.kernelPatches = lib.optionals (isCrosvm && pkgs.stdenv.hostPlatform.isx86_64) [
+    {
+      name = "goldfish-battery";
+      patch = null;
+      structuredExtraConfig = {
+        GOLDFISH = lib.kernel.yes;
+        BATTERY_GOLDFISH = lib.kernel.module;
+      };
+    }
+  ];
+
   system.stateVersion = lib.trivial.release;
 
   nixpkgs = {
@@ -222,9 +234,7 @@ in
     optimize.enable = false;
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;
-    mem = lib.mkDefault 512;
-    hypervisor = "qemu";
-
+    mem = lib.mkDefault (if isCrosvm then 1024 else 512);
     shares = [
       {
         tag = "ghaf-common";
@@ -248,7 +258,7 @@ in
       !(globalConfig.storage.storeOnDisk.enable or false)
     ) "/nix/.rw-store";
 
-    qemu = {
+    qemu = lib.mkIf (!isCrosvm) {
       machine =
         {
           # Use the same machine type as the host
@@ -261,6 +271,10 @@ in
         "qemu-xhci"
       ];
     };
+    crosvm.extraArgs = lib.optionals isCrosvm [
+      "--battery"
+      "type=goldfish"
+    ];
   }
   // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
     let

--- a/modules/microvm/sysvms/dispvm-base.nix
+++ b/modules/microvm/sysvms/dispvm-base.nix
@@ -163,8 +163,6 @@ in
     # display-only default, smaller than GPU VM's 6000.
     vcpu = 4;
     mem = lib.mkDefault 4000;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/gpuvm-base.nix
+++ b/modules/microvm/sysvms/gpuvm-base.nix
@@ -249,8 +249,6 @@ in
     # profile/vmConfig can shrink it.
     vcpu = 4;
     mem = lib.mkDefault 6000;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -30,6 +30,7 @@
 #   base.extendModules { modules = [ ../services ]; }
 #
 {
+  config,
   lib,
   pkgs,
   inputs,
@@ -46,6 +47,7 @@ let
   performanceEnabled = lib.ghaf.features.isEnabledFor globalConfig "performance" vmName;
   localeEnabled = lib.ghaf.features.isEnabledFor globalConfig "locale" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
+  isCrosvm = config.microvm.hypervisor == "crosvm";
 
   # A list of applications from all AppVMs (accessed via hostConfig)
   enabledVms = lib.filterAttrs (_: vm: vm.enable) (hostConfig.appvms or { });
@@ -351,6 +353,17 @@ in
     ) [ "/Shares/Unsafe flatpak-vm share/.flatpak-share" ];
   };
 
+  boot.kernelPatches = lib.optionals (isCrosvm && pkgs.stdenv.hostPlatform.isx86_64) [
+    {
+      name = "goldfish-battery";
+      patch = null;
+      structuredExtraConfig = {
+        GOLDFISH = lib.kernel.yes;
+        BATTERY_GOLDFISH = lib.kernel.module;
+      };
+    }
+  ];
+
   system.stateVersion = lib.trivial.release;
 
   nixpkgs = {
@@ -363,8 +376,7 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 6;
     mem = lib.mkDefault 6144;
-    hypervisor = "qemu";
-
+    vsock.cid = hostConfig.networking.thisVm.cid or 5;
     shares = [
       {
         tag = "ghaf-common";
@@ -388,12 +400,10 @@ in
       !(globalConfig.storage.storeOnDisk.enable or false)
     ) "/nix/.rw-store";
 
-    qemu = {
+    qemu = lib.mkIf (!isCrosvm) {
       extraArgs = [
         "-device"
         "qemu-xhci"
-        "-device"
-        "vhost-vsock-pci,guest-cid=${toString (hostConfig.networking.thisVm.cid or 5)}"
       ];
 
       machine =
@@ -404,6 +414,10 @@ in
         }
         .${globalConfig.platform.hostSystem or "x86_64-linux"};
     };
+    crosvm.extraArgs = lib.optionals isCrosvm [
+      "--battery"
+      "type=goldfish"
+    ];
   }
   // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
     let

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -330,7 +330,7 @@ in
       pkgs.libva-utils
       pkgs.glib
     ]
-    ++ [ pkgs.vhotplug ]
+    ++ [ (if isCrosvm then pkgs.ghaf-device-manager else pkgs.vhotplug) ]
     ++ [ pkgs.xrdb ];
     sessionVariables = lib.optionalAttrs (globalConfig.debug.enable or false) (
       {

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -48,6 +48,11 @@ let
   localeEnabled = lib.ghaf.features.isEnabledFor globalConfig "locale" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
   isCrosvm = config.microvm.hypervisor == "crosvm";
+  deviceManagerPackage =
+    if hostConfig.passthrough.deviceManagerBackend == "ghaf-device-manager" then
+      pkgs.ghaf-device-manager
+    else
+      pkgs.vhotplug;
 
   # A list of applications from all AppVMs (accessed via hostConfig)
   enabledVms = lib.filterAttrs (_: vm: vm.enable) (hostConfig.appvms or { });
@@ -330,7 +335,7 @@ in
       pkgs.libva-utils
       pkgs.glib
     ]
-    ++ [ (if isCrosvm then pkgs.ghaf-device-manager else pkgs.vhotplug) ]
+    ++ [ deviceManagerPackage ]
     ++ [ pkgs.xrdb ];
     sessionVariables = lib.optionalAttrs (globalConfig.debug.enable or false) (
       {

--- a/modules/microvm/sysvms/idsvm/idsvm-base.nix
+++ b/modules/microvm/sysvms/idsvm/idsvm-base.nix
@@ -109,7 +109,6 @@ in
   ++ (lib.optional (globalConfig.debug.enable or false) pkgs.tcpdump);
 
   microvm = {
-    hypervisor = "qemu";
     optimize.enable = true;
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -16,6 +16,7 @@
 #   base.extendModules { modules = [ ... ]; }
 #
 {
+  config,
   lib,
   pkgs,
   inputs,
@@ -30,6 +31,7 @@ let
   wifiEnabled = lib.ghaf.features.isEnabledFor globalConfig "wifi" vmName;
   timezoneEnabled = lib.ghaf.features.isEnabledFor globalConfig "timezone" vmName;
   netVmAddress = hostConfig.networking.thisVm.ipv4 or "192.168.100.1";
+  isCrosvm = config.microvm.hypervisor == "crosvm";
 in
 {
   _file = ./netvm-base.nix;
@@ -263,8 +265,6 @@ in
     optimize.enable = false;
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 1024;
-    hypervisor = "qemu";
-
     shares = [
       {
         tag = "ghaf-common";
@@ -294,7 +294,7 @@ in
       !(globalConfig.storage.storeOnDisk.enable or false)
     ) "/nix/.rw-store";
 
-    qemu = {
+    qemu = lib.mkIf (!isCrosvm) {
       machine =
         {
           # Use the same machine type as the host

--- a/modules/microvm/sysvms/patches/chromiumos-virtio-tpm.patch
+++ b/modules/microvm/sysvms/patches/chromiumos-virtio-tpm.patch
@@ -1,0 +1,531 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: vadik likholetov <vadikas@gmail.com>
+Date: Wed, 12 Aug 2026 00:00:00 +0300
+Subject: [PATCH] tpm: add ChromiumOS virtio transport for Ghaf guests
+
+The driver is based on ChromiumOS commit
+04fdb1751c20b807c81be7b43e2de7389e2b25ca, originally authored by
+David Tolnay. Regenerate the patch against Linux 7.1.7 so its context
+and index metadata detect future source drift.
+
+Ghaf-specific changes:
+- define ChromiumOS-private virtio device ID 62 locally;
+- support the tpm_class_ops.send API before and after Linux 6.17;
+- expose the complete TPM response buffer on the pre-6.17 ABI; and
+- reset the virtio device and detach its unused buffer before freeing
+  probe state after TPM startup failure.
+
+Signed-off-by: vadik likholetov <vadikas@gmail.com>
+---
+
+diff --git a/drivers/char/tpm/Kconfig b/drivers/char/tpm/Kconfig
+index 8a8f692b60880c1914d3d52c0256befbfd109b79..334766cdf78ad50c7e3e540606bf3f1d6c6cce49 100644
+--- a/drivers/char/tpm/Kconfig
++++ b/drivers/char/tpm/Kconfig
+@@ -254,5 +254,14 @@ config TCG_SVSM
+ 	  level (usually VMPL0).  To compile this driver as a module, choose M
+ 	  here; the module will be called tpm_svsm.
+ 
++config TCG_VIRTIO_VTPM
++	tristate "Virtio vTPM"
++	depends on TCG_TPM && VIRTIO
++	help
++	  This driver provides the guest kernel side of TPM over Virtio. If
++	  you are building Linux to run inside of a hypervisor that supports
++	  TPM over Virtio, say Yes and the virtualized TPM will be
++	  accessible from the guest.
++
+ source "drivers/char/tpm/st33zp24/Kconfig"
+ endif # TCG_TPM
+diff --git a/drivers/char/tpm/Makefile b/drivers/char/tpm/Makefile
+index 5b5cdc0d32e4e5ecf0803e785913f455d32fa1ff..5f5dad2ec800c22c5c01eb69c99de5360a0372dd 100644
+--- a/drivers/char/tpm/Makefile
++++ b/drivers/char/tpm/Makefile
+@@ -44,6 +44,7 @@ obj-$(CONFIG_TCG_XEN) += xen-tpmfront.o
+ obj-$(CONFIG_TCG_CRB) += tpm_crb.o
+ obj-$(CONFIG_TCG_ARM_CRB_FFA) += tpm_crb_ffa.o
+ obj-$(CONFIG_TCG_VTPM_PROXY) += tpm_vtpm_proxy.o
++obj-$(CONFIG_TCG_VIRTIO_VTPM) += tpm_virtio.o
+ obj-$(CONFIG_TCG_FTPM_TEE) += tpm_ftpm_tee.o
+ obj-$(CONFIG_TCG_SVSM) += tpm_svsm.o
+ obj-$(CONFIG_TCG_LOONGSON) += tpm_loongson.o
+diff --git a/drivers/char/tpm/tpm_virtio.c b/drivers/char/tpm/tpm_virtio.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..d086efb03c3d45ff355f6d4db27479eadfe696cf
+--- /dev/null
++++ b/drivers/char/tpm/tpm_virtio.c
+@@ -0,0 +1,474 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright 2019 Google Inc.
++ *
++ * Author: David Tolnay <dtolnay@gmail.com>
++ *
++ * ---
++ *
++ * Device driver for TPM over virtio.
++ *
++ * This driver employs a single virtio queue to handle both send and recv. TPM
++ * commands are sent over virtio to the hypervisor during a TPM send operation
++ * and responses are received over the same queue during a recv operation.
++ *
++ * The driver contains a single buffer that is the only buffer we ever place on
++ * the virtio queue. Commands are copied from the caller's command buffer into
++ * the driver's buffer before handing off to virtio, and responses are received
++ * into the driver's buffer then copied into the caller's response buffer. This
++ * allows us to be resilient to timeouts. When a send or recv operation times
++ * out, the caller is free to destroy their buffer; we don't want the hypervisor
++ * continuing to perform reads or writes against that destroyed buffer.
++ *
++ * This driver does not support concurrent send and recv operations. Mutual
++ * exclusion is upheld by the tpm_mutex lock held in tpm-interface.c around the
++ * calls to chip->ops->send and chip->ops->recv.
++ *
++ * The intended hypervisor-side implementation is as follows.
++ *
++ *     while true:
++ *         await next virtio buffer.
++ *         expect first descriptor in chain to be guest-to-host.
++ *         read tpm command from that buffer.
++ *         synchronously perform TPM work determined by the command.
++ *         expect second descriptor in chain to be host-to-guest.
++ *         write TPM response into that buffer.
++ *         place buffer on virtio used queue indicating how many bytes written.
++ */
++
++#include <linux/version.h>
++#include <linux/virtio_config.h>
++
++#define VIRTIO_ID_TPM 62
++
++#include "tpm.h"
++
++/*
++ * Timeout duration when waiting on the hypervisor to complete its end of the
++ * TPM operation. This timeout is relatively high because certain TPM operations
++ * can take dozens of seconds.
++ */
++#define TPM_VIRTIO_TIMEOUT (120 * HZ)
++
++struct vtpm_device {
++	/*
++	 * Data structure for integration with the common code of the TPM driver
++	 * in tpm-chip.c.
++	 */
++	struct tpm_chip *chip;
++
++	/*
++	 * Virtio queue for sending TPM commands out of the virtual machine and
++	 * receiving TPM responses back from the hypervisor.
++	 */
++	struct virtqueue *vq;
++
++	/*
++	 * Completion that is notified when a virtio operation has been
++	 * fulfilled by the hypervisor.
++	 */
++	struct completion complete;
++
++	/*
++	 * Whether driver currently holds ownership of the virtqueue buffer.
++	 * When false, the hypervisor is in the process of reading or writing
++	 * the buffer and the driver must not touch it.
++	 */
++	bool driver_has_buffer;
++
++	/*
++	 * Whether during the most recent TPM operation, a virtqueue_kick failed
++	 * or a wait timed out.
++	 *
++	 * The next send or recv operation will attempt a kick upon seeing this
++	 * status. That should clear up the queue in the case that the
++	 * hypervisor became temporarily nonresponsive, such as by resource
++	 * exhaustion on the host. The extra kick enables recovery from kicks
++	 * going unnoticed by the hypervisor as well as recovery from virtio
++	 * callbacks going unnoticed by the guest kernel.
++	 */
++	bool needs_kick;
++
++	/* Number of bytes available to read from the virtqueue buffer. */
++	unsigned int readable;
++
++	/*
++	 * Buffer in which all virtio transfers take place. Buffer size is the
++	 * maximum legal TPM command or response message size.
++	 */
++	u8 virtqueue_buffer[TPM_BUFSIZE];
++};
++
++/*
++ * Wait for ownership of the virtqueue buffer.
++ *
++ * The why-string should begin with "waiting to..." or "waiting for..." with no
++ * trailing newline. It will appear in log output.
++ *
++ * Returns zero for success, otherwise negative error.
++ */
++static int vtpm_wait_for_buffer(struct vtpm_device *dev, const char *why)
++{
++	int ret;
++	struct tpm_chip *chip = dev->chip;
++	unsigned long deadline = jiffies + TPM_VIRTIO_TIMEOUT;
++
++	/* Kick queue if needed. */
++	if (dev->needs_kick) {
++		bool did_kick = virtqueue_kick(dev->vq);
++		if (!did_kick) {
++			dev_notice(&chip->dev, "kick failed; will retry\n");
++			return -EBUSY;
++		}
++		dev->needs_kick = false;
++	}
++
++	while (!dev->driver_has_buffer) {
++		unsigned long now = jiffies;
++
++		/* Check timeout, otherwise `deadline - now` may underflow. */
++		if time_after_eq(now, deadline) {
++			dev_warn(&chip->dev, "timed out %s\n", why);
++			dev->needs_kick = true;
++			return -ETIMEDOUT;
++		}
++
++		/*
++		 * Wait to be signaled by virtio callback.
++		 *
++		 * Positive ret is jiffies remaining until timeout when the
++		 * completion occurred, which means successful completion. Zero
++		 * ret is timeout. Negative ret is error.
++		 */
++		ret = wait_for_completion_killable_timeout(
++				&dev->complete, deadline - now);
++
++		/* Log if completion did not occur. */
++		if (ret == -ERESTARTSYS) {
++			/* Not a warning if it was simply interrupted. */
++			dev_dbg(&chip->dev, "interrupted %s\n", why);
++		} else if (ret == 0) {
++			dev_warn(&chip->dev, "timed out %s\n", why);
++			ret = -ETIMEDOUT;
++		} else if (ret < 0) {
++			dev_warn(&chip->dev, "failed while %s: error %d\n",
++					why, -ret);
++		}
++
++		/*
++		 * Return error if completion did not occur. Schedule kick to be
++		 * retried at the start of the next send/recv to help unblock
++		 * the queue.
++		 */
++		if (ret < 0) {
++			dev->needs_kick = true;
++			return ret;
++		}
++
++		/* Completion occurred. Expect response buffer back. */
++		if (virtqueue_get_buf(dev->vq, &dev->readable)) {
++			dev->driver_has_buffer = true;
++
++			if (dev->readable > TPM_BUFSIZE) {
++				dev_crit(&chip->dev,
++						"hypervisor bug: response exceeds max size,"
++						" %u > %u\n",
++						dev->readable,
++						(unsigned int) TPM_BUFSIZE);
++				dev->readable = TPM_BUFSIZE;
++				return -EPROTO;
++			}
++		}
++	}
++
++	return 0;
++}
++
++static int vtpm_op_send(struct tpm_chip *chip, u8 *caller_buf, size_t bufsiz
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++			, size_t cmd_len
++#endif
++)
++{
++	int ret;
++	bool did_kick;
++	struct scatterlist sg_outbuf, sg_inbuf;
++	struct scatterlist *sgs[2] = { &sg_outbuf, &sg_inbuf };
++	struct vtpm_device *dev = dev_get_drvdata(&chip->dev);
++	u8 *virtqueue_buf = dev->virtqueue_buffer;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
++	size_t cmd_len = bufsiz;
++#endif
++
++	dev_dbg(&chip->dev, "vtpm_op_send %zu bytes\n", cmd_len);
++
++	if (cmd_len > TPM_BUFSIZE) {
++		dev_err(&chip->dev,
++				"command is too long, %zu > %zu\n",
++				cmd_len, (size_t) TPM_BUFSIZE);
++		return -EINVAL;
++	}
++
++	/*
++	 * Wait until hypervisor relinquishes ownership of the virtqueue buffer.
++	 *
++	 * This may block if the previous recv operation timed out in the guest
++	 * kernel but is still being processed by the hypervisor. Also may block
++	 * if send operations are performed back-to-back, such as if something
++	 * in the caller failed in between a send and recv.
++	 *
++	 * During normal operation absent of any errors or timeouts, this does
++	 * not block.
++	 */
++	ret = vtpm_wait_for_buffer(dev, "waiting to begin send");
++	if (ret) {
++		return ret;
++	}
++
++	/* Driver owns virtqueue buffer and may now write into it. */
++	memcpy(virtqueue_buf, caller_buf, cmd_len);
++
++	/*
++	 * Enqueue the virtqueue buffer once as outgoing virtio data (written by
++	 * the virtual machine and read by the hypervisor) and again as incoming
++	 * data (written by the hypervisor and read by the virtual machine).
++	 * This step moves ownership of the virtqueue buffer from driver to
++	 * hypervisor.
++	 *
++	 * Note that we don't know here how big of a buffer the caller will use
++	 * with their later call to recv. We allow the hypervisor to write up to
++	 * the TPM max message size. If the caller ends up using a smaller
++	 * buffer with recv that is too small to hold the entire response, the
++	 * recv will return an error. This conceivably breaks TPM
++	 * implementations that want to produce a different verbosity of
++	 * response depending on the receiver's buffer size.
++	 */
++	sg_init_one(&sg_outbuf, virtqueue_buf, cmd_len);
++	sg_init_one(&sg_inbuf, virtqueue_buf, TPM_BUFSIZE);
++	ret = virtqueue_add_sgs(dev->vq, sgs, 1, 1, virtqueue_buf, GFP_KERNEL);
++	if (ret) {
++		dev_err(&chip->dev, "failed virtqueue_add_sgs\n");
++		return ret;
++	}
++
++	/* Kick the other end of the virtqueue after having added a buffer. */
++	did_kick = virtqueue_kick(dev->vq);
++	if (!did_kick) {
++		dev->needs_kick = true;
++		dev_notice(&chip->dev, "kick failed; will retry\n");
++
++		/*
++		 * We return 0 anyway because what the caller doesn't know can't
++		 * hurt them. They can call recv and it will retry the kick. If
++		 * that works, everything is fine.
++		 *
++		 * If the retry in recv fails too, they will get -EBUSY from
++		 * recv.
++		 */
++	}
++
++	/*
++	 * Hypervisor is now processing the TPM command asynchronously. It will
++	 * read the command from the output buffer and write the response into
++	 * the input buffer (which are the same buffer). When done, it will send
++	 * back the buffers over virtio and the driver's virtio callback will
++	 * complete dev->complete so that we know the response is ready to be
++	 * read.
++	 *
++	 * It is important to have copied data out of the caller's buffer into
++	 * the driver's virtqueue buffer because the caller is free to destroy
++	 * their buffer when this call returns. We can't avoid copying by
++	 * waiting here for the hypervisor to finish reading, because if that
++	 * wait times out, we return and the caller may destroy their buffer
++	 * while the hypervisor is continuing to read from it.
++	 */
++	dev->driver_has_buffer = false;
++	return 0;
++}
++
++static int vtpm_op_recv(struct tpm_chip *chip, u8 *caller_buf, size_t len)
++{
++	int ret;
++	struct vtpm_device *dev = dev_get_drvdata(&chip->dev);
++	u8 *virtqueue_buf = dev->virtqueue_buffer;
++
++	dev_dbg(&chip->dev, "vtpm_op_recv\n");
++
++	/*
++	 * Wait until the virtqueue buffer is owned by the driver.
++	 *
++	 * This will usually block while the hypervisor finishes processing the
++	 * most recent TPM command.
++	 */
++	ret = vtpm_wait_for_buffer(dev, "waiting for TPM response");
++	if (ret) {
++		return ret;
++	}
++
++	dev_dbg(&chip->dev, "received %u bytes\n", dev->readable);
++
++	if (dev->readable > len) {
++		dev_notice(&chip->dev,
++				"TPM response is bigger than receiver's buffer:"
++				" %u > %zu\n",
++				dev->readable, len);
++		return -EINVAL;
++	}
++
++	/* Copy response over to the caller. */
++	memcpy(caller_buf, virtqueue_buf, dev->readable);
++
++	return dev->readable;
++}
++
++static void vtpm_op_cancel(struct tpm_chip *chip)
++{
++	/*
++	 * Cancel is not called in this driver's use of tpm-interface.c. It may
++	 * be triggered through tpm-sysfs but that can be implemented as needed.
++	 * Be aware that tpm-sysfs performs cancellation without holding the
++	 * tpm_mutex that protects our send and recv operations, so a future
++	 * implementation will need to consider thread safety of concurrent
++	 * send/recv and cancel.
++	 */
++	dev_notice(&chip->dev, "cancellation is not implemented\n");
++}
++
++static u8 vtpm_op_status(struct tpm_chip *chip)
++{
++	/*
++	 * Status is for TPM drivers that want tpm-interface.c to poll for
++	 * completion before calling recv. Usually this is when the hardware
++	 * needs to be polled i.e. there is no other way for recv to block on
++	 * the TPM command completion.
++	 *
++	 * Polling goes until `(status & complete_mask) == complete_val`. This
++	 * driver defines both complete_mask and complete_val as 0 and blocks on
++	 * our own completion object in recv instead.
++	 */
++	return 0;
++}
++
++static const struct tpm_class_ops vtpm_ops = {
++	.flags = TPM_OPS_AUTO_STARTUP,
++	.send = vtpm_op_send,
++	.recv = vtpm_op_recv,
++	.cancel = vtpm_op_cancel,
++	.status = vtpm_op_status,
++	.req_complete_mask = 0,
++	.req_complete_val = 0,
++};
++
++static void vtpm_virtio_complete(struct virtqueue *vq)
++{
++	struct virtio_device *vdev = vq->vdev;
++	struct vtpm_device *dev = vdev->priv;
++
++	complete(&dev->complete);
++}
++
++static int vtpm_probe(struct virtio_device *vdev)
++{
++	int err;
++	struct vtpm_device *dev;
++	struct virtqueue *vq;
++	struct tpm_chip *chip;
++
++	dev_dbg(&vdev->dev, "vtpm_probe\n");
++
++	dev = kzalloc(sizeof(struct vtpm_device), GFP_KERNEL);
++	if (!dev) {
++		err = -ENOMEM;
++		dev_err(&vdev->dev, "failed kzalloc\n");
++		goto err_dev_alloc;
++	}
++	vdev->priv = dev;
++
++	vq = virtio_find_single_vq(vdev, vtpm_virtio_complete, "vtpm");
++	if (IS_ERR(vq)) {
++		err = PTR_ERR(vq);
++		dev_err(&vdev->dev, "failed virtio_find_single_vq\n");
++		goto err_virtio_find;
++	}
++	dev->vq = vq;
++
++	chip = tpm_chip_alloc(&vdev->dev, &vtpm_ops);
++	if (IS_ERR(chip)) {
++		err = PTR_ERR(chip);
++		dev_err(&vdev->dev, "failed tpm_chip_alloc\n");
++		goto err_chip_alloc;
++	}
++	dev_set_drvdata(&chip->dev, dev);
++	chip->flags |= TPM_CHIP_FLAG_TPM2;
++	dev->chip = chip;
++
++	init_completion(&dev->complete);
++	dev->driver_has_buffer = true;
++	dev->needs_kick = false;
++	dev->readable = 0;
++
++	/*
++	 * Required in order to enable vq use in probe function for auto
++	 * startup.
++	 */
++	virtio_device_ready(vdev);
++
++	err = tpm_chip_register(dev->chip);
++	if (err) {
++		dev_err(&vdev->dev, "failed tpm_chip_register\n");
++		goto err_chip_register;
++	}
++
++	return 0;
++
++err_chip_register:
++	virtio_reset_device(vdev);
++	virtqueue_detach_unused_buf(dev->vq);
++	put_device(&dev->chip->dev);
++err_chip_alloc:
++	vdev->config->del_vqs(vdev);
++err_virtio_find:
++	kfree(dev);
++err_dev_alloc:
++	return err;
++}
++
++static void vtpm_remove(struct virtio_device *vdev)
++{
++	struct vtpm_device *dev = vdev->priv;
++
++	/* Undo tpm_chip_register. */
++	tpm_chip_unregister(dev->chip);
++
++	/* Undo tpm_chip_alloc. */
++	put_device(&dev->chip->dev);
++
++	vdev->config->reset(vdev);
++	vdev->config->del_vqs(vdev);
++
++	kfree(dev);
++}
++
++static struct virtio_device_id id_table[] = {
++	{
++		.device = VIRTIO_ID_TPM,
++		.vendor = VIRTIO_DEV_ANY_ID,
++	},
++	{},
++};
++MODULE_DEVICE_TABLE(virtio, id_table);
++
++static struct virtio_driver vtpm_driver = {
++	.driver.name = KBUILD_MODNAME,
++	.driver.owner = THIS_MODULE,
++	.id_table = id_table,
++	.probe = vtpm_probe,
++	.remove = vtpm_remove,
++};
++
++module_virtio_driver(vtpm_driver);
++
++MODULE_AUTHOR("David Tolnay (dtolnay@gmail.com)");
++MODULE_DESCRIPTION("Virtio vTPM Driver");
++MODULE_VERSION("1.0");
++MODULE_LICENSE("GPL");

--- a/modules/microvm/vm-config.nix
+++ b/modules/microvm/vm-config.nix
@@ -3,11 +3,13 @@
 #
 # VM Configuration Module
 #
-# Provides ghaf.virtualization.vmConfig for resource allocation and
-# profile/downstream customization.
+# Provides ghaf.virtualization.vmConfig for VMM selection, resource
+# allocation, and profile/downstream customization.
 #
 # This is separate from hardware.definition which handles physical
 # hardware properties. vmConfig handles:
+# - VMM selection - QEMU by default for system VMs, profile-specific system VM
+#   overrides, crosvm for AppVMs, and per-VM overrides
 # - Resource allocation (mem, vcpu) - varies by profile
 # - Profile-specific modules (apps, services)
 # - Downstream customizations
@@ -18,6 +20,7 @@
 #   └── extraModules: Hardware quirks ONLY (GPU passthrough, OVMF)
 #
 #   virtualization.vmConfig (VARIES by profile)
+#   ├── VMM selection: default plus per-system-VM overrides
 #   ├── Resource allocation: mem, vcpu
 #   └── extraModules: Profile apps, services, downstream config
 #
@@ -28,6 +31,7 @@
 #   4. virtualization.vmConfig.sysvms.guivm.extraModules <- profile/downstream (highest priority)
 #
 {
+  config,
   lib,
   ...
 }:
@@ -41,6 +45,24 @@ let
   # System VM configuration submodule (guivm, netvm, audiovm, adminvm, idsvm)
   systemVmConfigType = types.submodule {
     options = {
+      vmm = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "qemu"
+            "crosvm"
+          ]
+        );
+        default = null;
+        description = ''
+          VMM used for this system VM.
+          If null, uses ghaf.virtualization.vmConfig.defaultSysVmVmm.
+
+          This setting takes effect when the VM's evaluated configuration
+          includes lib.ghaf.vm.applyVmConfig.
+        '';
+        example = "crosvm";
+      };
+
       mem = mkOption {
         type = types.nullOr types.int;
         default = null;
@@ -85,6 +107,21 @@ let
   # App VM configuration submodule (uses mem/vcpu for consistency with system VM definitions)
   appVmConfigType = types.submodule {
     options = {
+      vmm = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "qemu"
+            "crosvm"
+          ]
+        );
+        default = null;
+        description = ''
+          VMM used for this App VM.
+          If null, uses ghaf.virtualization.vmConfig.defaultAppVmVmm.
+        '';
+        example = "qemu";
+      };
+
       mem = mkOption {
         type = types.nullOr types.int;
         default = null;
@@ -101,9 +138,10 @@ let
         type = types.nullOr types.int;
         default = null;
         description = ''
-          Memory balloon ratio. The VM is allocated mem * (balloonRatio + 1)
-          bytes of memory, with ballooning enabled when balloonRatio > 0.
-          If null, uses the default from the VM definition (typically 2).
+          Memory balloon ratio. The VM is allocated
+          mem * (balloonRatio + 1) MB of memory, with ballooning enabled
+          when balloonRatio > 0. If null, uses the default from the VM
+          definition (typically 2).
         '';
       };
 
@@ -119,16 +157,48 @@ in
   _file = ./vm-config.nix;
 
   options.ghaf.virtualization.vmConfig = {
+    defaultSysVmVmm = mkOption {
+      type = types.enum [
+        "qemu"
+        "crosvm"
+      ];
+      default = "qemu";
+      description = ''
+        Default VMM for system VMs without a per-VM override.
+
+        This setting takes effect when the VM's evaluated configuration
+        includes lib.ghaf.vm.applyVmConfig. Cloud Hypervisor is intentionally
+        not selectable because AdminVM does not switch root to stage 2 with it.
+      '';
+      example = "qemu";
+    };
+
+    defaultAppVmVmm = mkOption {
+      type = types.enum [
+        "qemu"
+        "crosvm"
+      ];
+      default = "crosvm";
+      description = ''
+        Default VMM for App VMs without a per-VM override.
+      '';
+      example = "crosvm";
+    };
+
     sysvms = mkOption {
       type = types.attrsOf systemVmConfigType;
       default = { };
       description = ''
         Per-system-VM configuration. Keys should match system VM names
         (e.g., guivm, netvm, audiovm, adminvm, idsvm).
+
+        These settings take effect when the corresponding VM's evaluated
+        configuration includes lib.ghaf.vm.applyVmConfig.
       '';
       example = literalExpression ''
         {
           guivm = { mem = 16384; vcpu = 8; };
+          adminvm.vmm = "qemu"; # Optional AdminVM fallback
           netvm = { extraModules = [ ./my-net-config.nix ]; };
         }
       '';
@@ -142,13 +212,17 @@ in
       '';
       example = literalExpression ''
         {
-          chromium = { mem = 8192; extraModules = [ ./chrome.nix ]; };
+          chromium = { vmm = "qemu"; mem = 8192; extraModules = [ ./chrome.nix ]; };
           comms = { mem = 4096; };
         }
       '';
     };
   };
 
-  # No config block - this is a pure options module
-  # Consumption happens in profiles via lib.ghaf.vm.applyVmConfig
+  # Keep QEMU as the system-wide default while migrating AdminVM to crosvm.
+  # Encrypted AdminVMs still need QEMU's TPM path until crosvm TPM support is
+  # wired. Targets and downstream configurations can override this selection.
+  config.ghaf.virtualization.vmConfig.sysvms.adminvm.vmm = lib.mkDefault (
+    if config.ghaf.global-config.storage.encryption.enable then "qemu" else "crosvm"
+  );
 }

--- a/modules/microvm/vm-config.nix
+++ b/modules/microvm/vm-config.nix
@@ -9,7 +9,7 @@
 # This is separate from hardware.definition which handles physical
 # hardware properties. vmConfig handles:
 # - VMM selection - QEMU by default for system VMs, profile-specific system VM
-#   overrides, crosvm for AppVMs, and per-VM overrides
+#   overrides, and per-VM overrides
 # - Resource allocation (mem, vcpu) - varies by profile
 # - Profile-specific modules (apps, services)
 # - Downstream customizations
@@ -30,11 +30,7 @@
 #   3. hardware.definition.guivm.extraModules          <- hardware-specific (GPU quirks)
 #   4. virtualization.vmConfig.sysvms.guivm.extraModules <- profile/downstream (highest priority)
 #
-{
-  config,
-  lib,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib)
     mkOption
@@ -178,11 +174,11 @@ in
         "qemu"
         "crosvm"
       ];
-      default = "crosvm";
+      default = "qemu";
       description = ''
         Default VMM for App VMs without a per-VM override.
       '';
-      example = "crosvm";
+      example = "qemu";
     };
 
     sysvms = mkOption {
@@ -219,10 +215,4 @@ in
     };
   };
 
-  # Keep QEMU as the system-wide default while migrating AdminVM to crosvm.
-  # Encrypted AdminVMs still need QEMU's TPM path until crosvm TPM support is
-  # wired. Targets and downstream configurations can override this selection.
-  config.ghaf.virtualization.vmConfig.sysvms.adminvm.vmm = lib.mkDefault (
-    if config.ghaf.global-config.storage.encryption.enable then "qemu" else "crosvm"
-  );
 }

--- a/modules/partitioning/btrfs-postboot.nix
+++ b/modules/partitioning/btrfs-postboot.nix
@@ -138,6 +138,16 @@ in
 
     systemd.services =
       let
+        vmsWithEncryptedStorage = lib.filterAttrs (
+          _name: vm:
+          let
+            vmConfig = lib.ghaf.vm.getConfig vm;
+          in
+          vmConfig != null
+          && lib.hasAttr "storagevm" vmConfig.ghaf
+          && vmConfig.ghaf.storagevm.encryption.enable
+        ) config.microvm.vms;
+
         extendbtrfs = pkgs.writeShellApplication {
           name = "extendbtrfs";
           runtimeInputs = [ pkgs.btrfs-progs ];
@@ -177,6 +187,17 @@ in
             requires = [ "extendbtrfs.service" ];
           }
         ) config.microvm.vms
-      );
+      )
+      // lib.mapAttrs' (
+        vmName: _:
+        lib.nameValuePair "format-microvm-storage-${vmName}" {
+          # Encrypted VM storage is prepared by a separate oneshot before the
+          # VMM starts. Order that writer directly, rather than only ordering
+          # microvm@, so it cannot fill the initial 2 GiB Btrfs filesystem
+          # while extendbtrfs is still growing /persist on first boot.
+          after = [ "extendbtrfs.service" ];
+          requires = [ "extendbtrfs.service" ];
+        }
+      ) vmsWithEncryptedStorage;
   };
 }

--- a/modules/partitioning/btrfs-postboot.nix
+++ b/modules/partitioning/btrfs-postboot.nix
@@ -136,7 +136,7 @@ in
     # inside the running Ghaf host.
     boot.postBootCommands = "${postBootCmds}/bin/postBootScript";
 
-    systemd.services.extendbtrfs =
+    systemd.services =
       let
         extendbtrfs = pkgs.writeShellApplication {
           name = "extendbtrfs";
@@ -148,18 +148,35 @@ in
         };
       in
       {
-        enable = true;
-        description = "Extend the btrfs filesystem";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "persist.mount" ];
-        requires = [ "persist.mount" ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          StandardOutput = "journal";
-          StandardError = "journal";
-          ExecStart = "${extendbtrfs}/bin/extendbtrfs";
+        extendbtrfs = {
+          enable = true;
+          description = "Extend the btrfs filesystem";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "persist.mount" ];
+          requires = [ "persist.mount" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            StandardOutput = "journal";
+            StandardError = "journal";
+            ExecStart = "${extendbtrfs}/bin/extendbtrfs";
+          };
         };
-      };
+      }
+      // lib.optionalAttrs config.ghaf.virtualization.microvm.storeOnDisk.enable (
+        lib.mapAttrs' (
+          vmName: _:
+          lib.nameValuePair "microvm@${vmName}" {
+            # Disk-backed VM runners create sparse images and filesystems below
+            # /persist before launching the VMM. On first boot /persist is still
+            # a 2 GiB Btrfs filesystem until extendbtrfs completes. Starting the
+            # runners concurrently can fill it, leaving touched but unformatted
+            # images which the runners then mistake for initialized volumes on
+            # later boots.
+            after = [ "extendbtrfs.service" ];
+            requires = [ "extendbtrfs.service" ];
+          }
+        ) config.microvm.vms
+      );
   };
 }

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -82,7 +82,7 @@ in
         # Export GUI VM base for profiles to extend
         guivmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.guivm-base
             inputs.self.nixosModules.guivm-features
             # Import nixpkgs config module to get overlays
@@ -108,7 +108,7 @@ in
         # Export Admin VM base for profiles to extend
         adminvmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.adminvm-base
             inputs.self.nixosModules.adminvm-features
             # Import nixpkgs config module to get overlays
@@ -133,7 +133,7 @@ in
         # Export IDS VM base for profiles to extend
         idsvmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.idsvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -157,7 +157,7 @@ in
         # Export Audio VM base for profiles to extend
         audiovmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.audiovm-base
             inputs.self.nixosModules.audiovm-features
             # Import nixpkgs config module to get overlays
@@ -183,7 +183,7 @@ in
         # Export Net VM base for profiles to extend
         netvmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.netvm-base
             inputs.self.nixosModules.netvm-features
             # Import nixpkgs config module to get overlays
@@ -220,7 +220,7 @@ in
           in
           lib.nixosSystem {
             modules = [
-              inputs.microvm.nixosModules.microvm
+              inputs.self.nixosModules.microvm-nix
               inputs.self.nixosModules.appvm-base
               # Import nixpkgs config module to get overlays
               {

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -4,7 +4,6 @@
   config,
   lib,
   inputs,
-  pkgs,
   ...
 }:
 let
@@ -300,7 +299,6 @@ in
               cfg.netvmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
-                  hostPkgs = pkgs;
                   vmName = "netvm";
                 };
               }
@@ -313,7 +311,6 @@ in
               cfg.adminvmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
-                  hostPkgs = pkgs;
                   vmName = "adminvm";
                 };
               }
@@ -337,7 +334,6 @@ in
                 ]
                 ++ lib.ghaf.vm.applyVmConfig {
                   inherit config;
-                  hostPkgs = pkgs;
                   vmName = "guivm";
                 };
               }
@@ -351,7 +347,6 @@ in
               cfg.audiovmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
-                  hostPkgs = pkgs;
                   vmName = "audiovm";
                 };
               }

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -4,6 +4,7 @@
   config,
   lib,
   inputs,
+  pkgs,
   ...
 }:
 let
@@ -214,13 +215,8 @@ in
         mkAppVm =
           vmDef:
           let
-            # Apply vmConfig.appvms overrides (mem, vcpu)
-            vmCfg = config.ghaf.virtualization.vmConfig.appvms.${vmDef.name} or { };
-            effectiveDef =
-              vmDef
-              // lib.optionalAttrs ((vmCfg.mem or null) != null) { inherit (vmCfg) mem; }
-              // lib.optionalAttrs ((vmCfg.vcpu or null) != null) { inherit (vmCfg) vcpu; }
-              // lib.optionalAttrs ((vmCfg.balloonRatio or null) != null) { inherit (vmCfg) balloonRatio; };
+            resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+            inherit (resolved) effectiveDef selectedVmm;
           in
           lib.nixosSystem {
             modules = [
@@ -235,7 +231,7 @@ in
                 };
               }
             ]
-            ++ (vmCfg.extraModules or [ ]);
+            ++ resolved.extraModules;
             specialArgs = lib.ghaf.vm.mkSpecialArgs {
               inherit lib inputs;
               globalConfig = hostGlobalConfig;
@@ -247,6 +243,7 @@ in
                 // {
                   # App VM-specific hostConfig fields
                   appvm = effectiveDef;
+                  appvmVmm = selectedVmm;
                   # Pass shared directory config for storage
                   sharedVmDirectory =
                     config.ghaf.virtualization.microvm-host.sharedVmDirectory or {
@@ -297,6 +294,7 @@ in
               cfg.netvmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
+                  hostPkgs = pkgs;
                   vmName = "netvm";
                 };
               }
@@ -309,6 +307,7 @@ in
               cfg.adminvmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
+                  hostPkgs = pkgs;
                   vmName = "adminvm";
                 };
               }
@@ -332,6 +331,7 @@ in
                 ]
                 ++ lib.ghaf.vm.applyVmConfig {
                   inherit config;
+                  hostPkgs = pkgs;
                   vmName = "guivm";
                 };
               }
@@ -345,6 +345,7 @@ in
               cfg.audiovmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
+                  hostPkgs = pkgs;
                   vmName = "audiovm";
                 };
               }

--- a/modules/profiles/laptop-x86.nix
+++ b/modules/profiles/laptop-x86.nix
@@ -259,6 +259,12 @@ in
         x86_64.common.enable = true;
         tpm2.enable = true;
         passthrough = {
+          deviceManager.backend = lib.mkDefault (
+            if lib.all (vm: vm.type == "crosvm") config.ghaf.hardware.passthrough.vhotplug.vms then
+              "ghaf-device-manager"
+            else
+              "vhotplug"
+          );
           vhotplug.enable = true;
           usbQuirks.enable = true;
 

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -258,12 +258,8 @@ in
         orin.mkAppVm =
           vmDef:
           let
-            vmCfg = config.ghaf.virtualization.vmConfig.appvms.${vmDef.name} or { };
-            effectiveDef =
-              vmDef
-              // lib.optionalAttrs ((vmCfg.mem or null) != null) { inherit (vmCfg) mem; }
-              // lib.optionalAttrs ((vmCfg.vcpu or null) != null) { inherit (vmCfg) vcpu; }
-              // lib.optionalAttrs ((vmCfg.balloonRatio or null) != null) { inherit (vmCfg) balloonRatio; };
+            resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+            inherit (resolved) effectiveDef selectedVmm;
           in
           lib.nixosSystem {
             modules = [
@@ -277,7 +273,7 @@ in
                 };
               }
             ]
-            ++ (vmCfg.extraModules or [ ]);
+            ++ resolved.extraModules;
             specialArgs = lib.ghaf.vm.mkSpecialArgs {
               inherit lib inputs;
               globalConfig = hostGlobalConfig;
@@ -288,6 +284,7 @@ in
                 }
                 // {
                   appvm = effectiveDef;
+                  appvmVmm = selectedVmm;
                   sharedVmDirectory =
                     config.ghaf.virtualization.microvm-host.sharedVmDirectory or {
                       enable = false;
@@ -369,6 +366,7 @@ in
             evaluatedConfig = config.ghaf.profiles.orin.netvmBase.extendModules {
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
+                hostPkgs = pkgs;
                 vmName = "netvm";
               };
             };
@@ -380,6 +378,7 @@ in
             evaluatedConfig = cfg.adminvmBase.extendModules {
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
+                hostPkgs = pkgs;
                 vmName = "adminvm";
               };
             };
@@ -395,6 +394,7 @@ in
             evaluatedConfig = config.ghaf.profiles.orin.gpuvmBase.extendModules {
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
+                hostPkgs = pkgs;
                 vmName = "gpuvm";
               };
             };
@@ -408,6 +408,7 @@ in
             evaluatedConfig = config.ghaf.profiles.orin.dispvmBase.extendModules {
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
+                hostPkgs = pkgs;
                 vmName = "dispvm";
               };
             };
@@ -425,6 +426,7 @@ in
               config.ghaf.profiles.orin.guivmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
+                  hostPkgs = pkgs;
                   vmName = "guivm";
                 };
               }

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -137,7 +137,7 @@ in
         # Export Net VM base for profiles to extend
         orin.netvmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.netvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -162,7 +162,7 @@ in
         # Export Admin VM base for profiles to extend
         orin.adminvmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.adminvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -186,7 +186,7 @@ in
         # Export GPU VM base for profiles to extend
         orin.gpuvmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.gpuvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -210,7 +210,7 @@ in
         # Export Disp VM base for profiles to extend
         orin.dispvmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.dispvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -233,7 +233,7 @@ in
 
         orin.guivmBase = lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.guivm-base
             inputs.self.nixosModules.guivm-features
             inputs.self.nixosModules.orin-guivm-specialization
@@ -263,7 +263,7 @@ in
           in
           lib.nixosSystem {
             modules = [
-              inputs.microvm.nixosModules.microvm
+              inputs.self.nixosModules.microvm-nix
               inputs.self.nixosModules.appvm-base
               {
                 nixpkgs = {

--- a/modules/profiles/orin.nix
+++ b/modules/profiles/orin.nix
@@ -137,7 +137,7 @@ in
         # Export Net VM base for profiles to extend
         orin.netvmBase = lib.nixosSystem {
           modules = [
-            inputs.self.nixosModules.microvm-nix
+            inputs.microvm.nixosModules.microvm
             inputs.self.nixosModules.netvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -162,7 +162,7 @@ in
         # Export Admin VM base for profiles to extend
         orin.adminvmBase = lib.nixosSystem {
           modules = [
-            inputs.self.nixosModules.microvm-nix
+            inputs.microvm.nixosModules.microvm
             inputs.self.nixosModules.adminvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -186,7 +186,7 @@ in
         # Export GPU VM base for profiles to extend
         orin.gpuvmBase = lib.nixosSystem {
           modules = [
-            inputs.self.nixosModules.microvm-nix
+            inputs.microvm.nixosModules.microvm
             inputs.self.nixosModules.gpuvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -210,7 +210,7 @@ in
         # Export Disp VM base for profiles to extend
         orin.dispvmBase = lib.nixosSystem {
           modules = [
-            inputs.self.nixosModules.microvm-nix
+            inputs.microvm.nixosModules.microvm
             inputs.self.nixosModules.dispvm-base
             # Import nixpkgs config module to get overlays
             {
@@ -233,7 +233,7 @@ in
 
         orin.guivmBase = lib.nixosSystem {
           modules = [
-            inputs.self.nixosModules.microvm-nix
+            inputs.microvm.nixosModules.microvm
             inputs.self.nixosModules.guivm-base
             inputs.self.nixosModules.guivm-features
             inputs.self.nixosModules.orin-guivm-specialization
@@ -258,12 +258,16 @@ in
         orin.mkAppVm =
           vmDef:
           let
-            resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
-            inherit (resolved) effectiveDef selectedVmm;
+            vmCfg = config.ghaf.virtualization.vmConfig.appvms.${vmDef.name} or { };
+            effectiveDef =
+              vmDef
+              // lib.optionalAttrs ((vmCfg.mem or null) != null) { inherit (vmCfg) mem; }
+              // lib.optionalAttrs ((vmCfg.vcpu or null) != null) { inherit (vmCfg) vcpu; }
+              // lib.optionalAttrs ((vmCfg.balloonRatio or null) != null) { inherit (vmCfg) balloonRatio; };
           in
           lib.nixosSystem {
             modules = [
-              inputs.self.nixosModules.microvm-nix
+              inputs.microvm.nixosModules.microvm
               inputs.self.nixosModules.appvm-base
               {
                 nixpkgs = {
@@ -273,7 +277,7 @@ in
                 };
               }
             ]
-            ++ resolved.extraModules;
+            ++ (vmCfg.extraModules or [ ]);
             specialArgs = lib.ghaf.vm.mkSpecialArgs {
               inherit lib inputs;
               globalConfig = hostGlobalConfig;
@@ -284,7 +288,6 @@ in
                 }
                 // {
                   appvm = effectiveDef;
-                  appvmVmm = selectedVmm;
                   sharedVmDirectory =
                     config.ghaf.virtualization.microvm-host.sharedVmDirectory or {
                       enable = false;
@@ -366,7 +369,6 @@ in
             evaluatedConfig = config.ghaf.profiles.orin.netvmBase.extendModules {
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
-                hostPkgs = pkgs;
                 vmName = "netvm";
               };
             };
@@ -378,7 +380,6 @@ in
             evaluatedConfig = cfg.adminvmBase.extendModules {
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
-                hostPkgs = pkgs;
                 vmName = "adminvm";
               };
             };
@@ -394,7 +395,6 @@ in
             evaluatedConfig = config.ghaf.profiles.orin.gpuvmBase.extendModules {
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
-                hostPkgs = pkgs;
                 vmName = "gpuvm";
               };
             };
@@ -408,7 +408,6 @@ in
             evaluatedConfig = config.ghaf.profiles.orin.dispvmBase.extendModules {
               modules = lib.ghaf.vm.applyVmConfig {
                 inherit config;
-                hostPkgs = pkgs;
                 vmName = "dispvm";
               };
             };
@@ -426,7 +425,6 @@ in
               config.ghaf.profiles.orin.guivmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
-                  hostPkgs = pkgs;
                   vmName = "guivm";
                 };
               }

--- a/modules/profiles/vm.nix
+++ b/modules/profiles/vm.nix
@@ -138,6 +138,10 @@ in
       # Pure function - extensions are applied via extendModules in appvm.nix
       mkAppVm =
         vmDef:
+        let
+          resolved = lib.ghaf.vm.resolveAppVmConfig { inherit config vmDef; };
+          inherit (resolved) effectiveDef selectedVmm;
+        in
         lib.nixosSystem {
           modules = [
             inputs.microvm.nixosModules.microvm
@@ -149,18 +153,20 @@ in
                 inherit (config.nixpkgs) config;
               };
             }
-          ];
+          ]
+          ++ resolved.extraModules;
           specialArgs = lib.ghaf.vm.mkSpecialArgs {
             inherit lib inputs;
             globalConfig = hostGlobalConfig;
             hostConfig =
               lib.ghaf.vm.mkHostConfig {
                 inherit config;
-                vmName = "${vmDef.name}-vm";
+                vmName = "${effectiveDef.name}-vm";
               }
               // {
                 # App VM-specific hostConfig fields
-                appvm = vmDef;
+                appvm = effectiveDef;
+                appvmVmm = selectedVmm;
                 sharedVmDirectory =
                   config.ghaf.virtualization.microvm-host.sharedVmDirectory or {
                     enable = false;

--- a/modules/profiles/vm.nix
+++ b/modules/profiles/vm.nix
@@ -64,7 +64,7 @@ in
       # Export Net VM base
       netvmBase = lib.nixosSystem {
         modules = [
-          inputs.microvm.nixosModules.microvm
+          inputs.self.nixosModules.microvm-nix
           inputs.self.nixosModules.netvm-base
           {
             nixpkgs = {
@@ -88,7 +88,7 @@ in
       # Export Audio VM base
       audiovmBase = lib.nixosSystem {
         modules = [
-          inputs.microvm.nixosModules.microvm
+          inputs.self.nixosModules.microvm-nix
           inputs.self.nixosModules.audiovm-base
           inputs.self.nixosModules.audiovm-features
           {
@@ -113,7 +113,7 @@ in
       # Export Admin VM base
       adminvmBase = lib.nixosSystem {
         modules = [
-          inputs.microvm.nixosModules.microvm
+          inputs.self.nixosModules.microvm-nix
           inputs.self.nixosModules.adminvm-base
           inputs.self.nixosModules.adminvm-features
           {
@@ -144,7 +144,7 @@ in
         in
         lib.nixosSystem {
           modules = [
-            inputs.microvm.nixosModules.microvm
+            inputs.self.nixosModules.microvm-nix
             inputs.self.nixosModules.appvm-base
             {
               nixpkgs = {

--- a/modules/reference/hardware/intel-laptop/extra-config-host.nix
+++ b/modules/reference/hardware/intel-laptop/extra-config-host.nix
@@ -5,9 +5,23 @@
   ...
 }:
 {
-  ghaf.services.power-manager.suspend = {
-    mode = lib.mkDefault "auto";
-    s2idleModels = [ "System76 Darter Pro" ];
+  ghaf = {
+    global-config.storage.encryption.enable = true;
+
+    services.power-manager.suspend = {
+      mode = lib.mkDefault "auto";
+      s2idleModels = [ "System76 Darter Pro" ];
+    };
+
+    # Generic Intel laptop targets exercise the complete Crosvm stack. Keep
+    # machine-specific targets on their existing VMM selections.
+    virtualization.vmConfig = {
+      defaultSysVmVmm = "crosvm";
+      defaultAppVmVmm = "crosvm";
+      # Override the encrypted AdminVM's conservative QEMU fallback; vm-tpm
+      # wires TPM passthrough for Crosvm.
+      sysvms.adminvm.vmm = "crosvm";
+    };
   };
 
   # Add system76 and system76-io kernel modules to host

--- a/modules/reference/hardware/intel-laptop/extra-config-host.nix
+++ b/modules/reference/hardware/intel-laptop/extra-config-host.nix
@@ -6,8 +6,6 @@
 }:
 {
   ghaf = {
-    global-config.storage.encryption.enable = true;
-
     services.power-manager.suspend = {
       mode = lib.mkDefault "auto";
       s2idleModels = [ "System76 Darter Pro" ];
@@ -18,8 +16,7 @@
     virtualization.vmConfig = {
       defaultSysVmVmm = "crosvm";
       defaultAppVmVmm = "crosvm";
-      # Override the encrypted AdminVM's conservative QEMU fallback; vm-tpm
-      # wires TPM passthrough for Crosvm.
+      # vm-tpm wires TPM passthrough for encrypted Crosvm variants.
       sysvms.adminvm.vmm = "crosvm";
     };
   };

--- a/modules/reference/hardware/intel-laptop/extra-config-host.nix
+++ b/modules/reference/hardware/intel-laptop/extra-config-host.nix
@@ -5,6 +5,10 @@
   ...
 }:
 {
+  # Keep the recovery menu available without delaying every normal boot by the
+  # systemd-boot default timeout.
+  boot.loader.timeout = lib.mkDefault 1;
+
   ghaf = {
     services.power-manager.suspend = {
       mode = lib.mkDefault "auto";

--- a/modules/reference/hardware/vm-budgets.nix
+++ b/modules/reference/hardware/vm-budgets.nix
@@ -12,5 +12,11 @@
   };
 
   # Tablet-class units.
-  minimal.sysvms.guivm.mem = 2047;
+  minimal.sysvms = {
+    guivm.mem = 2047;
+    # Keep AudioVM at its QEMU-sized budget on tablet-class machines. The
+    # Crosvm default uses 1024 MiB, which is too large for this constrained
+    # profile.
+    audiovm.mem = 512;
+  };
 }

--- a/modules/reference/profiles/mvp-orinuser-trial.nix
+++ b/modules/reference/profiles/mvp-orinuser-trial.nix
@@ -4,7 +4,6 @@
   config,
   lib,
   inputs,
-  pkgs,
   ...
 }:
 let
@@ -51,7 +50,6 @@ in
           ]
           ++ lib.ghaf.vm.applyVmConfig {
             inherit config;
-            hostPkgs = pkgs;
             vmName = "guivm";
           };
           specialArgs = lib.ghaf.vm.mkSpecialArgs {

--- a/modules/reference/profiles/mvp-orinuser-trial.nix
+++ b/modules/reference/profiles/mvp-orinuser-trial.nix
@@ -4,6 +4,7 @@
   config,
   lib,
   inputs,
+  pkgs,
   ...
 }:
 let
@@ -50,6 +51,7 @@ in
           ]
           ++ lib.ghaf.vm.applyVmConfig {
             inherit config;
+            hostPkgs = pkgs;
             vmName = "guivm";
           };
           specialArgs = lib.ghaf.vm.mkSpecialArgs {

--- a/modules/reference/profiles/mvp-user-trial-extras.nix
+++ b/modules/reference/profiles/mvp-user-trial-extras.nix
@@ -3,7 +3,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
@@ -50,7 +49,6 @@ in
           evaluatedConfig = config.ghaf.profiles.laptop-x86.idsvmBase.extendModules {
             modules = lib.ghaf.vm.applyVmConfig {
               inherit config;
-              hostPkgs = pkgs;
               vmName = "idsvm";
             };
           };

--- a/modules/reference/profiles/mvp-user-trial-extras.nix
+++ b/modules/reference/profiles/mvp-user-trial-extras.nix
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.ghaf.reference.profiles.mvp-user-trial-extras;
 in
@@ -42,7 +47,13 @@ in
           enable = lib.mkForce true;
           mitmproxy.enable = lib.mkForce true;
           # Use the new evaluatedConfig pattern from laptop-x86 profile
-          evaluatedConfig = config.ghaf.profiles.laptop-x86.idsvmBase;
+          evaluatedConfig = config.ghaf.profiles.laptop-x86.idsvmBase.extendModules {
+            modules = lib.ghaf.vm.applyVmConfig {
+              inherit config;
+              hostPkgs = pkgs;
+              vmName = "idsvm";
+            };
+          };
         };
       };
 

--- a/overlays/flake-module.nix
+++ b/overlays/flake-module.nix
@@ -26,6 +26,11 @@
       });
     };
 
+    ghaf-device-manager = _final: prev: {
+      ghaf-device-manager =
+        inputs.ghaf-device-manager.packages.${prev.stdenv.hostPlatform.system}.default;
+    };
+
     # Jetson-only Python fixes for the EDK2/UEFI firmware build. Deliberately
     # excluded from `default`: it rewrites pythonPackagesExtensions globally.
     # Applied by modules/reference/hardware/jetpack/default.nix.
@@ -42,6 +47,7 @@
       inputs.self.overlays.own-pkgs-overlay
       inputs.self.overlays.custom-packages
       inputs.self.overlays.crosvm
+      inputs.self.overlays.ghaf-device-manager
       #external overlays that we use
       inputs.ghafpkgs.overlays.default
       inputs.ctrl-panel.overlays.default

--- a/overlays/flake-module.nix
+++ b/overlays/flake-module.nix
@@ -10,6 +10,21 @@
   flake.overlays = {
     cross-compilation = import ./cross-compilation;
     custom-packages = import ./custom-packages;
+    crosvm = _final: prev: {
+      crosvm = prev.crosvm.overrideAttrs (old: {
+        src = inputs.ghaf-crosvm;
+        cargoDeps = prev.rustPlatform.fetchCargoVendor {
+          src = inputs.ghaf-crosvm;
+          hash = "sha256-lU30pTzJ1hYyHcpFKemZou9d2ZqSlFu4JC+IUe2Gm5A=";
+        };
+        cargoBuildFeatures = (old.cargoBuildFeatures or (old.buildFeatures or [ ])) ++ [
+          "pci-hotplug"
+          "power-monitor-sysfs"
+          "vtpm"
+        ];
+        buildInputs = (old.buildInputs or [ ]) ++ [ prev.dbus ];
+      });
+    };
 
     # Jetson-only Python fixes for the EDK2/UEFI firmware build. Deliberately
     # excluded from `default`: it rewrites pythonPackagesExtensions globally.
@@ -26,6 +41,7 @@
       #internal overlays
       inputs.self.overlays.own-pkgs-overlay
       inputs.self.overlays.custom-packages
+      inputs.self.overlays.crosvm
       #external overlays that we use
       inputs.ghafpkgs.overlays.default
       inputs.ctrl-panel.overlays.default

--- a/overlays/flake-module.nix
+++ b/overlays/flake-module.nix
@@ -10,25 +10,40 @@
   flake.overlays = {
     cross-compilation = import ./cross-compilation;
     custom-packages = import ./custom-packages;
-    crosvm = _final: prev: {
-      crosvm = prev.crosvm.overrideAttrs (old: {
-        src = inputs.ghaf-crosvm;
-        cargoDeps = prev.rustPlatform.fetchCargoVendor {
+    crosvm =
+      _final: prev:
+      inputs.nixpkgs.lib.optionalAttrs prev.stdenv.hostPlatform.isx86_64 {
+        crosvm = prev.crosvm.overrideAttrs (old: {
           src = inputs.ghaf-crosvm;
-          hash = "sha256-lU30pTzJ1hYyHcpFKemZou9d2ZqSlFu4JC+IUe2Gm5A=";
-        };
-        cargoBuildFeatures = (old.cargoBuildFeatures or (old.buildFeatures or [ ])) ++ [
-          "pci-hotplug"
-          "power-monitor-sysfs"
-          "vtpm"
-        ];
-        buildInputs = (old.buildInputs or [ ]) ++ [ prev.dbus ];
-      });
-    };
+          cargoDeps = prev.rustPlatform.fetchCargoVendor {
+            src = inputs.ghaf-crosvm;
+            hash = "sha256-lU30pTzJ1hYyHcpFKemZou9d2ZqSlFu4JC+IUe2Gm5A=";
+          };
+          cargoBuildFeatures = (old.cargoBuildFeatures or (old.buildFeatures or [ ])) ++ [
+            "pci-hotplug"
+            "power-monitor-sysfs"
+            "vtpm"
+          ];
+          buildInputs = (old.buildInputs or [ ]) ++ [ prev.dbus ];
+        });
+      };
 
-    ghaf-device-manager = _final: prev: {
-      ghaf-device-manager =
-        inputs.ghaf-device-manager.packages.${prev.stdenv.hostPlatform.system}.default;
+    ghaf-device-manager =
+      _final: prev:
+      inputs.nixpkgs.lib.optionalAttrs prev.stdenv.hostPlatform.isx86_64 {
+        ghaf-device-manager =
+          inputs.ghaf-device-manager.packages.${prev.stdenv.hostPlatform.system}.default;
+      };
+
+    # Carry the two focused logging fixes from ghafpkgs#362 until it merges,
+    # while retaining the authoritative tiiuae/ghafpkgs input.
+    ghafpkgs-crosvm-fixes = _final: prev: {
+      ghaf-mem-manager = prev.ghaf-mem-manager.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [ ./patches/ghaf-mem-manager-no-syslog.patch ];
+      });
+      ghaf-usb-applet = prev.ghaf-usb-applet.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [ ./patches/ghaf-usb-applet-log-level.patch ];
+      });
     };
 
     # Jetson-only Python fixes for the EDK2/UEFI firmware build. Deliberately
@@ -50,6 +65,7 @@
       inputs.self.overlays.ghaf-device-manager
       #external overlays that we use
       inputs.ghafpkgs.overlays.default
+      inputs.self.overlays.ghafpkgs-crosvm-fixes
       inputs.ctrl-panel.overlays.default
       inputs.givc.overlays.default
       inputs.gp-gui.overlays.default

--- a/overlays/patches/ghaf-mem-manager-no-syslog.patch
+++ b/overlays/patches/ghaf-mem-manager-no-syslog.patch
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Carry https://github.com/tiiuae/ghafpkgs/pull/362 until it merges.
+diff --git a/src/crosvm.rs b/src/crosvm.rs
+index de5ddfe9..4d4a7881 100644
+--- a/src/crosvm.rs
++++ b/src/crosvm.rs
+@@ -50,7 +50,10 @@ impl CrosvmEndpoint {
+ 
+     async fn command(&self, arguments: &[&str]) -> Result<Output> {
+         let mut command = Command::new(&self.binary);
+-        command.args(arguments).kill_on_drop(true);
++        command
++            .arg("--no-syslog")
++            .args(arguments)
++            .kill_on_drop(true);
+         let output = timeout(TIMEOUT, command.output())
+             .await
+             .with_context(|| {
+@@ -150,7 +153,7 @@ mod tests {
+         let script = format!(
+             r#"#!/bin/sh
+ printf '%s\n' "$@" >> '{}'
+-if [ "$1" = balloon_stats ]; then
++if [ "$2" = balloon_stats ]; then
+     printf '%s\n' '{{"BalloonStats":{{"stats":{{"available_memory":2147483648,"free_memory":1073741824}},"balloon_actual":4294967296}}}}'
+ fi
+ "#,
+@@ -170,7 +173,7 @@ fi
+         );
+         assert_eq!(
+             fs::read_to_string(&log)?,
+-            "balloon_stats\n/run/crosvm.sock\n"
++            "--no-syslog\nballoon_stats\n/run/crosvm.sock\n"
+         );
+         fs::write(&log, "")?;
+ 
+@@ -180,7 +183,7 @@ fi
+ 
+         assert_eq!(
+             fs::read_to_string(log)?,
+-            "balloon\n8589934592\n/run/crosvm.sock\n"
++            "--no-syslog\nballoon\n8589934592\n/run/crosvm.sock\n"
+         );
+         Ok(())
+     }

--- a/overlays/patches/ghaf-usb-applet-log-level.patch
+++ b/overlays/patches/ghaf-usb-applet-log-level.patch
@@ -23,3 +23,24 @@ index 97d2817c..761f9cab 100755
          event = msg.get("event", "")
          if event == "usb_select_vm":
              self.show_notif_window(msg)
+diff --git a/src/ghaf_usb_applet/settings.py b/src/ghaf_usb_applet/settings.py
+--- a/src/ghaf_usb_applet/settings.py
++++ b/src/ghaf_usb_applet/settings.py
+@@ -10,8 +10,6 @@ from gi.repository import Gtk, Gdk, Pango, GLib
+ from ghaf_usb_applet.api_client import APIClient
+ from ghaf_usb_applet.logger import logger
+ 
+-import json
+-
+ 
+ class OptionsPopover(Gtk.Popover):
+     def __init__(self, parent_widget, title, options, selected, on_chosen):
+@@ -135,7 +133,7 @@ class DeviceSettings(Gtk.ApplicationWindow):
+     def refresh(self):
+         try:
+             self._model = self.apiclient.get_devices_pretty()
+-            logger.info(json.dumps(self._model, indent=4, sort_keys=True))
++            logger.debug("USB device inventory: %s", self._model)
+         except Exception as e:
+             logger.exception("Failed fetching devices")
+             GLib.idle_add(self._notify_error, "Device Error", f"Message: {e}")

--- a/overlays/patches/ghaf-usb-applet-log-level.patch
+++ b/overlays/patches/ghaf-usb-applet-log-level.patch
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Carry https://github.com/tiiuae/ghafpkgs/pull/362 until it merges.
+diff --git a/src/ghaf_usb_applet/notification_handler.py b/src/ghaf_usb_applet/notification_handler.py
+index 97d2817c..761f9cab 100755
+--- a/src/ghaf_usb_applet/notification_handler.py
++++ b/src/ghaf_usb_applet/notification_handler.py
+@@ -2,7 +2,6 @@
+ # SPDX-License-Identifier: Apache-2.0
+ 
+ import subprocess
+-import json
+ 
+ from ghaf_usb_applet.api_client import APIClient
+ from ghaf_usb_applet.logger import logger
+@@ -31,7 +30,7 @@ class NotificationHandler:
+         return th
+ 
+     def notify_user(self, msg):
+-        logger.info(f"Device notification: {json.dumps(msg, indent=4)}")
++        logger.debug("Device notification: %s", msg)
+         event = msg.get("event", "")
+         if event == "usb_select_vm":
+             self.show_notif_window(msg)

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -106,7 +106,6 @@ let
               ghaf.virtualization.microvm.netvm.evaluatedConfig = netvmBase.extendModules {
                 modules = lib.ghaf.vm.applyVmConfig {
                   inherit config;
-                  hostPkgs = pkgs;
                   vmName = "netvm";
                 };
               };

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -104,7 +104,11 @@ let
 
               # Wire up netvm using inline netvmBase
               ghaf.virtualization.microvm.netvm.evaluatedConfig = netvmBase.extendModules {
-                modules = config.ghaf.hardware.definition.netvm.extraModules or [ ];
+                modules = lib.ghaf.vm.applyVmConfig {
+                  inherit config;
+                  hostPkgs = pkgs;
+                  vmName = "netvm";
+                };
               };
             }
           )

--- a/targets/generic-x86_64/flake-module.nix
+++ b/targets/generic-x86_64/flake-module.nix
@@ -70,7 +70,7 @@ let
               # Create inline netvmBase (following laptop-x86 pattern)
               netvmBase = lib.nixosSystem {
                 modules = [
-                  inputs.microvm.nixosModules.microvm
+                  inputs.self.nixosModules.microvm-nix
                   inputs.self.nixosModules.netvm-base
                   # Import nixpkgs config for overlays
                   {

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -122,20 +122,40 @@ let
                     netvm = {
                       enable = true;
                       evaluatedConfig = vmProfile.netvmBase.extendModules {
-                        modules = [ netvmGivcModule ];
+                        modules = [
+                          netvmGivcModule
+                        ]
+                        ++ lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          hostPkgs = pkgs;
+                          vmName = "netvm";
+                        };
                       };
                     };
 
                     audiovm = {
                       enable = true;
                       evaluatedConfig = vmProfile.audiovmBase.extendModules {
-                        modules = [ audiovmGivcModule ];
+                        modules = [
+                          audiovmGivcModule
+                        ]
+                        ++ lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          hostPkgs = pkgs;
+                          vmName = "audiovm";
+                        };
                       };
                     };
 
                     adminvm = {
                       enable = true;
-                      evaluatedConfig = vmProfile.adminvmBase;
+                      evaluatedConfig = vmProfile.adminvmBase.extendModules {
+                        modules = lib.ghaf.vm.applyVmConfig {
+                          inherit config;
+                          hostPkgs = pkgs;
+                          vmName = "adminvm";
+                        };
+                      };
                     };
 
                     # NOTE: GUI runs on host, not in a gui-vm

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -127,7 +127,6 @@ let
                         ]
                         ++ lib.ghaf.vm.applyVmConfig {
                           inherit config;
-                          hostPkgs = pkgs;
                           vmName = "netvm";
                         };
                       };
@@ -141,7 +140,6 @@ let
                         ]
                         ++ lib.ghaf.vm.applyVmConfig {
                           inherit config;
-                          hostPkgs = pkgs;
                           vmName = "audiovm";
                         };
                       };
@@ -152,7 +150,6 @@ let
                       evaluatedConfig = vmProfile.adminvmBase.extendModules {
                         modules = lib.ghaf.vm.applyVmConfig {
                           inherit config;
-                          hostPkgs = pkgs;
                           vmName = "adminvm";
                         };
                       };

--- a/tests/flake-module.nix
+++ b/tests/flake-module.nix
@@ -39,6 +39,7 @@
           cosmic-panels = pkgs.callPackage ./cosmic/panels.nix { inherit self; };
           cosmic-shortcuts = pkgs.callPackage ./cosmic/shortcuts.nix { inherit self; };
           flatpak-options = pkgs.callPackage ./flatpak/options.nix { inherit self; };
+          microvm-tpm-vmm-parity = pkgs.callPackage ./microvm/tpm-vmm-parity.nix { inherit self; };
           uplink-resolver = pkgs.callPackage ./uplink-resolver { };
           logging-fss = pkgs.callPackage ./logging { inherit self; };
           fss-classifier-unit = pkgs.callPackage ./logging/classifier-unit.nix { };

--- a/tests/logging/test_scripts/fss_verification.nix
+++ b/tests/logging/test_scripts/fss_verification.nix
@@ -96,7 +96,7 @@ _: ''
 
           # The NTP wait happens in the separate sync unit, after networking.
           test -s /run/ghaf-clock-sync-state
-          grep -E "sync_result=(synchronized|timeout|disabled|timedatectl-unavailable)" /run/ghaf-clock-sync-state
+          grep -E "sync_result=(synchronized|timeout|disabled|sync-tool-unavailable)" /run/ghaf-clock-sync-state
 
           # The early journal flush only waits on the fast barrier, never the NTP unit.
           for unit in systemd-journal-flush.service journal-fss-setup.service journal-fss-verify.service; do

--- a/tests/microvm/tpm-vmm-parity.nix
+++ b/tests/microvm/tpm-vmm-parity.nix
@@ -41,6 +41,12 @@ let
     vm:
     lib.elem "dev-tpmrm0.device" vm.systemd.services.storagevm-enroll.requires
     && lib.elem "dev-tpmrm0.device" vm.systemd.services.storagevm-enroll.after;
+  formatsAfterPersistExpansion =
+    host: name:
+    let
+      service = host.systemd.services."format-microvm-storage-${name}";
+    in
+    lib.elem "extendbtrfs.service" service.after && lib.elem "extendbtrfs.service" service.requires;
 
   systemVmAssertions = lib.concatLists (
     lib.mapAttrsToList (
@@ -85,6 +91,10 @@ let
           ok = waitsForTpm qemu && waitsForTpm crosvm;
         }
         {
+          name = "${name}: encrypted release storage waits for persistent filesystem expansion";
+          ok = formatsAfterPersistExpansion qemuHost name && formatsAfterPersistExpansion crosvmHost name;
+        }
+        {
           name = "${name}: Crosvm guest includes the virtio TPM transport";
           ok = lib.elem "chromiumos-virtio-tpm" (patchNames crosvm);
         }
@@ -113,6 +123,10 @@ let
         {
           name = "${name}: Crosvm debug VM waits for the TPM before storage enrollment";
           ok = waitsForTpm crosvmDebug;
+        }
+        {
+          name = "${name}: Crosvm debug storage waits for persistent filesystem expansion";
+          ok = formatsAfterPersistExpansion crosvmDebugHost name;
         }
         {
           name = "${name}: Crosvm debug guest includes the virtio TPM transport";

--- a/tests/microvm/tpm-vmm-parity.nix
+++ b/tests/microvm/tpm-vmm-parity.nix
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# VM-free check for TPM parity between encrypted QEMU and Crosvm system VMs.
+{
+  self,
+  lib,
+  runCommand,
+}:
+let
+  qemuHost = self.nixosConfigurations.lenovo-t14-amd-gen5-release.config;
+  crosvmDebugHost = self.nixosConfigurations.intel-laptop-debug.config;
+  crosvmHost = self.nixosConfigurations.intel-laptop-release.config;
+
+  systemVms = {
+    "admin-vm" = "0x81701000";
+    "audio-vm" = "0x81702000";
+    "gui-vm" = "0x81703000";
+    "net-vm" = "0x81704000";
+  };
+  appVms = [
+    "business-vm"
+    "chrome-vm"
+    "comms-vm"
+    "flatpak-vm"
+    "media-vm"
+  ];
+
+  vmConfig = host: name: host.microvm.vms.${name}.evaluatedConfig.config;
+
+  hasArgPair =
+    flag: value: args:
+    if builtins.length args < 2 then
+      false
+    else
+      (builtins.head args == flag && builtins.elemAt args 1 == value)
+      || hasArgPair flag value (builtins.tail args);
+
+  patchNames = vm: map (patch: patch.name) vm.boot.kernelPatches;
+  waitsForTpm =
+    vm:
+    lib.elem "dev-tpmrm0.device" vm.systemd.services.storagevm-enroll.requires
+    && lib.elem "dev-tpmrm0.device" vm.systemd.services.storagevm-enroll.after;
+
+  systemVmAssertions = lib.concatLists (
+    lib.mapAttrsToList (
+      name: rootNVIndex:
+      let
+        qemu = vmConfig qemuHost name;
+        crosvmDebug = vmConfig crosvmDebugHost name;
+        crosvm = vmConfig crosvmHost name;
+      in
+      [
+        {
+          name = "${name}: QEMU release VM enables TPM passthrough";
+          ok = qemu.microvm.hypervisor == "qemu" && qemu.ghaf.virtualization.microvm.tpm.passthrough.enable;
+        }
+        {
+          name = "${name}: QEMU release VM uses the expected TPM resource-manager device";
+          ok =
+            hasArgPair "-tpmdev" "passthrough,id=tpmrm0,path=/dev/tpmrm0,cancel-path=/tmp/cancel"
+              qemu.microvm.qemu.extraArgs;
+        }
+        {
+          name = "${name}: Crosvm release VM enables TPM passthrough";
+          ok =
+            crosvm.microvm.hypervisor == "crosvm" && crosvm.ghaf.virtualization.microvm.tpm.passthrough.enable;
+        }
+        {
+          name = "${name}: Crosvm release VM uses the same TPM resource-manager device";
+          ok = hasArgPair "--tpm-device" "/dev/tpmrm0" crosvm.microvm.crosvm.extraArgs;
+        }
+        {
+          name = "${name}: both VMMs preserve the VM-specific TPM NV index";
+          ok =
+            qemu.ghaf.virtualization.microvm.tpm.passthrough.rootNVIndex == rootNVIndex
+            && crosvm.ghaf.virtualization.microvm.tpm.passthrough.rootNVIndex == rootNVIndex;
+        }
+        {
+          name = "${name}: both release VMs enable encrypted persistent storage";
+          ok = qemu.ghaf.storagevm.encryption.enable && crosvm.ghaf.storagevm.encryption.enable;
+        }
+        {
+          name = "${name}: both release VMs wait for the TPM before storage enrollment";
+          ok = waitsForTpm qemu && waitsForTpm crosvm;
+        }
+        {
+          name = "${name}: Crosvm guest includes the virtio TPM transport";
+          ok = lib.elem "chromiumos-virtio-tpm" (patchNames crosvm);
+        }
+        {
+          name = "${name}: Crosvm release initrd loads the virtio TPM transport";
+          ok = lib.elem "tpm_virtio" crosvm.boot.initrd.kernelModules;
+        }
+        {
+          name = "${name}: Crosvm debug VM enables TPM passthrough";
+          ok =
+            crosvmDebug.microvm.hypervisor == "crosvm"
+            && crosvmDebug.ghaf.virtualization.microvm.tpm.passthrough.enable;
+        }
+        {
+          name = "${name}: Crosvm debug VM uses the TPM resource-manager device";
+          ok = hasArgPair "--tpm-device" "/dev/tpmrm0" crosvmDebug.microvm.crosvm.extraArgs;
+        }
+        {
+          name = "${name}: Crosvm debug VM preserves the VM-specific TPM NV index";
+          ok = crosvmDebug.ghaf.virtualization.microvm.tpm.passthrough.rootNVIndex == rootNVIndex;
+        }
+        {
+          name = "${name}: Crosvm debug VM enables encrypted persistent storage";
+          ok = crosvmDebug.ghaf.storagevm.encryption.enable;
+        }
+        {
+          name = "${name}: Crosvm debug VM waits for the TPM before storage enrollment";
+          ok = waitsForTpm crosvmDebug;
+        }
+        {
+          name = "${name}: Crosvm debug guest includes the virtio TPM transport";
+          ok = lib.elem "chromiumos-virtio-tpm" (patchNames crosvmDebug);
+        }
+        {
+          name = "${name}: Crosvm debug initrd loads the virtio TPM transport";
+          ok = lib.elem "tpm_virtio" crosvmDebug.boot.initrd.kernelModules;
+        }
+      ]
+    ) systemVms
+  );
+
+  appVmAssertions = map (
+    name:
+    let
+      vm = vmConfig crosvmHost name;
+    in
+    {
+      name = "${name}: Crosvm AppVM retains its isolated swtpm backend";
+      ok =
+        vm.microvm.hypervisor == "crosvm"
+        && vm.ghaf.virtualization.microvm.tpm.emulated.enable
+        && vm.ghaf.virtualization.microvm.tpm.emulated.runInVM
+        && lib.elem "tpm_virtio" vm.boot.initrd.kernelModules
+        && hasArgPair "--swtpm" "vtpm.sock" vm.microvm.crosvm.extraArgs;
+    }
+  ) appVms;
+
+  assertions = [
+    {
+      name = "QEMU host grants the microvm user TPM device access";
+      ok = lib.elem "tss" qemuHost.users.users.microvm.extraGroups;
+    }
+    {
+      name = "Crosvm host grants the microvm user TPM device access";
+      ok = lib.elem "tss" crosvmHost.users.users.microvm.extraGroups;
+    }
+    {
+      name = "Crosvm debug host grants the microvm user TPM device access";
+      ok = lib.elem "tss" crosvmDebugHost.users.users.microvm.extraGroups;
+    }
+  ]
+  ++ systemVmAssertions
+  ++ appVmAssertions;
+
+  failed = map (assertion: assertion.name) (lib.filter (assertion: !assertion.ok) assertions);
+in
+assert lib.assertMsg (failed == [ ]) "microvm TPM VMM parity: ${lib.concatStringsSep "; " failed}";
+runCommand "microvm-tpm-vmm-parity" { } ''touch "$out"''

--- a/tests/microvm/tpm-vmm-parity.nix
+++ b/tests/microvm/tpm-vmm-parity.nix
@@ -9,9 +9,11 @@
 }:
 let
   qemuHost = self.nixosConfigurations.lenovo-t14-amd-gen5-release.config;
-  crosvmDebugHost = self.nixosConfigurations.intel-laptop-debug.config;
   crosvmHost = self.nixosConfigurations.intel-laptop-release.config;
 
+  # This map is the pinned cross-VMM storage contract. The authoritative NV
+  # indices remain in the corresponding {admin,audio,gui,net}vm-base modules;
+  # changing one side without the other must fail this parity check.
   systemVms = {
     "admin-vm" = "0x81701000";
     "audio-vm" = "0x81702000";
@@ -53,7 +55,6 @@ let
       name: rootNVIndex:
       let
         qemu = vmConfig qemuHost name;
-        crosvmDebug = vmConfig crosvmDebugHost name;
         crosvm = vmConfig crosvmHost name;
       in
       [
@@ -102,40 +103,6 @@ let
           name = "${name}: Crosvm release initrd loads the virtio TPM transport";
           ok = lib.elem "tpm_virtio" crosvm.boot.initrd.kernelModules;
         }
-        {
-          name = "${name}: Crosvm debug VM enables TPM passthrough";
-          ok =
-            crosvmDebug.microvm.hypervisor == "crosvm"
-            && crosvmDebug.ghaf.virtualization.microvm.tpm.passthrough.enable;
-        }
-        {
-          name = "${name}: Crosvm debug VM uses the TPM resource-manager device";
-          ok = hasArgPair "--tpm-device" "/dev/tpmrm0" crosvmDebug.microvm.crosvm.extraArgs;
-        }
-        {
-          name = "${name}: Crosvm debug VM preserves the VM-specific TPM NV index";
-          ok = crosvmDebug.ghaf.virtualization.microvm.tpm.passthrough.rootNVIndex == rootNVIndex;
-        }
-        {
-          name = "${name}: Crosvm debug VM enables encrypted persistent storage";
-          ok = crosvmDebug.ghaf.storagevm.encryption.enable;
-        }
-        {
-          name = "${name}: Crosvm debug VM waits for the TPM before storage enrollment";
-          ok = waitsForTpm crosvmDebug;
-        }
-        {
-          name = "${name}: Crosvm debug storage waits for persistent filesystem expansion";
-          ok = formatsAfterPersistExpansion crosvmDebugHost name;
-        }
-        {
-          name = "${name}: Crosvm debug guest includes the virtio TPM transport";
-          ok = lib.elem "chromiumos-virtio-tpm" (patchNames crosvmDebug);
-        }
-        {
-          name = "${name}: Crosvm debug initrd loads the virtio TPM transport";
-          ok = lib.elem "tpm_virtio" crosvmDebug.boot.initrd.kernelModules;
-        }
       ]
     ) systemVms
   );
@@ -164,10 +131,6 @@ let
     {
       name = "Crosvm host grants the microvm user TPM device access";
       ok = lib.elem "tss" crosvmHost.users.users.microvm.extraGroups;
-    }
-    {
-      name = "Crosvm debug host grants the microvm user TPM device access";
-      ok = lib.elem "tss" crosvmDebugHost.users.users.microvm.extraGroups;
     }
   ]
   ++ systemVmAssertions


### PR DESCRIPTION
## Description of Changes

Select Crosvm by default for the generic `intel-laptop-*` NetVM, AudioVM, GUIVM, AdminVM, and AppVM configurations while preserving per-VM QEMU overrides, the generic VM target, named laptops, and all aarch64/platform-device QEMU paths.

Add physical TPM, battery, lid, NHLT, PCI and USB hotplug, VMM-aware shutdown, Intel IGD OpRegion and GSC proxy support, suspend-safe VFIO reattachment, native Crosvm s2idle resume, and USB isochronous output.

This PR is the sole Ghaf merge candidate for the migration and contains the complete, rebased, and logically grouped implementation previously split across draft PRs #2106 and #2123.

The review fixes make PCI startup fail closed, bound device-manager connection attempts, order each affected MicroVM after the selected device manager, report readiness only after the Crosvm control socket exists, grant VFIO group access, keep StoreDisk EROFS images read-only and non-root, and retain QEMU error behavior and rollback paths.

### Type of Change

- [x] New feature
- [x] Bug fix
- [x] Update
- [x] Improvement / Refactor
- [x] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

- Supersedes draft PRs #2106 and #2123. Their complete implementation is grouped here; neither draft is intended to merge.
- Depends on tiiuae/vhotplug#22 for the explicit QEMU fallback
- Builds on merged tiiuae/ghaf-device-manager#1
- Builds on merged tiiuae/ghaf-crosvm#8, which promoted the #6/#7 stack to main
- Uses canonical microvm.nix main and carries the StoreDisk runner fix from microvm-nix/microvm.nix#584 as a local module overlay until that PR merges.
- Builds on merged tiiuae/ghaf-crosvm#1 and tiiuae/ghaf-crosvm#2

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit
- [x] Author has added reviewers and removed PR draft status
- [x] QEMU rollback controls preserved
- [x] Generic VM and aarch64 platform-device paths remain on QEMU

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

Generic VM and Orin configurations are evaluated as QEMU regression guards; they were not hardware-tested in this round.

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Boot the installer and complete encrypted provisioning.
2. Verify all intended VMs use Crosvm, `ghaf-device-manager.service` is active, and vhotplug is absent from the default all-Crosvm image.
3. Verify each StoreDisk EROFS image is attached with `ro=true`, the guest uses `root=fstab`, and no guest receives `root=/dev/vda`.
4. Exercise Wi-Fi, playback/capture, USB-headset plug/unplug, display/input, battery, lid, Bluetooth, and kill-switch handling.
5. Suspend and resume; confirm the native Crosvm resume path completes and all guests return.
6. Reboot the StoreDisk image and confirm AppVM persistent-home data survives unchanged.

### Source and CI validation

- `nix fmt -- --fail-on-change`
- `nix develop --command reuse lint`
- `nix build .#checks.x86_64-linux.pre-commit --print-build-logs`
- complete `intel-laptop-debug-installer` and `intel-laptop-storeDisk-debug-installer` builds
- Crosvm package build with 135 tests
- all ten GitHub eval shards and selected GitHub package builds passed on the previous head
- the signed commit rewrite triggered a fresh CI round
- the repository-wide local `nix flake check` is resource-inconclusive: it reached `checks.x86_64-linux.flatpak-options` and exited 137 because this command consistently overloads the validation host

### Darter Pro hardware acceptance

Normal image:

- all nine MicroVMs used the pinned Crosvm binary; only `ghaf-device-manager` was enabled
- native s2idle suspend/resume returned all eight internal guests with zero failed units
- Sennheiser USB headset playback and microphone capture worked
- the audio applet tracked physical USB headset plug/unplug correctly
- Bluetooth, touchpad speed, integrated speakers, analog headset, and Bluetooth headset remained working

StoreDisk image (installer SHA-256 `2ff453bb5a9acf6d7caa2fadc3709359f55d78bedff27682f2667484ca3247a2`):

- all nine first-boot install units completed with `success/0`
- all nine VMs ran Crosvm with read-only EROFS stores and `root=fstab`
- all eight internal guests accepted authenticated login, mounted persistent storage from `/dev/vdb`, and resolved DNS
- after a full host reboot and boot-ID change, all nine VMs returned with zero failed units
- BusinessVM and FlatpakVM home markers retained the same inode, timestamp, owner, size, and SHA-256; the markers were removed after verification

### Remaining follow-ups

- stale network indicator after resume was not reproduced in the final round
- duplicate native/USB Ethernet interface report was not reproduced in the final round
- USB route switching is fixed; the reported Bluetooth route-switching failure still needs a focused reproduction
- focused Robot `suspension`, `functional`, `gui`, and `pre-merge` groups were not run
- external `jenkins-pre-merge` build 2726 is currently red
- the PR remains blocked until CI is green and the changes-requested review is revisited