### PR TITLE
fix(nvidia): enable Orin fTPM firmware

### DIFF
--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -209,41 +209,6 @@ let
     '';
   };
 
-  loadFtpmModuleApp = pkgs.writeShellApplication {
-    name = "ghaf-load-ftpm-module";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.kmod
-      pkgs.systemd
-    ];
-    text = ''
-      set -euo pipefail
-
-      if [ -e /dev/tpmrm0 ]; then
-        echo "fTPM device already present, skipping"
-        exit 0
-      fi
-
-      if ! systemctl is-active --quiet tee-supplicant.service; then
-        echo "tee-supplicant is not active" >&2
-        exit 1
-      fi
-
-      if ! timeout 20s modprobe tpm_ftpm_tee; then
-        echo "Failed to load tpm_ftpm_tee" >&2
-        exit 1
-      fi
-
-      udevadm settle --timeout=5 || true
-      if [ ! -e /dev/tpmrm0 ]; then
-        echo "tpm_ftpm_tee loaded but /dev/tpmrm0 is missing" >&2
-        exit 1
-      fi
-
-      echo "Loaded tpm_ftpm_tee"
-    '';
-  };
-
   firmwareEkbImage =
     pkgs.buildPackages.runCommand "ghaf-eks-t234"
       {
@@ -843,6 +808,12 @@ in
       cfg.flashScriptOverrides.signedArtifactsPath != null
     );
     hardware.nvidia-jetpack.firmware.eksFile = "${firmwareEkbImage}/eks_t234.img";
+    hardware.nvidia-jetpack.firmware.optee.ftpm = {
+      enable = true;
+      # Non-secure development boards do not have a fuse-derived EPS. Keep
+      # the explicitly insecure injection path out of secure-boot images.
+      unsecureInjectEPS.enable = !cfg.secureboot.enable;
+    };
     hardware.nvidia-jetpack.kernel.version = "${cfg.kernelVersion}";
     # jetpack-nixos hardcodes the trailing rootfs device as mmcblk0p1; replay
     # the same default here but route it through cfg.flashScriptOverrides.deviceDiskRootfsPartition
@@ -887,10 +858,6 @@ in
 
       modprobeConfig.enable = true;
 
-      # Prevent early autoload; load in stage-2 after local filesystems
-      # and tee-supplicant are up.
-      blacklistedKernelModules = [ "tpm_ftpm_tee" ];
-
       kernelPatches = [
         {
           name = "vsock-config";
@@ -914,11 +881,10 @@ in
           };
         }
         {
-          name = "ftpm-config";
+          name = "disable-ftpm-hwrng";
           patch = null;
           structuredExtraConfig = with lib.kernel; {
             EXPERT = yes;
-            TCG_FTPM_TEE = module;
             # Disable TPM hwrng to prevent constant fTPM polling pressure
             # that can saturate the OP-TEE single-lane fTPM TA under load.
             HW_RANDOM_TPM = no;
@@ -933,6 +899,17 @@ in
             HID_LOGITECH_DJ = yes;
             HID_LOGITECH_HIDPP = yes;
           };
+        }
+      ]
+      ++ lib.optionals (cfg.kernelVersion == "upstream-6-6") [
+        {
+          # NVIDIA's r36 OP-TEE uses the legacy wait-queue RPC contract:
+          # normal world must periodically return from a notification wait so
+          # secure world can recheck the condition. The vendor 5.15 driver
+          # does this every 100 ms, while upstream 6.6 waits indefinitely and
+          # deadlocks the fTPM self-test during tpm_chip_register().
+          name = "optee-notification-wait-timeout";
+          patch = ./optee-notification-wait-timeout.patch;
         }
       ]
       ++ lib.optionals (cfg.diskEncryption.enable && cfg.kernelVersion == "upstream-6-6") [
@@ -1156,40 +1133,15 @@ in
       };
     };
 
