### PR TITLE
fix(bluetooth): BLE mouse doesn't work

### DIFF
--- a/modules/common/services/bluetooth.nix
+++ b/modules/common/services/bluetooth.nix
@@ -79,12 +79,16 @@ in
     ];
 
     # Uinput kernel module
-    boot.kernelModules = [ "uinput" ];
+    boot.kernelModules = [
+      "uinput"
+      "uhid"
+    ];
 
     # Rfkill udev rule
     services.udev.extraRules = ''
       KERNEL=="rfkill", SUBSYSTEM=="misc", GROUP="${bluetoothUser}"
       KERNEL=="uinput", SUBSYSTEM=="misc", GROUP="${bluetoothUser}"
+      KERNEL=="uhid", GROUP="${bluetoothUser}" MODE="0660"
     '';
 
     # Dbus policy updates


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
For a BLE device using HID over GATT (HOGP), UHID is required because BlueZ uses the UHID interface to connect the Bluetooth HID device to the Linux HID subsystem. This allows the kernel to recognize the BLE device as a standard HID device, such as a mouse or keyboard, and expose the appropriate input events to the system.

Fixes: https://jira.tii.ae/browse/SSRCSP-8798

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Pair any BLE mouse using the Bluetooth Manager.
2. Verify that the mouse is connected and functioning properly.
