### PR TITLE
feat(orin): add secure A/B update canaries

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -167,6 +167,7 @@ export default defineConfig({
                         "ghaf/dev/guides/extending-targets",
                         "ghaf/dev/guides/downstream-setup",
                         "ghaf/dev/guides/migration",
+                        "ghaf/dev/guides/orin-secure-ab-testing",
                       ],
                     },
                     {

--- a/docs/src/content/docs/ghaf/dev/architecture/ab-update.mdx
+++ b/docs/src/content/docs/ghaf/dev/architecture/ab-update.mdx
@@ -1,150 +1,1032 @@
 ---
-title: A/B Image Update
+title: Secure A/B Image Updates
 ---
 {/*
 SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 SPDX-License-Identifier: CC-BY-SA-4.0
 */}
 
-# A/B Image Update
+# Secure A/B image updates
 
-This page describes the Ghaf image-based A/B update model from three angles:
+This document describes the signed A/B update architecture used by the NVIDIA
+Jetson Orin NX and AGX debug canaries. It covers the trust model, encrypted
+storage layout, manifest contract, transactional installer, first-boot
+provisioning, and health-gated rollback. See
+[Orin secure A/B testing](/ghaf/dev/guides/orin-secure-ab-testing) for executable
+test cases and hardware acceptance procedures.
 
-1. high-level architecture,
-2. operational workflow on a target machine,
-3. implementation details in the build pipeline and manifest tooling.
+:::caution[Development canaries]
+The UEFI and update keys described here are development keys. They do not
+represent NVIDIA fused BootROM trust or a production HSM-backed signing system.
+NX on internal NVMe and AGX on internal eMMC are separate runtime targets; an
+artifact accepted on one target is never evidence for the other.
+:::
 
-## Intro and A/B architecture
+## Goals and invariants
 
-Ghaf uses an image-based A/B update model for immutable systems with dm-verity.
+The implementation maintains these invariants:
 
-- The system keeps versioned **root** and **verity** volumes in LVM.
-- One slot is active (currently booted), and one slot is used as the update target.
-- UKI files are managed in the EFI partition and tied to the slot version/hash.
+- APP is a LUKS2 container. Its decrypted payload is an LVM physical volume.
+- Exactly one root/verity pair is active and the active pair is never modified.
+- At most two complete root/verity pairs exist. Updates reuse the inactive pair.
+- `/` and `/nix/store` remain immutable and dm-verity protected.
+- `/persist` and swap are inside LUKS but are shared across system slots.
+- A manifest binds the exact target, monotonic generation, artifact hashes,
+  packed and unpacked sizes, and full dm-verity root hash.
+- The UKI is independently signed and embeds the same root hash and generation.
+- All authentication and policy checks complete before storage mutation.
+- Installation stages data, verifies it, installs the UKI atomically, and
+  changes boot selection last.
+- Installing an update does not reboot the system.
+- A trial receives three boot attempts and is blessed only after storage and
+  configured core Ghaf MicroVMs are healthy.
+- Failed trials roll back only the immutable system pair; `/persist` is not
+  reverted.
+- Downgrades are rejected unless a debug build explicitly enables and invokes
+  the downgrade override.
 
-An update payload is a small, self-contained artifact set:
+## Storage and boot architecture
 
-- root image,
-- verity image,
-- kernel/UKI image,
-- manifest.
+QSPI firmware and the EFI System Partition (ESP) remain unencrypted. APP uses
+the following layering:
 
-At a high level, update installation writes new images into a non-active slot, updates the corresponding UKI, and switches boot selection to the new slot. The previous slot remains available for rollback.
-
-The manifest is the contract between build-time artifacts and install-time execution. It identifies which files belong together and provides integrity metadata used by the updater.
-
-## Operational workflow (target machine)
-
-Operationally, image updates are handled by `ota-update image` subcommands.
-
-Typical workflow:
-
-1. Validate payload.
-2. Install payload into the selected non-active slot.
-3. Check resulting slot status.
-
-Example commands:
-
-```sh
-# Validate manifest and artifact checksums
-ota-update image validate --manifest /persist/sysupdate/ghaf_x.y.z_xxxxxxxx.manifest
-
-# Install image (optionally enable checksum validation explicitly)
-ota-update image install --manifest /persist/sysupdate/ghaf_x.y.z_xxxxxxxx.manifest --validate
-
-# Show slot/runtime status
-ota-update image status
+```mermaid
+flowchart TB
+  QSPI[QSPI firmware<br/>unencrypted] --> SB[UEFI Secure Boot]
+  ESP[ESP, FAT32<br/>systemd-boot and signed UKIs<br/>unencrypted] --> SB
+  APP[APP partition] --> LUKS[LUKS2 cryptroot]
+  LUKS --> PV[LVM PV, VG pool]
+  PV --> RA[root generation A<br/>EROFS]
+  PV --> VA[verity generation A]
+  PV --> RB[root generation B<br/>EROFS]
+  PV --> VB[verity generation B]
+  PV --> P[persist<br/>Btrfs]
+  PV --> S[swap<br/>randomly encrypted]
+  SB --> UKI[Selected signed UKI]
+  UKI --> RA
+  UKI --> VA
 ```
 
-`ota-update image` always requires an explicit manifest path. In practice, we place image payloads under `/persist/sysupdate` as an operational convention.
+The root image contains the immutable Nix store. The UKI kernel command line
+contains `ghaf.storehash=<64-hex-root-hash>` and
+`ghaf.generation=<positive-integer>`. The initrd uses these values to select the
+matching LVM pair and create the dm-verity mapping.
 
-Note: this directory is reachable from Net VM, so artifacts can be uploaded with `ssh`/`scp` to the target host through the Net VM access path.
+Logical-volume names encode the version and the first 16 hexadecimal digits of
+the root hash:
 
-Other operational commands:
+```text
+pool/root_<version>_<hash-fragment>
+pool/verity_<version>_<hash-fragment>
+```
 
-- `ota-update image remove --version <version> [--hash <fragment>]` removes an installed non-active slot.
-- `--dry-run` (top-level image flag) prints the execution plan without applying changes.
+During installation, temporary LVs use `root_staging_<hash-fragment>` and
+`verity_staging_<hash-fragment>`. They are renamed only after both images have
+been written and `veritysetup verify` succeeds. Runtime discovery also recovers
+or removes incomplete staging state left by an interrupted installation.
 
-Runtime safety notes:
+## Trust model
 
-- `ota-update` uses a global lock (`/run/ota-update.lock`) to prevent concurrent update execution.
-- Removing the active slot is rejected.
+### Development trust directory
 
-## Implementation details
+One persistent local directory is shared by the NX and AGX canaries. Generate
+it outside Git and outside any path copied to the Nix store:
 
-### Build pipeline (`verity-volume.nix`)
+```sh
+umask 077
+nix run .#ghaf-dev-keygen -- --output /secure/local/ghaf-dev-keys
+```
 
-The image build pipeline creates update artifacts in this order:
+`ghaf-dev-keygen` refuses to overwrite an existing trust set and creates:
 
-1. Build root filesystem image.
-2. Generate verity image and dm-verity root hash.
-3. Build UKI and embed the verity hash into kernel cmdline.
-4. Compress root/verity payload images.
-5. Generate manifest.
+| File | Purpose |
+| --- | --- |
+| `PK.key`, `PK.crt` | RSA-2048 UEFI Platform Key |
+| `KEK.key`, `KEK.crt` | RSA-2048 UEFI Key Exchange Key |
+| `db.key`, `db.crt` | RSA-2048 UEFI allowed-signature database and UKI signing |
+| `update.key` | Ed25519 detached-manifest signing key |
+| `update.pub` | Raw 32-byte Ed25519 verification key installed on the target |
+| `recovery-passphrases/` | One mode-0600 printable LUKS recovery passphrase per flash |
 
-This logic is implemented in `modules/partitioning/verity-volume.nix`.
+Private keys must remain on the signing/flash host. The target receives only
+`db.crt` and `update.pub`.
 
-The install-time utility used above, `ota-update`, lives in the `ghaf-givc`
-subproject (crate `ota-update`; flake input `givc`).
+Record a non-secret public-trust inventory when the directory is created and
+before every candidate build:
 
-An important related component is `veritysetup-generator`, provided via flake
-input `nix-store-veritysetup-generator`
-(`github:tiiuae/ghaf-nix-store-veritysetup-generator/ghaf`) and integrated as
-`ghaf-store-veritysetup-generator` in `modules/partitioning/flake-module.nix`.
+```sh
+(
+  cd "$GHAF_DEV_KEY_DIR"
+  sha256sum PK.crt KEK.crt db.crt update.pub
+  openssl x509 -in db.crt -noout -fingerprint -sha256 -dates -subject
+)
+```
 
-### Manifest and artifact identity
+Store the inventory with release evidence, not the private keys. The flash
+script embeds the four file digests seen during impure evaluation. Before it
+prepares any image, it requires the runtime `GHAF_DEV_KEY_DIR` to contain the
+same public files and verifies that `db.key` matches `db.crt` and `update.key`
+matches `update.pub`. A public-trust mismatch fails exactly with:
 
-The manifest stores release identity and integrity metadata for root/verity/kernel artifacts. It ties together:
+```text
+ERROR: GHAF_DEV_KEY_DIR public trust does not match the trust embedded at image evaluation: <file>
+  Rebuild the flash script with this exact GHAF_DEV_KEY_DIR.
+```
 
-- version + hash fragment naming,
-- dm-verity root hash,
-- file checksums and sizes.
+A private/public mismatch identifies either `db.key/db.crt` or
+`update.key/update.pub`. Never work around either error by mixing files from
+two directories: rebuild with the intended complete directory.
 
-Install-time logic consumes this manifest to validate payload consistency and to produce an installation plan.
+Pure evaluation and CI builds do not require external settings. When
+`GHAF_DEV_KEY_DIR` is unset, the canary uses repository development UEFI
+certificates and the public RFC 8032 test-vector key. The corresponding update
+private key is public knowledge, so this mode is for evaluation/build coverage
+only. Evaluation prints exactly:
 
-Manifest format (current shape):
+```text
+<target>: GHAF_DEV_KEY_DIR is unset; using repository development public trust for evaluation/build only. Secure A/B flashing and update signing require GHAF_DEV_KEY_DIR from ghaf-dev-keygen; the exported flash script falls back to the generic unsigned target.
+```
+
+When `--impure` exposes a complete external public trust set, evaluation uses
+it and prints exactly:
+
+```text
+<target>: using external public trust from GHAF_DEV_KEY_DIR; private signing keys remain outside the Nix store.
+```
+
+If `GHAF_DEV_KEY_DIR` is set but a required public file is missing, evaluation
+fails and lists the missing file names. Secure A/B flashing and update signing
+always require the external private keys and fail before mutation if the
+variable or any required file is absent.
+
+The CI-only A/B image remains available for build coverage, but it must never
+be deployed: its update verification key is public knowledge. To keep the
+standard flash attribute useful in CI and development, the exported
+`*-verity-luks-debug-*-flash-script` delegates to the same board's existing
+generic unsigned target instead of invoking the secure A/B flash
+implementation. It prints exactly:
+
+```text
+WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead.
+  Requested: <secure-A/B-target>
+  Fallback:  <generic-target>
+  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen to flash the secure A/B canary.
+```
+
+The fallback is a different image and partitioning configuration; it does not
+silently turn the CI-only A/B image into a deployable image. The wrapper strips
+secure-image-only `--secure-boot`, `-u`/`--uki`, and
+`-s`/`--signed-sd-image` arguments with explicit warnings so they cannot alter
+the generic fallback. The internal secure A/B flash implementation retains its
+original fail-closed check as defense in depth when invoked directly.
+
+### Independent authentication layers
+
+The update has two independent signatures:
+
+1. A raw 64-byte detached Ed25519 signature authenticates the exact manifest
+   bytes. Its default path is `<manifest>.sig`.
+2. The UEFI `db` key signs the UKI. The updater verifies its Authenticode
+   signature against the configured `db.crt`, and firmware verifies it during
+   boot.
+
+The manifest signature binds the payload metadata. The UKI signature prevents
+an attacker from substituting boot code. The updater additionally extracts the
+UKI command line and requires its root hash and generation to equal the signed
+manifest values.
+
+### LUKS keyslots
+
+The flash process formats APP as LUKS2 with the temporary manufacturer key in
+slot 0 and a newly generated recovery passphrase in slot 1. On first boot, the
+OP-TEE device-unique-key flow replaces the manufacturer credential while
+preserving the recovery slot. The recovery passphrase is printed during flash
+and saved under `GHAF_DEV_KEY_DIR/recovery-passphrases/` without a trailing
+newline.
+
+Never put a recovery passphrase in Git, logs, issue trackers, or test reports.
+Record only the recovery file name and whether recovery unlock passed.
+
+### Development-key lifecycle
+
+Treat one trust directory as an indivisible, named set. Back it up encrypted,
+restrict it to release operators, record certificate expiry and public
+fingerprints, and associate every recovery-passphrase filename with the board
+and flash record without recording the passphrase itself. Keep an encrypted,
+offline LUKS header backup for each flashed APP device; the header and recovery
+passphrase are both sensitive recovery material.
+
+There is no supported in-place trust rotation or revocation workflow in this
+development canary. Losing a private signing key prevents new updates; losing
+the only matching recovery material can make storage recovery impossible.
+Creating a new trust directory requires rebuilding and destructively reflashing
+the canary, then generating a new per-flash recovery passphrase. Do not overwrite
+or partially replace files in an existing directory.
+
+## Signed manifest v2
+
+Build output contains compressed root and verity images, a UKI, and a manifest.
+After signing, a payload directory has this shape:
+
+```text
+ghaf_<version>_<hash>.manifest
+ghaf_<version>_<hash>.manifest.sig
+ghaf_root_<version>_<hash>.raw.zst
+ghaf_verity_<version>_<hash>.raw.zst
+ghaf_kernel_<version>_<hash>.efi
+```
+
+The manifest schema is:
 
 ```json
 {
-  "manifest_version": 0,
-  "system": "x86_64-linux",
+  "manifest_version": 2,
+  "system": "aarch64-linux",
+  "target": "nvidia-jetson-orin-nx-verity-luks-debug",
+  "generation": 8,
   "meta": {},
-  "version": "26.04.1",
-  "root_verity_hash": "<64-hex>",
+  "version": "26.08.1",
+  "root_verity_hash": "<exactly 64 hexadecimal characters>",
   "root": {
     "file": "ghaf_root_<version>_<hash>.raw.zst",
-    "sha256": "<hex>",
-    "packed_size": 0,
-    "unpacked_size": 0
+    "sha256": "<64-hex SHA-256>",
+    "packed_size": 2147483648,
+    "unpacked_size": 6442450944
   },
   "verity": {
     "file": "ghaf_verity_<version>_<hash>.raw.zst",
-    "sha256": "<hex>",
-    "packed_size": 0,
-    "unpacked_size": 0
+    "sha256": "<64-hex SHA-256>",
+    "packed_size": 67108864,
+    "unpacked_size": 134217728
   },
   "kernel": {
     "file": "ghaf_kernel_<version>_<hash>.efi",
-    "sha256": "<hex>",
-    "unpacked_size": 0
+    "sha256": "<64-hex SHA-256>",
+    "packed_size": 67108864,
+    "unpacked_size": 67108864
   }
 }
 ```
 
-All artifact file names in the manifest are interpreted relative to the manifest file location.
+Artifact names must be basenames, not paths. All artifacts are resolved relative
+to the manifest. `packed_size` describes the transferred file;
+`unpacked_size` sizes and bounds the destination LV. Generation must be a
+positive integer. `system` records the Nix target platform for compatible
+tooling. The target must exactly equal the target configured on the device.
 
-The `meta` field is reserved for human-readable user information and/or structured metadata, including potential future GUI-facing usage.
-
-### `mk-manifest` utility (target design)
-
-`mk-manifest` is the build-time utility responsible for manifest lifecycle operations.
-
-- `build`: produce final artifact names and a manifest for a new payload.
-- `sign`: produce a signed kernel artifact and write an updated manifest.
-- `rehash`: recompute kernel integrity fields in an existing manifest.
-
-In the current target design, the utility is packaged as `ghaf-mk-manifest`, and exposed for convenience via:
+Sign an unsigned build output without modifying its source directory:
 
 ```sh
-nix run .#mk-manifest -- --help
+nix run .#ghaf-sign-update -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input result-update/ghaf_<version>_<hash>.manifest \
+  --output signed-update
 ```
+
+The signer copies the payload, recomputes root and verity metadata, signs the
+UKI with `db.key`, recomputes its metadata, and finally signs the exact manifest
+with `update.key`.
+
+## Publishing and fetching updates
+
+There are two development delivery paths:
+
+- a static HTTP server on the developer machine for a manual, isolated-lab
+  round trip; and
+- an OCI Distribution-compatible HTTPS registry for authenticated repository,
+  discovery, and credential testing.
+
+In both paths, `net-vm` owns the network connection and writes into the host's
+shared `/persist/sysupdate` directory. The Ghaf host—not `net-vm`—performs the
+trusted validation and storage installation. Transport success is never
+authorization to install.
+
+```mermaid
+flowchart LR
+  D[Developer host<br/>build and sign] --> S[Static development server<br/>HTTP]
+  D --> R[OCI registry<br/>HTTPS]
+  S --> N[Orin net-vm<br/>manual fetch]
+  R --> N[Orin net-vm<br/>discover and pull]
+  N --> P[Shared /persist/sysupdate]
+  P --> H[Ghaf host<br/>validate and install]
+  H --> B[Boot-counted trial]
+```
+
+| Capability | Current canary | Operator or future policy |
+| --- | --- | --- |
+| Build and sign | Developer host | Manual, external private keys |
+| Static HTTP fetch | `net-vm` | Manual, isolated development only |
+| OCI discover and pull | `net-vm` | Manual command with provisioned credential |
+| Host validation and install | Ghaf host | Manual, privileged command |
+| Reboot into trial | Ghaf host | Manual operator decision |
+| Health blessing or rollback | Ghaf host | Automatic after a trial boots |
+| Scheduled discovery/download | Not configured | Requires a timer, backoff, capacity policy, and credential provisioning |
+| Approval and unattended install/reboot | Not configured | Requires fleet policy, maintenance windows, audit logging, and recovery ownership |
+
+Do not describe manual device-initiated pull as unattended updating. Automation
+must preserve the network/trusted-host boundary, serialize installation with the
+existing lock, require a completely published bundle, and define who approves
+download, install, and reboot separately.
+
+### Static development HTTP server
+
+Use this path to test an NX or AGX on the same controlled development network
+without setting up an OCI registry. Plain HTTP has no server authentication,
+confidentiality, repository policy, or rollback protection. The detached
+manifest signature, artifact hashes, exact target, accepted generation, UKI
+signature, and embedded root hash still protect installation, but an attacker
+can observe traffic, deny service, or substitute data that validation will
+reject. Never use this path as a production update service.
+
+The secure canary `net-vm` contains `curl` and `jq` for this procedure. The
+Ghaf host intentionally has no direct external fetch step.
+
+#### Prepare a public server directory
+
+Start with an already signed NX or AGX payload. Open a developer shell with the
+server tools if the machine does not provide them:
+
+```sh
+nix shell nixpkgs#python3 nixpkgs#jq nixpkgs#curl
+```
+
+Create a new directory containing only the five public payload files. Do not
+serve the build tree, trust directory, recovery passphrases, or private keys:
+
+```sh
+SIGNED_DIR="signed-nx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+test -s "$SIGNED_MANIFEST"
+test -s "$SIGNED_MANIFEST.sig"
+
+HTTP_ROOT="$(mktemp -d)"
+install -m 0644 "$SIGNED_MANIFEST" "$HTTP_ROOT/manifest.json"
+install -m 0644 "$SIGNED_MANIFEST.sig" "$HTTP_ROOT/manifest.json.sig"
+
+for kind in root verity kernel; do
+  artifact="$(jq -er --arg kind "$kind" '.[$kind].file' "$SIGNED_MANIFEST")"
+  case "$artifact" in
+    "" | .* | *[!A-Za-z0-9._-]*)
+      echo "Unsafe $kind artifact name: $artifact" >&2
+      exit 1
+      ;;
+  esac
+  test -s "$SIGNED_DIR/$artifact"
+  install -m 0644 "$SIGNED_DIR/$artifact" "$HTTP_ROOT/$artifact"
+done
+
+test "$(find "$HTTP_ROOT" -mindepth 1 -maxdepth 1 -type f | wc -l)" -eq 5
+find "$HTTP_ROOT" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' | sort
+```
+
+The manifest is copied byte-for-byte to the stable HTTP name `manifest.json`;
+renaming it does not invalidate its detached signature. The three artifact
+names remain exactly those signed into the manifest.
+
+#### Bind and test the server
+
+Choose an unused non-privileged port and an address on the developer interface
+reachable from the Orin physical network. Do not bind only to loopback. Keep
+the advertised origin out of Git and test reports:
+
+```sh
+export UPDATE_HTTP_BIND='<developer-interface-address>'
+export UPDATE_HTTP_PORT='<non-privileged-port>'
+export UPDATE_HTTP_ORIGIN="http://${UPDATE_HTTP_BIND}:${UPDATE_HTTP_PORT}"
+
+python3 -m http.server \
+  --bind "$UPDATE_HTTP_BIND" \
+  --directory "$HTTP_ROOT" \
+  "$UPDATE_HTTP_PORT"
+```
+
+Leave that command in its own terminal. If the developer firewall blocks the
+port, add a temporary inbound TCP rule scoped to the development interface and
+the target network only. Do not open the server to an untrusted network.
+
+From a second developer terminal, confirm that HTTP returns the exact signed
+manifest:
+
+```sh
+curl --fail --silent --show-error \
+  "$UPDATE_HTTP_ORIGIN/manifest.json" \
+  | cmp - "$HTTP_ROOT/manifest.json"
+```
+
+#### Fetch from the device's `net-vm`
+
+Open the debug console or an authenticated administrative session to
+`net-vm`. Set the origin to the developer server and choose a new shared
+destination. The following function rejects path-like manifest names and
+publishes each file only after its download succeeds:
+
+```sh
+export UPDATE_HTTP_ORIGIN='http://<developer-interface-address>:<port>'
+export GHAF_UPDATE_GENERATION='<candidate-generation>'
+FETCH_PARENT=/persist/sysupdate
+FINAL_DIR="$FETCH_PARENT/http-generation-$GHAF_UPDATE_GENERATION"
+test ! -e "$FINAL_DIR" || {
+  echo "Refusing to reuse published fetch directory: $FINAL_DIR" >&2
+  exit 1
+}
+FETCH_DIR="$(mktemp -d "$FETCH_PARENT/.http-generation-$GHAF_UPDATE_GENERATION.XXXXXX")"
+chmod 0755 "$FETCH_DIR"
+
+fetch_file() {
+  file="$1"
+  case "$file" in
+    "" | .* | *[!A-Za-z0-9._-]*)
+      echo "Unsafe update file name: $file" >&2
+      return 1
+      ;;
+  esac
+  curl --fail --show-error --location \
+    --proto '=http' --proto-redir '=http' \
+    --retry 3 --retry-all-errors \
+    --output "$FETCH_DIR/$file.part" \
+    "$UPDATE_HTTP_ORIGIN/$file"
+  mv -- "$FETCH_DIR/$file.part" "$FETCH_DIR/$file"
+}
+
+fetch_file manifest.json
+fetch_file manifest.json.sig
+
+for kind in root verity kernel; do
+  artifact="$(jq -er --arg kind "$kind" '.[$kind].file' "$FETCH_DIR/manifest.json")"
+  fetch_file "$artifact"
+done
+
+touch "$FETCH_DIR/fetch.complete"
+sync "$FETCH_DIR"
+mv -T -- "$FETCH_DIR" "$FINAL_DIR"
+sync "$FETCH_PARENT"
+FETCH_DIR="$FINAL_DIR"
+```
+
+If a transfer fails, do not create `fetch.complete`. Retain the hidden temporary
+directory as failure evidence or delete that exact directory after inspecting
+it; the next attempt must create a new temporary directory. Never retry inside
+an old published directory, because it may contain a stale completion marker or
+artifacts from a different manifest. The final same-filesystem rename publishes
+all five files and the marker together. A successful HTTP status does not
+authenticate any file.
+
+#### Validate and install on the Ghaf host
+
+Return to the Ghaf host. The shared directory is the same path there. Require
+the completion marker, then run all three updater phases explicitly:
+
+```sh
+PULLED_MANIFEST="/persist/sysupdate/http-generation-<candidate-generation>/manifest.json"
+test -f "$(dirname "$PULLED_MANIFEST")/fetch.complete"
+test -s "$PULLED_MANIFEST"
+test -s "$PULLED_MANIFEST.sig"
+
+sudo ota-update image validate --manifest "$PULLED_MANIFEST"
+sudo ota-update image --dry-run install --manifest "$PULLED_MANIFEST"
+sudo ota-update image install --manifest "$PULLED_MANIFEST"
+```
+
+Validation must complete before any LVM or ESP mutation. Installation must
+report that a reboot is required and must not reboot automatically. Reboot
+under operator control and observe the normal three-attempt health-gated trial.
+
+For AGX, use a signed AGX directory and the exact AGX manifest target; the HTTP
+server and `net-vm` steps are otherwise identical. Storage installation then
+targets the AGX eMMC inactive pair rather than the NX NVMe inactive pair.
+
+#### Negative tests and cleanup
+
+Before accepting this transport path, exercise these cases:
+
+- stop the server during each of the five downloads: no completion marker is
+  written and no host installation is attempted;
+- alter the fetched manifest, signature, UKI, root image, or verity image: host
+  validation fails before mutation;
+- offer a correctly signed payload for the other Orin target: exact-target
+  policy rejects it;
+- offer an accepted or older generation: generation policy rejects it; and
+- fetch successfully but omit `fetch.complete`: the documented operator
+  procedure stops before validation/install.
+
+After the run, stop the server, remove the temporary firewall rule, and either
+retain the public server directory with the test evidence or delete that exact
+temporary directory after checking its contents. Never record the developer
+address, credentials, private keys, or recovery passphrase in committed
+documentation.
+
+The registry artifact contains the exact signed manifest as its OCI config and
+four required layers:
+
+- detached Ed25519 signature,
+- signed UKI,
+- compressed root image, and
+- compressed verity image.
+
+An optional changelog can be a fifth layer. Pull preserves the manifest bytes
+and writes the signature as `manifest.json.sig`, allowing the normal
+`ota-update image validate` command to authenticate the downloaded bundle.
+
+### Registry setup
+
+The registry must support the OCI Distribution API over HTTPS. Create a
+repository for the NX canary and issue separate credentials:
+
+- a short-lived or CI-scoped write credential for the developer host, and
+- a read-only credential for `net-vm`.
+
+Use role-based variables rather than embedding an endpoint or credential in the
+source tree:
+
+```sh
+export REGISTRY_ENDPOINT='<registry-dns-name>'
+export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
+export UPDATE_TAG="generation-$GHAF_UPDATE_GENERATION"
+export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
+read -rsp 'Registry token: ' REGISTRY_TOKEN
+export REGISTRY_TOKEN
+```
+
+Omit `--token` for a deliberately anonymous repository. Basic authentication is
+also available through `--username` and `--password`. Do not use `--insecure`
+outside an isolated throwaway test registry.
+
+#### Disposable local HTTPS registry
+
+Use this procedure when no registry service is available. It follows the
+[CNCF Distribution deployment model](https://distribution.github.io/distribution/about/deploying/)
+with TLS and bcrypt `htpasswd` authentication. The registry is disposable and
+has no repository-level authorization: its one short-lived credential can both
+push and pull, so it does not demonstrate production read-only policy.
+
+Choose a lab DNS name that resolves to the developer interface from both the
+developer host and `net-vm`. Keep its address out of committed files:
+
+```sh
+export CONTAINER_ENGINE=podman # use docker if that is the approved engine
+export REGISTRY_DNS='<registry-dns-name>'
+export REGISTRY_BIND='<developer-interface-address>'
+export REGISTRY_PORT='<non-privileged-port>'
+export REGISTRY_ENDPOINT="${REGISTRY_DNS}:${REGISTRY_PORT}"
+export REGISTRY_ROOT="$(mktemp -d)"
+install -d -m 0700 \
+  "$REGISTRY_ROOT/auth" "$REGISTRY_ROOT/certs" "$REGISTRY_ROOT/data"
+```
+
+Create a two-day development CA and a server certificate with the DNS name in
+its subject alternative name:
+
+```sh
+openssl req -x509 -newkey rsa:3072 -nodes -days 2 -sha256 \
+  -subj '/CN=Ghaf disposable registry CA/' \
+  -keyout "$REGISTRY_ROOT/certs/ca.key" \
+  -out "$REGISTRY_ROOT/certs/ca.crt"
+openssl req -new -newkey rsa:3072 -nodes -sha256 \
+  -subj "/CN=$REGISTRY_DNS/" \
+  -keyout "$REGISTRY_ROOT/certs/server.key" \
+  -out "$REGISTRY_ROOT/certs/server.csr"
+printf 'subjectAltName=DNS:%s\nextendedKeyUsage=serverAuth\n' "$REGISTRY_DNS" \
+  > "$REGISTRY_ROOT/certs/server.ext"
+openssl x509 -req -days 2 -sha256 \
+  -in "$REGISTRY_ROOT/certs/server.csr" \
+  -CA "$REGISTRY_ROOT/certs/ca.crt" \
+  -CAkey "$REGISTRY_ROOT/certs/ca.key" -CAcreateserial \
+  -extfile "$REGISTRY_ROOT/certs/server.ext" \
+  -out "$REGISTRY_ROOT/certs/server.crt"
+```
+
+Create one random test password without placing it in shell history or the
+`htpasswd` command line, then start Distribution Registry 3:
+
+```sh
+export REGISTRY_USER=ghaf-update-test
+read -rsp 'Disposable registry password: ' REGISTRY_PASSWORD
+printf '\n'
+export REGISTRY_PASSWORD
+printf '%s\n' "$REGISTRY_PASSWORD" \
+  | "$CONTAINER_ENGINE" run --rm -i --entrypoint htpasswd \
+      docker.io/library/httpd:2 -Bni "$REGISTRY_USER" \
+  > "$REGISTRY_ROOT/auth/htpasswd"
+
+"$CONTAINER_ENGINE" run -d --name ghaf-update-registry \
+  --publish "${REGISTRY_BIND}:${REGISTRY_PORT}:5000" \
+  --volume "$REGISTRY_ROOT/data:/var/lib/registry:Z" \
+  --volume "$REGISTRY_ROOT/certs:/certs:Z,ro" \
+  --volume "$REGISTRY_ROOT/auth:/auth:Z,ro" \
+  --env REGISTRY_HTTP_TLS_CERTIFICATE=/certs/server.crt \
+  --env REGISTRY_HTTP_TLS_KEY=/certs/server.key \
+  --env REGISTRY_AUTH=htpasswd \
+  --env 'REGISTRY_AUTH_HTPASSWD_REALM=Ghaf development registry' \
+  --env REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+  docker.io/library/registry:3
+
+curl --fail --silent --show-error \
+  --cacert "$REGISTRY_ROOT/certs/ca.crt" \
+  --user "$REGISTRY_USER:$REGISTRY_PASSWORD" \
+  "https://${REGISTRY_ENDPOINT}/v2/"
+```
+
+For developer-host `ota-update` commands, set
+`SSL_CERT_FILE="$REGISTRY_ROOT/certs/ca.crt"` and replace `--token` with
+`--username "$REGISTRY_USER" --password "$REGISTRY_PASSWORD"`. Transfer only
+`ca.crt` to `net-vm` through the authenticated administrative channel, compare
+its SHA-256 with the developer-host value, and set `SSL_CERT_FILE` to that copy
+before discover or pull. Never fetch the CA from the registry it is meant to
+authenticate. The password is visible in the current CLI process arguments;
+use only this short-lived disposable credential on a controlled test system.
+
+After the host and device round trips, save only artifact digests and results,
+then stop the container and delete the exact temporary root after verifying its
+path:
+
+```sh
+"$CONTAINER_ENGINE" rm -f ghaf-update-registry
+test -n "$REGISTRY_ROOT" && test "$REGISTRY_ROOT" != / && rm -rf -- "$REGISTRY_ROOT"
+unset REGISTRY_PASSWORD SSL_CERT_FILE
+```
+
+### Publish from the developer host
+
+After building and signing the candidate, locate the signed manifest and push
+the complete bundle:
+
+```sh
+SIGNED_DIR="signed-nx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+test -n "$SIGNED_MANIFEST"
+test -s "$SIGNED_MANIFEST.sig"
+
+nix run 'path:../ghaf-givc#ota-update' -- \
+  registry --token "$REGISTRY_TOKEN" push \
+  --manifest "$SIGNED_MANIFEST" \
+  "$UPDATE_REF"
+```
+
+The push fails if any manifest artifact or detached signature is absent. Record
+the returned OCI manifest digest with the test evidence.
+
+### Test a round-trip fetch on the developer host
+
+Pull into a temporary directory before offering the update to hardware:
+
+```sh
+PULL_ROOT="$(mktemp -d)"
+nix run 'path:../ghaf-givc#ota-update' -- \
+  registry --token "$REGISTRY_TOKEN" pull --validate \
+  --destination "$PULL_ROOT" \
+  "$UPDATE_REF"
+
+PULLED_MANIFEST="$PULL_ROOT/$UPDATE_REPOSITORY_PATH/$UPDATE_TAG/manifest.json"
+test -s "$PULLED_MANIFEST"
+test -s "$PULLED_MANIFEST.sig"
+cmp "$SIGNED_MANIFEST" "$PULLED_MANIFEST"
+cmp "$SIGNED_MANIFEST.sig" "$PULLED_MANIFEST.sig"
+```
+
+`registry pull --validate` checks OCI blob digests plus manifest artifact sizes
+and hashes. It does not replace the signed image-policy validation. Authenticate
+the round-tripped bundle separately:
+
+```sh
+nix run 'path:../ghaf-givc#ota-update' -- image validate \
+  --manifest "$PULLED_MANIFEST" \
+  --trusted-key "$GHAF_DEV_KEY_DIR/update.pub" \
+  --uki-trusted-cert "$GHAF_DEV_KEY_DIR/db.crt" \
+  --target nvidia-jetson-orin-nx-verity-luks-debug \
+  --accepted-generation-file "$PULL_ROOT/accepted-generation"
+```
+
+An absent accepted-generation file means no generation has yet been accepted in
+this isolated transport test.
+
+### Fetch on the NX through `net-vm`
+
+The Ghaf host intentionally does not need a direct external network path.
+`net-vm` includes `ota-update` and mounts the host's `/persist/sysupdate` through
+virtiofs. From a `net-vm` console or authenticated administrative session:
+
+```sh
+export REGISTRY_ENDPOINT='<registry-dns-name>'
+export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
+export UPDATE_TAG='<approved-tag>'
+export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
+read -rsp 'Read-only registry token: ' REGISTRY_TOKEN
+export REGISTRY_TOKEN
+
+ota-update registry --token "$REGISTRY_TOKEN" discover \
+  "${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}"
+
+ota-update registry --token "$REGISTRY_TOKEN" pull --validate \
+  --destination /persist/sysupdate \
+  "$UPDATE_REF"
+```
+
+Do not pass `--install` to `registry pull`. Network retrieval belongs to
+`net-vm`; target policy validation and LVM/ESP mutation belong to the host. The
+pull result is visible on the host at:
+
+```text
+/persist/sysupdate/<namespace>/ghaf-orin-nx/<approved-tag>/manifest.json
+/persist/sysupdate/<namespace>/ghaf-orin-nx/<approved-tag>/manifest.json.sig
+```
+
+On the Ghaf host, validate, preview, and install the fetched payload:
+
+```sh
+PULLED_MANIFEST='/persist/sysupdate/<namespace>/ghaf-orin-nx/<approved-tag>/manifest.json'
+
+sudo ota-update image validate --manifest "$PULLED_MANIFEST"
+sudo ota-update image --dry-run install --manifest "$PULLED_MANIFEST"
+sudo ota-update image install --manifest "$PULLED_MANIFEST"
+```
+
+Confirm that installation reports a reboot requirement without rebooting, then
+reboot under operator control and observe the health-gated trial.
+
+This is device-initiated fetching because the pull executes on the NX's
+network-owning VM. The current canary does not schedule registry discovery or
+installation automatically; adding a timer and securely provisioned read token
+is a separate fleet-policy decision.
+
+## Installer validation and transaction
+
+The target configuration provides these defaults:
+
+```text
+GHAF_UPDATE_TRUSTED_KEY=/etc/ghaf/update/update.pub
+GHAF_UKI_TRUSTED_CERT=/etc/ghaf/update/db.crt
+GHAF_UPDATE_TARGET=<exact canary target>
+GHAF_ACCEPTED_GENERATION_FILE=/persist/common/ota/accepted-generation
+```
+
+NixOS writes these values through `environment.sessionVariables`, and the
+configured `sudo` PAM service imports the system environment. The short
+`sudo ota-update ...` examples therefore work on a normally booted canary. In a
+rescue shell, chroot, or any context that does not use that PAM path, pass every
+trust input explicitly:
+
+```sh
+sudo ota-update image install \
+  --manifest "$PULLED_MANIFEST" \
+  --signature "$PULLED_MANIFEST.sig" \
+  --trusted-key /etc/ghaf/update/update.pub \
+  --uki-trusted-cert /etc/ghaf/update/db.crt \
+  --target '<exact-canary-target>' \
+  --accepted-generation-file /persist/common/ota/accepted-generation
+```
+
+Before downloading or installing, check the shared download area, ESP, and VG:
+
+```sh
+df -h /persist /boot
+find /persist/sysupdate -mindepth 1 -maxdepth 2 -type f -printf '%s %p\n' | sort -n
+find /boot/EFI/Linux -maxdepth 1 -type f -printf '%s %f\n' | sort -n
+sudo vgs --units b --nosuffix -o vg_name,vg_size,vg_free pool
+sudo lvs --units b --nosuffix -o lv_name,lv_size pool
+jq '{generation, root: .root.unpacked_size, verity: .verity.unpacked_size, kernel: .kernel.packed_size}' "$PULLED_MANIFEST"
+```
+
+Run the dry-run plan before mutation. A candidate larger than the inactive LVs
+requires sufficient VG free space for their resize; insufficient space fails
+before writes and never permits shrinking or overwriting the active pair. Keep
+room on the ESP for the temporary UKI plus the two managed entries. Prune OCI
+downloads with `ota-update registry prune --destination /persist/sysupdate`;
+inspect and remove only explicitly identified hidden HTTP temporary directories.
+Never delete the active UKI, active LVs, accepted-generation file, or an
+unexamined staging LV to make space.
+
+`ota-update image install` performs the following sequence:
+
+```mermaid
+flowchart TD
+  A[Acquire /run/ota-update.lock] --> B[Verify detached Ed25519 signature]
+  B --> C[Parse and structurally validate manifest v2]
+  C --> D[Check exact target and generation policy]
+  D --> E[Verify artifact sizes and SHA-256 hashes]
+  E --> F[Verify source UKI signature, root hash, and generation]
+  F --> G[Discover active and inactive slots]
+  G --> H[Copy UKI into a private directory under /run]
+  H --> I[Recheck snapshot size, hash, signature, root hash, and generation]
+  I --> J[Recover stale staging state]
+  J --> K[Create or rename staging LVs]
+  K --> L[Supervised decompression and direct writes]
+  L --> M[veritysetup verify]
+  M --> N[Commit final LV names]
+  N --> O[Atomically install the private UKI snapshot as +3]
+  O --> P[Set boot default to candidate-specific UKI glob]
+  P --> Q[Return; reboot remains operator-controlled]
+```
+
+The lock is acquired before runtime discovery, preventing two installers from
+choosing the same inactive slot from stale state. Decompression and writing are
+separately supervised processes, so a decompressor failure cannot be hidden by
+a successful downstream writer.
+
+The UKI snapshot closes the validation-to-copy race on the `net-vm`-writable
+shared directory. Root and verity data remain safe against a post-validation
+source change because the newly written pair must reproduce the signed full
+verity root hash before either LV name or boot state is committed.
+
+Validation can be run without mutation:
+
+```sh
+ota-update image validate \
+  --manifest /persist/sysupdate/ghaf_<version>_<hash>.manifest
+```
+
+Preview the complete mutation plan:
+
+```sh
+ota-update image --dry-run install \
+  --manifest /persist/sysupdate/ghaf_<version>_<hash>.manifest
+```
+
+Install after validation:
+
+```sh
+sudo ota-update image install \
+  --manifest /persist/sysupdate/ghaf_<version>_<hash>.manifest
+```
+
+The command reports that a reboot is required but never reboots automatically.
+Use `ota-update image status` to inspect discovered UKIs and LVs. Removal is
+restricted to a non-active slot:
+
+```sh
+sudo ota-update image remove --version <version> --hash <hash-fragment>
+```
+
+`--allow-downgrade` is compiled only with the `debug-downgrade` feature. It must
+not be enabled in production packages.
+
+## Boot counting, health, and rollback
+
+The new UKI is installed with systemd-boot's three-attempt suffix, for example:
+
+```text
+/boot/EFI/Linux/ghaf-26.08.1-0123456789abcdef+3.efi
+```
+
+Trial activation deliberately sets the persistent default to a
+candidate-specific glob:
+
+```sh
+bootctl set-default 'ghaf-<version>-<hash>*.efi'
+```
+
+Do not replace this with either an exact trial default or the broad
+`ghaf-*.efi` namespace. An exact `LoaderEntryDefault` can continue selecting an
+exhausted `+0-3` entry. A broad glob can select an older entry when two updates
+share the same OS version and their hash fragments sort differently. The
+candidate-specific wildcard selects the intended counted trial while allowing
+systemd-boot to fall back after its attempts are exhausted. Only a healthy
+generation is promoted to an exact persistent default.
+
+`ghaf-boot-health.service` runs after LUKS, `/persist`, `microvms.target`, and
+the configured core MicroVM services. It requires:
+
+- the configured LUKS mapper to be active,
+- the configured dm-verity mapper to be active,
+- `/nix/store` and `/persist` to be mounted,
+- every configured core Ghaf MicroVM service to be active, and
+- a valid `ghaf.generation` on the kernel command line.
+
+AppVM readiness and interactive login are intentionally not blessing gates.
+
+For a healthy new generation, the service calls `systemd-bless-boot good`, sets
+the exact current UKI as the persistent default, and atomically advances
+`/persist/common/ota/accepted-generation`. A healthy fallback with a lower
+generation is allowed to run but does not lower the accepted generation.
+
+If a counted trial is unhealthy, the service re-arms the same entry while tries
+remain and requests a reboot. After the final failed attempt it leaves the
+managed glob in place; the next boot selects the blessed fallback. Initrd and
+stage-2 watchdogs, `boot.panic_on_fail`, and `panic=10` allow early verity
+failures to consume attempts on Orin.
+
+## First-boot provisioning
+
+The flash image contains only the initial root/verity pair. First boot is
+idempotent and performs these operations in dependency order:
+
+1. Retrieve the temporary disk key through the OP-TEE DUK path.
+2. Unlock APP as `/dev/mapper/cryptroot`.
+3. Preserve recovery slot 1 while rotating the manufacturer credential.
+4. Expand the physical APP partition to the available storage boundary.
+5. Resize the open LUKS mapping while the key remains in the initrd keyring.
+6. Resize the LVM PV.
+7. Create the randomly encrypted 4096 MiB swap LV.
+8. Create and format the Btrfs persist LV.
+9. Leave 1.5 times the initial root-plus-verity size, plus 64 MiB, free for the
+   second system pair.
+
+The first-boot services may be rerun after interruption. Existing swap and
+persist LVs are detected and retained. More precisely:
+
+- APP partition, open-LUKS, and PV resize operations are idempotent; rerun only
+  after confirming `cryptroot` is open on the intended APP partition;
+- an existing swap LV is retained and the ordered NixOS swap service completes
+  its initialization;
+- an existing blank persist LV is formatted as Btrfs on the next run;
+- an existing Btrfs persist LV is never reformatted; and
+- any other detected filesystem on the persist LV stops first boot with an
+  exact error and requires investigation, not `mkfs --force`.
+
+Do not attempt OTA conversion of an unencrypted APP partition, a raw root
+filesystem, a VG without the managed root/verity naming model, or any layout
+that cannot identify exactly one active immutable pair. Wrapping an existing
+installation in LUKS2 and establishing the initial trust/ESP/LVM layout require
+a destructive canary reflash. A legacy slot name is migratable only when it is
+already inside the expected unlocked VG and runtime discovery identifies it
+unambiguously.
+
+## Canary configurations and build workflow
+
+The two configurations are:
+
+| Configuration | Runtime storage | Coverage policy |
+| --- | --- | --- |
+| `nvidia-jetson-orin-nx-verity-luks-debug` | internal NVMe | build and hardware acceptance |
+| `nvidia-jetson-orin-agx-verity-luks-debug` | internal eMMC | build and hardware acceptance |
+
+The AGX canary disables the optional OP-TEE-backed firmware TPM. Hardware
+testing found that its `tpm_ftpm_tee` probe can remain in uninterruptible sleep
+and prevent reboot. This does not disable the independent OP-TEE
+device-unique-key service used to unlock APP. The NX canary retains fTPM and EK
+provisioning.
+
+Set a new positive generation for every candidate. Heavy Nix commands must run
+sequentially and use a wall-clock timeout:
+
+```sh
+export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
+export GHAF_UPDATE_GENERATION=8
+
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
+  -o result-nx-update
+
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-ghafImage \
+  -o result-agx-update
+```
+
+Build the NX flash entry point separately:
+
+```sh
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-flash-script \
+  -o result-nx-flash
+```
+
+:::danger[Evaluation resource bound]
+Do not run two heavy evaluations of this flake concurrently. Wrap every large
+evaluation or build in `timeout 2h`.
+:::
+
+## Source ownership map
+
+| Concern | Ghaf source |
+| --- | --- |
+| Canary targets, trust injection, watchdogs | `targets/nvidia-jetson-orin/flake-module.nix` |
+| Root/verity/UKI/manifest build | `modules/partitioning/verity-volume.nix` |
+| Manifest generation | `modules/partitioning/mk-manifest.py` |
+| Flash ESP, LUKS, recovery key | `modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix` |
+| Initial LVM image | `modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix` |
+| DUK, APP and LUKS resize | `modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix` |
+| Persist, swap, B-slot reservation | `modules/partitioning/firstboot-persist.nix` |
+| Health gate and blessing | `modules/partitioning/boot-health.nix` |
+| Development key generator | `packages/pkgs-by-name/ghaf-dev-keygen/` |
+| Update signer | `packages/pkgs-by-name/ghaf-sign-update/` |
+
+The installer lives in the `ghaf-givc` repository:
+
+| Concern | ghaf-givc source |
+| --- | --- |
+| CLI and trust arguments | `crates/ota-update/src/image/cli.rs` |
+| Manifest schema and policy | `crates/ota-update/src/image/manifest.rs` |
+| Pre-mutation validation | `crates/ota-update/src/image/install.rs` |
+| Slot discovery and staging recovery | `crates/ota-update/src/image/runtime.rs` |
+| Transaction construction | `crates/ota-update/src/image/plan.rs` |
+| Supervised writes | `crates/ota-update/src/image/executor.rs` |
+| Ed25519 verification | `crates/ota-update/src/image/signature.rs` |
+| UKI discovery and naming | `crates/ota-update/src/image/uki.rs` |
+| OCI publish, fetch, and signature transport | `crates/ota-update/src/registry/` |
+| Privileged OVMF integration test | `nixos/tests/ota-update-image.nix` |
+
+## Security boundaries and non-goals
+
+- Rollback changes the immutable system pair only. It does not snapshot or
+  restore `/persist`.
+- QSPI and ESP confidentiality is not provided; integrity comes from the UEFI
+  trust chain and signed UKIs.
+- Development keys are not production key management.
+- The implementation does not claim NVIDIA fused Secure Boot.
+- AGX runtime behavior is not accepted from NX results, or conversely.
+- An unsigned UKI being rejected is necessary, but firmware falling through to
+  network boot is not proof that a signed fallback was selected.
+- Automatic recovery from a hard hang is not accepted on a board until that
+  board's physical watchdog/reset path is demonstrated.
+- Release readiness requires repeated signed updates, corruption rollback,
+  recovery-key testing, power interruption at every transaction phase, and
+  automatic health rollback on every promoted hardware target.

--- a/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
@@ -1,0 +1,1204 @@
+---
+title: Orin Secure A/B Testing
+---
+{/*
+SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+*/}
+
+# Orin secure A/B testing
+
+This guide defines the downstream development and manual acceptance procedures
+for the [secure A/B image-update architecture](/ghaf/dev/architecture/ab-update).
+It is written for repeatable evidence collection: every case states its
+prerequisites, procedure, expected result, and recovery boundary.
+Implementation-internal validation is intentionally outside this guide's scope.
+
+:::danger[Destructive hardware tests]
+Flashing, corruption, and power-interruption cases destroy data on the selected
+target. Run them only on an explicitly authorized Orin in recovery mode. USB
+VID/PID alone is not authorization. Capture topology and serial identity, require
+exactly one recovery-mode Tegra target, and stop on any ambiguity.
+:::
+
+## Scope and acceptance policy
+
+- Orin NX 16 GB with internal NVMe and Orin AGX with internal eMMC are distinct
+  runtime acceptance targets. Test artifacts and evidence are not transferable
+  between them.
+- QSPI and ESP are outside LUKS; APP, LVM, both system pairs, persist, and swap
+  are in scope.
+- Rollback protects the immutable system pair. Shared `/persist` must survive
+  every successful update, failed trial, and rollback.
+- A trial is accepted only after LUKS, dm-verity, `/persist`, and all configured
+  core Ghaf MicroVMs are healthy.
+- AppVMs and interactive login are not health-gate dependencies.
+- Hard-hang rollback is not accepted until a physical watchdog/reset test passes.
+- A test run is not release acceptance until every required case is recorded
+  against a device identity, build generation, Git revision, and timestamp.
+
+## Test records
+
+Create a directory outside the source tree for each run:
+
+```sh
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-orin-nx-ab"
+EVIDENCE_DIR="$PWD/../test-evidence/$RUN_ID"
+mkdir -p "$EVIDENCE_DIR"
+chmod 0700 "$EVIDENCE_DIR"
+```
+
+Record only public build and device metadata:
+
+```sh
+git rev-parse HEAD > "$EVIDENCE_DIR/ghaf-head.txt"
+git -C ../ghaf-givc rev-parse HEAD > "$EVIDENCE_DIR/givc-head.txt"
+date -u --iso-8601=seconds > "$EVIDENCE_DIR/started-at.txt"
+```
+
+Do not copy private keys or recovery passphrases into the evidence directory.
+For every test case record:
+
+| Field | Required content |
+| --- | --- |
+| Test ID | Stable identifier from this document |
+| Build | Ghaf and ghaf-givc revisions, system, target, version, generation, manifest SHA-256 |
+| Device | Board model, ECID, USB topology path, storage device, serial endpoint |
+| Start/end | UTC timestamps |
+| Preconditions | Active slot, accepted generation, boot entry, persist sentinel |
+| Actions | Exact commands and intentional fault point |
+| Result | Pass, fail, blocked, or not run |
+| Evidence | Serial log, journal, `bootctl`, `lvs`, cryptsetup and verity status |
+| Recovery | Final active slot and whether manual intervention was needed |
+
+## Common setup
+
+### Pure CI build mode
+
+External trust settings are optional for evaluation and build discovery. With
+`GHAF_DEV_KEY_DIR` unset, evaluate both canaries without `--impure`:
+
+```sh
+env -u GHAF_DEV_KEY_DIR timeout 2h nix eval \
+  '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
+
+env -u GHAF_DEV_KEY_DIR timeout 2h nix eval \
+  '.#nixosConfigurations."nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
+```
+
+Each evaluation must succeed and emit the target-specific message ending in:
+
+```text
+GHAF_DEV_KEY_DIR is unset; using repository development public trust for evaluation/build only. Secure A/B flashing and update signing require GHAF_DEV_KEY_DIR from ghaf-dev-keygen; the exported flash script falls back to the generic unsigned target.
+```
+
+This public fallback is deliberately unsafe for deployment. It exists only so
+CI can evaluate and build the secure A/B image without access to local secrets.
+Build the exported NX and AGX flash attributes sequentially, then inspect each
+wrapper without running it. Confirm it selects the board-matched generic image
+and contains the exact warning:
+
+```text
+WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead.
+  Requested: <secure-A/B-target>
+  Fallback:  <generic-target>
+  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen to flash the secure A/B canary.
+```
+
+The wrapper does not deploy the CI-only A/B image. It delegates to the existing
+generic unsigned target, which has a different image and partition layout. It
+strips `--secure-boot`, `-u`/`--uki`, and `-s`/`--signed-sd-image` with explicit
+warnings so secure-image-only arguments cannot alter the fallback. Do not
+execute either wrapper during this source-only check; flashing remains a
+separate, explicitly authorized operation.
+
+### Repository and key environment
+
+Use the dedicated Ghaf and ghaf-givc worktrees. Keep the trust directory outside
+both repositories:
+
+```sh
+export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
+test -d "$GHAF_DEV_KEY_DIR"
+test -s "$GHAF_DEV_KEY_DIR/db.key"
+test -s "$GHAF_DEV_KEY_DIR/db.crt"
+test -s "$GHAF_DEV_KEY_DIR/update.key"
+test -s "$GHAF_DEV_KEY_DIR/update.pub"
+```
+
+If the directory does not exist, create it once:
+
+```sh
+umask 077
+nix run .#ghaf-dev-keygen -- --output "$GHAF_DEV_KEY_DIR"
+```
+
+Evaluate with the external public trust exposed:
+
+```sh
+timeout 2h nix eval --impure \
+  '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
+```
+
+It must succeed and emit the target-specific message ending in:
+
+```text
+using external public trust from GHAF_DEV_KEY_DIR; private signing keys remain outside the Nix store.
+```
+
+Pointing `GHAF_DEV_KEY_DIR` at an incomplete directory must fail evaluation
+with `GHAF_DEV_KEY_DIR is set but missing required public trust files:` followed
+by the exact missing file names. Running a flash script with the variable unset
+must fail with `ERROR: GHAF_DEV_KEY_DIR is required for secure A/B canary
+flashes.`; missing flash/sign files are reported by their exact paths.
+
+Record `sha256sum PK.crt KEK.crt db.crt update.pub` with the non-secret build
+evidence. Build a flash script with trust directory A, then, with no recovery
+target attached, invoke it using an independently generated directory B. It must
+exit before work-directory or device preparation with:
+
+```text
+ERROR: GHAF_DEV_KEY_DIR public trust does not match the trust embedded at image evaluation: <file>
+  Rebuild the flash script with this exact GHAF_DEV_KEY_DIR.
+```
+
+Repeat with directory A restored and confirm the trust check passes. Replacing
+only `db.key` or `update.key` with a key from B must fail with the corresponding
+`private key does not match public trust` diagnostic. Never perform these
+negative tests while a recovery-mode target is attached.
+
+### Build resource limits
+
+Run heavy evaluations and builds sequentially, each under `timeout 2h`. Do not
+launch the NX and AGX image builds concurrently.
+
+### Candidate build
+
+Choose a positive generation greater than the target's accepted generation:
+
+```sh
+export GHAF_UPDATE_GENERATION=10
+
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
+  -o result-nx-generation-$GHAF_UPDATE_GENERATION
+```
+
+Create the signed transport directory:
+
+```sh
+IMAGE_DIR="result-nx-generation-$GHAF_UPDATE_GENERATION"
+MANIFEST="$(find -L "$IMAGE_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+test -n "$MANIFEST"
+jq -e --argjson generation "$GHAF_UPDATE_GENERATION" '
+  .system == "aarch64-linux"
+  and .target == "nvidia-jetson-orin-nx-verity-luks-debug"
+  and .generation == $generation
+' "$MANIFEST" >/dev/null
+
+nix run .#ghaf-sign-update -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input "$MANIFEST" \
+  --output "signed-nx-generation-$GHAF_UPDATE_GENERATION"
+```
+
+Verify that the signed output contains one manifest, its detached signature,
+and all three named artifacts. Transfer the directory without changing file
+contents to `/persist/sysupdate/<generation>/` on the target.
+
+### Registry delivery variables
+
+For OCI delivery, configure an HTTPS registry without recording its endpoint or
+credentials in Git:
+
+```sh
+export REGISTRY_ENDPOINT='<registry-dns-name>'
+export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
+export UPDATE_TAG="generation-$GHAF_UPDATE_GENERATION"
+export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
+read -rsp 'Registry token: ' REGISTRY_TOKEN
+export REGISTRY_TOKEN
+REGISTRY_AUTH_ARGS=(--token "$REGISTRY_TOKEN")
+```
+
+The developer credential requires push access. The NX `net-vm` credential must
+be read-only. Use neither a production credential nor `--insecure` for this
+development test.
+
+For the disposable TLS registry procedure in the architecture guide, use its
+short-lived basic credential instead:
+
+```sh
+REGISTRY_AUTH_ARGS=(--username "$REGISTRY_USER" --password "$REGISTRY_PASSWORD")
+export SSL_CERT_FILE='<verified-path-to-disposable-registry-ca.crt>'
+```
+
+Native `htpasswd` authentication does not enforce read-only repository scope;
+record that limitation and tear the registry down after the test.
+
+### Static HTTP delivery variables
+
+For an isolated manual lab test, record placeholders rather than a developer
+machine address in the test plan:
+
+```sh
+export UPDATE_HTTP_BIND='<developer-interface-address>'
+export UPDATE_HTTP_PORT='<non-privileged-port>'
+export UPDATE_HTTP_ORIGIN="http://${UPDATE_HTTP_BIND}:${UPDATE_HTTP_PORT}"
+```
+
+The address must be reachable from the Orin `net-vm` physical uplink. Scope any
+temporary firewall opening to that interface and target network. Plain HTTP is
+only a transport test; host-side signature and policy validation remain
+mandatory.
+
+### REG-000: Disposable local registry setup
+
+**Purpose:** Establish a reproducible OCI Distribution endpoint when no managed
+development registry exists.
+
+**Procedure:** Follow the architecture guide's
+[disposable local HTTPS registry](/ghaf/dev/architecture/ab-update/#disposable-local-https-registry)
+procedure. Before publishing an update, require all of the following:
+
+1. the registry DNS name resolves from the developer host and `net-vm`;
+2. a request without credentials returns `401`;
+3. a request with the disposable basic credential and verified CA returns a
+   successful `/v2/` response;
+4. changing or omitting `SSL_CERT_FILE` makes TLS validation fail; and
+5. the CA SHA-256 copied to `net-vm` equals the developer-host value.
+
+Set `REGISTRY_AUTH_ARGS` to the basic-auth form above, run REG-001 and REG-002,
+then stop the container and delete only its verified temporary data root.
+
+**Expected:** Push, host pull, and device self-fetch all use HTTPS and the
+verified CA. Artifact and signed-manifest validation pass after transport. The
+record states that native `htpasswd` is not a read-only authorization test and
+contains no endpoint, address, password, or CA private key.
+
+### REG-001: Developer-host publish and fetch round trip
+
+**Purpose:** Prove the published OCI artifact includes the detached signature
+and that registry transport preserves the exact authenticated manifest bytes.
+
+**Procedure:**
+
+```sh
+SIGNED_DIR="signed-nx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+test -s "$SIGNED_MANIFEST"
+test -s "$SIGNED_MANIFEST.sig"
+
+nix run 'path:../ghaf-givc#ota-update' -- \
+  registry "${REGISTRY_AUTH_ARGS[@]}" push \
+  --manifest "$SIGNED_MANIFEST" \
+  "$UPDATE_REF"
+
+PULL_ROOT="$(mktemp -d)"
+nix run 'path:../ghaf-givc#ota-update' -- \
+  registry "${REGISTRY_AUTH_ARGS[@]}" pull --validate \
+  --destination "$PULL_ROOT" \
+  "$UPDATE_REF"
+
+PULLED_MANIFEST="$PULL_ROOT/$UPDATE_REPOSITORY_PATH/$UPDATE_TAG/manifest.json"
+cmp "$SIGNED_MANIFEST" "$PULLED_MANIFEST"
+cmp "$SIGNED_MANIFEST.sig" "$PULLED_MANIFEST.sig"
+
+nix run 'path:../ghaf-givc#ota-update' -- image validate \
+  --manifest "$PULLED_MANIFEST" \
+  --trusted-key "$GHAF_DEV_KEY_DIR/update.pub" \
+  --uki-trusted-cert "$GHAF_DEV_KEY_DIR/db.crt" \
+  --target nvidia-jetson-orin-nx-verity-luks-debug \
+  --accepted-generation-file "$PULL_ROOT/accepted-generation"
+```
+
+**Expected:** Push reports an OCI manifest digest. Pull writes
+`manifest.json`, `manifest.json.sig`, the signed UKI, root, and verity files.
+Both `cmp` commands and signed image validation succeed.
+
+**Negative cases:** Remove the signature layer, modify the pulled manifest, or
+modify one artifact. Pull or signed validation must fail as appropriate. No
+target storage is involved in this test.
+
+### REG-002: NX self-fetch through `net-vm`
+
+**Purpose:** Prove the NX fetches its own update over its network-owning VM while
+the host retains exclusive ownership of authentication policy and storage
+mutation.
+
+**Prerequisites:** REG-001 passed; the candidate tag is approved; `net-vm` has
+external registry reachability and a read-only credential; the host and
+`net-vm` both expose `/persist/sysupdate`.
+
+**Procedure in `net-vm`:**
+
+```sh
+export REGISTRY_ENDPOINT='<registry-dns-name>'
+export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
+export UPDATE_TAG='<approved-tag>'
+export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
+read -rsp 'Read-only registry token: ' REGISTRY_TOKEN
+export REGISTRY_TOKEN
+REGISTRY_AUTH_ARGS=(--token "$REGISTRY_TOKEN")
+
+ota-update registry "${REGISTRY_AUTH_ARGS[@]}" discover \
+  "${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}"
+
+ota-update registry "${REGISTRY_AUTH_ARGS[@]}" pull --validate \
+  --destination /persist/sysupdate \
+  "$UPDATE_REF"
+```
+
+Record the OCI digest and printed manifest path. Do not use `--install`.
+
+**Procedure on the Ghaf host:**
+
+```sh
+PULLED_MANIFEST='/persist/sysupdate/<namespace>/ghaf-orin-nx/<approved-tag>/manifest.json'
+test -s "$PULLED_MANIFEST"
+test -s "$PULLED_MANIFEST.sig"
+
+sudo ota-update image validate --manifest "$PULLED_MANIFEST"
+sudo ota-update image --dry-run install --manifest "$PULLED_MANIFEST"
+sudo ota-update image install --manifest "$PULLED_MANIFEST"
+```
+
+Continue with BT-001 for a healthy payload or BT-002 for a health-failure
+payload.
+
+**Expected:** `net-vm` downloads into the shared directory without host network
+access. The host authenticates the manifest and UKI, enforces target and
+generation policy, installs only the inactive pair, and does not reboot
+automatically. The subsequent trial follows the normal health/rollback rules.
+
+**Boundary:** This test is manually initiated on the device. Periodic discovery,
+credential provisioning, approval policy, and unattended installation are not
+enabled by this canary.
+
+### REG-003: Static development HTTP server and device fetch
+
+**Purpose:** Prove a developer machine can expose only a signed payload, the
+Orin device can fetch all five files through `net-vm`, and the Ghaf host rejects
+incomplete or unauthenticated downloads before storage mutation.
+
+**Prerequisites:** A signed NX or AGX candidate exists; its generation is newer
+than the target's accepted generation; the developer machine and Orin uplink
+share a controlled network; `net-vm` exposes `/persist/sysupdate`; and the
+operator can access both `net-vm` and the Ghaf host.
+
+**Procedure on the developer machine:**
+
+```sh
+SIGNED_DIR="signed-nx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+test -s "$SIGNED_MANIFEST"
+test -s "$SIGNED_MANIFEST.sig"
+
+HTTP_ROOT="$(mktemp -d)"
+install -m 0644 "$SIGNED_MANIFEST" "$HTTP_ROOT/manifest.json"
+install -m 0644 "$SIGNED_MANIFEST.sig" "$HTTP_ROOT/manifest.json.sig"
+
+for kind in root verity kernel; do
+  artifact="$(jq -er --arg kind "$kind" '.[$kind].file' "$SIGNED_MANIFEST")"
+  case "$artifact" in
+    "" | .* | *[!A-Za-z0-9._-]*) exit 1 ;;
+  esac
+  install -m 0644 "$SIGNED_DIR/$artifact" "$HTTP_ROOT/$artifact"
+done
+
+test "$(find "$HTTP_ROOT" -mindepth 1 -maxdepth 1 -type f | wc -l)" -eq 5
+
+python3 -m http.server \
+  --bind "$UPDATE_HTTP_BIND" \
+  --directory "$HTTP_ROOT" \
+  "$UPDATE_HTTP_PORT"
+```
+
+Leave the server in its own terminal. In a second developer terminal, require
+an exact manifest round trip:
+
+```sh
+curl --fail --silent --show-error \
+  "$UPDATE_HTTP_ORIGIN/manifest.json" \
+  | cmp - "$HTTP_ROOT/manifest.json"
+```
+
+**Procedure in `net-vm`:**
+
+```sh
+export UPDATE_HTTP_ORIGIN='http://<developer-interface-address>:<port>'
+export GHAF_UPDATE_GENERATION='<candidate-generation>'
+FETCH_PARENT=/persist/sysupdate
+FINAL_DIR="$FETCH_PARENT/http-generation-$GHAF_UPDATE_GENERATION"
+test ! -e "$FINAL_DIR" || exit 1
+FETCH_DIR="$(mktemp -d "$FETCH_PARENT/.http-generation-$GHAF_UPDATE_GENERATION.XXXXXX")"
+chmod 0755 "$FETCH_DIR"
+
+fetch_file() {
+  file="$1"
+  case "$file" in
+    "" | .* | *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  curl --fail --show-error --location \
+    --proto '=http' --proto-redir '=http' \
+    --retry 3 --retry-all-errors \
+    --output "$FETCH_DIR/$file.part" \
+    "$UPDATE_HTTP_ORIGIN/$file"
+  mv -- "$FETCH_DIR/$file.part" "$FETCH_DIR/$file"
+}
+
+fetch_file manifest.json
+fetch_file manifest.json.sig
+for kind in root verity kernel; do
+  artifact="$(jq -er --arg kind "$kind" '.[$kind].file' "$FETCH_DIR/manifest.json")"
+  fetch_file "$artifact"
+done
+touch "$FETCH_DIR/fetch.complete"
+sync "$FETCH_DIR"
+mv -T -- "$FETCH_DIR" "$FINAL_DIR"
+sync "$FETCH_PARENT"
+FETCH_DIR="$FINAL_DIR"
+```
+
+Record the five filenames, sizes, server request results, and the shared fetch
+directory. Do not record the developer address.
+
+**Procedure on the Ghaf host:**
+
+```sh
+PULLED_MANIFEST="/persist/sysupdate/http-generation-<candidate-generation>/manifest.json"
+test -f "$(dirname "$PULLED_MANIFEST")/fetch.complete"
+test -s "$PULLED_MANIFEST"
+test -s "$PULLED_MANIFEST.sig"
+
+sudo ota-update image validate --manifest "$PULLED_MANIFEST"
+sudo ota-update image --dry-run install --manifest "$PULLED_MANIFEST"
+sudo ota-update image install --manifest "$PULLED_MANIFEST"
+```
+
+Continue with BT-001. Use an AGX signed directory and generation for the AGX;
+the same network flow then installs to the inactive eMMC pair.
+
+**Expected:** The server exposes exactly five public files. `net-vm` performs
+every network request and writes the shared directory. The host performs all
+authentication and target/generation policy checks, preserves the active pair,
+installs the inactive pair, and does not reboot automatically.
+
+**Negative cases:** Stop the server during each download and require that no
+final directory is published and that any hidden temporary directory lacks
+`fetch.complete`. Retry into a newly created temporary directory; never reuse a
+previous final directory or marker. Separately tamper with the manifest,
+signature, and each of the three artifacts; use a signed wrong-target payload;
+and use a signed accepted or older generation. Every host validation must fail before
+LVM or ESP mutation. Do not run `install` after a failed `validate` or dry run.
+
+**Cleanup:** Stop the HTTP server, remove its temporary scoped firewall rule,
+and retain or delete only the exact public staging directory after inspecting
+its contents. Keep private trust material and recovery passphrases outside the
+server root throughout the test.
+
+### Baseline target evidence
+
+Before every mutating target test, capture:
+
+```sh
+sudo ota-update image status
+bootctl status --no-pager
+bootctl list --no-pager
+/run/current-system/systemd/lib/systemd/systemd-bless-boot status || true
+cat /proc/cmdline
+cat /persist/common/ota/accepted-generation
+cryptsetup status cryptroot
+veritysetup status nix-store
+findmnt /nix/store
+findmnt /persist
+sudo pvs
+sudo vgs
+sudo lvs -a -o lv_name,lv_size,lv_attr,devices pool
+systemctl is-active \
+  microvm@admin-vm.service \
+  microvm@disp-vm.service \
+  microvm@gpu-vm.service \
+  microvm@net-vm.service
+```
+
+Create or confirm a non-secret persist sentinel:
+
+```sh
+sudo install -d -m 0700 /persist/common/ota-test
+printf '%s\n' "$RUN_ID" | sudo tee /persist/common/ota-test/sentinel >/dev/null
+sync
+```
+
+The active version/hash from `/proc/cmdline` and `ota-update image status` is
+the protected slot. Stop immediately if it cannot be identified unambiguously.
+
+## Privileged virtual integration
+
+### IT-001: Real LUKS2/LVM/OVMF integration
+
+**Purpose:** Exercise the updater against real loopback-backed LUKS2, LVM,
+root/verity pairs, persist, systemd-boot, and OVMF.
+
+**Procedure (ghaf-givc worktree):**
+
+```sh
+timeout 2h nix build \
+  .#checks.x86_64-linux.vmTests-ota-update-image \
+  --print-build-logs
+```
+
+**Expected:** The test formats LUKS2, opens `cryptpool`, creates VG `pool`,
+installs the signed update, verifies the planned commands, retains the active
+pair, preserves the persist sentinel, removes the inactive pair, recreates the
+missing empty pair, and installs again. The test exits zero.
+
+### IT-002: Repeated A to B to A reuse
+
+**Purpose:** Demonstrate bounded storage use over repeated updates.
+
+**Procedure:** Extend or run the privileged fixture with three strictly
+increasing generations. After each successful health simulation, treat the new
+pair as active and install the next generation.
+
+**Expected:** LV count remains two root and two verity LVs. The pair active at
+the beginning of each install is byte-for-byte unchanged. The inactive physical
+space is reused for the third generation.
+
+### IT-003: Transaction failure matrix
+
+**Purpose:** Exercise every installer boundary without relying only on mocks.
+
+Repeat the integration fixture with failure injected at each boundary:
+
+| Fault point | Required postcondition |
+| --- | --- |
+| Root decompressor exits non-zero | Active pair unchanged; failure reported even if writer exits zero |
+| Root write fails or is short | No final LV names and no boot-default change |
+| Verity decompressor/write fails | Active pair unchanged; staging recoverable |
+| `veritysetup verify` fails | No UKI activation and no boot-default change |
+| First final LV rename succeeds, second fails | Next run recovers incomplete commit without touching active pair |
+| UKI temporary write or sync fails | No partial managed UKI selected |
+| UKI rename succeeds, default selection fails | Old default remains usable; rerun is idempotent |
+| Process killed after default selection | Complete `+3` trial exists; no active-slot data changed |
+
+For every row, capture pre/post LV UUIDs, active LV hashes, ESP directory listing,
+and loader variables. The test fails if the active root or verity LV changes.
+
+## UEFI boot and rollback tests
+
+### BT-001: Healthy three-attempt trial is blessed
+
+**Prerequisites:** A valid signed update newer than the accepted generation and
+all health dependencies configured healthy.
+
+**Procedure:**
+
+1. Validate and dry-run the update.
+2. Record the active pair and exact persistent default.
+3. Install the update.
+4. Confirm a `+3.efi` UKI exists and the default is the matching
+   `ghaf-<version>-<hash>*.efi` candidate glob.
+5. Confirm the installer did not reboot.
+6. Reboot once into the trial.
+7. Wait for `ghaf-boot-health.service` and capture its journal.
+
+**Expected:** The new generation boots, health succeeds, the entry loses its
+counter suffix through blessing, its exact UKI becomes the persistent default,
+and the accepted-generation file advances atomically. The old pair remains as
+the inactive fallback and the persist sentinel remains unchanged.
+
+### BT-002: Core-VM health failure rolls back
+
+Build the candidate with the debug-only health failure:
+
+```sh
+export GHAF_AB_TEST_UNHEALTHY=1
+export GHAF_UPDATE_GENERATION=<newer-generation>
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
+  -o result-unhealthy
+unset GHAF_AB_TEST_UNHEALTHY
+```
+
+Sign, validate, and install normally. Reboot without manually selecting entries.
+
+**Expected:** The trial boots three times. Each run fails because
+`microvm@ab-health-failure-injection.service` is not active, reboots, and
+consumes one attempt. The fourth selection boots the previously blessed pair.
+The accepted generation does not advance and persist remains intact.
+
+### BT-003: Corrupted root or verity rolls back
+
+**Prerequisites:** A valid installed trial, serial capture running, and an
+unambiguous mapping from the trial manifest to its inactive LVs.
+
+**Procedure:**
+
+1. Confirm the trial root LV is not the active root LV.
+2. Record hashes of both active LVs.
+3. After installation but before reboot, corrupt one 4096-byte block in the
+   trial root or verity LV. For a root corruption case, block 256 is suitable:
+
+   ```sh
+   TRIAL_ROOT=/dev/pool/root_<trial-version>_<trial-hash>
+   test -b "$TRIAL_ROOT"
+   sudo dd if=/dev/zero of="$TRIAL_ROOT" \
+     bs=4096 seek=256 count=1 conv=notrunc,fsync status=none
+   ```
+
+4. Reboot and do not interact with the boot menu.
+5. Count trial boots and capture the exact dm-verity failure from serial.
+
+**Expected:** Each trial fails dm-verity, panics or reaches the configured reset
+path, and consumes an attempt. After three failures, systemd-boot selects the
+previously blessed pair. Its root/verity hashes still match the baseline and
+persist is unchanged.
+
+### BT-004: Persistent-state invariant
+
+Run after BT-001, BT-002, and BT-003:
+
+```sh
+test "$(sudo cat /persist/common/ota-test/sentinel)" = "$RUN_ID"
+findmnt --mountpoint /persist
+```
+
+**Expected:** The same Btrfs persist LV is mounted before, during, and after slot
+changes. No rollback procedure reformats or replaces it.
+
+## NX hardware acceptance
+
+### HW-001: Recovery-target authorization
+
+Capture topology before attaching the authorized target:
+
+```sh
+lsusb > "$EVIDENCE_DIR/lsusb-before.txt"
+lsusb -t > "$EVIDENCE_DIR/lsusb-tree-before.txt"
+```
+
+Attach the NX in recovery mode and capture again:
+
+```sh
+lsusb > "$EVIDENCE_DIR/lsusb-after.txt"
+lsusb -t > "$EVIDENCE_DIR/lsusb-tree-after.txt"
+diff -u "$EVIDENCE_DIR/lsusb-before.txt" "$EVIDENCE_DIR/lsusb-after.txt" || true
+```
+
+Required checks:
+
+1. The new device identifies as `0955:7323 NVIDIA Corp. T234 [Orin NX 16GB]`.
+2. Its newly appearing physical USB path is recorded.
+3. Exactly one NVIDIA recovery-mode target remains connected when flash starts.
+4. Any previously observed `0955:7023` APX target is disconnected or otherwise
+   excluded before invoking NVIDIA flash tooling.
+5. The matching serial adapter identity and device node are recorded.
+
+Example fail-closed count check:
+
+```sh
+test "$(lsusb | grep -Ec '0955:(7023|7323)')" -eq 1
+test "$(lsusb -d 0955:7323 | wc -l)" -eq 1
+```
+
+Stop if either assertion fails or if topology does not uniquely identify the
+authorized NX.
+
+### HW-002: Serial capture before flash
+
+Inspect and record the serial endpoint:
+
+```sh
+export SERIAL_DEVICE='<authorized-serial-device>'
+udevadm info --query=property --name="$SERIAL_DEVICE" \
+  > "$EVIDENCE_DIR/serial-udev.txt"
+```
+
+In a dedicated terminal, configure 115200 baud and start a timestamped capture
+before the flash command:
+
+```sh
+sudo stty -F "$SERIAL_DEVICE" 115200 raw -echo
+sudo stdbuf -oL cat "$SERIAL_DEVICE" \
+  | ts '%Y-%m-%dT%H:%M:%.S%z' \
+  | tee "$EVIDENCE_DIR/orin-serial.log"
+```
+
+If `ts` is unavailable, capture without it and record timestamps separately.
+Keep this terminal running through first boot and rollback tests.
+
+### HW-003: Build and flash the NX NVMe canary
+
+Build the flash script, sequentially and with the key directory available:
+
+```sh
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-flash-script \
+  -o result-nx-flash
+```
+
+Immediately before flashing, repeat HW-001's count checks. Then invoke the
+secure-boot variant and UKI path:
+
+```sh
+sudo --preserve-env=GHAF_DEV_KEY_DIR \
+  ./result-nx-flash/bin/flash-ghaf-host --secure-boot -u
+```
+
+**Expected:** The flash script selects the NX NVMe layout, signs EFI binaries
+outside the Nix store, creates LUKS2 APP, records a new recovery passphrase, and
+flashes the authorized NX. Save flash output after redacting the passphrase.
+Do not claim success from the command exit alone; require serial first boot and
+the post-flash checks below.
+
+### HW-004: Secure Boot negative and positive paths
+
+1. Confirm the signed systemd-boot binary and signed UKI boot.
+2. Copy an unsigned UKI to a distinct managed test name on the ESP.
+3. Select it once from firmware or systemd-boot without replacing the blessed
+   signed entry.
+4. Capture the firmware rejection on serial.
+5. Remove the unsigned test artifact and confirm the signed entry still boots.
+
+**Expected:** The unsigned UKI never reaches its kernel. Firmware fallback to
+PXE or the UEFI shell counts only as rejection; separately prove that the signed
+fallback remains selectable. Never replace the only known-good signed UKI.
+
+### HW-005: DUK rotation and recovery unlock
+
+After first boot:
+
+```sh
+sudo cryptsetup status cryptroot
+sudo cryptsetup luksDump /dev/disk/by-uuid/0ada0e5b-0e5b-4e5b-8e5b-0000000000a9
+```
+
+Confirm the manufacturer credential no longer unlocks APP and the recovery
+passphrase from this flash still does. Test recovery from initrd or a controlled
+rescue environment so the already-open mapping cannot create a false positive.
+
+Create a protected header backup after key rotation and before update testing:
+
+```sh
+export APP_DEVICE='<raw-APP-partition>'
+export LUKS_HEADER_BACKUP='<encrypted-offline-staging-path>/app-luks2-header.bin'
+test -b "$APP_DEVICE"
+umask 077
+sudo cryptsetup luksHeaderBackup "$APP_DEVICE" \
+  --header-backup-file "$LUKS_HEADER_BACKUP"
+sudo chmod 0600 "$LUKS_HEADER_BACKUP"
+```
+
+Move the backup into encrypted offline custody and record its non-secret
+inventory identifier with the flash's recovery-passphrase filename. Do not put
+the header backup in the ordinary evidence bundle or leave an unencrypted copy
+on `/persist`.
+
+**Expected:** Normal reboot unlock is unattended through OP-TEE DUK. The old
+manufacturer credential fails. Recovery slot 1 succeeds. Record only pass/fail
+and the recovery file name, never the passphrase.
+
+### HW-006: Encrypted layout and first-boot provisioning
+
+Run the baseline evidence commands. Verify:
+
+- the NVMe APP partition contains LUKS2,
+- `/dev/mapper/cryptroot` is active,
+- VG `pool` is backed by the open mapper rather than raw NVMe,
+- one initial root/verity pair and one reserved inactive capacity exist,
+- persist is Btrfs and mounted read-write,
+- swap is active with random encryption,
+- `nix-store` dm-verity is active, and
+- first-boot resize and persist services succeeded.
+
+Reboot once more and confirm all first-boot operations are idempotent.
+
+On a fresh destructive-test flash, include first-boot interruption points after
+APP expansion, open-LUKS resize, PV resize, swap LV creation, persist LV
+creation, and persist formatting. After each restart, require the service to
+converge without duplicate LVs. In particular, an existing blank persist LV is
+formatted as Btrfs, existing Btrfs is retained with its contents, and an
+unexpected filesystem type stops with an error rather than being reformatted.
+Test the unexpected-filesystem branch only in the disposable integration
+fixture, never by replacing a hardware target's real persist filesystem.
+
+### HW-007: Signed A to B to A update reuse
+
+1. Establish a healthy accepted A generation and persist sentinel.
+2. Install a valid newer B generation and complete BT-001.
+3. Build, sign, and install a third generation.
+4. Complete BT-001 again so physical slot A is reused.
+5. Compare LV counts, LV sizes, boot entries, accepted generation, and persist.
+
+**Expected:** Both updates validate, stage, and bless successfully. The updater
+never writes the pair active at install start. Only two complete pairs remain,
+and persist contains the original sentinel.
+
+### HW-008: Rejection matrix
+
+Run `ota-update image validate` and then `install` where appropriate for these
+payloads:
+
+| Variant | Expected result |
+| --- | --- |
+| Missing signature | Reject before manifest parsing or mutation |
+| Random or wrong-key signature | Reject Ed25519 verification |
+| Manifest changed after signing | Reject Ed25519 verification |
+| Root artifact changed | Reject SHA-256 or size validation |
+| Verity artifact changed | Reject SHA-256 or size validation |
+| Unsigned or wrong-key UKI | Reject UKI signature validation |
+| Signed manifest for AGX on NX | Reject exact target policy |
+| Generation equal to accepted | Reject generation policy |
+| Generation below accepted | Reject generation policy |
+| UKI embeds another root hash | Reject UKI/manifest agreement |
+| UKI embeds another generation | Reject UKI/manifest agreement |
+
+For every row, compare active LV hashes, `lvs`, `/boot/EFI/Linux`, and boot
+default before and after. They must not change.
+
+### HW-009: Core-VM health rollback
+
+Perform BT-002 on the NX. Capture all three `ghaf-boot-health` failures, each
+reboot, counter-name transition, final fallback selection, accepted generation,
+and persist sentinel.
+
+### HW-010: Physical corruption rollback
+
+Perform BT-003 on the NX for root corruption and repeat for verity corruption.
+Require three observed failed trials and an automatic fourth selection of the
+previously blessed pair, without keyboard input.
+
+### HW-011: Physical power-interruption matrix
+
+For each row, begin from a healthy accepted pair, install a fresh generation,
+and remove power only after serial/journal/LV evidence confirms the named phase:
+
+| Phase | Recovery assertion after power restore |
+| --- | --- |
+| Validate, before mutation | Old pair boots; no staging LVs or trial UKI |
+| Staging LV creation | Old pair boots; next install recovers staging |
+| Root decompression/write | Old pair boots; partial root is never selected |
+| Verity decompression/write | Old pair boots; partial pair is never selected |
+| `veritysetup verify` | Old pair boots; uncommitted pair is recoverable |
+| First LV final rename | Old pair boots; incomplete commit is recovered |
+| UKI temporary installation | Old pair boots; no partial UKI is selected |
+| UKI atomic rename | Old pair boots or complete trial is discoverable |
+| Boot-default commit | Either old default or complete `+3` trial; never partial data |
+| First, second, and third trial boot | Counter consumption resumes and ends at fallback |
+| Health blessing before generation-state rename | Rerun converges without lowering accepted generation |
+
+After each interruption, capture state before retrying. The recovery action is
+normally rerunning the same signed install; do not manually rename LVs unless
+the test specifically evaluates the documented rescue procedure.
+
+### HW-012: Hard-hang watchdog acceptance
+
+Inject a controlled hard hang during a counted trial, not merely a service
+failure or clean reboot. Observe the physical Tegra watchdog reset on serial and
+repeat until the three attempt counter is exhausted.
+
+**Expected:** Every hang produces a hardware reset within the configured bound,
+consumes exactly one attempt, and eventually selects the blessed fallback.
+Until this passes, record hard-hang rollback as blocked rather than inferred
+from panic or service-failure tests.
+
+## AGX eMMC hardware acceptance
+
+### AGX-001: eMMC canary build
+
+```sh
+export GHAF_UPDATE_GENERATION=<candidate-generation>
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-ghafImage \
+  -o result-agx-update
+
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-flash-script \
+  -o result-agx-flash
+```
+
+Require manifest system `aarch64-linux`, the exact AGX target, and the intended
+generation, then retain the build logs. Do not flash an NX with AGX artifacts.
+
+Sign and validate the update bundle before connecting it to target storage:
+
+```sh
+IMAGE_DIR=result-agx-update
+MANIFEST="$(find -L "$IMAGE_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+SIGNED_DIR="signed-agx-generation-$GHAF_UPDATE_GENERATION"
+
+jq -e --argjson generation "$GHAF_UPDATE_GENERATION" '
+  .system == "aarch64-linux"
+  and .target == "nvidia-jetson-orin-agx-verity-luks-debug"
+  and .generation == $generation
+' "$MANIFEST" >/dev/null
+
+nix run .#ghaf-sign-update -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input "$MANIFEST" \
+  --output "$SIGNED_DIR"
+
+SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+nix run 'path:../ghaf-givc#ota-update' -- image validate \
+  --manifest "$SIGNED_MANIFEST" \
+  --trusted-key "$GHAF_DEV_KEY_DIR/update.pub" \
+  --uki-trusted-cert "$GHAF_DEV_KEY_DIR/db.crt" \
+  --target nvidia-jetson-orin-agx-verity-luks-debug \
+  --accepted-generation-file ./accepted-generation
+```
+
+The validation environment must provide `sbverify`. The
+`accepted-generation` file contains the AGX generation accepted before this
+candidate, not the NX value.
+
+### AGX-002: Recovery identity and flash
+
+Capture serial output from the running board before requesting recovery. Verify
+that the device-tree model identifies an AGX developer kit and that APP is on
+internal eMMC. Record the current USB topology, then request forced recovery.
+
+After recovery, require all of the following:
+
+- exactly one authorized Tegra recovery target is present;
+- its USB path is the recovery sibling of the serial-identified AGX operator
+  interface;
+- the recovery query returns the recorded AGX ECID;
+- the serial capture is running before flash starts; and
+- the flash script names `mmcblk0`, never the NX NVMe device.
+
+USB ID `0955:7023` is expected for this AGX generation, but is not sufficient
+authorization by itself. Stop if another APX target is present or topology is
+ambiguous.
+
+```sh
+export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
+
+sudo --preserve-env=GHAF_DEV_KEY_DIR \
+  result-agx-flash/bin/flash-ghaf-host
+```
+
+Store the newly printed recovery passphrase in the protected trust directory.
+Never put it in a shell argument, build log, test record, Git, or the Nix store.
+
+### AGX-003: Encrypted first-boot baseline
+
+Before installing any update, capture the generation-1 baseline over serial:
+
+```sh
+cat /proc/cmdline
+bootctl status --no-pager
+lsblk -o NAME,TYPE,FSTYPE,SIZE,MOUNTPOINTS
+sudo cryptsetup luksDump /dev/mmcblk0p2
+sudo pvs
+sudo vgs
+sudo lvs -a -o lv_name,lv_size,lv_attr,devices
+findmnt / /nix/store /persist /boot
+sudo veritysetup status nix-store
+swapon --show
+systemctl --failed --no-pager
+systemctl is-active microvm@admin-vm.service microvm@net-vm.service
+systemctl is-active microvm@gpu-vm.service microvm@disp-vm.service
+systemctl status ghaf-boot-health.service --no-pager
+cat /persist/common/ota/accepted-generation
+```
+
+Require Secure Boot enabled, one root/verity pair, free LVM space reserved for
+the second pair, read-only verified `/nix/store`, read-write Btrfs `/persist`,
+encrypted swap, healthy configured core VMs, and an accepted generation that
+matches the booted UKI.
+
+Test both remaining credentials explicitly. The manufacturer passphrase must
+fail. Recovery slot 1 must unlock with external tokens disabled. Feed the
+recovery passphrase through a no-echo prompt; do not put it on a command line or
+in the journal.
+
+### AGX-004: DUK reboot and optional fTPM boundary
+
+The AGX secure A/B canary intentionally leaves
+`ghaf.hardware.nvidia.orin.ftpm.enable` disabled. The OP-TEE DUK path remains
+enabled and must unlock APP unattended on every reboot.
+
+```sh
+test ! -e /dev/tpmrm0
+! systemctl cat ghaf-load-ftpm-module.service
+systemctl reboot
+```
+
+Capture the entire shutdown and next boot. Require a prompt reboot, unattended
+LUKS unlock, the same `/persist` contents, no duplicate LVs, the same accepted
+generation, and no `tpm_ftpm_tee` task. A reboot blocked in
+`ftpm_tee_tpm_op_send` is a failure even if the health gate previously passed.
+
+### AGX-005: Signed A to B to A updates
+
+Deliver a correctly signed AGX generation greater than the accepted value by
+the developer-host registry round trip in REG-001 or by AGX self-fetch through
+`net-vm` as described in REG-002. Use the AGX target and a distinct AGX
+repository path. On the host, run validation, dry-run, and install in that
+order. Verify that installation does not reboot automatically.
+
+After manually rebooting, require the candidate to appear as a `+3` UKI. Let
+the health gate bless it, verify the accepted generation advances, then install
+a newer generation to prove B-to-A reuse. At every step assert that the active
+root and verity LVs were not written and that `/persist` retained its sentinel.
+
+Repeat the signed wrong-target, unsigned, tampered, and downgrade cases against
+the AGX. Then repeat health-failure, root-corruption, verity-corruption,
+power-interruption, and hard-hang cases from the common matrix. Record AGX and
+NX results separately.
+
+## Recovery and triage
+
+### Collect an operational evidence bundle
+
+Capture command output before retrying or changing state. Redact network and
+hardware identities before sharing it:
+
+```sh
+sudo ota-update image status
+bootctl status --no-pager
+bootctl list --no-pager
+find /boot/EFI/Linux -maxdepth 1 -type f -printf '%s %f\n' | sort
+sudo lvs -a -o lv_name,lv_size,lv_attr,lv_uuid,devices pool
+sudo pvs -o pv_name,pv_size,pv_free,pv_uuid
+sudo vgs -o vg_name,vg_size,vg_free,vg_uuid pool
+cryptsetup status cryptroot
+veritysetup status nix-store
+findmnt --mountpoint /nix/store
+findmnt --mountpoint /persist
+findmnt --mountpoint /boot
+systemctl --no-pager --full status \
+  firstboot-persist.service ghaf-boot-health.service microvms.target
+journalctl -b --no-pager \
+  -u firstboot-persist.service -u ghaf-boot-health.service
+journalctl -b -1 --no-pager \
+  -u firstboot-persist.service -u ghaf-boot-health.service || true
+```
+
+Also retain the updater's validation, dry-run, and install console output. Record
+the active version/hash, accepted generation, candidate generation, boot-count
+suffix, and whether the persist sentinel is unchanged. Never collect private
+keys or recovery-passphrase contents.
+
+### Rescue decision matrix
+
+| Observed state | Supported action | Boundary |
+| --- | --- | --- |
+| One inactive `root_staging_<id>` or `verity_staging_<id>` beside one active pair | Rerun the exact signed candidate; the missing counterpart is created and both inactive images are rewritten | Automatic only for one-sided staging in the active VG |
+| One final inactive LV and its matching staging peer after interrupted final renames | Rerun the exact signed candidate | Discovery rejoins the inactive pair; ambiguous names stop |
+| Complete candidate LVs but no candidate UKI | Rerun the exact signed candidate | Candidate data is verified and rewritten before UKI activation |
+| Candidate UKI exists but default selection failed | Rerun the exact signed candidate | Updater completes only candidate-specific default selection |
+| Orphan `<candidate>.efi.tmp` | Preserve evidence, then rerun the exact candidate | Atomic install replaces the temporary path; the old default remains |
+| ESP lacks space | Remove only a proven stale `.tmp` or non-active managed UKI, then rerun | Never remove the current or only blessed fallback |
+| VG lacks space for inactive-slot resize | Use a smaller candidate or reflash with a larger layout | Never shrink or delete the active pair manually |
+| Hidden incomplete HTTP fetch directory | Retain for evidence or delete that exact directory; retry into a new temporary directory | Never add a marker or reuse old contents |
+| Existing blank persist LV | Restart `firstboot-persist.service` | It formats the blank LV once |
+| Existing Btrfs persist LV | Restart first boot normally | Contents must be retained |
+| Unexpected filesystem on persist | Stop and investigate | No automatic or forced formatting |
+| Public-trust or private/public key mismatch | Restore the evaluated complete key directory or rebuild | Never mix trust sets |
+| Signature, target, generation, hash, UKI, or verity failure | Reject the candidate and preserve evidence | Do not repair authenticated content in place |
+| Ambiguous active pair, more than two storage groups, or non-staging partial LV | Stop and escalate | No undocumented LV rename/delete procedure |
+| DUK and matching recovery unlock both fail | Stop and use the protected header backup/recovery process | Never delete keyslots or reformat APP |
+
+An unencrypted, raw-root, non-LVM, or otherwise incompatible pre-canary layout
+is not a rescue case; it requires a destructive reflash to establish LUKS2,
+LVM A/B, ESP trust, and recovery material.
+
+### Trial does not roll back
+
+Capture, in this order:
+
+```sh
+bootctl status --no-pager
+bootctl list --no-pager
+/run/current-system/systemd/lib/systemd/systemd-bless-boot status || true
+find /boot/EFI/Linux -maxdepth 1 -type f -printf '%f\n' | sort
+journalctl -b -u ghaf-boot-health.service --no-pager
+cat /proc/cmdline
+```
+
+Check that the trial filename has a boot-count suffix, the persistent default is
+the matching candidate-specific `ghaf-<version>-<hash>*.efi` glob during the
+trial, and the old blessed UKI still exists. A broad `ghaf-*.efi` glob is a
+failure: equal-version UKIs can then be selected by hash ordering instead of by
+update generation. Do not set an exhausted trial as an exact default.
+
+### Update refuses to install
+
+Run `validate` first and preserve its exact error. Check the detached signature,
+target, accepted generation, artifact sizes and hashes, UKI certificate, and UKI
+command line before investigating LVM. Authentication failures are expected to
+occur before runtime mutation.
+
+### Incomplete staging state
+
+Record `ota-update image status`, `lvs -a`, and ESP contents. Match the state to
+the rescue matrix before rerunning the exact same signed update. Automatic
+recovery is intentionally limited to recognizable inactive staging or partial
+commit states. Stop if a name is not in the managed namespace, an LV is in a
+different VG, the active pair is ambiguous, or more than two storage groups
+exist.
+
+### Recovery-key failure
+
+Do not delete any LUKS keyslot. Confirm the recovery file belongs to this exact
+flash and contains no added newline. Preserve a LUKS header backup if one exists,
+then investigate from a controlled rescue environment.
+
+## Validation snapshot and remaining gates
+
+The implementation campaign on 2026-08-19 established the following evidence:
+
+The NX and AGX were each authorized by comparing before/after USB topology,
+recovery identity, board model, storage target, and the matching serial adapter.
+Exact USB paths, ECIDs, serial numbers, device nodes, hostnames, and network
+addresses remain in access-controlled run evidence rather than evergreen
+documentation. No ambiguous or unrelated recovery target was flashed.
+
+| Area | Status | Evidence boundary |
+| --- | --- | --- |
+| Privileged OVMF integration | Passed | focused `vmTests-ota-update-image` build |
+| NX and AGX image builds | Passed | target-matched cross builds, sequential |
+| Static HTTP device fetch | Passed on AGX | `net-vm` fetched a five-file signed payload from a temporary development server into shared persist; host validation/install remained separate |
+| NX encrypted first boot | Passed | LUKS/LVM/verity/persist and core VMs healthy |
+| NX repeated signed updates | Passed | inactive-slot reuse and accepted generation advancement |
+| NX corrupted trial rollback | Passed | generation 9 failed dm-verity three times and generation 7 returned automatically |
+| Persist across rollback | Passed | the run-specific non-secret sentinel remained present |
+| Unsigned UKI rejection | Partial | rejection observed; firmware fell through to network rather than selecting signed fallback automatically |
+| AGX encrypted first boot | Passed | internal eMMC LUKS/LVM/verity/persist, DUK rotation, recovery slot, and core VMs healthy |
+| AGX signed updates | Passed | generations 1 to 2 to 3 proved both physical slots, inactive-slot reuse, active-pair immutability, self-fetch, and accepted-generation advancement |
+| AGX clean reboot | Passed | disabling the optional fTPM removed the OP-TEE probe hang; ordinary shutdown, cold boot, unattended DUK unlock, and health blessing passed repeatedly |
+| AGX trial selection | Passed after fix | a broad default selected the older equal-version UKI; a candidate-specific wildcard selected and blessed generation 3 |
+| All physical power cuts | Not run | HW-011 remains a release gate |
+| Physical hard-hang watchdog | Not run | HW-012 remains a release gate |
+
+The AGX return-slot update ended with generation 3 active and accepted, exactly
+two root/verity pairs, no staging LVs, the generation-2 active pair unchanged
+during installation, both update-fetch sentinels intact on shared persist, and
+the candidate promoted from `+3` to its exact persistent default. The baseline
+fTPM-enabled image required a physical power cycle after the OP-TEE TPM probe
+blocked shutdown; the fTPM-disabled generations completed ordinary reboots.
+
+The validated NX rollback ended on the previously blessed generation, with all
+configured core MicroVM services active, `ghaf-boot-health.service` successful,
+the expected dm-verity root hash, and the persistent default resolving to the
+exact blessed entry.
+These observations are a snapshot, not a substitute for repeating the complete
+matrix on a release candidate.
+
+## Release stop conditions
+
+Do not promote the canaries if any of the following is true:
+
+- the recovery USB target or serial endpoint is ambiguous,
+- the active pair cannot be proven untouched,
+- a negative validation case mutates LVM or ESP state,
+- trial attempts do not decrement exactly once per failed boot,
+- accepted generation advances before successful health blessing,
+- rollback changes or loses shared persist,
+- manufacturer-key rotation removes the recovery keyslot,
+- a physical power interruption requires undocumented manual LV surgery,
+- the watchdog cannot reset a hard-hung counted trial,
+- one board's runtime result is used as evidence for the other, or
+- development-key results are represented as production Secure Boot assurance.

--- a/flake.lock
+++ b/flake.lock
@@ -454,6 +454,7 @@
       "original": {
         "owner": "tiiuae",
         "repo": "ghaf-givc",
+        "rev": "0e09911b2d5c23876dc8ed7f4fd6266768b9f19d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -119,7 +119,7 @@
     #
     # TEMPORARILY pinned to a commit rather than the branch head
     givc = {
-      url = "github:tiiuae/ghaf-givc";
+      url = "github:tiiuae/ghaf-givc/0e09911b2d5c23876dc8ed7f4fd6266768b9f19d";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/modules/partitioning/boot-health.nix
+++ b/modules/partitioning/boot-health.nix
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.boot-health;
+  vmNames =
+    (lib.attrNames config.microvm.vms)
+    ++ lib.optional (cfg.debugUnhealthyMicrovm != null) cfg.debugUnhealthyMicrovm;
+  vmServices = map (name: "microvm@${name}.service") vmNames;
+  health = pkgs.writeShellApplication {
+    name = "ghaf-boot-health";
+    runtimeInputs = with pkgs; [
+      coreutils
+      cryptsetup
+      util-linux
+      systemd
+    ];
+    text = ''
+      set -euo pipefail
+
+      bootctl=${pkgs.systemd}/bin/bootctl
+      bless_boot=${pkgs.systemd}/lib/systemd/systemd-bless-boot
+      boot_status="$($bless_boot status 2>/dev/null || true)"
+      current_stub=""
+      while IFS= read -r status_line; do
+        if [[ "$status_line" == *"/EFI/Linux/"* ]]; then
+          current_stub="''${status_line##*/EFI/Linux/}"
+          break
+        fi
+      done < <("$bootctl" status --no-pager 2>/dev/null || true)
+
+      trial_boot=false
+      trial_entry=""
+      trial_tries_left=""
+      # Once the final try has been consumed, systemd-bless-boot no longer
+      # reports "indeterminate", but the currently executing UKI still has
+      # its boot-counting suffix (for example +0-3.efi).  It remains a failed
+      # trial and must reboot so systemd-boot can select the blessed fallback.
+      if [[ "$current_stub" =~ ^(.+)\+([0-9]+)(-[0-9]+)?\.efi$ ]]; then
+        trial_boot=true
+        trial_entry="''${BASH_REMATCH[1]}.efi"
+        trial_tries_left="''${BASH_REMATCH[2]}"
+      elif [[ "$boot_status" == "indeterminate" ]]; then
+        # Fail closed if systemd reports a trial but bootctl does not expose a
+        # parseable counter. Rebooting here could consume the fallback early.
+        trial_boot=true
+      fi
+
+      fail() {
+        echo "ghaf-boot-health: $*" >&2
+        if $trial_boot; then
+          if [[ -z "$trial_entry" || -z "$trial_tries_left" ]]; then
+            echo "ghaf-boot-health: cannot safely identify the current trial entry" >&2
+            exit 1
+          fi
+          # LoaderEntryOneShot is consumed when an attempt starts. Re-arm the
+          # same entry while tries remain; after +0, leave the persistent
+          # blessed default untouched so the reboot selects the fallback.
+          if (( trial_tries_left > 0 )); then
+            "$bootctl" set-oneshot "$trial_entry" || {
+              echo "ghaf-boot-health: could not schedule the next trial attempt" >&2
+              exit 1
+            }
+          fi
+          systemctl reboot --message="Ghaf A/B trial health check failed: $*"
+        fi
+        exit 1
+      }
+
+      cryptsetup status ${lib.escapeShellArg cfg.luksMapper} >/dev/null \
+        || fail "LUKS mapping ${cfg.luksMapper} is not active"
+      veritysetup status ${lib.escapeShellArg cfg.verityMapper} >/dev/null \
+        || fail "verity mapping ${cfg.verityMapper} is not active"
+      findmnt --mountpoint /nix/store >/dev/null || fail "/nix/store is not mounted"
+      findmnt --mountpoint /persist >/dev/null || fail "/persist is not mounted"
+      ${lib.concatMapStringsSep "\n" (service: ''
+        systemctl is-active --quiet ${lib.escapeShellArg service} \
+          || fail "core VM service ${service} is not active"
+      '') vmServices}
+
+      generation=""
+      read -r -a kernel_cmdline < /proc/cmdline
+      for arg in "''${kernel_cmdline[@]}"; do
+        case "$arg" in ghaf.generation=*) generation="''${arg#*=}" ;; esac
+      done
+      [[ "$generation" =~ ^[1-9][0-9]*$ ]] || fail "missing or invalid ghaf.generation"
+
+      accepted=${lib.escapeShellArg cfg.acceptedGenerationFile}
+      accepted_generation=0
+      if [[ -e "$accepted" ]]; then
+        read -r accepted_generation < "$accepted"
+        [[ "$accepted_generation" =~ ^[1-9][0-9]*$ ]] \
+          || fail "accepted generation state is invalid"
+      fi
+
+      if (( generation < accepted_generation )); then
+        echo "ghaf-boot-health: healthy fallback generation $generation; accepted generation remains $accepted_generation"
+        exit 0
+      fi
+      if (( generation == accepted_generation )); then
+        echo "ghaf-boot-health: generation $generation remains healthy"
+        exit 0
+      fi
+
+      if $trial_boot; then
+        "$bless_boot" good \
+          || fail "systemd could not bless the trial boot"
+      fi
+
+      current_entry="$current_stub"
+      if [[ "$current_entry" =~ ^(.+)\+[0-9]+(-[0-9]+)?\.efi$ ]]; then
+        current_entry="''${BASH_REMATCH[1]}.efi"
+      fi
+      [[ "$current_entry" == *.efi ]] || {
+        echo "ghaf-boot-health: cannot identify the healthy boot entry" >&2
+        exit 1
+      }
+      "$bootctl" set-default "$current_entry" || {
+        echo "ghaf-boot-health: could not promote the healthy boot entry" >&2
+        exit 1
+      }
+
+      install -d -m 0700 "$(dirname "$accepted")"
+      printf '%s\n' "$generation" > "$accepted.tmp"
+      chmod 0600 "$accepted.tmp"
+      sync -f "$accepted.tmp"
+      mv "$accepted.tmp" "$accepted"
+      sync -f "$(dirname "$accepted")"
+      echo "ghaf-boot-health: generation $generation accepted"
+    '';
+  };
+in
+{
+  options.ghaf.boot-health = {
+    enable = lib.mkEnableOption "health-gated systemd-boot A/B trial blessing";
+    luksMapper = lib.mkOption {
+      type = lib.types.str;
+      default = config.ghaf.hardware.nvidia.orin.diskEncryption.mapperName;
+    };
+    verityMapper = lib.mkOption {
+      type = lib.types.str;
+      default = "nix-store";
+    };
+    acceptedGenerationFile = lib.mkOption {
+      type = lib.types.str;
+      default = "/persist/common/ota/accepted-generation";
+    };
+    debugUnhealthyMicrovm = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Debug-only nonexistent MicroVM name used to exercise trial-boot rollback.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.debugUnhealthyMicrovm == null || config.ghaf.profiles.debug.enable;
+        message = "ghaf.boot-health.debugUnhealthyMicrovm is restricted to debug images";
+      }
+    ];
+    # The generic systemd service blesses solely on reaching boot-complete.
+    # Ghaf needs the stricter storage and MicroVM health gate above.
+    systemd.services.systemd-bless-boot.enable = false;
+    systemd.services.ghaf-boot-health = {
+      description = "Validate and bless a Ghaf A/B trial boot";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "cryptsetup.target"
+        "persist.mount"
+        "microvms.target"
+      ]
+      ++ vmServices;
+      wants = [
+        "persist.mount"
+        "microvms.target"
+      ]
+      ++ vmServices;
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = lib.getExe health;
+        TimeoutStartSec = "10min";
+      };
+    };
+    environment.systemPackages = [ health ];
+  };
+}

--- a/modules/partitioning/firstboot-persist.nix
+++ b/modules/partitioning/firstboot-persist.nix
@@ -7,9 +7,8 @@
 # to minimize flash image size (~5.5 GiB instead of ~16 GiB). On first
 # boot this service:
 #
-#   1. Resizes the GPT and APP partition to fill the eMMC
-#   2. Expands the LVM PV to match
-#   3. Creates swap and persist LVs from the free space, reserving
+#   1. Expands the LVM PV after initrd has grown APP and the open LUKS mapping
+#   2. Creates swap and persist LVs from the free space, reserving
 #      enough room for a future B-slot root+verity pair (OTA updates)
 #
 # Every step is idempotent — the service can be interrupted and re-run
@@ -35,36 +34,22 @@ let
     runtimeInputs = with pkgs; [
       gnugrep
       gawk
-      util-linux
-      gptfdisk
-      parted
       lvm2
       coreutils
       btrfs-progs
+      util-linux
     ];
     text = ''
       set -euo pipefail
       echo "firstboot-persist: starting at $(date)"
 
-      # --- Resize APP partition to fill the eMMC (idempotent) ---
+      # Initrd grows APP and the open LUKS mapping while the OP-TEE DUK is
+      # still available in its shared keyring.  Only the PV and new LVs are
+      # safe to grow here after switch-root.
 
       PV_PATH=$(pvdisplay -C -o pv_name --noheadings -S vg_name=pool | head -n1 | tr -d '[:space:]')
-      P_DEVPATH=$(readlink -f "$PV_PATH")
-      echo "PV: $PV_PATH -> $P_DEVPATH"
-
-      if [[ "$P_DEVPATH" =~ [0-9]+$ ]]; then
-        PARTNUM=$(echo "$P_DEVPATH" | grep -o '[0-9]*$')
-        PARENT_DISK=/dev/$(lsblk --nodeps --noheadings -o pkname "$P_DEVPATH")
-      else
-        echo "ERROR: cannot determine partition number from $P_DEVPATH"
-        exit 1
-      fi
-
-      echo "Fixing GPT and resizing partition $PARTNUM on $PARENT_DISK..."
-      sgdisk "$PARENT_DISK" -e || true
-      # parted resizepart updates the kernel's partition size synchronously
-      # via BLKPG_RESIZE_PARTITION ioctl, so no partprobe/udevadm needed.
-      parted -s -a opt "$PARENT_DISK" "resizepart $PARTNUM 100%" || true
+      [[ -n "$PV_PATH" ]] || { echo "ERROR: pool PV not found"; exit 1; }
+      echo "PV: $PV_PATH -> $(readlink -f "$PV_PATH")"
 
       # pvresize is idempotent — no-op if PV already matches partition
       echo "Resizing PV..."
@@ -89,7 +74,7 @@ let
         echo "swap LV already exists, skipping."
       fi
 
-      # --- Create persist LV (skip if already exists) ---
+      # --- Create persist LV and finish an interrupted format if needed ---
 
       if [ ! -e /dev/pool/persist ]; then
         VG_FREE_MIB=$(vgs --noheadings -o vg_free --nosuffix --units m pool | tr -d '[:space:]')
@@ -104,11 +89,24 @@ let
         echo "Creating persist LV: $PERSIST_MIB MiB (leaving $RESERVE_MIB MiB for B-slot)"
         lvcreate -L "''${PERSIST_MIB}M" -n persist pool
 
-        echo "Formatting persist as btrfs..."
-        mkfs.btrfs -L persist /dev/pool/persist
       else
-        echo "persist LV already exists, skipping."
+        echo "persist LV already exists."
       fi
+
+      PERSIST_TYPE=$(blkid -o value -s TYPE /dev/pool/persist 2>/dev/null || true)
+      case "$PERSIST_TYPE" in
+        "")
+          echo "Formatting uninitialized persist LV as btrfs..."
+          mkfs.btrfs -L persist /dev/pool/persist
+          ;;
+        btrfs)
+          echo "persist LV already contains btrfs, retaining it."
+          ;;
+        *)
+          echo "ERROR: persist LV has unexpected filesystem type: $PERSIST_TYPE"
+          exit 1
+          ;;
+      esac
 
       echo "firstboot-persist: done."
     '';

--- a/modules/partitioning/mk-manifest.py
+++ b/modules/partitioning/mk-manifest.py
@@ -5,39 +5,72 @@ import argparse
 import hashlib
 import json
 import os
+import sys
+import tempfile
 
-parser = argparse.ArgumentParser(
-    description="Rename verity artifacts and generate manifest."
-)
-parser.add_argument(
-    "--version", required=True, help="Version string for @v placeholder."
-)
-parser.add_argument(
-    "--system", required=True, help="System identifier (e.g. x86_64-linux)."
-)
-parser.add_argument(
-    "--hash-file", required=True, help="Path to dm-verity root hash file."
-)
-parser.add_argument(
-    "--root-image", required=True, help="Path to compressed root image."
-)
-parser.add_argument(
-    "--verity-image", required=True, help="Path to compressed verity image."
-)
-parser.add_argument("--kernel-image", required=True, help="Path to kernel/UKI image.")
-parser.add_argument("--manifest", required=True, help="Output manifest path template.")
-parser.add_argument(
-    "--root-unpacked-size",
-    type=int,
-    required=True,
-    help="Uncompressed root image size in bytes.",
-)
-parser.add_argument(
-    "--verity-unpacked-size",
-    type=int,
-    required=True,
-    help="Uncompressed verity image size in bytes.",
-)
+
+def add_generate_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--version", required=True, help="Version string for @v placeholder."
+    )
+    parser.add_argument(
+        "--system",
+        required=True,
+        help="Nix system identifier (for example aarch64-linux).",
+    )
+    parser.add_argument(
+        "--target", required=True, help="Exact hardware/update target identifier."
+    )
+    parser.add_argument(
+        "--generation", required=True, type=int, help="Monotonic generation."
+    )
+    parser.add_argument(
+        "--hash-file", required=True, help="Path to dm-verity root hash file."
+    )
+    parser.add_argument(
+        "--root-image", required=True, help="Path to compressed root image."
+    )
+    parser.add_argument(
+        "--verity-image", required=True, help="Path to compressed verity image."
+    )
+    parser.add_argument(
+        "--kernel-image", required=True, help="Path to kernel/UKI image."
+    )
+    parser.add_argument(
+        "--manifest", required=True, help="Output manifest path template."
+    )
+    parser.add_argument(
+        "--root-unpacked-size",
+        type=int,
+        required=True,
+        help="Uncompressed root image size in bytes.",
+    )
+    parser.add_argument(
+        "--verity-unpacked-size",
+        type=int,
+        required=True,
+        help="Uncompressed verity image size in bytes.",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate and rehash Ghaf update manifests."
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    add_generate_arguments(commands.add_parser("generate"))
+    rehash = commands.add_parser(
+        "rehash", help="Recompute artifact hashes and packed sizes in a manifest."
+    )
+    rehash.add_argument(
+        "--manifest", required=True, help="Manifest to update atomically."
+    )
+
+    # Keep direct option invocation compatible with the original generator CLI.
+    argv = sys.argv[1:]
+    if argv and argv[0].startswith("-"):
+        argv.insert(0, "generate")
+    return parser.parse_args(argv)
 
 
 def fixname(filename: str, version: str, fragment: str) -> str:
@@ -54,34 +87,88 @@ def rename(filename: str, version: str, fragment: str) -> str:
 
 
 def sha256_file(path: str) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def file_size(path: str) -> int:
     return os.path.getsize(path)
 
 
-def main() -> None:
-    args = parser.parse_args()
+def validate_metadata(manifest: dict) -> None:
+    if manifest.get("manifest_version") != 2:
+        raise ValueError("manifest_version must be 2")
+    for field in ("system", "target", "version"):
+        if not isinstance(manifest.get(field), str) or not manifest[field].strip():
+            raise ValueError(f"manifest {field} must be a non-empty string")
+    generation = manifest.get("generation")
+    if (
+        isinstance(generation, bool)
+        or not isinstance(generation, int)
+        or generation <= 0
+    ):
+        raise ValueError("manifest generation must be a positive integer")
+    root_hash = manifest.get("root_verity_hash")
+    if (
+        not isinstance(root_hash, str)
+        or len(root_hash) != 64
+        or any(character not in "0123456789abcdefABCDEF" for character in root_hash)
+    ):
+        raise ValueError("root_verity_hash must be exactly 64 hexadecimal characters")
 
-    with open(args.hash_file, "r", encoding="utf-8") as f:
-        first_line = f.readline().strip()
+
+def artifact_path(manifest_path: str, manifest: dict, kind: str) -> str:
+    entry = manifest.get(kind)
+    if not isinstance(entry, dict):
+        raise TypeError(f"manifest {kind} entry must be an object")
+    name = entry.get("file")
+    if (
+        not isinstance(name, str)
+        or not name
+        or name != os.path.basename(name)
+        or name in (".", "..")
+    ):
+        raise ValueError(f"manifest {kind} file must be a safe basename")
+    return os.path.join(os.path.dirname(os.path.abspath(manifest_path)), name)
+
+
+def write_manifest(path: str, manifest: dict) -> None:
+    directory = os.path.dirname(os.path.abspath(path))
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.", dir=directory, text=True
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            json.dump(manifest, file, indent=2, sort_keys=True)
+            file.write("\n")
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def generate(args: argparse.Namespace) -> None:
+    with open(args.hash_file, "r", encoding="utf-8") as file:
+        first_line = file.readline().strip()
     if not first_line:
         raise ValueError("hash_file first line is empty")
 
     root_verity_hash = first_line.split()[0]
     if len(root_verity_hash) < 64 or any(
-        c not in "0123456789abcdefABCDEF" for c in root_verity_hash[:64]
+        character not in "0123456789abcdefABCDEF" for character in root_verity_hash[:64]
     ):
         raise ValueError(
             "hash_file must contain at least 64 hex characters in first line"
         )
     root_verity_hash = root_verity_hash[:64]
-
     storehash = root_verity_hash[:16]
 
     store = rename(args.root_image, args.version, storehash)
@@ -89,9 +176,11 @@ def main() -> None:
     kernel = rename(args.kernel_image, args.version, storehash)
 
     manifest = {
-        "manifest_version": 0,
+        "manifest_version": 2,
         "system": args.system,
-        "meta": {},  # FIXME: reserved for future, just arbitrary metadata
+        "target": args.target,
+        "generation": args.generation,
+        "meta": {},
         "version": args.version,
         "root_verity_hash": root_verity_hash,
         "root": {
@@ -109,14 +198,44 @@ def main() -> None:
         "kernel": {
             "file": os.path.basename(kernel),
             "sha256": sha256_file(kernel),
+            "packed_size": file_size(kernel),
             "unpacked_size": file_size(kernel),
         },
     }
-    with open(
-        fixname(args.manifest, args.version, storehash), "w", encoding="utf-8"
-    ) as file:
-        json.dump(manifest, file, indent=2, sort_keys=True)
-        file.write("\n")
+    validate_metadata(manifest)
+    write_manifest(fixname(args.manifest, args.version, storehash), manifest)
+
+
+def rehash(manifest_path: str) -> None:
+    with open(manifest_path, "r", encoding="utf-8") as file:
+        manifest = json.load(file)
+    validate_metadata(manifest)
+
+    for kind in ("root", "verity", "kernel"):
+        path = artifact_path(manifest_path, manifest, kind)
+        size = file_size(path)
+        manifest[kind]["sha256"] = sha256_file(path)
+        manifest[kind]["packed_size"] = size
+        if kind == "kernel":
+            manifest[kind]["unpacked_size"] = size
+        else:
+            unpacked_size = manifest[kind].get("unpacked_size")
+            if (
+                isinstance(unpacked_size, bool)
+                or not isinstance(unpacked_size, int)
+                or unpacked_size <= 0
+            ):
+                raise ValueError(f"manifest {kind} unpacked_size must be positive")
+
+    write_manifest(manifest_path, manifest)
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "generate":
+        generate(args)
+    else:
+        rehash(args.manifest)
 
 
 if __name__ == "__main__":

--- a/modules/partitioning/verity-volume.nix
+++ b/modules/partitioning/verity-volume.nix
@@ -15,14 +15,29 @@ in
   options.ghaf.partitioning.verity = {
     enable = lib.mkEnableOption "the verity (image-based) partitioning scheme";
 
-    uki-signing-key-dir = lib.mkOption {
-      type = lib.types.nullOr lib.types.path;
-      default = null;
+    target = lib.mkOption {
+      type = lib.types.str;
+      default = config.networking.hostName;
       description = ''
-        Directory containing db.key and db.crt for signing the UKI in
-        the OTA update image. When set, the UKI is signed at build time
-        so devices with Secure Boot enabled can boot from OTA-installed
-        slots. In production, the OTA server signs images instead.
+        Exact target identifier embedded in signed update manifests.
+      '';
+    };
+
+    generation = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 1;
+      description = "Monotonic update generation embedded in the manifest and UKI.";
+    };
+
+    erofsCompression = lib.mkOption {
+      type = lib.types.enum [
+        "zstd"
+        "lz4hc"
+      ];
+      default = "zstd";
+      description = ''
+        EROFS compression algorithm. Targets with older EROFS kernels can
+        select lz4hc explicitly.
       '';
     };
   };
@@ -33,12 +48,6 @@ in
     # nix-gc service would only fail.
     nix.gc.automatic = lib.mkForce false;
 
-    assertions = [
-      {
-        assertion = cfg.uki-signing-key-dir == null || debugEnable;
-        message = "uki-signing-key-dir puts private keys in the Nix store and must only be used in debug builds. In production, the OTA server signs images before distribution.";
-      }
-    ];
     system.build.ghafImage =
       let
         inherit (config.ghaf) version;
@@ -84,7 +93,7 @@ in
           fi
 
           time ${erofs-utils-nix}/bin/mkfs.erofs \
-            -zzstd -T 1 --all-root \
+            -z${cfg.erofsCompression} -T 1 --all-root \
             --workers="$mkfsWorkers" \
             -L nix-store \
             ${fsImage} \
@@ -108,21 +117,13 @@ in
           test -n "$verityRoothash" || (echo "bad root hash" >&2 && exit 1)
 
           # Create UKI kernel with embedded verityhash
-          sed -E "s/^(Cmdline=.*)/\1 ghaf.storehash=$verityRoothash/" \
+          sed -E "s/^(Cmdline=.*)/\1 ghaf.storehash=$verityRoothash ghaf.generation=${toString cfg.generation}/" \
             ${config.boot.uki.configFile} >ukify-verity.conf
           ${pkgs.buildPackages.systemdUkify}/lib/systemd/ukify build \
             --config=ukify-verity.conf \
             --output="kernel.efi"
           # ${kernelImage} don't work for some reasons, so move kernel in place
           mv kernel.efi ${kernelImage}
-          ${lib.optionalString (cfg.uki-signing-key-dir != null) ''
-            echo "Signing UKI with Secure Boot key..."
-            ${pkgs.buildPackages.sbsigntool}/bin/sbsign \
-              --key ${cfg.uki-signing-key-dir}/db.key \
-              --cert ${cfg.uki-signing-key-dir}/db.crt \
-              --output ${kernelImage} ${kernelImage}
-          ''}
-
           # FIXME: move compression into mk-manifest.py and compute unpacked sizes there.
           rootUnpackedSize=$(stat -c%s ${fsImage})
           verityUnpackedSize=$(stat -c%s ${verityImage})
@@ -132,8 +133,11 @@ in
 
           # Create artifacts and manifest.
           ${pkgs.buildPackages.python3}/bin/python ${./mk-manifest.py} \
+            generate \
             --version ${version} \
             --system ${config.nixpkgs.hostPlatform.system} \
+            --target ${lib.escapeShellArg cfg.target} \
+            --generation ${toString cfg.generation} \
             --hash-file $out/dm-verity-root-hash \
             --root-image ${fsImage}.zst \
             --verity-image ${verityImage}.zst \

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -513,9 +513,16 @@ let
         uniqueKeyDescription=$1
         defaultKey=$2
         luksDev=$3
+        # The flash image reserves slot 1 for the printable recovery
+        # passphrase. Put the DUK in a known, separate slot so manufacturer
+        # removal cannot remove or rewrite recovery.
+        uniqueKeySlot=2
 
         printf "Switching to use device unique key. This might take a bit..\n"
-        if ! printf "%s" "$defaultKey" | cryptsetup luksAddKey --new-key-description "$uniqueKeyDescription" --key-file=- "$luksDev"; then
+        if ! printf "%s" "$defaultKey" | cryptsetup luksAddKey \
+          --new-key-description "$uniqueKeyDescription" \
+          --new-key-slot "$uniqueKeySlot" \
+          --key-file=- "$luksDev"; then
           printf "error: Failed to set unique key\n"
           handle_error
         fi
@@ -525,15 +532,11 @@ let
           handle_error
         fi
 
-        # luksAddKey/luksRemoveKey only swap keyslots; the volume key that
-        # actually encrypts the data is still the one the manufacturing
-        # passphrase protected. Reencrypt derives a fresh volume key from the
-        # device-unique key, so a leaked manufacturing passphrase grants nothing.
-        printf "Note: Re-encryption may take 1 minute for every 1 GB of data ...\n"
-        if ! cryptsetup reencrypt --key-description "$uniqueKeyDescription" "$luksDev"; then
-           printf "error: Re-encryption failed\n"
-           handle_error
-        fi
+        # Do not rotate the volume key here.  cryptsetup cannot re-wrap a
+        # recovery keyslot without knowing its passphrase, so volume-key
+        # re-encryption would discard the offline recovery credential.  Removing
+        # the manufacturer keyslot is sufficient to revoke that passphrase: it
+        # never exposed the random volume key itself.
       }
 
       # Resolve the LUKS partition by its pinned header UUID and verify it is a
@@ -591,6 +594,94 @@ let
         printf "error: Unable to add cryptrsetup token\n"
         handle_error
       fi
+    '';
+  };
+
+  # APP must be grown while the OP-TEE-derived key is still present in the
+  # initrd's shared keyring.  After switch-root that keyring is intentionally
+  # unreachable, so cryptsetup resize would otherwise prompt for a passphrase.
+  # The real-root firstboot service grows the PV and creates the remaining LVs.
+  resizeVerityLuksScript = pkgs.writeShellApplication {
+    name = "resize-verity-luks";
+    runtimeInputs = with pkgs; [
+      coreutils
+      cryptsetup
+      gptfdisk
+      parted
+      util-linux
+    ];
+    text = ''
+      set -euo pipefail
+
+      luks_dev=""
+      for dev in $(blkid -o device -t UUID=${luksUuid} 2>/dev/null); do
+        [ "$(blkid -o value -s TYPE "$dev" 2>/dev/null)" = "crypto_LUKS" ] || continue
+        luks_dev="$dev"
+        break
+      done
+      [ -n "$luks_dev" ] || { echo "ERROR: LUKS APP partition not found"; exit 1; }
+
+      real_dev=$(readlink -f "$luks_dev")
+      base_dev=$(basename "$real_dev")
+      part_num=$(cat "/sys/class/block/$base_dev/partition")
+      disk="/dev/$(basename "$(readlink -f "/sys/class/block/$base_dev/..")")"
+
+      echo "Growing APP partition $part_num on $disk..."
+      sgdisk -e "$disk" || true
+
+      # Grow to the largest partition size that is an exact multiple of the
+      # LUKS data-sector size.  A raw `resizepart 100%` can leave APP a few
+      # 512-byte sectors too long on NVMe; cryptsetup then refuses to grow a
+      # mapping whose data sector is 4096 bytes.
+      part_start=$(cat "/sys/class/block/$base_dev/start")
+      last_usable=""
+      while IFS= read -r line; do
+        if [[ "$line" =~ last\ usable\ sector\ is\ ([0-9]+) ]]; then
+          last_usable="''${BASH_REMATCH[1]}"
+          break
+        fi
+      done < <(sgdisk -p "$disk")
+      logical_sector_bytes=$(blockdev --getss "$disk")
+      luks_sector_bytes=""
+      while read -r field value _; do
+        if [ "$field" = "sector:" ]; then
+          luks_sector_bytes="$value"
+          break
+        fi
+      done < <(cryptsetup luksDump "$real_dev")
+
+      [[ "$part_start" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid APP start sector"; exit 1; }
+      [[ "$last_usable" =~ ^[0-9]+$ ]] || { echo "ERROR: GPT last usable sector not found"; exit 1; }
+      [[ "$logical_sector_bytes" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid disk sector size"; exit 1; }
+      [[ "$luks_sector_bytes" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid LUKS sector size"; exit 1; }
+      (( luks_sector_bytes >= logical_sector_bytes )) || { echo "ERROR: LUKS sector is smaller than disk sector"; exit 1; }
+      (( luks_sector_bytes % logical_sector_bytes == 0 )) || { echo "ERROR: incompatible LUKS and disk sector sizes"; exit 1; }
+
+      alignment=$((luks_sector_bytes / logical_sector_bytes))
+      max_part_sectors=$((last_usable - part_start + 1))
+      aligned_part_sectors=$((max_part_sectors / alignment * alignment))
+      aligned_end=$((part_start + aligned_part_sectors - 1))
+      (( aligned_part_sectors > 0 )) || { echo "ERROR: no usable aligned APP space"; exit 1; }
+
+      # NVIDIA's generated GPT can leave a handful of sectors outside the
+      # usable range.  --fix answers that repair prompt noninteractively.
+      parted -s -f -a none "$disk" unit s resizepart "$part_num" "''${aligned_end}s"
+      udevadm settle
+
+      # Do not race cryptsetup against the kernel's partition-table update.
+      for _ in $(seq 1 50); do
+        [ "$(cat "/sys/class/block/$base_dev/size")" -eq "$aligned_part_sectors" ] && break
+        sleep 0.1
+      done
+      [ "$(cat "/sys/class/block/$base_dev/size")" -eq "$aligned_part_sectors" ] || {
+        echo "ERROR: kernel did not observe the aligned APP size"
+        exit 1
+      }
+
+      echo "Growing open LUKS mapping ${cfg.diskEncryption.mapperName}..."
+      cryptsetup resize \
+        --key-description ${luksDiskKeyDescription} \
+        ${cfg.diskEncryption.mapperName}
     '';
   };
 
@@ -719,6 +810,15 @@ in
       defaultText = lib.literalExpression "config.ghaf.profiles.debug.enable";
     };
 
+    ftpm.enable = mkOption {
+      description = ''
+        Load the OP-TEE-backed firmware TPM during stage 2. This is independent
+        of the OP-TEE device-unique-key service used for disk encryption.
+      '';
+      type = types.bool;
+      default = true;
+    };
+
     diskEncryption = {
       enable = mkEnableOption "generic LUKS root filesystem encryption for eMMC APP partition";
 
@@ -835,12 +935,10 @@ in
         '';
       }
       {
-        assertion = !(cfg.diskEncryption.enable && verityEnabled);
+        assertion = !cfg.runtimeEkProvision.enable || cfg.ftpm.enable;
         message = ''
-          ghaf.hardware.nvidia.orin.diskEncryption.enable and
-          ghaf.partitioning.verity.enable are mutually exclusive root strategies:
-          verity owns fileSystems."/" as a tmpfs overlay, LUKS as an ext4 root on
-          /dev/mapper/${cfg.diskEncryption.mapperName}. Enable at most one.
+          ghaf.hardware.nvidia.orin.runtimeEkProvision.enable requires
+          ghaf.hardware.nvidia.orin.ftpm.enable.
         '';
       }
     ];
@@ -1041,6 +1139,7 @@ in
         ]
         ++ lib.optionals cfg.diskEncryption.deviceUniqueKey.enable [
           preDiskUniqueKeyScript
+          resizeVerityLuksScript
           postDiskUniqueKeyScript
         ];
 
@@ -1099,12 +1198,35 @@ in
           };
         };
 
+        resize-verity-luks = lib.mkIf verityEnabled {
+          description = "Grow verity APP and LUKS mapping before DUK cleanup";
+          wantedBy = [ "initrd-root-fs.target" ];
+          after = [
+            "systemd-cryptsetup@${cfg.diskEncryption.mapperName}.service"
+          ];
+          before = [
+            "initrd-root-fs.target"
+            "post-disk-unique-key.service"
+          ];
+          unitConfig = {
+            DefaultDependencies = false;
+          };
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${resizeVerityLuksScript}/bin/resize-verity-luks";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+            KeyringMode = "shared";
+          };
+        };
+
         post-disk-unique-key = {
           description = "Cleanup service for device unique key disk encryption";
           wantedBy = [ "initrd-switch-root.target" ];
-          after = [
-            "resize-partitions.service"
-          ];
+          after =
+            lib.optionals (!verityEnabled) [ "resize-partitions.service" ]
+            ++ lib.optionals verityEnabled [ "resize-verity-luks.service" ];
           unitConfig = {
             DefaultDependencies = false;
           };
@@ -1155,7 +1277,7 @@ in
       };
     };
 
-    systemd.services.ghaf-load-ftpm-module = {
+    systemd.services.ghaf-load-ftpm-module = mkIf cfg.ftpm.enable {
       description = "Load fTPM module after stage-2 OP-TEE readiness";
       wantedBy = [ "multi-user.target" ];
       wants = [
@@ -1180,7 +1302,7 @@ in
       };
     };
 
-    systemd.services.ghaf-provision-ek-certs = mkIf cfg.runtimeEkProvision.enable {
+    systemd.services.ghaf-provision-ek-certs = mkIf (cfg.ftpm.enable && cfg.runtimeEkProvision.enable) {
       description = "Provision fTPM EK certificates into standard NV indices";
       wantedBy = [ "multi-user.target" ];
       wants = [ "tee-supplicant.service" ];
@@ -1202,7 +1324,7 @@ in
       };
     };
 
-    systemd.services.ghaf-export-ek-endorsement-bundle = {
+    systemd.services.ghaf-export-ek-endorsement-bundle = mkIf cfg.ftpm.enable {
       description = "Export EK certs and build endorsement CA bundle";
       wantedBy = [ "multi-user.target" ];
       wants = [ "tee-supplicant.service" ];

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Partition template for A/B verity boot on NVIDIA Jetson Orin AGX.
+# Partition template for A/B verity boot on NVIDIA Jetson Orin.
 #
-# Produces a flash.xml with two partitions on eMMC:
+# Produces a flash.xml with two partitions on the target storage device:
 #   - ESP (512M, vfat) with systemd-boot + UKI
 #   - APP (LVM PV) with A/B root+verity slots, swap, persist
 #
@@ -18,17 +18,23 @@
 }:
 let
   cfg = config.ghaf.hardware.nvidia.orin;
+  trustDigests = cfg.secureboot.publicTrustDigests;
+  expectedPkDigest = trustDigests."PK.crt" or "";
+  expectedKekDigest = trustDigests."KEK.crt" or "";
+  expectedDbDigest = trustDigests."db.crt" or "";
+  expectedUpdateDigest = trustDigests."update.pub" or "";
 
   inherit (config.system.build) verityImages;
 
-  # eMMC partition layout as structured Nix data.
+  # Root storage partition layout as structured Nix data.
   # Serialized to JSON and spliced into NVIDIA's flash XML by
-  # splice-flash-xml.py, which replaces the <device type="sdmmc_user">
-  # children. This avoids fragile line-count splicing.
+  # splice-flash-xml.py, which replaces either the eMMC
+  # <device type="sdmmc_user"> or NVMe <device type="nvme"> children.
+  # This avoids fragile line-count splicing.
   #
   # All values are fully resolved at Nix build time (the APP partition
   # size is read from the LVM image derivation via --set).
-  partitionsEmmc = [
+  partitionsStorage = [
     {
       name = "master_boot_record";
       type = "protective_master_boot_record";
@@ -81,7 +87,7 @@ let
         percent_reserved = "0x808";
         unique_guid = "APPUUID";
         filename = "system.img";
-        description = "LVM PV containing A/B root+verity slots, swap, persist.";
+        description = "LUKS2 cryptpool containing an LVM PV with A/B root+verity, swap, persist.";
       };
     }
     {
@@ -98,15 +104,23 @@ let
     }
   ];
 
-  # Build the final flash.xml by replacing the sdmmc_user partitions
+  # Build the final flash.xml by replacing the storage-device partitions
   # in NVIDIA's template with our layout using XML-aware splicing.
+  #
+  # Orin NX has no eMMC. Its p3768 devkit must use NVIDIA's NVMe template;
+  # using the SDMMC template makes MB2 probe SDMMC instance 3, fail with
+  # "Secondary storage init failed", and hang in Busy Spin before flashing.
   partitionTemplate =
     let
       inherit (pkgs.nvidia-jetpack) bspSrc;
-      isIndustrial = config.hardware.nvidia-jetpack.som == "orin-agx-industrial";
+      inherit (config.hardware.nvidia-jetpack) som;
+      isIndustrial = som == "orin-agx-industrial";
+      isNvme = som == "orin-nx";
       xmlFile =
         if isIndustrial then
           "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_sdmmc_industrial.xml"
+        else if isNvme then
+          "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_nvme.xml"
         else
           "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_sdmmc.xml";
     in
@@ -116,9 +130,11 @@ let
       }
       ''
         python3 ${./splice-flash-xml.py} \
+          --device-type "${if isNvme then "nvme" else "sdmmc_user"}" \
+          ${lib.optionalString cfg.flashScriptOverrides.onlyQSPI "--remove-device"} \
           --set "APP.size=$(cat ${verityImages}/system.raw_size)" \
           ${xmlFile} \
-          ${pkgs.writeText "sdmmc-verity.json" (builtins.toJSON partitionsEmmc)} \
+          ${pkgs.writeText "verity-storage.json" (builtins.toJSON partitionsStorage)} \
           "$out"
       '';
 
@@ -132,6 +148,71 @@ let
     echo "Carrier board: ${config.hardware.nvidia-jetpack.carrierBoard}"
     echo "============================================================"
     echo ""
+
+    _external_public_trust=${
+      if config.ghaf.hardware.nvidia.orin.secureboot.externalPublicTrustConfigured then "1" else "0"
+    }
+    if [ "$_external_public_trust" != 1 ]; then
+      echo "ERROR: this flash script was built with CI-only public trust and cannot flash a secure A/B canary." >&2
+      echo "  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen." >&2
+      exit 1
+    fi
+
+    if [ -z "''${GHAF_DEV_KEY_DIR:-}" ]; then
+      echo "ERROR: GHAF_DEV_KEY_DIR is required for secure A/B canary flashes." >&2
+      exit 1
+    fi
+    for _required in PK.crt KEK.crt db.crt db.key update.pub update.key; do
+      if [ ! -s "$GHAF_DEV_KEY_DIR/$_required" ]; then
+        echo "ERROR: missing $GHAF_DEV_KEY_DIR/$_required" >&2
+        exit 1
+      fi
+    done
+
+    _check_public_trust() {
+      _trust_name="$1"
+      _expected_digest="$2"
+      _actual_digest=$("${pkgs.pkgsBuildBuild.coreutils}/bin/sha256sum" "$GHAF_DEV_KEY_DIR/$_trust_name")
+      _actual_digest="''${_actual_digest%% *}"
+      if [ -z "$_expected_digest" ] || [ "$_actual_digest" != "$_expected_digest" ]; then
+        echo "ERROR: GHAF_DEV_KEY_DIR public trust does not match the trust embedded at image evaluation: $_trust_name" >&2
+        echo "  Rebuild the flash script with this exact GHAF_DEV_KEY_DIR." >&2
+        exit 1
+      fi
+    }
+    _check_public_trust PK.crt ${lib.escapeShellArg expectedPkDigest}
+    _check_public_trust KEK.crt ${lib.escapeShellArg expectedKekDigest}
+    _check_public_trust db.crt ${lib.escapeShellArg expectedDbDigest}
+    _check_public_trust update.pub ${lib.escapeShellArg expectedUpdateDigest}
+
+    _trust_check_dir=$(mktemp -d)
+    "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" pkey \
+      -in "$GHAF_DEV_KEY_DIR/db.key" -pubout -outform DER \
+      -out "$_trust_check_dir/db-key.der"
+    "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" x509 \
+      -in "$GHAF_DEV_KEY_DIR/db.crt" -pubkey -noout \
+      -out "$_trust_check_dir/db-cert.pem"
+    "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" pkey \
+      -pubin -in "$_trust_check_dir/db-cert.pem" -outform DER \
+      -out "$_trust_check_dir/db-cert.der"
+    if ! "${pkgs.pkgsBuildBuild.diffutils}/bin/cmp" -s \
+      "$_trust_check_dir/db-key.der" "$_trust_check_dir/db-cert.der"; then
+      echo "ERROR: GHAF_DEV_KEY_DIR private key does not match public trust: db.key/db.crt" >&2
+      exit 1
+    fi
+
+    "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" pkey \
+      -in "$GHAF_DEV_KEY_DIR/update.key" -pubout -outform DER \
+      -out "$_trust_check_dir/update-key.der"
+    "${pkgs.pkgsBuildBuild.coreutils}/bin/tail" -c 32 \
+      "$_trust_check_dir/update-key.der" > "$_trust_check_dir/update-key.raw"
+    if [ "$("${pkgs.pkgsBuildBuild.coreutils}/bin/wc" -c < "$GHAF_DEV_KEY_DIR/update.pub")" -ne 32 ] \
+      || ! "${pkgs.pkgsBuildBuild.diffutils}/bin/cmp" -s \
+        "$_trust_check_dir/update-key.raw" "$GHAF_DEV_KEY_DIR/update.pub"; then
+      echo "ERROR: GHAF_DEV_KEY_DIR private key does not match public trust: update.key/update.pub" >&2
+      exit 1
+    fi
+    rm -rf "$_trust_check_dir"
 
     mkdir -pv "$WORKDIR/bootloader"
 
@@ -152,12 +233,7 @@ let
     cp "$_uki_src" "$_sign_dir/$_uki_name"
 
     # Sign EFI binaries if secure boot keys are available
-    _sb_key_dir="''${SECURE_BOOT_SIGNING_KEY_DIR:-${
-      if config.ghaf.hardware.nvidia.orin.secureboot.enable then
-        config.ghaf.hardware.nvidia.orin.secureboot.signingKeyDir
-      else
-        ""
-    }}"
+    _sb_key_dir="$GHAF_DEV_KEY_DIR"
     if [ -n "$_sb_key_dir" ] && [ -f "$_sb_key_dir/db.key" ] && [ -f "$_sb_key_dir/db.crt" ]; then
       echo "Signing EFI binaries with $_sb_key_dir/db.crt ..."
       for _efi in "$_sign_dir"/*.efi; do
@@ -171,8 +247,7 @@ let
         ''
           else
             echo "ERROR: Secure Boot is enabled but no signing keys found." >&2
-            echo "  Set SECURE_BOOT_SIGNING_KEY_DIR or place db.key + db.crt in:" >&2
-            echo "  $_sb_key_dir" >&2
+            echo "  Set GHAF_DEV_KEY_DIR to a directory from ghaf-dev-keygen." >&2
             exit 1
         ''
       else
@@ -193,11 +268,50 @@ let
     rm -rf "$_sign_dir"
     echo "ESP image built: $_esp"
 
-    echo "Decompressing pre-built system (LVM) sparse image..."
-    "${pkgs.pkgsBuildBuild.zstd}/bin/zstd" -f -d "${verityImages}/system.img.zst" -o "$WORKDIR/bootloader/system.img"
+    echo "Decompressing pre-built LVM payload..."
+    _plain="$WORKDIR/bootloader/system.lvm"
+    "${pkgs.pkgsBuildBuild.zstd}/bin/zstd" -f -d "${verityImages}/system.img.zst" -o "$_plain"
+    ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
+      _recovery_dir="$GHAF_DEV_KEY_DIR/recovery-passphrases"
+      mkdir -p "$_recovery_dir"
+      _recovery="$_recovery_dir/recovery-$(date -u +%Y%m%dT%H%M%SZ).txt"
+      # Store exactly the printable passphrase bytes that an operator types.
+      # A trailing newline would become part of a cryptsetup key file during
+      # enrollment and make the printed value fail interactive recovery.
+      "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" rand -base64 24 \
+        | "${pkgs.pkgsBuildBuild.coreutils}/bin/tr" -d '\n' > "$_recovery"
+      chmod 0600 "$_recovery"
+
+      _outer="$WORKDIR/bootloader/system.img"
+      truncate -s "$(cat ${verityImages}/system.raw_size)" "$_outer"
+      printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
+        | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" luksFormat --batch-mode \
+          --type luks2 --uuid ${config.ghaf.hardware.nvidia.orin.diskEncryption.luksUuid} \
+          --key-slot 0 \
+          --key-file=- "$_outer"
+      printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
+        | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" luksAddKey \
+          --new-key-slot 1 \
+          --key-file=- "$_outer" "$_recovery"
+      _mapper="ghaf-flash-$PPID"
+      printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
+        | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" open --key-file=- "$_outer" "$_mapper"
+      "${pkgs.pkgsBuildBuild.coreutils}/bin/dd" if="$_plain" of="/dev/mapper/$_mapper" bs=4M conv=fsync,notrunc status=progress
+      "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" close "$_mapper"
+      rm -f "$_plain"
+      echo "============================================================"
+      echo "RECOVERY PASSPHRASE (store securely; generated for this flash):"
+      cat "$_recovery"
+      printf '\n'
+      echo "Saved at: $_recovery"
+      echo "============================================================"
+    ''}
+    ${lib.optionalString (!config.ghaf.hardware.nvidia.orin.diskEncryption.enable) ''
+      mv "$_plain" "$WORKDIR/bootloader/system.img"
+    ''}
     # flash.sh -k APP looks for system.img relative to $WORKDIR
     ln -sf "$WORKDIR/bootloader/system.img" "$WORKDIR/system.img"
-    echo "LVM image: $("${pkgs.pkgsBuildBuild.coreutils}/bin/stat" -c%s "$WORKDIR/bootloader/system.img") bytes (compressed)"
+    echo "APP image: $("${pkgs.pkgsBuildBuild.coreutils}/bin/stat" -c%s "$WORKDIR/bootloader/system.img") bytes"
 
     # Ensure all DTB variants in kernel/dtb/ have NixOS overlays applied.
     # NixOS only applies deviceTree.overlays to the DTB named in

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -162,6 +162,10 @@ in
               # Minimal loader configuration
               cat > firmware/loader/loader.conf << EOF
               timeout 0
+              # Keep legacy ghaf_kernel_* images outside A/B selection. A
+              # boot-counted ghaf-* trial sorts ahead of the blessed entry
+              # until its attempts are exhausted, then sorts behind it.
+              default ghaf-*.efi
               editor no
               console-mode keep
               EOF

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/secureboot.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/secureboot.nix
@@ -33,15 +33,26 @@ let
 
   keysDir = cfg.keysSource;
 
-  requiredCertFiles = [
-    (keysDir + "/PK.crt")
-    (keysDir + "/KEK.crt")
-    (keysDir + "/db.crt")
-  ];
+  certFile =
+    name:
+    if cfg.certificateContents == null then
+      keysDir + "/${name}.crt"
+    else
+      pkgs.writeText "ghaf-secureboot-${name}.crt" cfg.certificateContents.${name};
 
-  pkEsl = eslFromCert "PK.esl" (keysDir + "/PK.crt");
-  kekEsl = eslFromCert "KEK.esl" (keysDir + "/KEK.crt");
-  dbEsl = eslFromCert "db.esl" (keysDir + "/db.crt");
+  requiredCertFiles =
+    if cfg.certificateContents == null then
+      [
+        (keysDir + "/PK.crt")
+        (keysDir + "/KEK.crt")
+        (keysDir + "/db.crt")
+      ]
+    else
+      [ ];
+
+  pkEsl = eslFromCert "PK.esl" (certFile "PK");
+  kekEsl = eslFromCert "KEK.esl" (certFile "KEK");
+  dbEsl = eslFromCert "db.esl" (certFile "db");
 in
 {
   options.ghaf.hardware.nvidia.orin.secureboot = {
@@ -53,9 +64,26 @@ in
       description = "Directory containing PK.crt, KEK.crt and db.crt used to generate ESLs.";
     };
 
+    certificateContents = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.submodule {
+          options = {
+            PK = lib.mkOption { type = lib.types.lines; };
+            KEK = lib.mkOption { type = lib.types.lines; };
+            db = lib.mkOption { type = lib.types.lines; };
+          };
+        }
+      );
+      default = null;
+      description = ''
+        Public UEFI certificates supplied as text. This imports only public
+        material when a development trust directory also contains private keys.
+      '';
+    };
+
     signingKeyDir = lib.mkOption {
       type = lib.types.str;
-      default = toString ../../../../secureboot/dev-keys;
+      default = "";
       description = ''
         Path to directory containing db.key and db.crt for signing EFI
         binaries at flash time (on the build host). This is intentionally
@@ -64,6 +92,30 @@ in
 
         Can be overridden at flash time via the SECURE_BOOT_SIGNING_KEY_DIR
         environment variable.
+      '';
+    };
+
+    externalPublicTrustConfigured = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      internal = true;
+      description = ''
+        Whether the image was evaluated with a complete external public trust
+        set. The exported flake flash entry point uses this marker to select
+        either the secure A/B implementation or the board-matched generic
+        unsigned fallback. The secure A/B implementation itself remains
+        fail-closed for CI-only images.
+      '';
+    };
+
+    publicTrustDigests = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      internal = true;
+      description = ''
+        SHA-256 digests of the external public trust files embedded during
+        evaluation. Flash scripts compare these with the runtime key directory
+        before signing or preparing images.
       '';
     };
   };

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
@@ -46,7 +46,16 @@ let
       exit 1
     fi
     ln -s "$uki" "$out/uki.efi"
-    basename "$uki" > "$out/uki-filename"
+
+    # The image artifact keeps its manifest-facing ghaf_kernel_* name, but
+    # systemd-boot and ota-update use ghaf-<version>-<hash>.efi as the stable
+    # managed entry ID.  Flash the initial UKI under that same name so the
+    # first slot participates in normal A/B discovery and is removed when its
+    # physical slot is reused.
+    manifest=$(find ${ghafImage} -name '*.manifest' | head -1)
+    version=$(${pkgs.buildPackages.jq}/bin/jq -er '.version' "$manifest")
+    root_hash=$(${pkgs.buildPackages.jq}/bin/jq -er '.root_verity_hash' "$manifest")
+    printf 'ghaf-%s-%s.efi\n' "$version" "''${root_hash:0:16}" > "$out/uki-filename"
 
     # systemd-boot
     ln -s "${config.systemd.package}/lib/systemd/boot/efi/systemd-bootaa64.efi" \
@@ -147,7 +156,9 @@ let
       # The image is small (only A-slot, ~5.5 GiB) so we just
       # zstd-compress the raw image directly — no sparse conversion needed.
       postVM = ''
-        ${buildPkgs.coreutils}/bin/stat -c%s "$out/system.img" > "$out/system.raw_size"
+        # Reserve space for the outer LUKS2 header created at flash time.
+        lvm_size=$(${buildPkgs.coreutils}/bin/stat -c%s "$out/system.img")
+        echo $((lvm_size + 32 * 1024 * 1024)) > "$out/system.raw_size"
         ${buildPkgs.zstd}/bin/zstd --compress --rm "$out/system.img" -o "$out/system.img.zst"
       '';
 

--- a/packages/pkgs-by-name/ghaf-dev-keygen/ghaf-dev-keygen.sh
+++ b/packages/pkgs-by-name/ghaf-dev-keygen/ghaf-dev-keygen.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+usage() {
+  echo "Usage: ghaf-dev-keygen --output DIR" >&2
+  exit 2
+}
+
+output=""
+while (($#)); do
+  case "$1" in
+  --output)
+    output="${2:-}"
+    shift 2
+    ;;
+  *) usage ;;
+  esac
+done
+[[ -n $output ]] || usage
+
+umask 077
+mkdir -p "$output/recovery-passphrases"
+chmod 0700 "$output" "$output/recovery-passphrases"
+for file in PK.key PK.crt KEK.key KEK.crt db.key db.crt update.key update.pub update.pub.der; do
+  if [[ -e "$output/$file" ]]; then
+    echo "Refusing to overwrite $output/$file" >&2
+    exit 1
+  fi
+done
+
+for name in PK KEK db; do
+  openssl req -new -x509 -newkey rsa:2048 -sha256 -nodes \
+    -subj "/CN=Ghaf development $name/" -days 3650 \
+    -keyout "$output/$name.key" -out "$output/$name.crt"
+done
+
+openssl genpkey -algorithm ED25519 -out "$output/update.key"
+openssl pkey -in "$output/update.key" -pubout -outform DER -out "$output/update.pub.der"
+tail -c 32 "$output/update.pub.der" >"$output/update.pub"
+rm "$output/update.pub.der"
+[[ $(stat -c%s "$output/update.pub") -eq 32 ]]
+chmod 0600 "$output"/*.key "$output/update.pub"
+echo "Development trust directory created at $output"
+echo "Private keys must remain outside Git and the Nix store."

--- a/packages/pkgs-by-name/ghaf-dev-keygen/package.nix
+++ b/packages/pkgs-by-name/ghaf-dev-keygen/package.nix
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  coreutils,
+  openssl,
+  writeShellApplication,
+}:
+writeShellApplication {
+  name = "ghaf-dev-keygen";
+  runtimeInputs = [
+    coreutils
+    openssl
+  ];
+  text = builtins.readFile ./ghaf-dev-keygen.sh;
+  meta.description = "Generate local Ghaf development UEFI and update signing keys";
+}

--- a/packages/pkgs-by-name/ghaf-sign-update/ghaf-sign-update.sh
+++ b/packages/pkgs-by-name/ghaf-sign-update/ghaf-sign-update.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+usage() {
+  echo "Usage: ghaf-sign-update --key-dir DIR --input MANIFEST --output DIR" >&2
+  exit 2
+}
+
+key_dir="" input="" output=""
+while (($#)); do
+  case "$1" in
+  --key-dir)
+    key_dir="${2:-}"
+    shift 2
+    ;;
+  --input)
+    input="${2:-}"
+    shift 2
+    ;;
+  --output)
+    output="${2:-}"
+    shift 2
+    ;;
+  *) usage ;;
+  esac
+done
+[[ -n $key_dir && -n $input && -n $output ]] || usage
+for required in db.key db.crt update.key; do
+  [[ -s "$key_dir/$required" ]] || {
+    echo "Missing $key_dir/$required" >&2
+    exit 1
+  }
+done
+[[ $(jq -er '
+  .manifest_version == 2
+  and (.system | type == "string" and length > 0)
+  and (.target | type == "string" and length > 0)
+  and (.generation | type == "number" and floor == . and . > 0)
+  and (.root_verity_hash | type == "string" and test("^[0-9a-fA-F]{64}$"))
+' "$input") == true ]]
+
+source_dir=$(cd "$(dirname "$input")" && pwd)
+mkdir -p "$output"
+manifest="$output/$(basename "$input")"
+cp "$input" "$manifest"
+
+for kind in root verity; do
+  file=$(jq -er ".$kind.file" "$manifest")
+  [[ $file == "$(basename -- "$file")" ]] || {
+    echo "Unsafe artifact path: $file" >&2
+    exit 1
+  }
+  jq -e --arg kind "$kind" '.[$kind].unpacked_size | type == "number" and floor == . and . > 0' \
+    "$manifest" >/dev/null
+  cp "$source_dir/$file" "$output/$file"
+done
+
+kernel=$(jq -er '.kernel.file' "$manifest")
+[[ $kernel == "$(basename -- "$kernel")" ]] || {
+  echo "Unsafe artifact path: $kernel" >&2
+  exit 1
+}
+sbsign --key "$key_dir/db.key" --cert "$key_dir/db.crt" \
+  --output "$output/$kernel" "$source_dir/$kernel"
+
+# Reuse the manifest generator's validation and hashing implementation after
+# UKI signing changes the kernel bytes.
+ghaf-update-manifest rehash --manifest "$manifest"
+
+openssl pkeyutl -sign -rawin -inkey "$key_dir/update.key" \
+  -in "$manifest" -out "$manifest.sig"
+[[ $(stat -c%s "$manifest.sig") -eq 64 ]]
+echo "Signed update written to $output"

--- a/packages/pkgs-by-name/ghaf-sign-update/package.nix
+++ b/packages/pkgs-by-name/ghaf-sign-update/package.nix
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  coreutils,
+  jq,
+  openssl,
+  python3,
+  sbsigntool,
+  writeShellApplication,
+  writeShellScriptBin,
+}:
+let
+  manifestTool = writeShellScriptBin "ghaf-update-manifest" ''
+    exec ${python3}/bin/python ${../../../modules/partitioning/mk-manifest.py} "$@"
+  '';
+in
+writeShellApplication {
+  name = "ghaf-sign-update";
+  runtimeInputs = [
+    coreutils
+    jq
+    openssl
+    sbsigntool
+    manifestTool
+  ];
+  text = builtins.readFile ./ghaf-sign-update.sh;
+  meta.description = "Sign a Ghaf update UKI and detached manifest outside the Nix store";
+}

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -13,6 +13,22 @@ let
   inherit (inputs) jetpack-nixos nixpkgs;
   system = "aarch64-linux";
   pkgsX86 = nixpkgs.legacyPackages.x86_64-linux;
+  updateGenerationText = builtins.getEnv "GHAF_UPDATE_GENERATION";
+  updateHealthFailureText = builtins.getEnv "GHAF_AB_TEST_UNHEALTHY";
+  updateGeneration =
+    if updateGenerationText == "" then
+      1
+    else if builtins.match "^[1-9][0-9]*$" updateGenerationText == null then
+      throw "GHAF_UPDATE_GENERATION must be a positive decimal integer"
+    else
+      builtins.fromJSON updateGenerationText;
+  updateHealthFailure =
+    if updateHealthFailureText == "" then
+      false
+    else if updateHealthFailureText == "1" then
+      true
+    else
+      throw "GHAF_AB_TEST_UNHEALTHY must be unset or 1";
   lazyPackage =
     name: drv:
     (lib.lazyDerivation {
@@ -106,6 +122,7 @@ let
     inputs.nix-store-veritysetup-generator.nixosModules.ghaf-store-veritysetup-generator
     ../../modules/partitioning/verity-volume.nix
     ../../modules/partitioning/firstboot-persist.nix
+    ../../modules/partitioning/boot-health.nix
     # Enable dm-verity and erofs in the kernel (not in the BSP default config)
     {
       boot.kernelPatches = [
@@ -123,6 +140,174 @@ let
       ];
     }
   ];
+
+  mkDevTrustModule =
+    target:
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      keyDir = builtins.getEnv "GHAF_DEV_KEY_DIR";
+      requiredPublic = [
+        "PK.crt"
+        "KEK.crt"
+        "db.crt"
+        "update.pub"
+      ];
+      missingPublic = lib.filter (name: !builtins.pathExists "${keyDir}/${name}") requiredPublic;
+      haveExternalPublic = keyDir != "" && missingPublic == [ ];
+      externalPublicFile =
+        name:
+        builtins.path {
+          path = builtins.toPath "${keyDir}/${name}";
+          name = "ghaf-dev-${name}";
+        };
+      fallbackUefiCertDir = ../../modules/secureboot/dev-keys;
+      # RFC 8032 test-vector public key 1. Its private seed is public, so this
+      # key is deliberately suitable only for pure evaluation and CI builds.
+      # Flashing still requires an external trust directory and never uses
+      # this key to sign anything.
+      fallbackUpdatePub = pkgs.runCommand "ghaf-ci-only-update.pub" { } ''
+        printf '%s' '11qYAYKxCrfVS/7TyWQHOg7hcvPapiMlrwIaaPcHURo=' \
+          | ${pkgs.buildPackages.coreutils}/bin/base64 --decode > "$out"
+        test "$(${pkgs.buildPackages.coreutils}/bin/wc -c < "$out")" -eq 32
+      '';
+      trustWarning =
+        if haveExternalPublic then
+          "${target}: using external public trust from GHAF_DEV_KEY_DIR; private signing keys remain outside the Nix store."
+        else
+          "${target}: GHAF_DEV_KEY_DIR is unset; using repository development public trust for evaluation/build only. Secure A/B flashing and update signing require GHAF_DEV_KEY_DIR from ghaf-dev-keygen; the exported flash script falls back to the generic unsigned target.";
+    in
+    {
+      assertions = lib.optional (keyDir != "") {
+        assertion = haveExternalPublic;
+        message = "${target}: GHAF_DEV_KEY_DIR is set but missing required public trust files: ${lib.concatStringsSep ", " missingPublic}.";
+      };
+      warnings = lib.optional (keyDir == "" || haveExternalPublic) trustWarning;
+
+      ghaf.hardware.nvidia.orin.secureboot.certificateContents =
+        if haveExternalPublic then
+          {
+            PK = builtins.readFile "${keyDir}/PK.crt";
+            KEK = builtins.readFile "${keyDir}/KEK.crt";
+            db = builtins.readFile "${keyDir}/db.crt";
+          }
+        else
+          {
+            PK = builtins.readFile (fallbackUefiCertDir + "/PK.crt");
+            KEK = builtins.readFile (fallbackUefiCertDir + "/KEK.crt");
+            db = builtins.readFile (fallbackUefiCertDir + "/db.crt");
+          };
+      ghaf.hardware.nvidia.orin.secureboot.externalPublicTrustConfigured = haveExternalPublic;
+      ghaf.hardware.nvidia.orin.secureboot.publicTrustDigests =
+        if haveExternalPublic then
+          lib.genAttrs requiredPublic (name: builtins.hashFile "sha256" "${keyDir}/${name}")
+        else
+          { };
+      environment.etc = {
+        "ghaf/update/update.pub".source =
+          if haveExternalPublic then externalPublicFile "update.pub" else fallbackUpdatePub;
+        "ghaf/update/db.crt".source =
+          if haveExternalPublic then externalPublicFile "db.crt" else fallbackUefiCertDir + "/db.crt";
+        # Keep consecutive canary generations distinct in the immutable root
+        # closure so their A/B LV names cannot collide.
+        "ghaf/update/generation".text = toString config.ghaf.partitioning.verity.generation;
+      };
+      environment.sessionVariables = {
+        GHAF_UPDATE_TRUSTED_KEY = "/etc/ghaf/update/update.pub";
+        GHAF_UKI_TRUSTED_CERT = "/etc/ghaf/update/db.crt";
+        GHAF_UPDATE_TARGET = target;
+        GHAF_ACCEPTED_GENERATION_FILE = config.ghaf.boot-health.acceptedGenerationFile;
+      };
+      environment.systemPackages = [ pkgs.sbsigntool ];
+    };
+
+  orinLocalBootFirstModule =
+    { pkgs, ... }:
+    {
+      # NVIDIA's development firmware can put HTTP/PXE entries before the
+      # internal storage entry. That turns every watchdog reset into a
+      # multi-minute network-boot timeout and, more importantly, delays A/B
+      # attempt consumption. Promote only the storage entry that successfully
+      # booted this system; never promote a shell, setup, or network entry.
+      systemd.services.ghaf-promote-local-uefi-boot = {
+        description = "Promote the booted internal storage UEFI entry";
+        after = [
+          "boot.mount"
+          "setup-jetson-efi-variables.service"
+        ];
+        requires = [ "boot.mount" ];
+        wantedBy = [ "multi-user.target" ];
+        path = with pkgs; [
+          coreutils
+          efibootmgr
+          gnugrep
+          gnused
+        ];
+        script = ''
+          state="$(efibootmgr)"
+          current="$(printf '%s\n' "$state" | sed -n 's/^BootCurrent:[[:space:]]*//p')"
+          order="$(printf '%s\n' "$state" | sed -n 's/^BootOrder:[[:space:]]*//p')"
+
+          if ! printf '%s\n' "$current" | grep -Eq '^[0-9A-Fa-f]{4}$'; then
+            echo "Cannot identify current UEFI boot entry: $current" >&2
+            exit 1
+          fi
+
+          label="$(
+            printf '%s\n' "$state" \
+              | sed -n "s/^Boot''${current}\\*\{0,1\}[[:space:]]*//p" \
+              | head -n1
+          )"
+          case "$label" in
+          "UEFI HTTP"* | "UEFI PXE"* | "UEFI Shell"* | "Enter Setup"* | "BootManagerMenuApp"* | "")
+            echo "Refusing to promote non-storage UEFI entry Boot$current: $label" >&2
+            exit 1
+            ;;
+          "UEFI "*) ;;
+          *)
+            echo "Refusing to promote unrecognized UEFI entry Boot$current: $label" >&2
+            exit 1
+            ;;
+          esac
+
+          first="''${order%%,*}"
+          if [ "$first" = "$current" ]; then
+            echo "Boot$current ($label) is already first in BootOrder"
+            exit 0
+          fi
+
+          newOrder="$current"
+          oldIFS="$IFS"
+          IFS=,
+          for entry in $order; do
+            if [ "$entry" != "$current" ]; then
+              newOrder="$newOrder,$entry"
+            fi
+          done
+          IFS="$oldIFS"
+
+          efibootmgr --bootorder "$newOrder"
+          echo "Promoted Boot$current ($label) ahead of network boot entries"
+        '';
+        serviceConfig.Type = "oneshot";
+      };
+    };
+
+  # Static HTTP is a deliberately manual development transport. Keep its
+  # download/parsing tools in the secure canary net-vm, which owns external
+  # networking, rather than giving the Ghaf host direct network access.
+  orinUpdateHttpFetchModule =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [
+        curl
+        jq
+      ];
+    };
 
   # Shared by the AGX and NX accelerated-guivm variants.
   acceleratedGuivmUsbRules = [
@@ -362,30 +547,68 @@ let
 
   ];
 
-  # A/B Verity Boot Configurations (AGX only)
+  # Secure A/B verity+LUKS canaries. The AGX canary leaves the firmware TPM
+  # disabled: its OP-TEE fTPM probe can remain uninterruptibly blocked and
+  # prevent reboot. This does not disable the separate OP-TEE DUK path used to
+  # unlock APP.
   verity-target-configs =
     map
       (
-        variant:
+        board:
         (ghaf-configuration {
-          name = "nvidia-jetson-orin-agx-verity";
+          name = "${board.name}-verity-luks";
           inherit system;
           profile = "orin";
-          hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-agx;
-          inherit variant;
-          extraModules = orinVerityModules;
+          inherit (board) hardwareModule;
+          variant = "debug";
+          extraModules = orinVerityModules ++ [
+            (mkDevTrustModule "${board.name}-verity-luks-debug")
+            orinLocalBootFirstModule
+            {
+              # The Tegra186 watchdog used by Orin accepts timeouts up to
+              # 255s. Arm it in both initrd and stage 2 so verity panics,
+              # early boot hangs, and shutdown hangs can consume a
+              # boot-counting attempt. systemd's 10 minute reboot-watchdog
+              # default is rejected by this device, so keep all configured
+              # timeouts within its range.
+              # NixOS' initrd panic-on-fail service triggers a SysRq crash
+              # when emergency.target is reached. Together with panic=10,
+              # this makes an unmountable or corrupted trial consume its
+              # systemd-boot attempt instead of waiting in an emergency
+              # shell while PID 1 continues to feed the watchdog.
+              boot.kernelParams = [
+                "boot.panic_on_fail"
+                "panic=10"
+              ];
+              boot.initrd.systemd.settings.Manager = {
+                WatchdogDevice = "/dev/watchdog0";
+                RuntimeWatchdogSec = "30s";
+                RebootWatchdogSec = "2min";
+              };
+              systemd.settings.Manager = {
+                WatchdogDevice = "/dev/watchdog0";
+                RuntimeWatchdogSec = "30s";
+                RebootWatchdogSec = "2min";
+              };
+            }
+          ];
           extraConfig = {
             reference.profiles.mvp-orinuser-trial.enable = true;
             partitioning.verity.enable = true;
-            partitioning.verity.uki-signing-key-dir = lib.mkIf (
-              variant == "debug"
-            ) ../../modules/secureboot/dev-keys;
+            # Linux 6.6 on Orin supports LZ4HC EROFS images but not the zstd
+            # format emitted by the current erofs-utils.
+            partitioning.verity.erofsCompression = "lz4hc";
+            partitioning.verity.target = "${board.name}-verity-luks-debug";
+            partitioning.verity.generation = updateGeneration;
             hardware.nvidia.orin.secureboot.enable = true;
-            # Debug builds enroll the dev certs so they match the dev signing
-            # keys; release builds keep the production certs from keysSource.
-            hardware.nvidia.orin.secureboot.keysSource = lib.mkIf (
-              variant == "debug"
-            ) ../../modules/secureboot/dev-keys;
+            hardware.nvidia.orin.diskEncryption.enable = true;
+            hardware.nvidia.orin.diskEncryption.deviceUniqueKey.enable = true;
+            hardware.nvidia.orin.ftpm.enable = board.enableFtpm;
+            hardware.nvidia.orin.runtimeEkProvision.enable = board.enableFtpm;
+            virtualization.vmConfig.sysvms.netvm.extraModules = [ orinUpdateHttpFetchModule ];
+            boot-health.enable = true;
+            boot-health.debugUnhealthyMicrovm =
+              if updateHealthFailure then "ab-health-failure-injection" else null;
           };
         })
         // {
@@ -398,8 +621,16 @@ let
         }
       )
       [
-        "debug"
-        "release"
+        {
+          name = "nvidia-jetson-orin-nx";
+          hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-nx;
+          enableFtpm = true;
+        }
+        {
+          name = "nvidia-jetson-orin-agx";
+          hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-agx;
+          enableFtpm = false;
+        }
       ];
   all-target-configs = target-configs ++ verity-target-configs;
 
@@ -469,8 +700,8 @@ let
       package = hostConfiguration.config.system.build.ghafImage;
     };
 
-  # LUKS and dm-verity are mutually exclusive root strategies (see the assertion
-  # in jetson-orin.nix), so the verity targets get no -luks variant.
+  # Secure verity canaries already contain the outer LUKS cryptpool, so do not
+  # generate duplicate synthetic -luks or -luks-uki variants for them.
   luksable-target-configs = builtins.filter (t: !isVerityTarget t) all-target-configs;
 
   # Add nodemoapps targets
@@ -482,6 +713,16 @@ let
     ++ (map (t: generate-luks (generate-nodemoapps t)) luksable-target-configs)
     ++ (map (t: generate-luks-uki (generate-nodemoapps t)) luksable-target-configs);
   crossTargets = map generate-cross-from-x86_64 targets;
+
+  genericUnsignedTarget =
+    t:
+    let
+      fallbackName = lib.replaceStrings [ "-verity-luks" ] [ "" ] t.name;
+    in
+    lib.findFirst (candidate: candidate.name == fallbackName)
+      (throw "No generic unsigned fallback target `${fallbackName}` for secure A/B target `${t.name}`")
+      crossTargets;
+
   flashTarget =
     t: qspiOnly:
     let
@@ -581,6 +822,55 @@ let
       '';
     };
 
+  exportedFlashTarget =
+    t:
+    if
+      isVerityTarget t
+      && !t.hostConfiguration.config.ghaf.hardware.nvidia.orin.secureboot.externalPublicTrustConfigured
+    then
+      let
+        fallback = genericUnsignedTarget t;
+        fallbackFlash = flashTarget fallback false;
+      in
+      pkgsX86.writeShellApplication {
+        name = "flash-ghaf-host";
+        text = ''
+          echo "WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead." >&2
+          echo "  Requested: ${t.name}" >&2
+          echo "  Fallback:  ${fallback.name}" >&2
+          echo "  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen to flash the secure A/B canary." >&2
+
+          args=()
+          while (($#)); do
+            case "$1" in
+              --secure-boot)
+                echo "WARNING: ignoring --secure-boot because the CI-only fallback is explicitly unsigned." >&2
+                shift
+                ;;
+              -u|--uki)
+                echo "WARNING: ignoring $1 because the generic fallback does not use a UKI image." >&2
+                shift
+                ;;
+              -s|--signed-sd-image)
+                if (($# < 2)); then
+                  echo "ERROR: $1 requires an image directory argument." >&2
+                  exit 2
+                fi
+                echo "WARNING: ignoring $1 and its argument because the fallback uses its built-in generic unsigned image." >&2
+                shift 2
+                ;;
+              *)
+                args+=("$1")
+                shift
+                ;;
+            esac
+          done
+          exec ${fallbackFlash}/bin/flash-ghaf-host "''${args[@]}"
+        '';
+      }
+    else
+      flashTarget t false;
+
   # Filter verity targets without forcing every hostConfiguration.config during
   # package-set evaluation.
   isVerityTarget = t: t.isVerity or false;
@@ -616,7 +906,7 @@ in
             t:
             #Note: secureTarget does not toggle between secureboot on/off!!
             lib.nameValuePair "${t.name}-flash-script" (
-              lazyPackage "${t.name}-flash-script" (flashTarget t false)
+              lazyPackage "${t.name}-flash-script" (exportedFlashTarget t)
             )
           ) flashCrossTargets
         )


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Add secure A/B image updates for NVIDIA Jetson Orin NX on internal NVMe and AGX on internal eMMC.

This change:

- adds `nvidia-jetson-orin-nx-verity-luks-debug` and `nvidia-jetson-orin-agx-verity-luks-debug`;
- changes APP to LUKS2 containing an LVM pool with root/verity A/B pairs, shared persist, and encrypted swap;
- provisions APP through the OP-TEE device-unique-key path while preserving a per-flash recovery keyslot;
- makes interrupted persist provisioning idempotent: blank existing LVs are formatted, Btrfs is retained, and unexpected filesystems fail closed;
- builds signed manifest v2 payloads and injects trusted Ed25519 and UEFI public trust;
- adds `ghaf-dev-keygen` and `ghaf-sign-update`, with private keys remaining outside Git and the Nix store;
- binds each secure A/B flash script to the public trust used at evaluation and verifies its runtime public/private key pairs before image preparation;
- keeps external trust optional for pure CI evaluation/build and makes the exported keyless flash entry point warn and delegate to the board-matched existing generic unsigned target;
- preserves fail-closed behavior inside the secure A/B implementation and selects it only when external trust was embedded at evaluation;
- installs candidate-specific three-attempt UKIs and blesses only after LUKS, dm-verity, persist, and configured core MicroVMs are healthy; and
- documents setup, build, flash, host-driven and self-fetched updates, development servers, key lifecycle, observability, interruption recovery, rescue boundaries, and NX/AGX test matrices.

CI-only evaluation prints exactly:

```text
<target>: GHAF_DEV_KEY_DIR is unset; using repository development public trust for evaluation/build only. Secure A/B flashing and update signing require GHAF_DEV_KEY_DIR from ghaf-dev-keygen; the exported flash script falls back to the generic unsigned target.
```

The exported CI-only flash wrapper then prints:

```text
WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead.
  Requested: <secure-A/B-target>
  Fallback:  <generic-target>
  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen to flash the secure A/B canary.
