### PR TITLE
feat(alloy-logging): add useuniqueid option for tenant ID in alloy logging configuration

### DIFF
--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -92,6 +92,19 @@ rec {
             default = "";
             description = "Logging server endpoint";
           };
+
+          useUniqueId = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Whether to use a unique ID for the tenant in the logging server
+              configuration. If true, the unique ID is derived from the machine's
+              /etc/machine-id file. If false, no tenant ID is used.
+
+              This setting is useful for multi-tenant logging setups where each
+              machine should have its own unique identifier.
+            '';
+          };
         };
       };
 

--- a/modules/common/logging/alloy-server.nix
+++ b/modules/common/logging/alloy-server.nix
@@ -39,6 +39,19 @@ in
       default = null;
     };
 
+    useUniqueId = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to use a unique ID for the tenant in the logging server
+        configuration. If true, the unique ID is derived from the machine's
+        /etc/common/device-id file. If false, no tenant ID is used.
+
+        This setting is useful for multi-tenant logging setups where each
+        machine should have its own unique identifier.
+      '';
+    };
+
     identifierFilePath = mkOption {
       description = ''
         This configuration option used to specify the identifier file path.
@@ -136,7 +149,6 @@ in
             // Alloy service can read file in this specific location
             filename = "${cfg.identifierFilePath}"
           }
-
           // TLS materials arrive via systemd credentials
           local.file "tls_cert" {
             filename = sys.env("CREDENTIALS_DIRECTORY") + "/loki_cert"
@@ -224,7 +236,7 @@ in
                 username = "ghaf"
                 password_file = "/etc/loki/pass"
               }
-
+              ${optionalString cfg.useUniqueId "tenant_id = local.file.macAddress.content"}
               batch_size          = "256KiB"
               max_backoff_period  = "30s"
               max_backoff_retries = 0

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -138,7 +138,7 @@ in
         # logging can be enabled without forwarding to a server
         enable = globalConfig.logging.enable && globalConfig.logging.server.enable;
         endpoint = globalConfig.logging.server.endpoint or "";
-
+        useUniqueId = globalConfig.logging.server.useUniqueId or false;
         tls = {
           serverName = "loki.ghaflogs.vedenemo.dev";
         };


### PR DESCRIPTION
Add logging.server.useuniqueid to control whether the Loki tenant ID is derived from machine-id or disabled.

This keeps the default behavior for standard setups while allowing explicit per-machine unique IDs in multi-tenant logging deployments.

By default the feature is enabled, i.e. tenant id is the machine MAC address.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [X] Orin AGX `aarch64`
- [X] Orin NX `aarch64`
- [X] Intel Laptop `x86_64`
- [X] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [X] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

Verify if tenant id is properly passed to Grafana.