### PR TITLE
test(user-provision): enable recovery key in automated user provisioning

### DIFF
--- a/packages/pkgs-by-name/user-provision/user-provision.sh
+++ b/packages/pkgs-by-name/user-provision/user-provision.sh
@@ -1405,9 +1405,6 @@ non_interactive_setup() {
   export PASSWORD
   export NEWPASSWORD="$PASSWORD"
 
-  # Disable recovery key for non-interactive mode
-  RECOVERY_KEY=false
-
   debug "Creating user account with the following settings:"
   debug "Username:     $USERNAME"
   debug "Real name:    $REALNAME"


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Minor change to user-provision script to enable recovery key creation for non-interactive (automated) runs.
The recovery key (and QR code) will be visible in the journal during test execution.
Done by request :saluting_face: 

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
