### PR TITLE
docs(installer): correct when stale boot entries arise

### DIFF
--- a/lib/installer-boot-lib.sh
+++ b/lib/installer-boot-lib.sh
@@ -79,6 +79,40 @@ find_esp_loader() {
   printf '%s\n' "$loader"
 }
 
+# Remove Ghaf entries whose ESP is gone. Reinstalling the same image reuses its
+# entry; an image whose ESP lands a different PARTUUID strands the old one, and
+# they accumulate and never expire. Measured: three on a Dell RA13250 over the
+# B-slot work, on a machine that then booted into recovery.
+#
+# Keyed on "no partition with this PARTUUID exists", not "not the one we just
+# wrote": a Ghaf install on a second disk is still bootable and must survive.
+prune_stale_boot_entries() {
+  local keep="$1" live entries stale bootnum uuid
+
+  command -v efibootmgr >/dev/null 2>&1 || return 0
+
+  live="$(lsblk -no PARTUUID 2>/dev/null | tr -d '[:blank:]' | tr '[:upper:]' '[:lower:]' | grep . || true)"
+  # No readable partition table means every entry looks stale. Do nothing.
+  [ -n "$live" ] || return 0
+
+  entries="$(efibootmgr -v 2>/dev/null || true)"
+  stale="$(
+    printf '%s\n' "$entries" |
+      sed -n 's/^Boot\([0-9A-Fa-f]\{4\}\)\*\{0,1\}[[:blank:]]*Ghaf[[:blank:]].*HD([0-9]*,GPT,\([0-9A-Fa-f-]\{1,\}\),.*/\1 \2/p' || true
+  )"
+
+  while read -r bootnum uuid; do
+    [ -n "$bootnum" ] || continue
+    [ "$bootnum" != "$keep" ] || continue
+    printf '%s\n' "$live" | grep -qxF "$(printf '%s' "$uuid" | tr '[:upper:]' '[:lower:]')" && continue
+    echo "Removing stale boot entry Boot$bootnum ($uuid)"
+    efibootmgr -b "$bootnum" -B >/dev/null 2>&1 ||
+      echo "WARNING: could not remove Boot$bootnum." >&2
+  done <<EOF
+$stale
+EOF
+}
+
 # Point the firmware at the disk just written. Before this, the only thing
 # stopping a netbooted machine reinstalling in a loop was the server shutting
 # down after one transfer, which a fleet server cannot do.
