### PR TITLE
fix(crosvm): pin xHCI UAS completion fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     "ghaf-crosvm": {
       "flake": false,
       "locked": {
-        "lastModified": 1787689308,
-        "narHash": "sha256-nDHIs8d6y4Pa/ze/XZ5d5vx/uTMc6wDYLnPFIST7NjA=",
+        "lastModified": 1787724426,
+        "narHash": "sha256-7JjNkqwJg4wie3ESosbxCS3iGcV10keqr3WyuZX/CFM=",
         "ref": "refs/heads/fix/uas-stop-endpoint",
-        "rev": "0b0e069b1aaad9e07932b506ddd2993e7790df9f",
-        "revCount": 11725,
+        "rev": "f2f3d2102da1f69dd151221bae13b9046ed79b15",
+        "revCount": 11726,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/tiiuae/ghaf-crosvm"

--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     "ghaf-crosvm": {
       "flake": false,
       "locked": {
-        "lastModified": 1787513199,
-        "narHash": "sha256-BG/Fh5KcNUP8Q1ngKN6Z7q1fh4hAdQK07/1qYkouhwQ=",
-        "ref": "refs/heads/main",
-        "rev": "fba7ba3a796f9459107ee04e5a6599ac52f45954",
-        "revCount": 11724,
+        "lastModified": 1787689308,
+        "narHash": "sha256-nDHIs8d6y4Pa/ze/XZ5d5vx/uTMc6wDYLnPFIST7NjA=",
+        "ref": "refs/heads/fix/uas-stop-endpoint",
+        "rev": "0b0e069b1aaad9e07932b506ddd2993e7790df9f",
+        "revCount": 11725,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/tiiuae/ghaf-crosvm"


### PR DESCRIPTION
## Description of Changes

Pin [ghaf-crosvm#10](https://github.com/tiiuae/ghaf-crosvm/pull/10) at commit `f2f3d2102da1f69dd151221bae13b9046ed79b15`.

The Crosvm series fixes two xHCI completion-liveness problems exposed by UAS SSD passthrough:

1. Complete Stop Endpoint after successful synchronous host URB cancellation instead of retaining the shared callback until its completion record is reaped.
2. Avoid an interrupt-moderation hole that can write a completion to the event ring, suppress its interrupt, and never schedule later delivery.

The second fix matches the observed timing sensitivity: adding a few transfer-path log lines hides the failure by delaying the event beyond the moderation window. Until Crosvm has timer-backed interrupt moderation, it now favors extra interrupts over indefinitely stranded completions.

There is no QEMU fallback in this change. This draft must be repinned to the Crosvm mainline merge commit after the dependency PR merges.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [x] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

- Depends on [tiiuae/ghaf-crosvm#10](https://github.com/tiiuae/ghaf-crosvm/pull/10)

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

No Ghaf documentation change is needed for this dependency-only bug fix. The PR remains draft pending validation on the original UAS reproducer and the Crosvm dependency merge.

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other

### Test Steps To Verify

1. Install the `.#intel-laptop-debug-installer` image built from this PR.
2. Cold boot the target with the external UAS SSD attached.
3. Pass the SSD to the target AppVM through ghaf-device-manager.
4. Confirm `lsusb -t` reports the UAS driver and run the workload that reliably reproduced the failure.
5. Detach and re-attach the SSD while monitoring host and guest logs.
6. Repeat clean cold boots and confirm the disk mounts without resets, command timeouts, or xHCI controller death.

### Validation completed

- New interrupt-liveness regression fails on the previous PR head (`TimedOut`) and passes on the fixed head (`Signaled`)
- Crosvm xHCI tests: 35 passed
- Crosvm cancellation regression tests: 4 passed
- Crosvm USB-enabled workspace check: passed
- Crosvm quick presubmit: 1615 passed, 9 skipped
- Ghaf locked Crosvm package build: passed, including 136 package tests
- Exact `.#intel-laptop-debug-installer` build: passed
- Installer ISO: 9,404,364,800 bytes; SHA-256 `94181eacbe75970052feca597db26c5b209bf3c1695ad737de684cd89842914e`
- The installed host runs the exact Crosvm output from the installer; its binary hash matches the locally built output
- Samsung PSSD T7 in `gui-vm`: initial installed boot, 3/3 detach/re-attach cycles, 3/3 warm host reboots, and 3/3 full power-off cold boots all enumerated and mounted through UAS
- Cold-boot host and guest boot IDs were distinct for every captured cycle
- `gui-vm` stayed active with `NRestarts=0`; fatal xHCI/UAS timeout/reset/controller-death scans remained zero
- No drive contents were read during validation

One non-fatal `Set TR Deq Ptr` state-mismatch warning occurs per attach, and early boot attachment retries while the event ring is uninitialized. These did not prevent enumeration or kill the controller, but remain follow-up issues.

This completes local hardware acceptance for the Samsung T7 / `gui-vm` setup. The original SanDisk Extreme Pro / `flatpak-vm` cold-boot reproduction remains a separate pending validation.
