### PR TITLE
feat(orin): Add pkvm 6.18 kernel for the Ghaf host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ result*
 ghaf-host.qcow2
 .direnv/
 .idea
-linux-*/
 .serena/
 gcroot/
 .pre-commit-config.yaml

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -42,7 +42,8 @@ path = [
   "packages/pkgs-by-name/fingwit/0001-check-all-pam-services-for-fprintd.patch",
   "overlays/custom-packages/spire4ghaf/0001-spire-with-basic-plugins.patch",
   "modules/common/theming/*.yaml",
-  "modules/common/theming/*.ron"
+  "modules/common/theming/*.ron",
+  "modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/0002-rtk_btusb-Fix-for-kernel-6.16.patch"
 ]
 
 [[annotations]]
@@ -168,3 +169,10 @@ SPDX-FileCopyrightText = [
   "2022-2026 TII (SSRC) and the Ghaf contributors"
 ]
 path = "overlays/jetpack-nvdisplay/*.patch"
+
+[[annotations]]
+SPDX-License-Identifier = "MIT"
+SPDX-FileCopyrightText = "Copyright 2022-2024 Anduril Industries"
+path = [
+  "packages/pkgs-by-name/linux-pkvm-jetson/*.patch"
+]

--- a/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
@@ -49,6 +49,8 @@
       nvidia.passthroughs.gpu_vm.enable = true;
       nvidia.passthroughs.disp_vm.enable = true;
 