-    systemd.services.ghaf-load-ftpm-module = {
-      description = "Load fTPM module after stage-2 OP-TEE readiness";
-      wantedBy = [ "multi-user.target" ];
-      wants = [
-        "local-fs.target"
-        "tee-supplicant.service"
-      ];
-      after = [
-        "local-fs.target"
-        "systemd-modules-load.service"
-        "tee-supplicant.service"
-      ];
-      before = [
-        "ghaf-provision-ek-certs.service"
-        "ghaf-export-ek-endorsement-bundle.service"
-      ];
-      unitConfig.ConditionPathExists = "!/dev/tpmrm0";
-
-      serviceConfig = {
-        Type = "oneshot";
-        TimeoutStartSec = "80s";
-        ExecStart = lib.getExe loadFtpmModuleApp;
-      };
-    };
-
     systemd.services.ghaf-provision-ek-certs = mkIf cfg.runtimeEkProvision.enable {
       description = "Provision fTPM EK certificates into standard NV indices";
       wantedBy = [ "multi-user.target" ];
-      wants = [ "tee-supplicant.service" ];
+      requires = [ "ftpm-driver.service" ];
       after = [
         "local-fs.target"
         "systemd-modules-load.service"
         "tee-supplicant.service"
-        "ghaf-load-ftpm-module.service"
+        "ftpm-driver.service"
       ];
       unitConfig.ConditionPathExists = "/dev/tpmrm0";
       unitConfig.OnSuccess = [ "ghaf-export-ek-endorsement-bundle.service" ];
@@ -1206,12 +1158,12 @@ in
     systemd.services.ghaf-export-ek-endorsement-bundle = {
       description = "Export EK certs and build endorsement CA bundle";
       wantedBy = [ "multi-user.target" ];
-      wants = [ "tee-supplicant.service" ];
+      requires = [ "ftpm-driver.service" ];
       after = [
         "local-fs.target"
         "systemd-modules-load.service"
         "tee-supplicant.service"
-        "ghaf-load-ftpm-module.service"
+        "ftpm-driver.service"
       ]
       ++ lib.optionals cfg.runtimeEkProvision.enable [
         "ghaf-provision-ek-certs.service"

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/optee-notification-wait-timeout.patch
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/optee-notification-wait-timeout.patch
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: GPL-2.0-only
+From: Ghaf contributors <ghaf@tii.ae>
+Subject: [PATCH] tee: optee: time out notification waits
+
+NVIDIA's r36 secure-world notification RPC expects normal world to return
+periodically so it can recheck the wait condition. Match the vendor kernel's
+100 ms polling behavior instead of waiting indefinitely.
+
+diff --git a/drivers/tee/optee/notif.c b/drivers/tee/optee/notif.c
+index 0d9cbad7c7a5..7e548e743144 100644
+--- a/drivers/tee/optee/notif.c
++++ b/drivers/tee/optee/notif.c
+@@ -9,0 +10 @@
++#include <linux/jiffies.h>
+@@ -14,0 +16,2 @@
++#define OPTEE_NOTIFICATION_WAIT_TIMEOUT msecs_to_jiffies(100)
++
+@@ -73 +76,2 @@
+-	wait_for_completion(&entry->c);
++	(void)wait_for_completion_timeout(&entry->c,
++					  OPTEE_NOTIFICATION_WAIT_TIMEOUT);

--- a/tests/flake-module.nix
+++ b/tests/flake-module.nix
@@ -46,6 +46,7 @@
           fss-test = pkgs.callPackage ./logging/test_scripts/fss-test.nix { };
           fss-triage = pkgs.callPackage ./logging/test_scripts/fss-triage.nix { };
           access-control-tests = pkgs.callPackage ./access-control { inherit self; };
+          orin-ftpm = pkgs.callPackage ./orin-ftpm.nix { inherit self; };
         };
     };
 }

