### PR TITLE
fix(user-provision): prompt for Wi-Fi password interactively

### DIFF
--- a/packages/pkgs-by-name/user-provision/user-provision.sh
+++ b/packages/pkgs-by-name/user-provision/user-provision.sh
@@ -554,7 +554,15 @@ setup_wifi() {
   local wifi_ssid
   wifi_ssid=$(prompt_input "Enter WiFi network name:" "network SSID") || return 1
 
-  if nmcli device wifi connect "$wifi_ssid" --ask; then
+  local wifi_password
+  wifi_password=$(prompt_password "Enter WiFi password (leave blank for open networks):" "password") || return 1
+
+  local connect_cmd=("nmcli" "device" "wifi" "connect" "$wifi_ssid")
+  if [[ -n $wifi_password ]]; then
+    connect_cmd+=("password" "$wifi_password")
+  fi
+
+  if "${connect_cmd[@]}"; then
     show_success "Successfully connected to '$wifi_ssid'"
   else
     show_error "Failed to connect to WiFi network '$wifi_ssid'"


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

During user provisioning `nmcli` fails to detect a proper console or a compliant TTY. As a result, it fails immediately.

Fix this by prompting the user for the password interactively using Ghaf's `prompt_password` (gum-based) helper function and passing it directly to the `nmcli` command line.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets
https://jira.tii.ae/browse/SSRCSP-8383

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

Steps to Reproduce

1. Change dnsProvider to correct IP address in  modules/common/users/ad-users.nix, in Tampere (and I believe also in the UAE office) that is 

dnsProvider = {
 name = "vm-ghaf-dev-dc.ghaf-test.com";
 ipAddress = "74.162.70.140";
}; 

2. Build image (I was using system76-darp11-b-debug)

3. Flash and boot

4. From the User Provisioning, select "Enroll AD user to homed"

5. Select "Setup WiFi" and connect to WiFi
Expected Behavior

User can give the SSID & password, device is connected to WiFi.
<img width="4032" height="3024" alt="IMG_8776" src="https://github.com/user-attachments/assets/134ea904-f979-435e-9281-e700abb7b72a" />