+      nvidia.virtualization.host.dce.enable = true;
+
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
         {

--- a/modules/reference/hardware/jetpack/agx/orin-agx.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx.nix
@@ -46,6 +46,8 @@
       nvidia.passthroughs.gpu_vm.enable = true;
       nvidia.passthroughs.disp_vm.enable = true;
 
+      nvidia.virtualization.host.dce.enable = true;
+
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
         {

--- a/modules/reference/hardware/jetpack/agx/orin-agx64.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx64.nix
@@ -44,6 +44,8 @@
       nvidia.passthroughs.gpu_vm.enable = true;
       nvidia.passthroughs.disp_vm.enable = true;
 
+      nvidia.virtualization.host.dce.enable = true;
+
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
         {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -860,7 +860,14 @@ in
     # assignment. At normal priority it would be a conflicting definition, and
     # the documented remedy would not evaluate.
     hardware.nvidia-jetpack.firmware.eksFile = lib.mkDefault "${firmwareEkbImage}/eks_t234.img";
-    hardware.nvidia-jetpack.kernel.version = "${cfg.kernelVersion}";
+
+    # Check for presence of kernel.version attribute since it is only defined in TII fork
+    hardware.nvidia-jetpack.kernel =
+      lib.optionalAttrs (options ? hardware.nvidia-jetpack.kernel.version)
+        {
+          version = cfg.kernelVersion;
+        };
+
     # jetpack-nixos hardcodes the trailing rootfs device as mmcblk0p1; replay
     # the same default here but route it through cfg.flashScriptOverrides.deviceDiskRootfsPartition
     # so per-SoM modules (e.g. orin-nx → nvme0n1p2) only set the option, not

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -145,6 +145,35 @@ let
           "$out"
       '';
 
+  # Parses Ghaf-specific flags out of the flash script's positional parameters
+  # and exports them for preFlashScript.
+  #
+  # This is spliced inline into jetpack-nixos' flash script rather than living
+  # inside preFlashScript, only there can `set --` rewrite the argument list
+  # that is later forwarded to flash.sh.
+  # flash.sh has no lowercase -s in its optstring, so an extra -s would abort
+  # the flash with an illegal-option error.
+  parseGhafFlashArgs = ''
+    flash_args=()
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -s | --signed-sd-image)
+          if [ "$#" -lt 2 ]; then
+            echo "ERROR: -s requires a directory argument" >&2
+            exit 1
+          fi
+          export SIGNED_SD_IMAGE_DIR="$2"
+          shift 2
+          ;;
+        *)
+          flash_args+=("$1")
+          shift
+          ;;
+      esac
+    done
+    set -- "''${flash_args[@]}"
+  '';
+
   # preFlashCommands: Extract images from sdImage and patch flash.xml
   preFlashScript = pkgs.pkgsBuildBuild.writeShellApplication {
     name = "pre-flash-commands";
@@ -344,6 +373,9 @@ in
       )
       {
         hardware.nvidia-jetpack.flashScriptOverrides.partitionTemplate = partitionTemplate;
-        hardware.nvidia-jetpack.flashScriptOverrides.preFlashCommands = "${preFlashScript}/bin/pre-flash-commands";
+        hardware.nvidia-jetpack.flashScriptOverrides.preFlashCommands = ''
+          ${parseGhafFlashArgs}
+          ${preFlashScript}/bin/pre-flash-commands
+        '';
       };
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/dce-probe-host.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/dce-probe-host.nix
@@ -17,11 +17,14 @@
 # Shared by AGX and NX (both Tegra234 + host-owned DCE): imported from
 # agx/orin-agx.nix and nx/orin-nx.nix.
 {
+  config,
   lib,
   pkgs,
   ...
 }:
 let
+  cfg = config.ghaf.hardware.nvidia.virtualization.host.dce;
+
   # Bare "nvidia,dce-host-proxy" node so the platform driver binds and creates
   # /dev/dce-host. Driver reads no reg/vpa (relays via tegra-dce's exported
   # CPU_RM client API), so the node only needs the compatible. Mirrors
@@ -48,105 +51,118 @@ in
 {
   _file = ./dce-probe-host.nix;
 
-  # Host display driver blacklisted (headless), so nothing in Linux claims the
-  # display clocks/power-domains (dpaux0, SOR, disp, DP PLLs) or the DCE. Then
-  # clk_disable_unused()/genpd_disable_unused() at late_initcall gate them off as
-  # "unused" -- but the host-owned DCE R5 needs them ON for DP-AUX (read EDID) and
-  # to drive the SOR (output). Symptom when gated: DP reads "connected" (HPD
-  # survives) but EDID is 0 bytes (AUX unclocked) and no mode is set (SOR
-  # unclocked) -> no signal. Keep unused clocks + power-domains on.
-  boot.kernelParams = [
-    "clk_ignore_unused"
-    "pd_ignore_unused"
-  ];
+  options.ghaf.hardware.nvidia.virtualization.host.dce.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Make the host the DCE owner for a display-passthrough topology: headless
+      host, forced tegra-dce load, dce-host-proxy + dce-iso-anchor built into
+      nvidia-oot-modules, and the "nvidia,dce-host-proxy" DT node that backs
+      /dev/dce-host.
+    '';
+  };
 
-  # Headless: nothing may bring up COSMIC/graphics and register a CPU_RM display
-  # client on the host; the host CCPLEX must never program display@13800000
-  # (it belongs to the guest).
-  ghaf.profiles.graphics.enable = lib.mkForce false;
+  config = lib.mkIf cfg.enable {
+    # Host display driver blacklisted (headless), so nothing in Linux claims the
+    # display clocks/power-domains (dpaux0, SOR, disp, DP PLLs) or the DCE. Then
+    # clk_disable_unused()/genpd_disable_unused() at late_initcall gate them off as
+    # "unused" -- but the host-owned DCE R5 needs them ON for DP-AUX (read EDID) and
+    # to drive the SOR (output). Symptom when gated: DP reads "connected" (HPD
+    # survives) but EDID is 0 bytes (AUX unclocked) and no mode is set (SOR
+    # unclocked) -> no signal. Keep unused clocks + power-domains on.
+    boot.kernelParams = [
+      "clk_ignore_unused"
+      "pd_ignore_unused"
+    ];
 
-  # Host kernel = base jetpack-nixos for orin-agx
-  # (pkgs.nvidia-jetpack.kernelPackages) + dce-host-proxy spliced into
-  # nvidia-oot-modules. mkForce required: hardware.nvidia-jetpack already sets
-  # boot.kernelPackages at normal priority.
-  boot.kernelPackages = lib.mkForce (
-    (pkgs.nvidia-jetpack.kernelPackages.extend pkgs.nvidia-jetpack.kernelPackagesOverlay).extend (
-      _final: prev: {
-        nvidia-oot-modules = prev.nvidia-oot-modules.overrideAttrs (o: {
-          # nvidia-oot-modules' src is the combined l4t-oot-modules-sources tree
-          # (nvidia-oot/, nvgpu/, nvdisplay/, ... each under its project name).
-          # dce-host-proxy links tegra-dce's EXPORT_SYMBOL'd DCE client API, so it
-          # must build INSIDE nvidia-oot (not the kernel tree). Flatten its source
-          # into dce/ (whose Makefile ccflags already resolve the public
-          # dce-client-ipc.h include) and add as its own obj-m .ko.
-          # dtc + xxd: dce-iso-anchor embeds its runtime DT overlay as a C array
-          # (compiled with -@ so &smmu_iso resolves against the live tree's
-          # __symbols__ at of_overlay_fdt_apply time).
-          nativeBuildInputs = (o.nativeBuildInputs or [ ]) ++ [
-            pkgs.buildPackages.dtc
-            pkgs.buildPackages.unixtools.xxd
-          ];
-          postPatch = (o.postPatch or "") + ''
-            install -D ${./sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.c} \
-              nvidia-oot/drivers/platform/tegra/dce/dce-host-proxy.c
-            install -D ${./sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.h} \
-              nvidia-oot/drivers/platform/tegra/dce/dce-host-proxy.h
-            echo 'obj-m += dce-host-proxy.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
+    # Headless: nothing may bring up COSMIC/graphics and register a CPU_RM display
+    # client on the host; the host CCPLEX must never program display@13800000
+    # (it belongs to the guest).
+    ghaf.profiles.graphics.enable = lib.mkForce false;
 
-            install -D ${./sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.c} \
-              nvidia-oot/drivers/platform/tegra/dce/dce-iso-anchor.c
-            dtc -@ -I dts -O dtb -o dce-iso-anchor.dtbo \
-              ${./sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.dts}
-            xxd -i -n dce_iso_anchor_dtbo dce-iso-anchor.dtbo \
-              > nvidia-oot/drivers/platform/tegra/dce/dce-iso-anchor-dtbo.h
-            echo 'obj-m += dce-iso-anchor.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
-          '';
-        });
+    # Host kernel = base jetpack-nixos for orin-agx
+    # (pkgs.nvidia-jetpack.kernelPackages) + dce-host-proxy spliced into
+    # nvidia-oot-modules. mkForce required: hardware.nvidia-jetpack already sets
+    # boot.kernelPackages at normal priority.
+    boot.kernelPackages = lib.mkForce (
+      (pkgs.nvidia-jetpack.kernelPackages.extend pkgs.nvidia-jetpack.kernelPackagesOverlay).extend (
+        _final: prev: {
+          nvidia-oot-modules = prev.nvidia-oot-modules.overrideAttrs (o: {
+            # nvidia-oot-modules' src is the combined l4t-oot-modules-sources tree
+            # (nvidia-oot/, nvgpu/, nvdisplay/, ... each under its project name).
+            # dce-host-proxy links tegra-dce's EXPORT_SYMBOL'd DCE client API, so it
+            # must build INSIDE nvidia-oot (not the kernel tree). Flatten its source
+            # into dce/ (whose Makefile ccflags already resolve the public
+            # dce-client-ipc.h include) and add as its own obj-m .ko.
+            # dtc + xxd: dce-iso-anchor embeds its runtime DT overlay as a C array
+            # (compiled with -@ so &smmu_iso resolves against the live tree's
+            # __symbols__ at of_overlay_fdt_apply time).
+            nativeBuildInputs = (o.nativeBuildInputs or [ ]) ++ [
+              pkgs.buildPackages.dtc
+              pkgs.buildPackages.unixtools.xxd
+            ];
+            postPatch = (o.postPatch or "") + ''
+              install -D ${./sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.c} \
+                nvidia-oot/drivers/platform/tegra/dce/dce-host-proxy.c
+              install -D ${./sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.h} \
+                nvidia-oot/drivers/platform/tegra/dce/dce-host-proxy.h
+              echo 'obj-m += dce-host-proxy.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
+
+              install -D ${./sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.c} \
+                nvidia-oot/drivers/platform/tegra/dce/dce-iso-anchor.c
+              dtc -@ -I dts -O dtb -o dce-iso-anchor.dtbo \
+                ${./sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.dts}
+              xxd -i -n dce_iso_anchor_dtbo dce-iso-anchor.dtbo \
+                > nvidia-oot/drivers/platform/tegra/dce/dce-iso-anchor-dtbo.h
+              echo 'obj-m += dce-iso-anchor.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
+            '';
+          });
+        }
+      )
+    );
+
+    # boot.extraModulePackages not needed: hardware.nvidia-jetpack already sets
+    # `boot.extraModulePackages = [ config.boot.kernelPackages.nvidia-oot-modules ]`
+    # for jetpackAtLeast "6", resolving against the forced boot.kernelPackages
+    # above, so dce-host-proxy.ko rides along automatically.
+
+    # Blacklist the host display RM stack so no CPU_RM display client registers
+    # and the host never programs display@13800000. tegra-dce deliberately NOT
+    # blacklisted (host must keep bootstrapping/owning the DCE R5). gpu-vm's
+    # default.nix also blacklists nvgpu/host1x; the lists merge.
+    boot.blacklistedKernelModules = [
+      "nvidia"
+      "nvidia_modeset"
+      "nvidia_drm"
+      "tegra_drm"
+    ];
+
+    # nvidia-oot modules do NOT autoload from a DT compatible match. Force-load
+    # tegra-dce (binds real d800000.dce, drives R5 bootstrap to LOCKED) and
+    # dce-host-proxy (binds the injected node, creates /dev/dce-host).
+    # dce-host-proxy links tegra-dce's symbols, so modprobe orders tegra-dce first.
+    boot.kernelModules = [
+      "tegra-dce"
+      "dce-host-proxy"
+      # smmu_iso SID-1 anchor: translating domain for the FE's ISO scanout stream
+      # with DCE high-IOVA -> carveout maps (else panel is lit-but-black under
+      # passthrough). Applies its own DT overlay at load.
+      "dce-iso-anchor"
+    ];
+
+    # /dev/dce-host is opened by patched QEMU (microvm user in kvm group) to relay
+    # guest DCE IPC. Grant kvm group access, mirroring the bpmp-host / vfio rule
+    # in gpu-vm's default.nix.
+    services.udev.extraRules = ''
+      KERNEL=="dce-host", GROUP="kvm", MODE="0660"
+    '';
+
+    hardware.deviceTree.enable = true;
+    hardware.deviceTree.overlays = [
+      {
+        name = "dce_host_overlay";
+        dtsFile = dceHostOverlay;
       }
-    )
-  );
-
-  # boot.extraModulePackages not needed: hardware.nvidia-jetpack already sets
-  # `boot.extraModulePackages = [ config.boot.kernelPackages.nvidia-oot-modules ]`
-  # for jetpackAtLeast "6", resolving against the forced boot.kernelPackages
-  # above, so dce-host-proxy.ko rides along automatically.
-
-  # Blacklist the host display RM stack so no CPU_RM display client registers
-  # and the host never programs display@13800000. tegra-dce deliberately NOT
-  # blacklisted (host must keep bootstrapping/owning the DCE R5). gpu-vm's
-  # default.nix also blacklists nvgpu/host1x; the lists merge.
-  boot.blacklistedKernelModules = [
-    "nvidia"
-    "nvidia_modeset"
-    "nvidia_drm"
-    "tegra_drm"
-  ];
-
-  # nvidia-oot modules do NOT autoload from a DT compatible match. Force-load
-  # tegra-dce (binds real d800000.dce, drives R5 bootstrap to LOCKED) and
-  # dce-host-proxy (binds the injected node, creates /dev/dce-host).
-  # dce-host-proxy links tegra-dce's symbols, so modprobe orders tegra-dce first.
-  boot.kernelModules = [
-    "tegra-dce"
-    "dce-host-proxy"
-    # smmu_iso SID-1 anchor: translating domain for the FE's ISO scanout stream
-    # with DCE high-IOVA -> carveout maps (else panel is lit-but-black under
-    # passthrough). Applies its own DT overlay at load.
-    "dce-iso-anchor"
-  ];
-
-  # /dev/dce-host is opened by patched QEMU (microvm user in kvm group) to relay
-  # guest DCE IPC. Grant kvm group access, mirroring the bpmp-host / vfio rule
-  # in gpu-vm's default.nix.
-  services.udev.extraRules = ''
-    KERNEL=="dce-host", GROUP="kvm", MODE="0660"
-  '';
-
-  hardware.deviceTree.enable = true;
-  hardware.deviceTree.overlays = [
-    {
-      name = "dce_host_overlay";
-      dtsFile = dceHostOverlay;
-    }
-  ];
+    ];
+  };
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/default.nix
@@ -10,6 +10,8 @@
     ./passthrough/gpu-vm
     ./passthrough/disp-vm
     ./passthrough/gui-vm
+    ./pkvm/orin-pkvm.nix
+    ./pkvm/orin-pkvm-host.nix
     ./ownership-assertions.nix
   ];
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/0002-rtk_btusb-Fix-for-kernel-6.16.patch
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/0002-rtk_btusb-Fix-for-kernel-6.16.patch
@@ -1,0 +1,74 @@
+From 87476de5e5ec6e71066824bc9c558990285b1128 Mon Sep 17 00:00:00 2001
+From: Hannu Lyytinen <hannu.lyytinen@unikie.com>
+Date: Wed, 26 Nov 2025 11:45:37 +0200
+Subject: [PATCH 02/11] rtk_btusb: Fix for kernel 6.16+
+
+Signed-off-by: Hannu Lyytinen <hannu.lyytinen@unikie.com>
+---
+ drivers/bluetooth/realtek/rtk_bt.c   | 6 +++---
+ drivers/bluetooth/realtek/rtk_bt.h   | 7 +++++++
+ drivers/bluetooth/realtek/rtk_coex.c | 2 +-
+ 3 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/bluetooth/realtek/rtk_bt.c b/drivers/bluetooth/realtek/rtk_bt.c
+index 7a778a96..9674260a 100644
+--- a/drivers/bluetooth/realtek/rtk_bt.c
++++ b/drivers/bluetooth/realtek/rtk_bt.c
+@@ -2037,12 +2037,12 @@ static int btusb_probe(struct usb_interface *intf,
+ 
+ #if HCI_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+ 	set_bit(BTUSB_USE_ALT3_FOR_WBS, &data->flags);
+-	set_bit(HCI_QUIRK_WIDEBAND_SPEECH_SUPPORTED, &hdev->quirks);
++	rtk_set_quirk(hdev, HCI_QUIRK_WIDEBAND_SPEECH_SUPPORTED);
+ #endif
+ 
+ #if HCI_VERSION_CODE >= KERNEL_VERSION(3, 7, 1)
+ 	if (!reset)
+-		set_bit(HCI_QUIRK_RESET_ON_CLOSE, &hdev->quirks);
++		rtk_set_quirk(hdev, HCI_QUIRK_RESET_ON_CLOSE);
+ #endif
+ 
+ 	/* Interface numbers are hardcoded in the specification */
+@@ -2059,7 +2059,7 @@ static int btusb_probe(struct usb_interface *intf,
+ 	}
+ 
+ #if HCI_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+-	set_bit(HCI_QUIRK_SIMULTANEOUS_DISCOVERY, &hdev->quirks);
++	rtk_set_quirk(hdev, HCI_QUIRK_SIMULTANEOUS_DISCOVERY);
+ #endif
+ 
+ 	err = hci_register_dev(hdev);
+diff --git a/drivers/bluetooth/realtek/rtk_bt.h b/drivers/bluetooth/realtek/rtk_bt.h
+index c60307ad..c9d8c21f 100644
+--- a/drivers/bluetooth/realtek/rtk_bt.h
++++ b/drivers/bluetooth/realtek/rtk_bt.h
+@@ -41,6 +41,13 @@
+ /* #define HCI_VERSION_CODE KERNEL_VERSION(3, 14, 41) */
+ #define HCI_VERSION_CODE LINUX_VERSION_CODE
+ 
++/* Kernel 6.16+ renamed hci_dev->quirks to hci_dev->quirk_flags and added hci_set_quirk() */
++#if HCI_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++#define rtk_set_quirk(hdev, nr) hci_set_quirk(hdev, nr)
++#else
++#define rtk_set_quirk(hdev, nr) set_bit((nr), &(hdev)->quirks)
++#endif
++
+ #define CONFIG_BTCOEX			1
+ #define CONFIG_BTUSB_WAKEUP_HOST	0
+ 
+diff --git a/drivers/bluetooth/realtek/rtk_coex.c b/drivers/bluetooth/realtek/rtk_coex.c
+index 08155ee2..cf0d200d 100644
+--- a/drivers/bluetooth/realtek/rtk_coex.c
++++ b/drivers/bluetooth/realtek/rtk_coex.c
+@@ -2430,7 +2430,7 @@ static void rtk_handle_le_terminate_big_complete_evt(u8 * p)
+ 
+ static void rtk_handle_le_big_sync_established_evt(void * p)
+ {
+-	struct hci_evt_le_big_sync_estabilished *ev = p;
++	struct hci_evt_le_big_sync_established *ev = p;
+ 	u8 status;
+ 	u16 big_handle;
+ 	u16 bis_handle;
+-- 
+2.34.1
+

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm-host.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm-host.nix
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
+let
+  cfg = config.ghaf.host.kernel.hardening;
+
+  nvidiaJetpackFixes = _final: prev: {
+    # Fix CUDA compile failures for x86_64 cross-compile build
+    config =
+      prev.config
+      // lib.optionalAttrs (prev.stdenv.hostPlatform.system != "aarch64-linux") {
+        cudaCapabilities = [ ];
+      };
+
+    nvidia-jetpack = prev.nvidia-jetpack.overrideScope (
+      _sfinal: sprev: {
+        # Fix build error with python 3.14:
+        #   importlib.metadata.PackageNotFoundError: No package metadata was found for uefi-firmware-parser
+        # Set dontCheckPythonMetadata to skip the pythonMetadataCheckPhase.
+        # The nested overrides are needed to reach inside the uefi-firmware-parser derivation.
+        patchfv = sprev.patchfv.override (prevArgs: {
+          python3Packages = prevArgs.python3Packages // {
+            buildPythonPackage =
+              args: prevArgs.python3Packages.buildPythonPackage (args // { dontCheckPythonMetadata = true; });
+          };
+        });
+      }
+    );
+  };
+
+  jetpackHostKconfig =
+    with lib.kernel;
+    {
+      VIRTIO_FS = module;
+      TCG_TIS = module;
+      RTW89 = module;
+      RTW89_8852CE = module;
+    }
+    // import "${inputs.jetpack-nixos}/pkgs/kernels/common-arch.nix" { inherit lib; };
+
+  ootExtraMakeFlags = [
+    "kernel_name=pkvm"
+    "NV_OOT_REALTEK_RTL8822CE_SKIP_BUILD=y"
+    "NV_OOT_REALTEK_RTL8852CE_SKIP_BUILD=y"
+  ];
+  ootMakeFlagsToRemove = [
+    "kernel_name=noble"
+  ];
+
+  jetpackKernelOverlay = final: prev: {
+    nvidia-jetpack = prev.nvidia-jetpack.overrideScope (
+      _sfinal: sprev: {
+        kernel = final.linux_6_18_jetson_pkvm.override {
+          argsOverride.defconfig = "debug_defconfig";
+          structuredExtraConfig = jetpackHostKconfig;
+        };
+
+        kernelPackagesOverlay =
+          kfinal: kprev:
+          let
+            base = sprev.kernelPackagesOverlay kfinal kprev;
+            inherit (kfinal) kernel;
+          in
+          base
+          // lib.optionalAttrs (base ? nvidia-oot-modules) {
+            nvidia-oot-modules = base.nvidia-oot-modules.overrideAttrs (oldAttrs: {
+              # Jetson r39 build requires `bc` and it is not provided by jetpack-nixos
+              nativeBuildInputs =
+                oldAttrs.nativeBuildInputs
+                ++ lib.optional (
+                  !lib.any (d: (d.pname or null) == "bc") oldAttrs.nativeBuildInputs
+                ) final.buildPackages.bc;
+
+              # The submodule path for OOT make is incorrect when using makeFlags instead of commonMakeFlags
+              makeFlags =
+                kernel.commonMakeFlags
+                ++ lib.subtractLists (
+                  kernel.makeFlags ++ ootMakeFlagsToRemove ++ ootExtraMakeFlags
+                ) oldAttrs.makeFlags
+                ++ ootExtraMakeFlags;
+
+              postPatch = (oldAttrs.postPatch or "") + ''
+                if ! grep -q rtk_set_quirk nvidia-oot/drivers/bluetooth/realtek/rtk_bt.h; then
+                  patch -p1 -d nvidia-oot < ${./0002-rtk_btusb-Fix-for-kernel-6.16.patch}
+                fi
+              '';
+            });
+          };
+      }
+    );
+  };
+in
+{
+  _file = ./orin-pkvm-host.nix;
+
+  config = lib.mkIf cfg.hypervisor.enable {
+    nixpkgs.overlays = [
+      nvidiaJetpackFixes
+      jetpackKernelOverlay
+    ];
+
+    ghaf.hardware.nvidia.orin.kernelVersion = lib.mkForce "stable-6-18-pkvm";
+
+    hardware.nvidia-jetpack.majorVersion = lib.mkForce "7";
+
+    # compilation of this nvidia-oot module was skipped
+    boot.initrd.availableKernelModules.rtl8852ce = lib.mkForce false;
+
+    # Passthroughs aren't ported yet
+    ghaf.hardware.nvidia.virtualization.enable = lib.mkForce false;
+    ghaf.hardware.nvidia.virtualization.host.dce.enable = lib.mkForce false;
+
+    ghaf.hardware.nvidia.passthroughs.mgbe0_net_vm.enable = lib.mkForce false;
+    ghaf.hardware.nvidia.passthroughs.gpu_vm.enable = lib.mkForce false;
+    ghaf.hardware.nvidia.passthroughs.disp_vm.enable = lib.mkForce false;
+
+    ghaf.hardware.nvidia.orin.agx.enableNetvmWlanPCIPassthrough = lib.mkForce false;
+  };
+}

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm.nix
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  ...
+}:
+{
+  _file = ./orin-pkvm.nix;
+
+  options.ghaf.host.kernel.hardening = {
+    hypervisor.enable = lib.mkEnableOption "support for protected guests on Orin AGX";
+  };
+}