--- a/tests/orin-ftpm.nix
+++ b/tests/orin-ftpm.nix
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  self,
+  lib,
+  runCommand,
+}:
+let
+  agx = self.nixosConfigurations."nvidia-jetson-orin-agx-debug".config;
+  nx = self.nixosConfigurations."nvidia-jetson-orin-nx-debug".config;
+  secureAgx = self.nixosConfigurations."nvidia-jetson-orin-agx-verity-debug".config;
+  assertions = [
+    {
+      name = "Orin firmware embeds fTPM and enables the upstream driver";
+      ok =
+        agx.hardware.nvidia-jetpack.firmware.optee.ftpm.enable
+        && nx.hardware.nvidia-jetpack.firmware.optee.ftpm.enable
+        && builtins.hasAttr "ftpm-driver" agx.systemd.services
+        && builtins.hasAttr "ftpm-driver" nx.systemd.services
+        && !builtins.hasAttr "ghaf-load-ftpm-module" agx.systemd.services
+        && !builtins.hasAttr "ghaf-load-ftpm-module" nx.systemd.services;
+    }
+    {
+      name = "development EPS injection is disabled for secure boot";
+      ok =
+        agx.hardware.nvidia-jetpack.firmware.optee.ftpm.unsecureInjectEPS.enable
+        && nx.hardware.nvidia-jetpack.firmware.optee.ftpm.unsecureInjectEPS.enable
+        && !secureAgx.hardware.nvidia-jetpack.firmware.optee.ftpm.unsecureInjectEPS.enable;
+    }
+    {
+      name = "upstream Linux uses the NVIDIA OP-TEE notification timeout";
+      ok =
+        builtins.any (patch: patch.name == "optee-notification-wait-timeout") agx.boot.kernelPatches
+        && builtins.any (patch: patch.name == "optee-notification-wait-timeout") nx.boot.kernelPatches;
+    }
+    {
+      name = "EK provisioning waits for the upstream fTPM driver";
+      ok =
+        lib.elem "ftpm-driver.service" agx.systemd.services.ghaf-provision-ek-certs.requires
+        && lib.elem "ftpm-driver.service" nx.systemd.services.ghaf-provision-ek-certs.requires;
+    }
+  ];
+  failed = map (assertion: assertion.name) (lib.filter (assertion: !assertion.ok) assertions);
+in
+assert lib.assertMsg (failed == [ ]) "Orin fTPM checks failed: ${lib.concatStringsSep "; " failed}";
+runCommand "orin-ftpm" { } ''touch "$out"''


### PR DESCRIPTION
## Description of Changes

Enable the JetPack fTPM firmware and use the upstream jetpack-nixos driver service on Jetson Orin AGX and NX targets.

The upstream Linux 6.6 OP-TEE notification wait blocks indefinitely with the NVIDIA r36 secure-world polling contract, leaving tpm_ftpm_tee stuck during TPM self-test. Add the vendor-compatible 100 ms notification timeout for the upstream 6.6 kernel so the driver can finish registration.

This change also:

- removes the Ghaf-specific module-loading service and duplicate module blacklist
- enables unsecure EPS injection only for non-secure development images
- orders EK certificate provisioning and export after ftpm-driver.service
- adds a focused evaluation check for AGX, NX, and secure-boot policy

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

- Uses the fTPM firmware integration from https://github.com/anduril/jetpack-nixos/pull/521
- Compatible with the provisioning work discussed in https://github.com/anduril/jetpack-nixos/pull/534

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

No user-facing documentation change is required for this driver and firmware fix. Reviewers are intentionally left to the normal project assignment flow.

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Build the AGX and NX debug images and flash scripts from x86_64.
2. Flash a non-secure AGX or NX development board.
3. Verify that `ftpm-driver.service` succeeds and `/dev/tpm0` plus `/dev/tpmrm0` exist.
4. Run `tpm2_getrandom` and `tpm2_getcap properties-fixed`; the device should report TPM 2.0 and the SSE fTPM vendor.
5. Verify EK provisioning/export succeeds and NV indices `0x1c00002` and `0x1c0000a` exist.
6. Reboot and verify TPM random still works and the EPS-derived endorsement state remains stable.

Validated locally:

- `nix fmt -- --fail-on-change`
- `nix develop --command reuse lint`
- `nix build .#checks.x86_64-linux.pre-commit --no-link`
- `nix build .#checks.x86_64-linux.orin-ftpm --no-link`
- AGX and NX debug image plus flash-script builds
- non-secure AGX and NX runtime validation was performed before extraction on the same fTPM module and kernel changes in the PR #2133 tree: driver registration, TPM 2.0 commands, EK NV indices, provisioning/export, and reboot persistence all passed
- the rebuilt kernel on this branch is byte-for-byte identical to the hardware-tested kernel; the direct-main AGX/NX images built successfully but were not reflashed
- secure AGX configuration evaluation confirms unsecure EPS injection is disabled; a secure image was not flashed
