### PR TITLE
build(crosvm): Follow merged UAS fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     "ghaf-crosvm": {
       "flake": false,
       "locked": {
-        "lastModified": 1787724426,
+        "lastModified": 1787809374,
         "narHash": "sha256-7JjNkqwJg4wie3ESosbxCS3iGcV10keqr3WyuZX/CFM=",
-        "ref": "refs/heads/fix/uas-stop-endpoint",
-        "rev": "f2f3d2102da1f69dd151221bae13b9046ed79b15",
-        "revCount": 11726,
+        "ref": "refs/heads/main",
+        "rev": "63e3c3482553212244aec55a3fee5646b37c98bd",
+        "revCount": 11727,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/tiiuae/ghaf-crosvm"


### PR DESCRIPTION
## Description of Changes

Follow the merged [ghaf-crosvm PR10](https://github.com/tiiuae/ghaf-crosvm/pull/10)
from the `ghaf-crosvm` main branch instead of its feature branch.

This changes the locked revision from the PR head `f2f3d210` to merge commit
`63e3c348`. The source `narHash` is unchanged, so this is provenance cleanup
without a Crosvm content change.

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

- https://github.com/tiiuae/ghaf-crosvm/pull/10

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - not applicable to a lock-only update
- [x] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

The resolved Crosvm source tree is unchanged, so no target-specific runtime
behavior changes.

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other: no installation required for provenance-only validation

### Test Steps To Verify

```bash
nix fmt -- --fail-on-change
nix develop --command reuse lint
nix build .#checks.x86_64-linux.pre-commit --no-link
git diff --check
```

Confirm that the old and new `ghaf-crosvm` lock entries have the same
`narHash`, while the new entry uses `refs/heads/main` at `63e3c348`.