--- a/modules/reference/hardware/jetpack/nx/orin-nx.nix
+++ b/modules/reference/hardware/jetpack/nx/orin-nx.nix
@@ -56,6 +56,8 @@
       nvidia.passthroughs.gpu_vm.enable = true;
       nvidia.passthroughs.disp_vm.enable = true;
 
+      nvidia.virtualization.host.dce.enable = true;
+
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
         {

--- a/overlays/jetpack-nvdisplay/default.nix
+++ b/overlays/jetpack-nvdisplay/default.nix
@@ -19,13 +19,17 @@
 # jetpack kernel itself still has the three-argument form, so the host build is
 # unaffected -- the conftest simply doesn't match there.
 #
+# L4T < 38 only. From r38 onwards the patch fails to apply because nvdisplay
+# already handles the four argument signature
+#
 # Scoped to the Jetson targets (applied by modules/reference/hardware/jetpack/
 # default.nix) rather than living in overlays.default, the same way
 # overlays.jetpack-python is. Drop this once tiiuae/jetpack-nixos carries the
 # patch in pkgs/kernels/r36/patches/nvdisplay/.
 (_final: prev: {
   nvidia-jetpack = prev.nvidia-jetpack.overrideScope (
-    _jfinal: jprev: {
+    _jfinal: jprev:
+    prev.lib.optionalAttrs (prev.lib.versionOlder jprev.l4tMajorMinorPatchVersion "38") {
       kernelPackagesOverlay =
         kfinal: kprev:
         let

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -23,6 +23,7 @@
     ghaf-vms = final.callPackage ./pkgs-by-name/ghaf-vms/package.nix { };
     gpu-vm-partition-manager-sdk = inputs.gpu-partition-manager.lib.mkSdk { pkgs = final; };
     hardware-scan = final.callPackage ./pkgs-by-name/hardware-scan/package.nix { };
+    linux_6_18_jetson_pkvm = final.callPackage ./pkgs-by-name/linux-pkvm-jetson/package.nix { };
     make-checks = final.callPackage ./pkgs-by-name/make-checks/package.nix { };
     memsocket = final.callPackage ./pkgs-by-name/memsocket/package.nix { };
     pci-binder = final.callPackage ./pkgs-by-name/pci-binder/package.nix { };

--- a/packages/pkgs-by-name/linux-pkvm-jetson/0001-usb-host-Export-xhci_irq.patch
+++ b/packages/pkgs-by-name/linux-pkvm-jetson/0001-usb-host-Export-xhci_irq.patch
@@ -1,0 +1,29 @@
+From 4b1552b3861382dcefd0ace133e7d52501499cb3 Mon Sep 17 00:00:00 2001
+From: Elliot Berman <eberman@anduril.com>
+Date: Tue, 26 Aug 2025 10:31:32 -0700
+Subject: [PATCH 1/2] usb: host: Export xhci_irq
+
+This symbol is used by xhci-tegra, which can be built in a separate
+module from xhci.
+
+Fixes: fd7de45afba5 ("NVIDIA: SAUCE: xhci: tegra: enable firmware log")
+Signed-off-by: Elliot Berman <eberman@anduril.com>
+---
+ drivers/usb/host/xhci-ring.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/usb/host/xhci-ring.c b/drivers/usb/host/xhci-ring.c
+index 7badf91645909..04186add014e4 100644
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -3254,6 +3254,7 @@ irqreturn_t xhci_irq(struct usb_hcd *hcd)
+ 
+ 	return ret;
+ }
++EXPORT_SYMBOL_GPL(xhci_irq);
+ 
+ irqreturn_t xhci_msi_irq(int irq, void *hcd)
+ {
+-- 
+2.50.0
+

--- a/packages/pkgs-by-name/linux-pkvm-jetson/0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch
+++ b/packages/pkgs-by-name/linux-pkvm-jetson/0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch
@@ -1,0 +1,37 @@
+From d122bf9d0678255039dc6e2833dc04f7865c62cc Mon Sep 17 00:00:00 2001
+From: Daniel Fullmer <dfullmer@anduril.com>
+Date: Sat, 14 Feb 2026 13:43:59 -0800
+Subject: [PATCH 2/2] Hack to select VIDEOBUF2_DMA_CONTIG
+
+drivers/media/platform/tegra/camera/vi/channel.c from linux-oot-modules
+has ifdefs for CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
+function. Otherwise it hits a WARN_ON() and outputs
+> tegra-capture-vi: failed to initialize VB2 queue
+
+This option unfortunately can't be set via extraConfig or
+structuredExtraConfig because the config option does not include a
+"prompt" and therefore kconfig sets its visibility to false, and it never
+shows up in "make config",  which prevents generate-config.pl from
+setting it.  Manually adding it to the defconfig doesn't work either.
+
+Here we have a hack to just reuse another option that _is_ already
+enabled and have it select the CONFIG_VIDEOBUF2_DMA_CONTIG
+---
+ drivers/media/common/videobuf2/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/common/videobuf2/Kconfig b/drivers/media/common/videobuf2/Kconfig
+index d2223a12c95fc..a2298bafa0b95 100644
+--- a/drivers/media/common/videobuf2/Kconfig
++++ b/drivers/media/common/videobuf2/Kconfig
+@@ -21,6 +21,7 @@ config VIDEOBUF2_VMALLOC
+ 	select VIDEOBUF2_CORE
+ 	select VIDEOBUF2_MEMOPS
+ 	select DMA_SHARED_BUFFER
++        select VIDEOBUF2_DMA_CONTIG
+ 
+ config VIDEOBUF2_DMA_SG
+ 	tristate
+-- 
+2.50.0
+

--- a/packages/pkgs-by-name/linux-pkvm-jetson/package.nix
+++ b/packages/pkgs-by-name/linux-pkvm-jetson/package.nix
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  buildLinux,
+  structuredExtraConfig ? { },
+  argsOverride ? { },
+  fetchFromGitHub,
+  ...
+}@args:
+buildLinux (
+  args
+  // {
+    pname = "linux-pkvm-jetson";
+    version = "6.18.0";
+    extraMeta.branch = "pkvm-v6.18-dev";
+
+    defconfig = "defconfig";
+
+    src = fetchFromGitHub {
+      owner = "tiiuae";
+      repo = "linux-pkvm-jetson";
+      rev = "37b706a21b55b3183faef75eb594dd249913826a"; # pkvm-v6.18-dev (29-06-2026)
+      hash = "sha256-BWfA7B9piYX6Gq+92f1PPqPjc9onS5DI+3qDVqfHDWs=";
+    };
+    autoModules = false;
+    ignoreConfigErrors = true;
+
+    # TODO try without common config
+    enableCommonConfig = true;
+
+    features = { };
+
+    kernelPatches = [
+      {
+        name = "usb: host: Export xhci_irq";
+        patch = ./0001-usb-host-Export-xhci_irq.patch;
+      }
+      {
+        name = "Hack-to-select-VIDEOBUF2_DMA_CONTIG";
+        patch = ./0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch;
+      }
+    ]
+    ++ args.kernelPatches or [ ];
+
+    structuredExtraConfig =
+      with lib.kernel;
+      {
+        # Override the default CMA_SIZE_MBYTES=32M setting in common-config.nix with the default from tegra_defconfig
+        # Otherwise, nvidia's driver craps out
+        CMA_SIZE_MBYTES = lib.mkForce (freeform "64");
+
+        ### So nat.service and firewall work ###
+        NF_TABLES = module; # This one should probably be in common-config.nix
+        # this NFT_NAT is not actually being set. when build with enableCommonConfig = false;
+        # and not ignoreConfigErrors = true; it will fail with error about unused option
+        # unused means that it wanted to set it as a module, but make oldconfig didn't ask it about that option,
+        # so it didn't get a chance to set it.
+        NFT_NAT = module;
+        NFT_MASQ = module;
+        NFT_REJECT = module;
+        NFT_COMPAT = module;
+        NFT_LOG = module;
+        NFT_COUNTER = module;
+
+        # search for "ip46tables" in nixpkgs and find all the -m options.
+        # Enable the corresponding Kconfigs
+        # TODO: nixpkgs should turn these on themselves.
+        NETFILTER_XT_MATCH_PKTTYPE = module;
+        NETFILTER_XT_MATCH_COMMENT = module;
+        NETFILTER_XT_MATCH_CONNTRACK = module;
+        NETFILTER_XT_MATCH_LIMIT = module;
+        NETFILTER_XT_MATCH_MARK = module;
+        NETFILTER_XT_MATCH_MULTIPORT = module;
+
+        IP_NF_MATCH_RPFILTER = module;
+
+        # IPv6 is enabled by default and without some of these `firewall.service` will explode.
+        IP6_NF_MATCH_AH = module;
+        IP6_NF_MATCH_EUI64 = module;
+        IP6_NF_MATCH_FRAG = module;
+        IP6_NF_MATCH_OPTS = module;
+        IP6_NF_MATCH_HL = module;
+        IP6_NF_MATCH_IPV6HEADER = module;
+        IP6_NF_MATCH_MH = module;
+        IP6_NF_MATCH_RPFILTER = module;
+        IP6_NF_MATCH_RT = module;
+        IP6_NF_MATCH_SRH = module;
+
+        # Needed since mdadm stuff is currently unconditionally included in the initrd
+        # This will hopefully get changed, see: https://github.com/NixOS/nixpkgs/pull/183314
+        MD_LINEAR = module;
+        MD_RAID0 = module;
+        MD_RAID1 = module;
+        MD_RAID10 = module;
+        MD_RAID456 = module;
+
+        # Needed for booting from USB
+        USB_UAS = module;
+
+        FW_LOADER_COMPRESS_XZ = yes;
+        FW_LOADER_COMPRESS_ZSTD = yes;
+
+        # Restore default LSM from security/Kconfig. Undoes Nvidia downstream changes.
+        LSM = freeform "landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf";
+
+        # drivers/media/platform/tegra/camera/vi/channel.c from
+        # linux-oot-modules has ifdefs for
+        # CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
+        # function.
+        # Otherwise it hits a WARN_ON() and outputs
+        # > tegra-capture-vi: failed to initialize VB2 queue
+        VIDEOBUF2_DMA_CONTIG = yes;
+      }
+      // structuredExtraConfig;
+  }
+  // argsOverride
+)

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -214,6 +214,25 @@ let
       };
     })
 
+    (
+      (ghaf-configuration {
+        name = "nvidia-jetson-orin-agx64-pvm";
+        inherit system;
+        profile = "orin";
+        hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-agx64;
+        variant = "debug";
+        extraModules = commonModules;
+        extraConfig = {
+          reference.profiles.mvp-orinuser-trial.enable = true;
+
+          host.kernel.hardening.hypervisor.enable = true;
+        };
+      })
+      // {
+        useLegacyFlash = true;
+      }
+    )
+
     (ghaf-configuration {
       name = "nvidia-jetson-orin-agx-industrial";
       inherit system;

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -485,6 +485,10 @@ let
   flashTarget =
     t: qspiOnly:
     let
+      # TEMP: Used by pkvm target
+      # legacyFlashScript keeps the old flash behavior
+      flashScriptAttr = if t.useLegacyFlash or false then "legacyFlashScript" else "signedFlashScript";
+
       # Shared by both secureboot variants so the two cannot drift apart.
       nxDiskOverrides = lib.optionalAttrs (lib.strings.hasInfix "nx" t.name && !qspiOnly) {
         # NX boots from USB or NVMe; the flash script targets NVMe.
@@ -508,7 +512,7 @@ let
       # construction. Each extra fixpoint is a full re-evaluation -- see
       # `extendModules` in nixpkgs lib/modules.nix, which shares nothing.
       innerName = noSBCfg.config.hardware.nvidia-jetpack.name;
-      noSB = noSBCfg.pkgs.nvidia-jetpack.signedFlashScript;
+      noSB = noSBCfg.pkgs.nvidia-jetpack.${flashScriptAttr};
       # Targets that already enable secureboot unconditionally get the identical
       # derivation back from `mkForce true`, so skip the second fixpoint entirely.
       withSB =
@@ -525,7 +529,7 @@ let
                 // nxDiskOverrides
               )
             ];
-          }).pkgs.nvidia-jetpack.signedFlashScript;
+          }).pkgs.nvidia-jetpack.${flashScriptAttr};
     in
     # Single `*-flash-script` entrypoint that picks between two
     # pre-built QSPI firmware variants at flash time.

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -525,12 +525,6 @@ let
           )
         ];
       };
