### PR TITLE
fix(intel-laptop): blacklist WWAN modules to stop a shutdown hang

### DIFF
--- a/modules/reference/hardware/intel-laptop/intel-laptop.nix
+++ b/modules/reference/hardware/intel-laptop/intel-laptop.nix
@@ -17,7 +17,7 @@
         "acpi_osi=linux"
         # `xe,` had lost its comma and read `xesnd_hda_intel`, which is not a
         # module -- so the i915 rival driver was never blacklisted on the host
-        "module_blacklist=iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,snd_sof_pci_intel_mtl,bluetooth,btusb,snd_pcm,mei_me,xe,snd_sof_pci_intel_lnl,spi_intel_pci,i801_smbus,nouveau,nvidia,nvidiafb,i2c_nvidia_gpu"
+        "module_blacklist=iwlwifi,snd_hda_intel,snd_sof_pci_intel_tgl,snd_sof_pci_intel_mtl,bluetooth,btusb,snd_pcm,mei_me,xe,snd_sof_pci_intel_lnl,spi_intel_pci,i801_smbus,nouveau,nvidia,nvidiafb,i2c_nvidia_gpu,option,qmi_wwan,cdc_mbim"
       ];
       stage1.kernelModules = [
         # Load i915 in the host initrd as a hardware workaround: some laptop models


### PR DESCRIPTION
## Description of Changes

An internal WWAN modem's `option` driver can loop forever retrying a write to
its AT-command port once the USB device starts disappearing during shutdown,
so the host never actually powers off or reboots -- indistinguishable from
outside from a genuine hang, since there is no display or network to show
anything is wrong.

Reproduced 0/12 (shutdown+reboot attempts) before this blacklist and 10/10
after, on a dell-7330 Rugged Extreme (Dell DW5821e-eSIM Snapdragon X20 LTE
modem), with a serial console attached to watch every attempt live.

A BIOS-level "disable WWAN radio" does not fix it: that's an RF kill switch,
not a bus-level disable, so the USB device still enumerates and the hang
still happens regardless.

### Type of Change

- [x] Bug fix

## Testing Instructions

### Applicable Targets

- [x] Intel Laptop `x86_64`

### Installation Method

- [x] Can be updated with `nixos-rebuild ... switch`

### Test Steps To Verify:

1. On a machine with an internal WWAN modem, run `nixos-rebuild switch`.
2. Reboot and shut down the machine several times.
3. Confirm the machine completes reboot/shutdown every time, with no
   `usb_wwan_write: submit urb 0 failed: -19` messages on the console.