```

This is an artifact boundary, not an in-place downgrade: the CI-only A/B image still contains public fallback update trust and is never deployed. The wrapper invokes the board's existing generic image and strips `--secure-boot`, UKI, and signed-image options with explicit warnings. Supplying keys only at flash time cannot upgrade a script evaluated without them; rebuild with the external directory.

When external trust is embedded but runtime public trust differs, the secure A/B implementation exits before image preparation with:

```text
ERROR: GHAF_DEV_KEY_DIR public trust does not match the trust embedded at image evaluation: <file>
  Rebuild the flash script with this exact GHAF_DEV_KEY_DIR.
```

AGX keeps DUK-based unattended unlock but disables optional firmware-TPM/EK provisioning because `tpm_ftpm_tee` blocked in OP-TEE probing on the tested board. NX retains fTPM and EK provisioning.

Uses merged tiiuae/ghaf-givc#478 and pins merge commit `b03c2959c8a435bb64a7da07a3da06831e055c23`.

### Type of Change

- [x] New feature
- [x] Bug fix
- [x] Update
- [ ] Improvement / Refactor
- [x] Documentation
- [x] Infrastructure / CI/CD

## Related Issues / Tickets

- tiiuae/ghaf-givc#478

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

The PR is ready for review. Destructive release gates listed below remain incomplete.

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other: later immutable-system generations use signed `ota-update image install` payloads

### Test Steps To Verify:

1. With `GHAF_DEV_KEY_DIR` unset, build the NX and AGX secure A/B flash attributes sequentially. Inspect, but do not execute, the wrappers and confirm each selects its board-matched generic target with the exact warning above.
2. Invoke a fallback wrapper only with `--help` plus secure-image-only arguments; confirm those arguments are explicitly discarded before the generic help path runs.
3. Generate a persistent development trust directory and inventory its public fingerprints.
4. Rebuild with `--impure`, `GHAF_DEV_KEY_DIR`, and a positive `GHAF_UPDATE_GENERATION`; confirm the exported flash attribute selects the secure A/B implementation.
5. Exercise matching trust, mismatched public trust, mismatched private/public key pairs, and missing runtime files. All failures must precede image preparation.
6. Sign and publish the manifest, detached signature, signed UKI, compressed root image, and compressed verity image using the documented host-side or device self-fetch procedures.
7. Validate and dry-run before install; repeat with interruption, tampering, wrong target, downgrade, stale completion marker, and insufficient-space cases.
8. Confirm the active pair is never modified, the inactive pair passes verity verification, the `+3` UKI is installed atomically, and installation does not reboot automatically.
9. Reboot, exercise health blessing and rollback, then repeat A-to-B-to-A while confirming inactive-slot reuse and shared persist preservation.

Validation completed on the final commits:

- Ghaf pre-commit hooks, formatting, and `git diff --check`
- updater tests: 77 library tests and one CLI test
- privileged OVMF/systemd-boot integration coverage
- CI-only NX and AGX flash-wrapper builds mapped to their respective generic unsigned targets
- fallback argument filtering exercised through the non-mutating `--help` path
- external-key NX and AGX flash builds selected the secure A/B implementation
- secure A/B NX NVMe and AGX eMMC flash-script builds against merged GIVC `b03c2959`
- canonical documentation build: 184 pages and all internal links valid
- prior NX runtime acceptance: unsigned-UKI rejection, DUK rotation, recovery unlock, storage layering, signed A-to-B-to-A, failed-health rollback, and corruption rollback
- prior AGX runtime acceptance: encrypted eMMC first boot, DUK rotation, recovery preservation, storage layering, signed generations 1-to-2-to-3, inactive-slot reuse, persist preservation, and ordinary reboot

This follow-up did not flash either board. Hardware results above are retained prior acceptance evidence, not claims from the final source-only rebuild.

Remaining release gates:

- physical power interruption at every installation phase;
- physical watchdog recovery from a true hard hang;
- repeat failed-health and root/verity corruption rollback specifically on AGX; and
- production key management and NVIDIA fused BootROM trust, which are outside the development-key scope.