### PR TITLE
fix(givc-cli): replace direct host-to-VM gRPC stop calls with CLI command

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,17 +334,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1786818071,
-        "narHash": "sha256-75cpo8uG1jbmei7aACnPPQNj8Bg1/1na61981LXDzAQ=",
+        "lastModified": 1786951490,
+        "narHash": "sha256-gPivBHx+QGd+oMfP/Qg1mqDKpYvnUtrX+LbnTlUukvQ=",
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "30660573c7fdb902943d61c08c478bd4afbd343d",
+        "rev": "1c4c0527a22f4a0e32187e21763e08565bc876b6",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
         "repo": "ghaf-givc",
-        "rev": "30660573c7fdb902943d61c08c478bd4afbd343d",
+        "rev": "1c4c0527a22f4a0e32187e21763e08565bc876b6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
     #
     # TEMPORARILY pinned to a commit rather than the branch head
     givc = {
-      url = "github:tiiuae/ghaf-givc/30660573c7fdb902943d61c08c478bd4afbd343d";
+      url = "github:tiiuae/ghaf-givc/1c4c0527a22f4a0e32187e21763e08565bc876b6";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -183,9 +183,7 @@ let
               ;;
             resume)
               echo "Signaling resume to $vm_name..."
-              # Stop unit command not yet implemented in GIVC admin service
-              grpcurl -cacert /etc/givc/ca-cert.pem -cert /etc/givc/cert.pem -key /etc/givc/key.pem \
-              -d '{"UnitName":"systemd-suspend.service"}' "$vm_name":9000 systemd.UnitControlService.StopUnit
+              ${givc-cli} stop service --vm "$vm_name" systemd-suspend.service
               ;;
             *)
               echo "Invalid action: $action"


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Use the newly supported `stop service` CLI command instead of making direct host-to-VM gRPC requests.

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Put the system in suspend state and then resume it. everything should be functional as before.