@@ -172,72 +206,12 @@ set_boot_to_disk() {
     echo "WARNING: could not determine the new boot entry number." >&2
   fi
 
+  prune_stale_boot_entries "$bootnum"
+
   # The only evidence anyone gets from an unattended fleet install.
   echo "--- efibootmgr ---"
   efibootmgr 2>/dev/null || true
   echo "------------------"
-}
-
-# Stop this machine netbooting again before the long part starts. A fleet is
-# put into PXE by hand (F12), so nothing can ssh in and arm it -- but our
-# installer is already running on it.
-#
-# The download can sit in a server's queue for hours; a machine power-cycled in
-# that window, with network boot ahead of its disk, returns to the installer.
-# set_boot_to_disk still runs after the write; this only covers the gap.
-#
-# Called before the wipe: afterwards there is no entry left to point at.
-point_bootnext_at_disk() {
-  local device_name="$1" esp="${2:-}"
-  local entries bootnum partuuid serial model
-
-  command -v efibootmgr >/dev/null 2>&1 || return 0
-  ensure_efivars || return 0
-
-  entries="$(efibootmgr -v 2>/dev/null || true)"
-  [ -n "$entries" ] || return 0
-
-  # The ESP that is on the disk right now, if this machine was installed before.
-  # Its PARTUUID appears in the firmware's own entry for it.
-  bootnum=""
-  if [ -n "$esp" ]; then
-    partuuid="$(lsblk -no PARTUUID "$esp" 2>/dev/null | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' || true)"
-    if [ -n "$partuuid" ]; then
-      bootnum="$(printf '%s\n' "$entries" | grep -i -- "$partuuid" |
-        sed -n 's/^Boot\([0-9A-Fa-f]\{4\}\).*/\1/p' | head -1 || true)"
-    fi
-  fi
-
-  # Otherwise the firmware's auto-created entry, which names the drive: on a
-  # Dell it reads "UEFI BG7 KIOXIA 1024GB 3GGPSDEUZ43B 1". The serial is the
-  # discriminating part, and it is what tells this disk from a second one.
-  if [ -z "$bootnum" ]; then
-    serial="$(lsblk -dno SERIAL "$device_name" 2>/dev/null | tr -d '[:space:]' || true)"
-    if [ -n "$serial" ]; then
-      bootnum="$(printf '%s\n' "$entries" | grep -iF -- "$serial" |
-        sed -n 's/^Boot\([0-9A-Fa-f]\{4\}\).*/\1/p' | head -1 || true)"
-    fi
-  fi
-  if [ -z "$bootnum" ]; then
-    model="$(lsblk -dno MODEL "$device_name" 2>/dev/null | sed 's/[[:space:]]*$//' || true)"
-    if [ -n "$model" ]; then
-      bootnum="$(printf '%s\n' "$entries" | grep -iF -- "$model" |
-        sed -n 's/^Boot\([0-9A-Fa-f]\{4\}\).*/\1/p' | head -1 || true)"
-    fi
-  fi
-
-  if [ -z "$bootnum" ]; then
-    # A disk that has never been bootable has no entry to point at. Nothing is
-    # wrong; set_boot_to_disk creates one once there is an ESP to name.
-    echo "No existing boot entry for $device_name yet; will create one after the write."
-    return 0
-  fi
-
-  if efibootmgr -n "$bootnum" >/dev/null 2>&1; then
-    echo "BootNext set to Boot$bootnum ($device_name) before downloading."
-  else
-    echo "WARNING: could not set BootNext before downloading; continuing." >&2
-  fi
 }
 
 # How long to sit in an install server's queue before giving up, in seconds.

--- a/modules/partitioning/btrfs-postboot.nix
+++ b/modules/partitioning/btrfs-postboot.nix
@@ -25,8 +25,11 @@ let
       vg_free=$(vgs --noheadings --nosuffix --units m -o vg_free pool 2>/dev/null | tr -d ' ' | cut -d. -f1 || true)
       if [ "''${vg_free:-0}" -ge "$b_needed" ]; then
         echo "Creating the B slot ($b_needed MiB) before persist claims the rest..."
-        if lvcreate -y -n root_empty -L "''${b_root}M" pool &&
-          lvcreate -y -n verity_empty -L "''${b_verity}M" pool; then
+        # -Zn -Wn: zeroing opens /dev/pool/<lv>, which udev has not made yet
+        # this early -- "device not cleared", and the create aborts. Empty
+        # placeholders an A/B update overwrites, so nothing needs clearing.
+        if DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n root_empty -L "''${b_root}M" pool &&
+          DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n verity_empty -L "''${b_verity}M" pool; then
           echo "B slot created."
         else
           echo "WARNING: could not create the B slot; A/B updates will be unavailable."

--- a/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-lib.sh
+++ b/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-lib.sh
@@ -390,16 +390,6 @@ do_enroll_secureboot() {
   debug "Secure Boot keys enrolled."
 }
 
-# Before the wipe: a machine interrupted mid-download returns to its own disk
-# rather than the installer. A factory-fresh disk has nothing to point at, which
-# is not an error.
-# shellcheck disable=SC2329
-do_point_bootnext() {
-  local dev="$1" esp
-  esp="$(find_esp_device "$dev" 2>/dev/null || true)"
-  point_bootnext_at_disk "$dev" "$esp" || true
-}
-
 # Create or reuse the EFI entry for the ESP just written, first in BootOrder.
 # Without it the machine boots the installer media it is still sitting in.
 # shellcheck disable=SC2329

