### PR TITLE
fix(netboot): missing packages when not run from the devshell

### DIFF
--- a/packages/pkgs-by-name/ghaf-netboot/package.nix
+++ b/packages/pkgs-by-name/ghaf-netboot/package.nix
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   coreutils,
+  gawk,
+  gnugrep,
+  gnused,
   iproute2,
   ipxe,
   lib,
@@ -63,6 +66,9 @@ writeShellApplication {
   runtimeInputs = [
     api
     coreutils
+    gawk # the interface guard rails, and the cmdline parse out of netboot.ipxe
+    gnugrep # --open-firewall, inspecting the nixos-fw set
+    gnused # rewriting the builder's cmdline
     iproute2 # ip route / ip addr, for the interface guard rails
     nftables # --open-firewall; PXE is dropped outright without it
     pixiecore # ProxyDHCP + TFTP; never assigns addresses


### PR DESCRIPTION
Add some basic utilities that were masked when you only run in the devshell and are prevalent when running stand alone.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
