### PR TITLE
fix(cosmic-settings-daemon): restore audio slider after suspend

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -699,7 +699,7 @@ in
               systemctl start ${service}
             '') cfg.vm.pciSuspendServices
           )
-          + optionalString (cfg.suspend.extraResumeCommands != "") ''
+          + optionalString (cfg.suspend.extraResumeCommands != "" && !cfg.gui.enable) ''
             # config.ghaf.services.power-manager.suspend.extraResumeCommands
             ${cfg.suspend.extraResumeCommands}
           '';

--- a/modules/desktop/graphics/cosmic/default.nix
+++ b/modules/desktop/graphics/cosmic/default.nix
@@ -439,7 +439,25 @@ in
       # Workaround for https://github.com/pop-os/cosmic-applets/issues/1390
       # TODO: Remove when upstream issue is fixed
       ''
-        ${lib.getExe' pkgs.busybox "killall"} -q cosmic-panel || true
+        pid=$(${lib.getExe' pkgs.busybox "pgrep"} -f "cosmic-panel" | ${lib.getExe' pkgs.busybox "head"} -n1)
+        if [ -n "$pid" ]; then
+          ${lib.getExe' pkgs.busybox "kill"} "$pid" || true
+        else
+          echo "No COSMIC panel PID found"
+        fi
+        #
+        # Workaround for volume slider not working and volume panels not showing after resume
+        # zlink 0.7.0 fixes the COSMIC settings daemon resume issue.
+        # TODO: Remove when zlink ≥ 0.7.0 is used by COSMIC (currently it's 0.5.0)
+        # COSMIC Cargo.lock reference:
+        # https://github.com/pop-os/cosmic-settings/blob/master/Cargo.lock#L9383
+        # Restart COSMIC settings daemon after suspend, as it may not resume properly on some systems
+        pid=$(${lib.getExe' pkgs.busybox "pgrep"} -f "cosmic-settings-daemon" | ${lib.getExe' pkgs.busybox "head"} -n1)
+        if [ -n "$pid" ]; then
+          ${lib.getExe' pkgs.busybox "kill"} -9 "$pid" || true
+        else
+          echo "No COSMIC settings daemon PID found"
+        fi
       '';
 
     systemd.user.services = {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

After suspend/resume, the audio volume slider no longer functions correctly. Changing the volume does not update the slider state, and the on-screen volume panel (OSD) is not displayed.
The work around is temporary until the below zlink fix is included in Cosmic.

https://github.com/z-galaxy/zlink/commit/13bad852fa28a977b8eacf56ca3d85a746f15faf

### Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

https://jira.tii.ae/browse/SSRCSP-8740
https://jira.tii.ae/browse/SSRCSP-8507

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

1. Log in to gui-vm.
2. Suspend the system and then resume it.
3. Log in again after resume.
4. Start audio playback (e.g., music or a video).
5. Adjust the volume using the audio slider in the top-right corner of the screen.
6. Verify that the audio volume changes accordingly.
7. Verify that the volume OSD/panel appears at the bottom of the screen when the volume is adjusted.

Expected Result:

1. Audio volume changes correctly when using the slider.
2. The volume OSD/panel is displayed when the volume level is changed.
3. No loss of audio control functionality after suspend/resume.

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [X] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:


<!--
### Test Steps To Verify:
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