--- a/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-tui.sh
+++ b/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-tui.sh
@@ -316,10 +316,6 @@ screen_running() {
     show_header "Installing Ghaf"
   fi
 
-  # Before the wipe: it matches an entry that exists now, and after the wipe
-  # there is none. Not a run_step -- having no entry yet is normal, not failure.
-  $WIPE_ONLY || do_point_bootnext "$DEVICE_NAME"
-
   # Also before the wipe: an image too big for the disk must not cost the data
   # already on it, and dd would otherwise write to end-of-device and leave a GPT
   # describing a disk that does not exist.

--- a/packages/pkgs-by-name/ghaf-installer/ghaf-installer.sh
+++ b/packages/pkgs-by-name/ghaf-installer/ghaf-installer.sh
@@ -323,12 +323,6 @@ find_esp_device() {
   return 1
 }
 
-if [ "$WIPE_ONLY" != true ]; then
-  # Before the wipe, while find_esp_device still has partitions. Empty is fine:
-  # the lib falls back to the drive's serial.
-  point_bootnext_at_disk "$DEVICE_NAME" "$(find_esp_device 2>/dev/null || true)"
-fi
-
 echo "Wiping device..."
 
 # Deactivate any active LVM volume groups on the device

--- a/packages/pkgs-by-name/ghaf-netboot/ghaf-netboot.sh
+++ b/packages/pkgs-by-name/ghaf-netboot/ghaf-netboot.sh
@@ -42,6 +42,7 @@ Options:
                            DESTRUCTIVE and requires --mac.
       --encrypt            With --install-target: enable disk encryption
       --secureboot         With --install-target: enroll Secure Boot keys
+      --extra-cmdline S    Append S to the target's kernel command line
   -p, --port <PORT>        HTTP port (default 8080)
   -t, --timeout <MIN>      Exit after this long (default 60, 0 disables).
                            Use 0 for a long-running fleet server.
@@ -98,6 +99,7 @@ TIMEOUT_MIN=60
 INSTALL_TARGET=""
 ENCRYPT=false
 SECUREBOOT=false
+EXTRA_CMDLINE=""
 FORCE_IFACE=false
 OPEN_FIREWALL=false
 DRY_RUN=false
@@ -160,6 +162,10 @@ while [ $# -gt 0 ]; do
   --secureboot)
     SECUREBOOT=true
     shift
+    ;;
+  --extra-cmdline)
+    EXTRA_CMDLINE="$2"
+    shift 2
     ;;
   -p | --port)
     PORT="$2"
@@ -459,6 +465,10 @@ if [ -n "$INSTALL_TARGET" ]; then
   $ENCRYPT && CMDLINE="$CMDLINE ghaf.install_encrypt"
   $SECUREBOOT && CMDLINE="$CMDLINE ghaf.install_secureboot"
 fi
+# Last, so it can override anything above. ghaf.install_noreboot belongs here:
+# it keeps a failed install on screen and reachable over ssh instead of
+# rebooting the evidence away.
+[ -n "$EXTRA_CMDLINE" ] && CMDLINE="$CMDLINE $EXTRA_CMDLINE"
 
 cat >&2 <<EOF
 ghaf-netboot:

--- a/tests/installer/netboot-fetch.nix
+++ b/tests/installer/netboot-fetch.nix
@@ -62,7 +62,12 @@ pkgs.testers.nixosTest {
     };
 
     machine = _: {
-      virtualisation.emptyDiskImages = [ (1024 * 256) ];
+      # The second disk exists only to carry a boot entry that is then made
+      # dangling, for the stale-entry subtest.
+      virtualisation.emptyDiskImages = [
+        (1024 * 256)
+        64
+      ];
       virtualisation.memorySize = 1024 * 16;
 
       # UEFI, so /sys/firmware/efi/efivars exists and set_boot_to_disk actually
@@ -92,6 +97,8 @@ pkgs.testers.nixosTest {
         # For the test's own assertions. ghaf-installer carries its own copy via
         # runtimeInputs, so this does not stand in for that.
         pkgs.efibootmgr
+        pkgs.gptfdisk
+        pkgs.parted
       ];
     };
   };
