### PR TITLE
feat(access-control): enable access control

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,17 +334,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786818071,
-        "narHash": "sha256-75cpo8uG1jbmei7aACnPPQNj8Bg1/1na61981LXDzAQ=",
+        "lastModified": 1787211791,
+        "narHash": "sha256-6Nh3K1ucp7e6mx0dkXRvpl2C2jHnZ+1nHm/F7vogjB8=",
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "30660573c7fdb902943d61c08c478bd4afbd343d",
+        "rev": "2fa09e6e8ff8de5d559099d41d888da53df4bf2d",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "30660573c7fdb902943d61c08c478bd4afbd343d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
     #
     # TEMPORARILY pinned to a commit rather than the branch head
     givc = {
-      url = "github:tiiuae/ghaf-givc/30660573c7fdb902943d61c08c478bd4afbd343d";
+      url = "github:tiiuae/ghaf-givc";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -183,9 +183,7 @@ let
               ;;
             resume)
               echo "Signaling resume to $vm_name..."
-              # Stop unit command not yet implemented in GIVC admin service
-              grpcurl -cacert /etc/givc/ca-cert.pem -cert /etc/givc/cert.pem -key /etc/givc/key.pem \
-              -d '{"UnitName":"systemd-suspend.service"}' "$vm_name":9000 systemd.UnitControlService.StopUnit
+              ${givc-cli} stop service --vm "$vm_name" systemd-suspend.service
               ;;
             *)
               echo "Invalid action: $action"

--- a/modules/givc/common.nix
+++ b/modules/givc/common.nix
@@ -53,7 +53,11 @@ in
     enable = mkEnableOption "gRPC inter-vm communication (GIVC)";
     debug = mkEnableOption "GIVC debug mode";
     accessControl = {
-      enable = mkEnableOption "access control for GIVC";
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = config.ghaf.givc.enableTls;
+        description = "Whether to enable access control for GIVC. Defaults to true if enableTls is true.";
+      };
       adminRules = mkOption {
         description = ''
           Defines access control policies for the GIVC Admin server.


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
- Enable GIVC access control across all VMs.
- `grpcurl` command replaced by `givc-cli`, now stop service requests routes through admin-vm.
(Feature functionality tested in PR #1998; this change only handles the enablement).

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

Test Steps To Verify:

- Test every functionality which requires inter vm communication e.g.

    - Download a pdf file in chrome vm and open it.
    - Watch video on youtube.

- Check log of givc agent in each vm there should not be any permission denied by access control policy
```
$journalctl -b 0 -u givc-<vmname>.service | grep -i cedar
```
- Check log of givc admin in admin vm there should not be any permission denied
```
$journalctl -b 0 -u givc-admin.service | grep -i cedar
```
