### PR TITLE
fix(orin): hash the LUKS device-unique key context

### DIFF
--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -501,9 +501,12 @@ let
         if [[ -z "$luksSerial" ]]; then
            printf "error: Failed to get luksDev serial\n"
            handle_error
-        else
-          echo "$luksSerial"
         fi
+
+        # Context = sha256 of the serial cut to 32 chars, under nvluks-srv-app's 40-char context cap.
+        luksSerial=$(printf "%s" "$luksSerial" | sha256sum | cut -c1-32)
+
+        echo "$luksSerial"
       }
 
       switch_to_use_device_unique_key() {


### PR DESCRIPTION
## Description of Changes

The device unique key script passes the disk's udev ID_SERIAL to
nvluks-srv-app as the OP-TEE context. nvluks-srv-app caps the context at
40 characters and USB disk serials are longer (44 chars for our PSSD),
so the key is never derived and the initrd reboot-loops on first boot.

Hash the serial (sha256, cut to 32 chars) and use that as the context
for all disks. Devices provisioned before this change derive a
different key and need re-provisioning.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Build a luks orin target and flash it to a USB SSD (ID_SERIAL longer than 40 chars).
2. Boot. Key derivation succeeds: no nvluks-srv-app usage error, keyslot switch runs.

Tested on Orin NX with a USB PSSD.
