### PR TITLE
fix(orin/sdimage): Parse the fdisk Sectors field in part_root_count

### DIFF
--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -261,7 +261,7 @@ in
           # root-partition offset and sector count
           part_root=$(echo -n "$fdisk_output" | tail -n 1 | head -n 1 | tr -s ' ')
           part_root_begin=$(echo -n "$part_root" | cut -d ' ' -f3)
-          part_root_count=$(echo -n "$part_root" | cut -d ' ' -f4)
+          part_root_count=$(echo -n "$part_root" | cut -d ' ' -f5)
 
           echo -n $part_esp_begin > $out/esp.offset
           echo -n $part_esp_count > $out/esp.size


### PR DESCRIPTION
The field count in `fdisk -l` output is shifted by 1 between the esp and root partitions because of the '*' in the Boot column. To parse the Start and Sectors fields for the root partition, cut should select fields 3 and 5.

The previous value was oversizing the root partition by 256M since it was parsing End instead of Sectors.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

Compare the contents of the `root.size` file in build result with manual run of `fdisk -l` on the sd .img. 
It should match the value of `Sectors`.

```
$cat root.size
32943376%

$ fdisk -l out_ghaf_image/nixos-image-sd-card-26.11.20260726.624af66-aarch64-linux.img
Device                                                                       Boot  Start      End  Sectors  Size Id Type
out_ghaf_image/nixos-image-sd-card-26.11.20260726.624af66-aarch64-linux.img1       16384   540671   524288  256M  b W95 FAT32
out_ghaf_image/nixos-image-sd-card-26.11.20260726.624af66-aarch64-linux.img2 *    540672 33484047 32943376 15.7G 83 Linux
```