-      # Read the board name off a fixpoint that is already forced for `noSB`
-      # rather than forcing `t.hostConfiguration` as a third one. The added
-      # modules do not touch `som`/`carrierBoard`, so the string is identical by
-      # construction. Each extra fixpoint is a full re-evaluation -- see
-      # `extendModules` in nixpkgs lib/modules.nix, which shares nothing.
-      innerName = noSBCfg.config.hardware.nvidia-jetpack.name;
       noSB = noSBCfg.pkgs.nvidia-jetpack.${flashScriptAttr};
       # Targets that already enable secureboot unconditionally get the identical
       # derivation back from `mkForce true`, so skip the second fixpoint entirely.
@@ -597,9 +591,9 @@ let
           esac
         done
         if [ "$sb" = 1 ]; then
-          exec ${withSB}/bin/flash-signed-${innerName} "''${args[@]}"
+          exec ${lib.getExe withSB} "''${args[@]}"
         else
-          exec ${noSB}/bin/flash-signed-${innerName} "''${args[@]}"
+          exec ${lib.getExe noSB} "''${args[@]}"
         fi
       '';
     };


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Adds a new target for Orin AGX 64 GB that selects the [pKVM 6.18 kernel](https://github.com/tiiuae/linux-pkvm-jetson) for Ghaf host. 

This kernel is originally built alongside the Linux for Tegra 38.2 NVIDIA BSP. The Ghaf integration selects Jetpack major version 7, which builds against Jetson r39.

The agx64-pvm target brings the following changes:

- Adds a new kernel package: `linux_6_18_jetson_pkvm` kernel, built from [tiiuae/linux-pkvm-jetson](https://github.com/tiiuae/linux-pkvm-jetson) (`pkvm-v6.18-dev` branch)

- Adds `orin-pkvm-host` module for Orin devices. Enabled with `ghaf.host.kernel.hardening.hypervisor`. This module also applies modifications to the jetpack-nixos config and packages, in order to fix build errors that arise from using a more recent kernel.

- The flash script target uses `nvidia-jetpack.legacyFlashScript` instead of `flashScript`. The behavior of these attributes changed in upstream jetpack-nixos: `flashScript` is a new flashing method that uses initrd but has the issue of not flashing the APP partition. `legacyFlashScript` corresponds to the previous flashing method.

- Adds `nvidia-jetson-orin-agx64-pvm` Ghaf compilation target that enables all of the above.

The PR also contains some minor changes:

- Add an enable flag for dce-probe-host.
- Fix behavior of the `-s` command line flag in the flash script.
- Gate some patches behind the L4T version being less than 38.

### Known Caveats

- Guests boot in non-protected mode for now.
- VFIO passthroughs are not yet ported, so all device passthroughs are disabled.

These will be addressed in an upcoming PR.

### Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

Uses #2133 as a base, although this PR should be generally independent of VMM changes.

## Checklist

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [X] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [X] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

The jetpack7 target changes the kernel and the BSP/QSPI firmware, so it needs a full flash.

### Test Steps To Verify:

1. Build the image

```bash
nix build .#nvidia-jetson-orin-agx64-pvm-debug-from-x86_64
```

2. Build the flash script and run it with the resulting sd image:

```bash
nix build -L .#nvidia-jetson-orin-agx64-pvm-debug-from-x86_64-flash-script
sudo ./result/bin/flash-ghaf-host -s /nix/store/4znlg0bmrb39fglmj4nfkhk1jlby3p93-nixos-image-sd-card-26.11.20260726.624af66-aarch64-linux.img.zst-aarch64-unknown-linux-gnu
```

3. Let the board boot and log in on `ghaf-host` (serial console).

4. Check the host kernel:

```bash
[0;ghaf@ghaf-host: ~ghaf@ghaf-host:~]$ uname -a
Linux ghaf-host 6.18.0 #1-NixOS SMP PREEMPT Tue Jan  1 00:00:00 UTC 1980 aarch64 GNU/Linux
```

5. Check pKVM is enabled:

```bash
[0;ghaf@ghaf-host: ~ghaf@ghaf-host:~]$ sudo dmesg | grep -i kvm
[sudo] password for ghaf:
[    0.140866] tegra-mc 2c00000.memory-controller: MC: Registered with pKVM IOMMU framework
[    0.213517] kvm [1]: nv: 568 coarse grained trap handlers
[    0.213792] kvm [1]: IPA Size Limit: 48 bits
[    1.033216] kvm [1]: GICv3: no GICV resource entry
[    1.033278] kvm [1]: disabling GICv2 emulation
[    1.033350] kvm [1]: GIC system register CPU interface enabled
[    1.033476] kvm [1]: vgic interrupt IRQ9
[    1.034363] kvm [1]: Protected hVHE mode initialized successfully
```

6. System VMs are expected to not start because they still use qemu with old option definitions. This is addressed in #2187 
