### PR TITLE
fix(tpm2-pytss): drop obsolete cross patch

### DIFF
--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -38,6 +38,21 @@
     );
   });
 
+  # tpm2-pytss 3.0.0rc1 already invokes $CC -E when preprocessing headers,
+  # so nixpkgs' older cross.patch no longer applies and is no longer needed.
+  pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+    (_pythonFinal: pythonPrev: {
+      tpm2-pytss = pythonPrev.tpm2-pytss.overrideAttrs (
+        oldAttrs:
+        final.lib.optionalAttrs (oldAttrs.version == "3.0.0rc1") {
+          patches = builtins.filter (patch: !(final.lib.hasSuffix "cross.patch" (toString patch))) (
+            oldAttrs.patches or [ ]
+          );
+        }
+      );
+    })
+  ];
+
   # Fix swtpm cross-compilation.
   # swtpm 0.10.1-unstable-2026-05-21 switched its local CA from gnutls certtool
   # to the openssl CLI, so configure.ac now does AC_PATH_PROG([OPENSSL], ...)


### PR DESCRIPTION
tpm2-pytss 3.0.0rc1 already invokes $CC -E when preprocessing headers. The older nixpkgs cross.patch no longer applies to this version and causes aarch64 cross-compilation to fail during patchPhase.

Remove that patch only for 3.0.0rc1 in the cross-compilation overlay.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