@@ -183,6 +190,39 @@ pkgs.testers.nixosTest {
         after = len([l for l in machine.succeed("efibootmgr").splitlines() if "Ghaf" in l])
         assert after == before, f"boot entries multiplied: {before} -> {after}"
 
+    with subtest("an install removes Ghaf entries whose ESP is gone"):
+        # Each install writes a new GPT, so the previous install's entry is left
+        # naming a PARTUUID that no longer exists. A Dell RA13250 carrying two
+        # of them booted into SupportAssist recovery rather than the disk.
+        machine.succeed("sgdisk --zap-all /dev/vdc && sgdisk -n 1:0:0 -t 1:ef00 /dev/vdc && partprobe /dev/vdc")
+        stale_uuid = machine.succeed("lsblk -no PARTUUID /dev/vdc1").strip().lower()
+        machine.succeed(
+            "efibootmgr -c -d /dev/vdc -p 1 -L Ghaf "
+            "-l '\\EFI\\systemd\\systemd-bootx64.efi'"
+        )
+        # Same disk, not labelled Ghaf: pruning must not touch another OS.
+        machine.succeed(
+            "efibootmgr -c -d /dev/vdc -p 1 -L 'Windows Boot Manager' "
+            "-l '\\EFI\\Microsoft\\Boot\\bootmgfw.efi'"
+        )
+        # Destroy the table the two entries point at.
+        machine.succeed("sgdisk --zap-all /dev/vdc && partprobe /dev/vdc")
+
+        machine.succeed('ghaf-installer </dev/null', timeout=900)
+        entries = machine.succeed("efibootmgr -v")
+        # Ghaf lines only: the Windows entry below shares this PARTUUID, and
+        # keeping it is the point of the next assertion.
+        ghaf_lines = "\n".join(l for l in entries.splitlines() if "Ghaf" in l)
+        assert stale_uuid not in ghaf_lines.lower(), (
+            f"stale Ghaf entry {stale_uuid} survived the install:\n{entries}"
+        )
+        assert "Windows Boot Manager" in entries, (
+            f"pruning removed an entry that was not ours:\n{entries}"
+        )
+        assert len([l for l in entries.splitlines() if "Ghaf" in l]) == 1, (
+            f"expected exactly the live Ghaf entry:\n{entries}"
+        )
+
     with subtest("the interactive front-end is wired to the same boot and queue code"):
         # A wiring check: the TUI is gum on tty1 and cannot be driven from a
         # test. It no longer has its own copy of this logic, so the subtests
@@ -190,7 +230,7 @@ pkgs.testers.nixosTest {
         tui = machine.succeed("command -v ghaf-installer-tui").strip()
 
         # Prepended into the wrapper by the package.
-        for fn in ["set_boot_to_disk", "point_bootnext_at_disk", "wait_for_image_slot"]:
+        for fn in ["set_boot_to_disk", "wait_for_image_slot"]:
             machine.succeed(f"grep -q '^{fn}() {{' {tui}")
 
         # Sourced at run time: the do_* wrappers and the image fetch live here.
@@ -198,7 +238,7 @@ pkgs.testers.nixosTest {
             f"grep -o '/nix/store/[a-z0-9]*-ghaf-installer-lib.sh' {tui} | head -1"
         ).strip()
         assert lib, f"ghaf-installer-tui does not source an installer lib:\n{tui}"
-        for fn in ["do_set_boot_entry", "do_point_bootnext"]:
+        for fn in ["do_set_boot_entry"]:
             machine.succeed(f"grep -q '^{fn}() {{' {lib}")
 
         # The do_* wrappers and the shared functions are defined in different
@@ -209,7 +249,6 @@ pkgs.testers.nixosTest {
             return machine.succeed(f"sed -n '/^{fn}() {{/,/^}}$/p' {lib}")
 
         assert "set_boot_to_disk" in body("do_set_boot_entry")
-        assert "point_bootnext_at_disk" in body("do_point_bootnext")
         assert "wait_for_image_slot" in body("do_install_image")
 
         # The fetch feeds bmaptool, so a mid-stream --retry corrupts the write.


### PR DESCRIPTION
Not "one per reinstall": reinstalling the same image reuses its entry, as two consecutive hardware installs showed. An entry is stranded when a rebuilt image lands a different ESP PARTUUID.

An earlier version of this claimed disko derives PARTUUIDs from the partition layout. That was over-read from two builds that were in fact the same derivation -- system.nixos.tags resolves to sfo-unknown in this build mode, so a commit never reaches the image. The mechanism is not established here, so it is not asserted.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
