### PR TITLE
feat(orin): Protected guest VM module on Orin AGX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ result*
 ghaf-host.qcow2
 .direnv/
 .idea
-linux-*/
 .serena/
 gcroot/
 .pre-commit-config.yaml

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -42,7 +42,8 @@ path = [
   "packages/pkgs-by-name/fingwit/0001-check-all-pam-services-for-fprintd.patch",
   "overlays/custom-packages/spire4ghaf/0001-spire-with-basic-plugins.patch",
   "modules/common/theming/*.yaml",
-  "modules/common/theming/*.ron"
+  "modules/common/theming/*.ron",
+  "modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/0002-rtk_btusb-Fix-for-kernel-6.16.patch"
 ]
 
 [[annotations]]
@@ -168,3 +169,10 @@ SPDX-FileCopyrightText = [
   "2022-2026 TII (SSRC) and the Ghaf contributors"
 ]
 path = "overlays/jetpack-nvdisplay/*.patch"
+
+[[annotations]]
+SPDX-License-Identifier = "MIT"
+SPDX-FileCopyrightText = "Copyright 2022-2024 Anduril Industries"
+path = [
+  "packages/pkgs-by-name/linux-pkvm-jetson/*.patch"
+]

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -43,7 +43,8 @@ path = [
   "overlays/custom-packages/spire4ghaf/0001-spire-with-basic-plugins.patch",
   "modules/common/theming/*.yaml",
   "modules/common/theming/*.ron",
-  "modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/0002-rtk_btusb-Fix-for-kernel-6.16.patch"
+  "modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/0002-rtk_btusb-Fix-for-kernel-6.16.patch",
+  "overlays/custom-packages/crosvm/0001-vhost-user-handle-ACCESS_PLATFORM-for-protected-guest.patch"
 ]
 
 [[annotations]]

--- a/modules/common/virtualization/crosvm.nix
+++ b/modules/common/virtualization/crosvm.nix
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Module to customize the crosvm package used by microvm and its compilation
+# options.
+#
+{
+  lib,
+  pkgs,
+  ...
+}:
+{
+  _file = ./crosvm.nix;
+
+  options.ghaf.virtualization.crosvm = {
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.crosvm;
+      defaultText = lib.literalExpression "pkgs.crosvm";
+      description = "The crosvm package used across Ghaf modules.";
+    };
+
+    features = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Additional features to compile in crosvm binary";
+    };
+
+    patches = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      description = "Patches to apply to crosvm.";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "info";
+      description = ''
+        Value for crosvm `--log-level` option, applied to every microVM
+        launched with the crosvm hypervisor. Set to null to leave at built-in
+        default.
+      '';
+    };
+
+    gdb = {
+      enable = lib.mkEnableOption ''
+        GDB debugging over local TCP.
+
+        Careful! enabling this feature causes the VM to pause its boot sequence and wait for a
+        GDB remote connection. It will not boot automatically on its own.
+      '';
+      port = lib.mkOption {
+        type = lib.types.int;
+        default = 9091;
+        description = "Listen port of the guest GDB server";
+      };
+    };
+  };
+}

--- a/modules/common/virtualization/default.nix
+++ b/modules/common/virtualization/default.nix
@@ -4,6 +4,7 @@
   _file = ./default.nix;
 
   imports = [
+    ./crosvm.nix
     ./nvidia-docker.nix
     ./nvidia-podman.nix
     ./qemu.nix

--- a/modules/microvm/common/vm-crosvm.nix
+++ b/modules/microvm/common/vm-crosvm.nix
@@ -7,7 +7,31 @@
   ...
 }:
 let
+  cfg = config.ghaf.virtualization.crosvm;
+
   isCrosvm = config.microvm.hypervisor == "crosvm";
+  withGdb = isCrosvm && cfg.gdb.enable;
+
+  crosvmPackage = cfg.package.overrideAttrs (oldAttrs: {
+    cargoBuildFeatures = oldAttrs.cargoBuildFeatures ++ cfg.features;
+    patches = (oldAttrs.patches or [ ]) ++ cfg.patches;
+  });
+
+  # `--log-level` is a global crosvm option, so argh only accepts it before the
+  # `run` subcommand.  microvm.nix appends `crosvm.extraArgs` after `run`, and
+  # crosvm ignores RUST_LOG, which leaves wrapping the binary as the only way to
+  # set the log level of the `microvm@<vm>.service` units.
+  crosvmWithLogLevel = pkgs.symlinkJoin {
+    name = "${crosvmPackage.name}-log-level";
+    paths = [ crosvmPackage ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/crosvm --add-flags "--log-level=${cfg.logLevel}"
+    '';
+    meta = (crosvmPackage.meta or { }) // {
+      mainProgram = "crosvm";
+    };
+  };
 in
 {
   _file = ./vm-crosvm.nix;
@@ -17,19 +41,47 @@ in
   # only their console rendering avoids adding seconds to every guest shutdown.
   systemd.settings.Manager.ShowStatus = lib.mkIf isCrosvm false;
 
-  # Crosvm's virtual IOMMU must be available before PCI enumeration.  Loading
-  # it as a module lets passthrough drivers race ahead of the IOMMU supplier;
-  # the late registration then leaves those devices without an IOMMU group and
-  # DMA-backed drivers cannot probe reliably.
-  boot.kernelPatches = lib.optionals (isCrosvm && pkgs.stdenv.hostPlatform.isx86_64) [
-    {
-      name = "crosvm-virtio-iommu-builtin";
-      patch = null;
-      structuredExtraConfig = with lib.kernel; {
-        VIRTIO = yes;
-        VIRTIO_PCI = yes;
-        VIRTIO_IOMMU = yes;
-      };
-    }
-  ];
+  boot.kernelPatches =
+    lib.optionals (isCrosvm && pkgs.stdenv.hostPlatform.isx86_64) [
+      # Crosvm's virtual IOMMU must be available before PCI enumeration.  Loading
+      # it as a module lets passthrough drivers race ahead of the IOMMU supplier;
+      # the late registration then leaves those devices without an IOMMU group and
+      # DMA-backed drivers cannot probe reliably.
+      {
+        name = "crosvm-virtio-iommu-builtin";
+        patch = null;
+        structuredExtraConfig = with lib.kernel; {
+          VIRTIO = yes;
+          VIRTIO_PCI = yes;
+          VIRTIO_IOMMU = yes;
+        };
+      }
+    ]
+    ++ lib.optionals withGdb [
+      {
+        name = "Kernel debug symbols";
+        patch = null;
+        structuredExtraConfig = with lib.kernel; {
+          DEBUG_INFO = yes;
+          DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT = yes;
+        };
+      }
+    ];
+
+  microvm.crosvm.package = if cfg.logLevel == null then crosvmPackage else crosvmWithLogLevel;
+
+  microvm.crosvm.extraArgs =
+    # SMT is not available on NVIDIA Jetson Orin or generally on ARM64 platforms.
+    # This causes crosvm to output unnecessary errors:
+    #   ERROR crosvm::crosvm::sys::linux::vcpu] Failed to enable core scheduling: No such device (os error 19)
+    lib.optionals pkgs.stdenv.hostPlatform.isAarch64 [
+      "--core-scheduling"
+      "false"
+    ]
+    ++ lib.optionals cfg.gdb.enable [
+      "--gdb"
+      "${lib.toString cfg.gdb.port}"
+    ];
+
+  microvm.vcpu = lib.mkIf withGdb (lib.mkForce 1);
 }

--- a/modules/microvm/common/vm-protected.nix
+++ b/modules/microvm/common/vm-protected.nix
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  _file = ./pkvm-guest.nix;
+
+  options.ghaf.virtualization.microvm.protected-vm = {
+    enable = lib.mkEnableOption "this guest to be run as a protected VM under the pKVM hypervisor.";
+  };
+
+  config = lib.mkIf config.ghaf.virtualization.microvm.protected-vm.enable {
+    assertions = [
+      {
+        assertion = pkgs.stdenv.hostPlatform.isAarch64;
+        message = "ghaf.virtualization.microvm.protected-vm expects ARM64 platform; got ${pkgs.stdenv.hostPlatform.system}.";
+      }
+    ];
+
+    microvm.crosvm.extraArgs = [
+      "--protected-vm-without-firmware"
+      "--unmap-guest-memory-on-fork"
+      "--disable-sandbox"
+      "--smccc-trng"
+    ];
+  };
+}

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -43,6 +43,7 @@
       ./common/storagevm.nix
       ./common/vm-crosvm.nix
       ./common/vm-networking.nix
+      ./common/vm-protected.nix
       ./common/vm-qemu.nix
       ./common/vm-swap.nix
       ./common/vm-tpm.nix

--- a/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx-industrial.nix
@@ -49,6 +49,8 @@
       nvidia.passthroughs.gpu_vm.enable = true;
       nvidia.passthroughs.disp_vm.enable = true;
 
+      nvidia.virtualization.host.dce.enable = true;
+
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
         {

--- a/modules/reference/hardware/jetpack/agx/orin-agx.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx.nix
@@ -46,6 +46,8 @@
       nvidia.passthroughs.gpu_vm.enable = true;
       nvidia.passthroughs.disp_vm.enable = true;
 
+      nvidia.virtualization.host.dce.enable = true;
+
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
         {

--- a/modules/reference/hardware/jetpack/agx/orin-agx64.nix
+++ b/modules/reference/hardware/jetpack/agx/orin-agx64.nix
@@ -44,6 +44,8 @@
       nvidia.passthroughs.gpu_vm.enable = true;
       nvidia.passthroughs.disp_vm.enable = true;
 
+      nvidia.virtualization.host.dce.enable = true;
+
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
         {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -860,7 +860,14 @@ in
     # assignment. At normal priority it would be a conflicting definition, and
     # the documented remedy would not evaluate.
     hardware.nvidia-jetpack.firmware.eksFile = lib.mkDefault "${firmwareEkbImage}/eks_t234.img";
-    hardware.nvidia-jetpack.kernel.version = "${cfg.kernelVersion}";
+
+    # Check for presence of kernel.version attribute since it is only defined in TII fork
+    hardware.nvidia-jetpack.kernel =
+      lib.optionalAttrs (options ? hardware.nvidia-jetpack.kernel.version)
+        {
+          version = cfg.kernelVersion;
+        };
+
     # jetpack-nixos hardcodes the trailing rootfs device as mmcblk0p1; replay
     # the same default here but route it through cfg.flashScriptOverrides.deviceDiskRootfsPartition
     # so per-SoM modules (e.g. orin-nx → nvme0n1p2) only set the option, not

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template.nix
@@ -145,6 +145,35 @@ let
           "$out"
       '';
 
+  # Parses Ghaf-specific flags out of the flash script's positional parameters
+  # and exports them for preFlashScript.
+  #
+  # This is spliced inline into jetpack-nixos' flash script rather than living
+  # inside preFlashScript, only there can `set --` rewrite the argument list
+  # that is later forwarded to flash.sh.
+  # flash.sh has no lowercase -s in its optstring, so an extra -s would abort
+  # the flash with an illegal-option error.
+  parseGhafFlashArgs = ''
+    flash_args=()
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -s | --signed-sd-image)
+          if [ "$#" -lt 2 ]; then
+            echo "ERROR: -s requires a directory argument" >&2
+            exit 1
+          fi
+          export SIGNED_SD_IMAGE_DIR="$2"
+          shift 2
+          ;;
+        *)
+          flash_args+=("$1")
+          shift
+          ;;
+      esac
+    done
+    set -- "''${flash_args[@]}"
+  '';
+
   # preFlashCommands: Extract images from sdImage and patch flash.xml
   preFlashScript = pkgs.pkgsBuildBuild.writeShellApplication {
     name = "pre-flash-commands";
@@ -344,6 +373,9 @@ in
       )
       {
         hardware.nvidia-jetpack.flashScriptOverrides.partitionTemplate = partitionTemplate;
-        hardware.nvidia-jetpack.flashScriptOverrides.preFlashCommands = "${preFlashScript}/bin/pre-flash-commands";
+        hardware.nvidia-jetpack.flashScriptOverrides.preFlashCommands = ''
+          ${parseGhafFlashArgs}
+          ${preFlashScript}/bin/pre-flash-commands
+        '';
       };
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/dce-probe-host.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/common/dce-virt-common/dce-probe-host.nix
@@ -17,11 +17,14 @@
 # Shared by AGX and NX (both Tegra234 + host-owned DCE): imported from
 # agx/orin-agx.nix and nx/orin-nx.nix.
 {
+  config,
   lib,
   pkgs,
   ...
 }:
 let
+  cfg = config.ghaf.hardware.nvidia.virtualization.host.dce;
+
   # Bare "nvidia,dce-host-proxy" node so the platform driver binds and creates
   # /dev/dce-host. Driver reads no reg/vpa (relays via tegra-dce's exported
   # CPU_RM client API), so the node only needs the compatible. Mirrors
@@ -48,105 +51,118 @@ in
 {
   _file = ./dce-probe-host.nix;
 
-  # Host display driver blacklisted (headless), so nothing in Linux claims the
-  # display clocks/power-domains (dpaux0, SOR, disp, DP PLLs) or the DCE. Then
-  # clk_disable_unused()/genpd_disable_unused() at late_initcall gate them off as
-  # "unused" -- but the host-owned DCE R5 needs them ON for DP-AUX (read EDID) and
-  # to drive the SOR (output). Symptom when gated: DP reads "connected" (HPD
-  # survives) but EDID is 0 bytes (AUX unclocked) and no mode is set (SOR
-  # unclocked) -> no signal. Keep unused clocks + power-domains on.
-  boot.kernelParams = [
-    "clk_ignore_unused"
-    "pd_ignore_unused"
-  ];
+  options.ghaf.hardware.nvidia.virtualization.host.dce.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Make the host the DCE owner for a display-passthrough topology: headless
+      host, forced tegra-dce load, dce-host-proxy + dce-iso-anchor built into
+      nvidia-oot-modules, and the "nvidia,dce-host-proxy" DT node that backs
+      /dev/dce-host.
+    '';
+  };
 
-  # Headless: nothing may bring up COSMIC/graphics and register a CPU_RM display
-  # client on the host; the host CCPLEX must never program display@13800000
-  # (it belongs to the guest).
-  ghaf.profiles.graphics.enable = lib.mkForce false;
+  config = lib.mkIf cfg.enable {
+    # Host display driver blacklisted (headless), so nothing in Linux claims the
+    # display clocks/power-domains (dpaux0, SOR, disp, DP PLLs) or the DCE. Then
+    # clk_disable_unused()/genpd_disable_unused() at late_initcall gate them off as
+    # "unused" -- but the host-owned DCE R5 needs them ON for DP-AUX (read EDID) and
+    # to drive the SOR (output). Symptom when gated: DP reads "connected" (HPD
+    # survives) but EDID is 0 bytes (AUX unclocked) and no mode is set (SOR
+    # unclocked) -> no signal. Keep unused clocks + power-domains on.
+    boot.kernelParams = [
+      "clk_ignore_unused"
+      "pd_ignore_unused"
+    ];
 
-  # Host kernel = base jetpack-nixos for orin-agx
-  # (pkgs.nvidia-jetpack.kernelPackages) + dce-host-proxy spliced into
-  # nvidia-oot-modules. mkForce required: hardware.nvidia-jetpack already sets
-  # boot.kernelPackages at normal priority.
-  boot.kernelPackages = lib.mkForce (
-    (pkgs.nvidia-jetpack.kernelPackages.extend pkgs.nvidia-jetpack.kernelPackagesOverlay).extend (
-      _final: prev: {
-        nvidia-oot-modules = prev.nvidia-oot-modules.overrideAttrs (o: {
-          # nvidia-oot-modules' src is the combined l4t-oot-modules-sources tree
-          # (nvidia-oot/, nvgpu/, nvdisplay/, ... each under its project name).
-          # dce-host-proxy links tegra-dce's EXPORT_SYMBOL'd DCE client API, so it
-          # must build INSIDE nvidia-oot (not the kernel tree). Flatten its source
-          # into dce/ (whose Makefile ccflags already resolve the public
-          # dce-client-ipc.h include) and add as its own obj-m .ko.
-          # dtc + xxd: dce-iso-anchor embeds its runtime DT overlay as a C array
-          # (compiled with -@ so &smmu_iso resolves against the live tree's
-          # __symbols__ at of_overlay_fdt_apply time).
-          nativeBuildInputs = (o.nativeBuildInputs or [ ]) ++ [
-            pkgs.buildPackages.dtc
-            pkgs.buildPackages.unixtools.xxd
-          ];
-          postPatch = (o.postPatch or "") + ''
-            install -D ${./sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.c} \
-              nvidia-oot/drivers/platform/tegra/dce/dce-host-proxy.c
-            install -D ${./sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.h} \
-              nvidia-oot/drivers/platform/tegra/dce/dce-host-proxy.h
-            echo 'obj-m += dce-host-proxy.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
+    # Headless: nothing may bring up COSMIC/graphics and register a CPU_RM display
+    # client on the host; the host CCPLEX must never program display@13800000
+    # (it belongs to the guest).
+    ghaf.profiles.graphics.enable = lib.mkForce false;
 
-            install -D ${./sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.c} \
-              nvidia-oot/drivers/platform/tegra/dce/dce-iso-anchor.c
-            dtc -@ -I dts -O dtb -o dce-iso-anchor.dtbo \
-              ${./sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.dts}
-            xxd -i -n dce_iso_anchor_dtbo dce-iso-anchor.dtbo \
-              > nvidia-oot/drivers/platform/tegra/dce/dce-iso-anchor-dtbo.h
-            echo 'obj-m += dce-iso-anchor.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
-          '';
-        });
+    # Host kernel = base jetpack-nixos for orin-agx
+    # (pkgs.nvidia-jetpack.kernelPackages) + dce-host-proxy spliced into
+    # nvidia-oot-modules. mkForce required: hardware.nvidia-jetpack already sets
+    # boot.kernelPackages at normal priority.
+    boot.kernelPackages = lib.mkForce (
+      (pkgs.nvidia-jetpack.kernelPackages.extend pkgs.nvidia-jetpack.kernelPackagesOverlay).extend (
+        _final: prev: {
+          nvidia-oot-modules = prev.nvidia-oot-modules.overrideAttrs (o: {
+            # nvidia-oot-modules' src is the combined l4t-oot-modules-sources tree
+            # (nvidia-oot/, nvgpu/, nvdisplay/, ... each under its project name).
+            # dce-host-proxy links tegra-dce's EXPORT_SYMBOL'd DCE client API, so it
+            # must build INSIDE nvidia-oot (not the kernel tree). Flatten its source
+            # into dce/ (whose Makefile ccflags already resolve the public
+            # dce-client-ipc.h include) and add as its own obj-m .ko.
+            # dtc + xxd: dce-iso-anchor embeds its runtime DT overlay as a C array
+            # (compiled with -@ so &smmu_iso resolves against the live tree's
+            # __symbols__ at of_overlay_fdt_apply time).
+            nativeBuildInputs = (o.nativeBuildInputs or [ ]) ++ [
+              pkgs.buildPackages.dtc
+              pkgs.buildPackages.unixtools.xxd
+            ];
+            postPatch = (o.postPatch or "") + ''
+              install -D ${./sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.c} \
+                nvidia-oot/drivers/platform/tegra/dce/dce-host-proxy.c
+              install -D ${./sources/drivers/platform/tegra/dce-host-proxy/dce-host-proxy.h} \
+                nvidia-oot/drivers/platform/tegra/dce/dce-host-proxy.h
+              echo 'obj-m += dce-host-proxy.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
+
+              install -D ${./sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.c} \
+                nvidia-oot/drivers/platform/tegra/dce/dce-iso-anchor.c
+              dtc -@ -I dts -O dtb -o dce-iso-anchor.dtbo \
+                ${./sources/drivers/platform/tegra/dce-iso-anchor/dce-iso-anchor.dts}
+              xxd -i -n dce_iso_anchor_dtbo dce-iso-anchor.dtbo \
+                > nvidia-oot/drivers/platform/tegra/dce/dce-iso-anchor-dtbo.h
+              echo 'obj-m += dce-iso-anchor.o' >> nvidia-oot/drivers/platform/tegra/dce/Makefile
+            '';
+          });
+        }
+      )
+    );
+
+    # boot.extraModulePackages not needed: hardware.nvidia-jetpack already sets
+    # `boot.extraModulePackages = [ config.boot.kernelPackages.nvidia-oot-modules ]`
+    # for jetpackAtLeast "6", resolving against the forced boot.kernelPackages
+    # above, so dce-host-proxy.ko rides along automatically.
+
+    # Blacklist the host display RM stack so no CPU_RM display client registers
+    # and the host never programs display@13800000. tegra-dce deliberately NOT
+    # blacklisted (host must keep bootstrapping/owning the DCE R5). gpu-vm's
+    # default.nix also blacklists nvgpu/host1x; the lists merge.
+    boot.blacklistedKernelModules = [
+      "nvidia"
+      "nvidia_modeset"
+      "nvidia_drm"
+      "tegra_drm"
+    ];
+
+    # nvidia-oot modules do NOT autoload from a DT compatible match. Force-load
+    # tegra-dce (binds real d800000.dce, drives R5 bootstrap to LOCKED) and
+    # dce-host-proxy (binds the injected node, creates /dev/dce-host).
+    # dce-host-proxy links tegra-dce's symbols, so modprobe orders tegra-dce first.
+    boot.kernelModules = [
+      "tegra-dce"
+      "dce-host-proxy"
+      # smmu_iso SID-1 anchor: translating domain for the FE's ISO scanout stream
+      # with DCE high-IOVA -> carveout maps (else panel is lit-but-black under
+      # passthrough). Applies its own DT overlay at load.
+      "dce-iso-anchor"
+    ];
+
+    # /dev/dce-host is opened by patched QEMU (microvm user in kvm group) to relay
+    # guest DCE IPC. Grant kvm group access, mirroring the bpmp-host / vfio rule
+    # in gpu-vm's default.nix.
+    services.udev.extraRules = ''
+      KERNEL=="dce-host", GROUP="kvm", MODE="0660"
+    '';
+
+    hardware.deviceTree.enable = true;
+    hardware.deviceTree.overlays = [
+      {
+        name = "dce_host_overlay";
+        dtsFile = dceHostOverlay;
       }
-    )
-  );
-
-  # boot.extraModulePackages not needed: hardware.nvidia-jetpack already sets
-  # `boot.extraModulePackages = [ config.boot.kernelPackages.nvidia-oot-modules ]`
-  # for jetpackAtLeast "6", resolving against the forced boot.kernelPackages
-  # above, so dce-host-proxy.ko rides along automatically.
-
-  # Blacklist the host display RM stack so no CPU_RM display client registers
-  # and the host never programs display@13800000. tegra-dce deliberately NOT
-  # blacklisted (host must keep bootstrapping/owning the DCE R5). gpu-vm's
-  # default.nix also blacklists nvgpu/host1x; the lists merge.
-  boot.blacklistedKernelModules = [
-    "nvidia"
-    "nvidia_modeset"
-    "nvidia_drm"
-    "tegra_drm"
-  ];
-
-  # nvidia-oot modules do NOT autoload from a DT compatible match. Force-load
-  # tegra-dce (binds real d800000.dce, drives R5 bootstrap to LOCKED) and
-  # dce-host-proxy (binds the injected node, creates /dev/dce-host).
-  # dce-host-proxy links tegra-dce's symbols, so modprobe orders tegra-dce first.
-  boot.kernelModules = [
-    "tegra-dce"
-    "dce-host-proxy"
-    # smmu_iso SID-1 anchor: translating domain for the FE's ISO scanout stream
-    # with DCE high-IOVA -> carveout maps (else panel is lit-but-black under
-    # passthrough). Applies its own DT overlay at load.
-    "dce-iso-anchor"
-  ];
-
-  # /dev/dce-host is opened by patched QEMU (microvm user in kvm group) to relay
-  # guest DCE IPC. Grant kvm group access, mirroring the bpmp-host / vfio rule
-  # in gpu-vm's default.nix.
-  services.udev.extraRules = ''
-    KERNEL=="dce-host", GROUP="kvm", MODE="0660"
-  '';
-
-  hardware.deviceTree.enable = true;
-  hardware.deviceTree.overlays = [
-    {
-      name = "dce_host_overlay";
-      dtsFile = dceHostOverlay;
-    }
-  ];
+    ];
+  };
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/default.nix
@@ -10,6 +10,8 @@
     ./passthrough/gpu-vm
     ./passthrough/disp-vm
     ./passthrough/gui-vm
+    ./pkvm/orin-pkvm.nix
+    ./pkvm/orin-pkvm-host.nix
     ./ownership-assertions.nix
   ];
 }

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/default.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/default.nix
@@ -11,6 +11,7 @@
     ./passthrough/disp-vm
     ./passthrough/gui-vm
     ./pkvm/orin-pkvm.nix
+    ./pkvm/orin-pkvm-guest.nix
     ./pkvm/orin-pkvm-host.nix
     ./ownership-assertions.nix
   ];

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/0002-rtk_btusb-Fix-for-kernel-6.16.patch
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/0002-rtk_btusb-Fix-for-kernel-6.16.patch
@@ -1,0 +1,74 @@
+From 87476de5e5ec6e71066824bc9c558990285b1128 Mon Sep 17 00:00:00 2001
+From: Hannu Lyytinen <hannu.lyytinen@unikie.com>
+Date: Wed, 26 Nov 2025 11:45:37 +0200
+Subject: [PATCH 02/11] rtk_btusb: Fix for kernel 6.16+
+
+Signed-off-by: Hannu Lyytinen <hannu.lyytinen@unikie.com>
+---
+ drivers/bluetooth/realtek/rtk_bt.c   | 6 +++---
+ drivers/bluetooth/realtek/rtk_bt.h   | 7 +++++++
+ drivers/bluetooth/realtek/rtk_coex.c | 2 +-
+ 3 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/bluetooth/realtek/rtk_bt.c b/drivers/bluetooth/realtek/rtk_bt.c
+index 7a778a96..9674260a 100644
+--- a/drivers/bluetooth/realtek/rtk_bt.c
++++ b/drivers/bluetooth/realtek/rtk_bt.c
+@@ -2037,12 +2037,12 @@ static int btusb_probe(struct usb_interface *intf,
+ 
+ #if HCI_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+ 	set_bit(BTUSB_USE_ALT3_FOR_WBS, &data->flags);
+-	set_bit(HCI_QUIRK_WIDEBAND_SPEECH_SUPPORTED, &hdev->quirks);
++	rtk_set_quirk(hdev, HCI_QUIRK_WIDEBAND_SPEECH_SUPPORTED);
+ #endif
+ 
+ #if HCI_VERSION_CODE >= KERNEL_VERSION(3, 7, 1)
+ 	if (!reset)
+-		set_bit(HCI_QUIRK_RESET_ON_CLOSE, &hdev->quirks);
++		rtk_set_quirk(hdev, HCI_QUIRK_RESET_ON_CLOSE);
+ #endif
+ 
+ 	/* Interface numbers are hardcoded in the specification */
+@@ -2059,7 +2059,7 @@ static int btusb_probe(struct usb_interface *intf,
+ 	}
+ 
+ #if HCI_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+-	set_bit(HCI_QUIRK_SIMULTANEOUS_DISCOVERY, &hdev->quirks);
++	rtk_set_quirk(hdev, HCI_QUIRK_SIMULTANEOUS_DISCOVERY);
+ #endif
+ 
+ 	err = hci_register_dev(hdev);
+diff --git a/drivers/bluetooth/realtek/rtk_bt.h b/drivers/bluetooth/realtek/rtk_bt.h
+index c60307ad..c9d8c21f 100644
+--- a/drivers/bluetooth/realtek/rtk_bt.h
++++ b/drivers/bluetooth/realtek/rtk_bt.h
+@@ -41,6 +41,13 @@
+ /* #define HCI_VERSION_CODE KERNEL_VERSION(3, 14, 41) */
+ #define HCI_VERSION_CODE LINUX_VERSION_CODE
+ 
++/* Kernel 6.16+ renamed hci_dev->quirks to hci_dev->quirk_flags and added hci_set_quirk() */
++#if HCI_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++#define rtk_set_quirk(hdev, nr) hci_set_quirk(hdev, nr)
++#else
++#define rtk_set_quirk(hdev, nr) set_bit((nr), &(hdev)->quirks)
++#endif
++
+ #define CONFIG_BTCOEX			1
+ #define CONFIG_BTUSB_WAKEUP_HOST	0
+ 
+diff --git a/drivers/bluetooth/realtek/rtk_coex.c b/drivers/bluetooth/realtek/rtk_coex.c
+index 08155ee2..cf0d200d 100644
+--- a/drivers/bluetooth/realtek/rtk_coex.c
++++ b/drivers/bluetooth/realtek/rtk_coex.c
+@@ -2430,7 +2430,7 @@ static void rtk_handle_le_terminate_big_complete_evt(u8 * p)
+ 
+ static void rtk_handle_le_big_sync_established_evt(void * p)
+ {
+-	struct hci_evt_le_big_sync_estabilished *ev = p;
++	struct hci_evt_le_big_sync_established *ev = p;
+ 	u8 status;
+ 	u16 big_handle;
+ 	u16 bis_handle;
+-- 
+2.34.1
+

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm-guest.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm-guest.nix
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.guest.hardening;
+
+  jetsonKernelDrv = pkgs.linux_6_18_jetson_pkvm.override {
+    argsOverride.defconfig = "guest_defconfig";
+  };
+
+  guestExtraConfig = {
+    boot.kernelPackages = pkgs.linuxPackagesFor jetsonKernelDrv;
+
+    boot.kernelPatches = [
+      {
+        name = "Additional virt guest config";
+        patch = null;
+        structuredExtraConfig = with lib.kernel; {
+          VSOCKETS = yes;
+          VSOCKETS_LOOPBACK = yes;
+          VIRTIO_VSOCKETS = yes;
+          VIRTIO_BALLOON = module;
+          VIRTIO_FS = module;
+          SCSI_VIRTIO = module;
+        };
+      }
+    ];
+
+    hardware.enableAllHardware = false;
+    boot.initrd.includeDefaultModules = false;
+    boot.initrd.availableKernelModules = [
+      "virtiofs"
+      "virtio_net"
+      "virtio_pci"
+      "virtio_mmio"
+      "virtio_blk"
+      "virtio_scsi"
+      "virtio_console"
+      "vsock"
+    ];
+
+    microvm.hypervisor = lib.mkForce "crosvm";
+    ghaf.virtualization.crosvm.features = [ "bpmp" ];
+    ghaf.virtualization.microvm.protected-vm.enable = true;
+  };
+in
+{
+  _file = ./orin-pkvm-guest.nix;
+
+  config = lib.mkIf cfg.protected.enable {
+    ghaf.virtualization.vmConfig.sysvms = {
+      netvm.extraModules = [
+        guestExtraConfig
+      ];
+
+      adminvm.extraModules = [
+        guestExtraConfig
+      ];
+    };
+
+    assertions = [
+      {
+        assertion = cfg.protected.enable -> config.ghaf.host.kernel.hardening.hypervisor.enable;
+        message = "Host kernel must have protected guest support to enable config.ghaf.guest.hardening";
+      }
+    ];
+  };
+}

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm-host.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm-host.nix
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
+let
+  cfg = config.ghaf.host.kernel.hardening;
+
+  nvidiaJetpackFixes = _final: prev: {
+    # Fix CUDA compile failures for x86_64 cross-compile build
+    config =
+      prev.config
+      // lib.optionalAttrs (prev.stdenv.hostPlatform.system != "aarch64-linux") {
+        cudaCapabilities = [ ];
+      };
+
+    nvidia-jetpack = prev.nvidia-jetpack.overrideScope (
+      _sfinal: sprev: {
+        # Fix build error with python 3.14:
+        #   importlib.metadata.PackageNotFoundError: No package metadata was found for uefi-firmware-parser
+        # Set dontCheckPythonMetadata to skip the pythonMetadataCheckPhase.
+        # The nested overrides are needed to reach inside the uefi-firmware-parser derivation.
+        patchfv = sprev.patchfv.override (prevArgs: {
+          python3Packages = prevArgs.python3Packages // {
+            buildPythonPackage =
+              args: prevArgs.python3Packages.buildPythonPackage (args // { dontCheckPythonMetadata = true; });
+          };
+        });
+      }
+    );
+  };
+
+  jetpackHostKconfig =
+    with lib.kernel;
+    {
+      VIRTIO_FS = module;
+      TCG_TIS = module;
+      RTW89 = module;
+      RTW89_8852CE = module;
+    }
+    // import "${inputs.jetpack-nixos}/pkgs/kernels/common-arch.nix" { inherit lib; };
+
+  ootExtraMakeFlags = [
+    "kernel_name=pkvm"
+    "NV_OOT_REALTEK_RTL8822CE_SKIP_BUILD=y"
+    "NV_OOT_REALTEK_RTL8852CE_SKIP_BUILD=y"
+  ];
+  ootMakeFlagsToRemove = [
+    "kernel_name=noble"
+  ];
+
+  jetpackKernelOverlay = final: prev: {
+    nvidia-jetpack = prev.nvidia-jetpack.overrideScope (
+      _sfinal: sprev: {
+        kernel = final.linux_6_18_jetson_pkvm.override {
+          argsOverride.defconfig = "debug_defconfig";
+          structuredExtraConfig = jetpackHostKconfig;
+        };
+
+        kernelPackagesOverlay =
+          kfinal: kprev:
+          let
+            base = sprev.kernelPackagesOverlay kfinal kprev;
+            inherit (kfinal) kernel;
+          in
+          base
+          // lib.optionalAttrs (base ? nvidia-oot-modules) {
+            nvidia-oot-modules = base.nvidia-oot-modules.overrideAttrs (oldAttrs: {
+              # Jetson r39 build requires `bc` and it is not provided by jetpack-nixos
+              nativeBuildInputs =
+                oldAttrs.nativeBuildInputs
+                ++ lib.optional (
+                  !lib.any (d: (d.pname or null) == "bc") oldAttrs.nativeBuildInputs
+                ) final.buildPackages.bc;
+
+              # The submodule path for OOT make is incorrect when using makeFlags instead of commonMakeFlags
+              makeFlags =
+                kernel.commonMakeFlags
+                ++ lib.subtractLists (
+                  kernel.makeFlags ++ ootMakeFlagsToRemove ++ ootExtraMakeFlags
+                ) oldAttrs.makeFlags
+                ++ ootExtraMakeFlags;
+
+              postPatch = (oldAttrs.postPatch or "") + ''
+                if ! grep -q rtk_set_quirk nvidia-oot/drivers/bluetooth/realtek/rtk_bt.h; then
+                  patch -p1 -d nvidia-oot < ${./0002-rtk_btusb-Fix-for-kernel-6.16.patch}
+                fi
+              '';
+            });
+          };
+      }
+    );
+  };
+in
+{
+  _file = ./orin-pkvm-host.nix;
+
+  config = lib.mkIf cfg.hypervisor.enable {
+    nixpkgs.overlays = [
+      nvidiaJetpackFixes
+      jetpackKernelOverlay
+    ];
+
+    ghaf.hardware.nvidia.orin.kernelVersion = lib.mkForce "stable-6-18-pkvm";
+
+    hardware.nvidia-jetpack.majorVersion = lib.mkForce "7";
+
+    # compilation of this nvidia-oot module was skipped
+    boot.initrd.availableKernelModules.rtl8852ce = lib.mkForce false;
+
+    # Passthroughs aren't ported yet
+    ghaf.hardware.nvidia.virtualization.enable = lib.mkForce false;
+    ghaf.hardware.nvidia.virtualization.host.dce.enable = lib.mkForce false;
+
+    ghaf.hardware.nvidia.passthroughs.mgbe0_net_vm.enable = lib.mkForce false;
+    ghaf.hardware.nvidia.passthroughs.gpu_vm.enable = lib.mkForce false;
+    ghaf.hardware.nvidia.passthroughs.disp_vm.enable = lib.mkForce false;
+
+    ghaf.hardware.nvidia.orin.agx.enableNetvmWlanPCIPassthrough = lib.mkForce false;
+  };
+}

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm.nix
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  ...
+}:
+{
+  _file = ./orin-pkvm.nix;
+
+  options.ghaf.host.kernel.hardening = {
+    hypervisor.enable = lib.mkEnableOption "support for protected guests on Orin AGX";
+  };
+}

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/pkvm/orin-pkvm.nix
@@ -10,4 +10,8 @@
   options.ghaf.host.kernel.hardening = {
     hypervisor.enable = lib.mkEnableOption "support for protected guests on Orin AGX";
   };
+
+  options.ghaf.guest.hardening = {
+    protected.enable = lib.mkEnableOption "protected mode for VMs on Orin AGX";
+  };
 }

--- a/modules/reference/hardware/jetpack/nx/orin-nx.nix
+++ b/modules/reference/hardware/jetpack/nx/orin-nx.nix
@@ -56,6 +56,8 @@
       nvidia.passthroughs.gpu_vm.enable = true;
       nvidia.passthroughs.disp_vm.enable = true;
 
+      nvidia.virtualization.host.dce.enable = true;
+
       # Net VM hardware-specific modules - use hardware.definition for composition model
       definition.netvm.extraModules = [
         {

--- a/overlays/custom-packages/crosvm/0001-vhost-user-handle-ACCESS_PLATFORM-for-protected-guest.patch
+++ b/overlays/custom-packages/crosvm/0001-vhost-user-handle-ACCESS_PLATFORM-for-protected-guest.patch
@@ -1,0 +1,57 @@
+From 4a89bc8e7afeaa4f62a95cd8b5024f8cce2a8c87 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Markku=20Ahvenj=C3=A4rvi?= <mankku@gmail.com>
+Date: Fri, 29 May 2026 15:01:54 +0300
+Subject: [PATCH] vhost-user: handle ACCESS_PLATFORM for protected guests
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Markku Ahvenjärvi <mankku@gmail.com>
+---
+ devices/src/virtio/vhost_user_frontend/mod.rs | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/devices/src/virtio/vhost_user_frontend/mod.rs b/devices/src/virtio/vhost_user_frontend/mod.rs
+index 4ee5233873ba..e97a921c7c2b 100644
+--- a/devices/src/virtio/vhost_user_frontend/mod.rs
++++ b/devices/src/virtio/vhost_user_frontend/mod.rs
+@@ -28,6 +28,7 @@ use base::SafeDescriptor;
+ use base::SendTube;
+ use base::WorkerThread;
+ use snapshot::AnySnapshot;
++use virtio_sys::virtio_config::VIRTIO_F_ACCESS_PLATFORM;
+ use vm_memory::GuestMemory;
+ use vmm_vhost::message::VhostUserConfigFlags;
+ use vmm_vhost::message::VhostUserMigrationPhase;
+@@ -130,8 +131,15 @@ impl VhostUserFrontend {
+         let allow_features = VIRTIO_DEVICE_TYPE_SPECIFIC_FEATURES_MASK
+             | base_features
+             | 1 << VHOST_USER_F_PROTOCOL_FEATURES;
+-        let avail_features =
++        let mut avail_features =
+             allow_features & backend_client.get_features().map_err(Error::GetFeatures)?;
++
++        // Protected VMs must expose ACCESS_PLATFORM to the guest even if the
++        // vhost-user backend does not advertise it.
++        if base_features & (1u64 << VIRTIO_F_ACCESS_PLATFORM) != 0 {
++            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
++        }
++
+         let mut acked_features = 0;
+ 
+         let allow_protocol_features = VhostUserProtocolFeatures::CONFIG
+@@ -399,6 +407,11 @@ impl VirtioDevice for VhostUserFrontend {
+ 
+     fn ack_features(&mut self, features: u64) {
+         self.acked_features |= features & self.avail_features;
++
++        // ACCESS_PLATFORM may have been negotiated with the guest, but for the backend that
++        // feature implies support for IOTLB/IOMMU mode which is currently not supported.
++        // Therefore do not pass it to the backend.
++        self.acked_features &= !(1u64 << VIRTIO_F_ACCESS_PLATFORM);
+     }
+ 
+     fn read_config(&self, offset: u64, data: &mut [u8]) {
+-- 
+2.51.2
+

--- a/overlays/custom-packages/crosvm/default.nix
+++ b/overlays/custom-packages/crosvm/default.nix
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# tiiuae fork of crosvm to bring pKVM patches
+{ prev }:
+let
+  version = "0-develop-2026-07-23";
+  src = prev.fetchFromGitHub {
+    owner = "tiiuae";
+    repo = "crosvm";
+    rev = "0b294d1c87ba3bcd7127df4706c6caf092c516ab"; # develop - Jun 30 2026
+    fetchSubmodules = true;
+    hash = "sha256-+aM0ifaxwWLtIk9YbCETixZWh/4fFWCcoCtA7XOpE9Y=";
+  };
+  cargoHash = "sha256-NEmMsCuiEOkanGwT/Oib9yhP+UeT+bCwGI9I3DCWyWU=";
+in
+if prev.stdenv.hostPlatform.isAarch64 then
+  prev.crosvm.overrideAttrs (old: {
+    inherit version src cargoHash;
+    # We need to also pass cargoHash to fetchCargoVendor, otherwise cargoDeps retains
+    # the original value from nixpkgs in its scope.
+    cargoDeps = prev.rustPlatform.fetchCargoVendor {
+      inherit (old) pname;
+      inherit src version;
+      hash = cargoHash;
+    };
+    cargoBuildFeatures = (old.cargoBuildFeatures or [ ]) ++ [
+      "gdb"
+      "pci-hotplug"
+      "vtpm"
+    ];
+    buildInputs = (old.buildInputs or [ ]) ++ [ prev.dbus ];
+    patches = [
+      ./0001-vhost-user-handle-ACCESS_PLATFORM-for-protected-guest.patch
+    ];
+  })
+else
+  prev.crosvm

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -19,6 +19,7 @@
   cosmic-reader = import ./cosmic/cosmic-reader { inherit prev; };
   cosmic-settings = import ./cosmic/cosmic-settings { inherit prev; };
   cosmic-settings-daemon = import ./cosmic/cosmic-settings-daemon { inherit prev; };
+  crosvm = import ./crosvm { inherit prev; };
   element-desktop = import ./element-desktop { inherit prev; };
   grafana-alloy = import ./grafana-alloy { inherit prev; };
   intel-gpu-tools = import ./intel-gpu-tools { inherit prev; };

--- a/overlays/jetpack-nvdisplay/default.nix
+++ b/overlays/jetpack-nvdisplay/default.nix
@@ -19,13 +19,17 @@
 # jetpack kernel itself still has the three-argument form, so the host build is
 # unaffected -- the conftest simply doesn't match there.
 #
+# L4T < 38 only. From r38 onwards the patch fails to apply because nvdisplay
+# already handles the four argument signature
+#
 # Scoped to the Jetson targets (applied by modules/reference/hardware/jetpack/
 # default.nix) rather than living in overlays.default, the same way
 # overlays.jetpack-python is. Drop this once tiiuae/jetpack-nixos carries the
 # patch in pkgs/kernels/r36/patches/nvdisplay/.
 (_final: prev: {
   nvidia-jetpack = prev.nvidia-jetpack.overrideScope (
-    _jfinal: jprev: {
+    _jfinal: jprev:
+    prev.lib.optionalAttrs (prev.lib.versionOlder jprev.l4tMajorMinorPatchVersion "38") {
       kernelPackagesOverlay =
         kfinal: kprev:
         let

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -23,6 +23,7 @@
     ghaf-vms = final.callPackage ./pkgs-by-name/ghaf-vms/package.nix { };
     gpu-vm-partition-manager-sdk = inputs.gpu-partition-manager.lib.mkSdk { pkgs = final; };
     hardware-scan = final.callPackage ./pkgs-by-name/hardware-scan/package.nix { };
+    linux_6_18_jetson_pkvm = final.callPackage ./pkgs-by-name/linux-pkvm-jetson/package.nix { };
     make-checks = final.callPackage ./pkgs-by-name/make-checks/package.nix { };
     memsocket = final.callPackage ./pkgs-by-name/memsocket/package.nix { };
     pci-binder = final.callPackage ./pkgs-by-name/pci-binder/package.nix { };

--- a/packages/pkgs-by-name/linux-pkvm-jetson/0001-usb-host-Export-xhci_irq.patch
+++ b/packages/pkgs-by-name/linux-pkvm-jetson/0001-usb-host-Export-xhci_irq.patch
@@ -1,0 +1,29 @@
+From 4b1552b3861382dcefd0ace133e7d52501499cb3 Mon Sep 17 00:00:00 2001
+From: Elliot Berman <eberman@anduril.com>
+Date: Tue, 26 Aug 2025 10:31:32 -0700
+Subject: [PATCH 1/2] usb: host: Export xhci_irq
+
+This symbol is used by xhci-tegra, which can be built in a separate
+module from xhci.
+
+Fixes: fd7de45afba5 ("NVIDIA: SAUCE: xhci: tegra: enable firmware log")
+Signed-off-by: Elliot Berman <eberman@anduril.com>
+---
+ drivers/usb/host/xhci-ring.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/usb/host/xhci-ring.c b/drivers/usb/host/xhci-ring.c
+index 7badf91645909..04186add014e4 100644
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -3254,6 +3254,7 @@ irqreturn_t xhci_irq(struct usb_hcd *hcd)
+ 
+ 	return ret;
+ }
++EXPORT_SYMBOL_GPL(xhci_irq);
+ 
+ irqreturn_t xhci_msi_irq(int irq, void *hcd)
+ {
+-- 
+2.50.0
+

--- a/packages/pkgs-by-name/linux-pkvm-jetson/0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch
+++ b/packages/pkgs-by-name/linux-pkvm-jetson/0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch
@@ -1,0 +1,37 @@
+From d122bf9d0678255039dc6e2833dc04f7865c62cc Mon Sep 17 00:00:00 2001
+From: Daniel Fullmer <dfullmer@anduril.com>
+Date: Sat, 14 Feb 2026 13:43:59 -0800
+Subject: [PATCH 2/2] Hack to select VIDEOBUF2_DMA_CONTIG
+
+drivers/media/platform/tegra/camera/vi/channel.c from linux-oot-modules
+has ifdefs for CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
+function. Otherwise it hits a WARN_ON() and outputs
+> tegra-capture-vi: failed to initialize VB2 queue
+
+This option unfortunately can't be set via extraConfig or
+structuredExtraConfig because the config option does not include a
+"prompt" and therefore kconfig sets its visibility to false, and it never
+shows up in "make config",  which prevents generate-config.pl from
+setting it.  Manually adding it to the defconfig doesn't work either.
+
+Here we have a hack to just reuse another option that _is_ already
+enabled and have it select the CONFIG_VIDEOBUF2_DMA_CONTIG
+---
+ drivers/media/common/videobuf2/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/common/videobuf2/Kconfig b/drivers/media/common/videobuf2/Kconfig
+index d2223a12c95fc..a2298bafa0b95 100644
+--- a/drivers/media/common/videobuf2/Kconfig
++++ b/drivers/media/common/videobuf2/Kconfig
+@@ -21,6 +21,7 @@ config VIDEOBUF2_VMALLOC
+ 	select VIDEOBUF2_CORE
+ 	select VIDEOBUF2_MEMOPS
+ 	select DMA_SHARED_BUFFER
++        select VIDEOBUF2_DMA_CONTIG
+ 
+ config VIDEOBUF2_DMA_SG
+ 	tristate
+-- 
+2.50.0
+

--- a/packages/pkgs-by-name/linux-pkvm-jetson/package.nix
+++ b/packages/pkgs-by-name/linux-pkvm-jetson/package.nix
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  buildLinux,
+  structuredExtraConfig ? { },
+  argsOverride ? { },
+  fetchFromGitHub,
+  ...
+}@args:
+buildLinux (
+  args
+  // {
+    pname = "linux-pkvm-jetson";
+    version = "6.18.0";
+    extraMeta.branch = "pkvm-v6.18-dev";
+
+    defconfig = "defconfig";
+
+    src = fetchFromGitHub {
+      owner = "tiiuae";
+      repo = "linux-pkvm-jetson";
+      rev = "37b706a21b55b3183faef75eb594dd249913826a"; # pkvm-v6.18-dev (29-06-2026)
+      hash = "sha256-BWfA7B9piYX6Gq+92f1PPqPjc9onS5DI+3qDVqfHDWs=";
+    };
+    autoModules = false;
+    ignoreConfigErrors = true;
+
+    # TODO try without common config
+    enableCommonConfig = true;
+
+    features = { };
+
+    kernelPatches = [
+      {
+        name = "usb: host: Export xhci_irq";
+        patch = ./0001-usb-host-Export-xhci_irq.patch;
+      }
+      {
+        name = "Hack-to-select-VIDEOBUF2_DMA_CONTIG";
+        patch = ./0002-Hack-to-select-VIDEOBUF2_DMA_CONTIG.patch;
+      }
+    ]
+    ++ args.kernelPatches or [ ];
+
+    structuredExtraConfig =
+      with lib.kernel;
+      {
+        # Override the default CMA_SIZE_MBYTES=32M setting in common-config.nix with the default from tegra_defconfig
+        # Otherwise, nvidia's driver craps out
+        CMA_SIZE_MBYTES = lib.mkForce (freeform "64");
+
+        ### So nat.service and firewall work ###
+        NF_TABLES = module; # This one should probably be in common-config.nix
+        # this NFT_NAT is not actually being set. when build with enableCommonConfig = false;
+        # and not ignoreConfigErrors = true; it will fail with error about unused option
+        # unused means that it wanted to set it as a module, but make oldconfig didn't ask it about that option,
+        # so it didn't get a chance to set it.
+        NFT_NAT = module;
+        NFT_MASQ = module;
+        NFT_REJECT = module;
+        NFT_COMPAT = module;
+        NFT_LOG = module;
+        NFT_COUNTER = module;
+
+        # search for "ip46tables" in nixpkgs and find all the -m options.
+        # Enable the corresponding Kconfigs
+        # TODO: nixpkgs should turn these on themselves.
+        NETFILTER_XT_MATCH_PKTTYPE = module;
+        NETFILTER_XT_MATCH_COMMENT = module;
+        NETFILTER_XT_MATCH_CONNTRACK = module;
+        NETFILTER_XT_MATCH_LIMIT = module;
+        NETFILTER_XT_MATCH_MARK = module;
+        NETFILTER_XT_MATCH_MULTIPORT = module;
+
+        IP_NF_MATCH_RPFILTER = module;
+
+        # IPv6 is enabled by default and without some of these `firewall.service` will explode.
+        IP6_NF_MATCH_AH = module;
+        IP6_NF_MATCH_EUI64 = module;
+        IP6_NF_MATCH_FRAG = module;
+        IP6_NF_MATCH_OPTS = module;
+        IP6_NF_MATCH_HL = module;
+        IP6_NF_MATCH_IPV6HEADER = module;
+        IP6_NF_MATCH_MH = module;
+        IP6_NF_MATCH_RPFILTER = module;
+        IP6_NF_MATCH_RT = module;
+        IP6_NF_MATCH_SRH = module;
+
+        # Needed since mdadm stuff is currently unconditionally included in the initrd
+        # This will hopefully get changed, see: https://github.com/NixOS/nixpkgs/pull/183314
+        MD_LINEAR = module;
+        MD_RAID0 = module;
+        MD_RAID1 = module;
+        MD_RAID10 = module;
+        MD_RAID456 = module;
+
+        # Needed for booting from USB
+        USB_UAS = module;
+
+        FW_LOADER_COMPRESS_XZ = yes;
+        FW_LOADER_COMPRESS_ZSTD = yes;
+
+        # Restore default LSM from security/Kconfig. Undoes Nvidia downstream changes.
+        LSM = freeform "landlock,lockdown,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf";
+
+        # drivers/media/platform/tegra/camera/vi/channel.c from
+        # linux-oot-modules has ifdefs for
+        # CONFIG_VIDEOBUF2_DMA_CONTIG, but actually requires it to
+        # function.
+        # Otherwise it hits a WARN_ON() and outputs
+        # > tegra-capture-vi: failed to initialize VB2 queue
+        VIDEOBUF2_DMA_CONTIG = yes;
+      }
+      // structuredExtraConfig;
+  }
+  // argsOverride
+)

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -214,6 +214,25 @@ let
       };
     })
 
+    (
+      (ghaf-configuration {
+        name = "nvidia-jetson-orin-agx64-pvm";
+        inherit system;
+        profile = "orin";
+        hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-agx64;
+        variant = "debug";
+        extraModules = commonModules;
+        extraConfig = {
+          reference.profiles.mvp-orinuser-trial.enable = true;
+
+          host.kernel.hardening.hypervisor.enable = true;
+        };
+      })
+      // {
+        useLegacyFlash = true;
+      }
+    )
+
     (ghaf-configuration {
       name = "nvidia-jetson-orin-agx-industrial";
       inherit system;

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -485,6 +485,10 @@ let
   flashTarget =
     t: qspiOnly:
     let
+      # TEMP: Used by pkvm target
+      # legacyFlashScript keeps the old flash behavior
+      flashScriptAttr = if t.useLegacyFlash or false then "legacyFlashScript" else "signedFlashScript";
+
       # Shared by both secureboot variants so the two cannot drift apart.
       nxDiskOverrides = lib.optionalAttrs (lib.strings.hasInfix "nx" t.name && !qspiOnly) {
         # NX boots from USB or NVMe; the flash script targets NVMe.
@@ -508,7 +512,7 @@ let
       # construction. Each extra fixpoint is a full re-evaluation -- see
       # `extendModules` in nixpkgs lib/modules.nix, which shares nothing.
       innerName = noSBCfg.config.hardware.nvidia-jetpack.name;
-      noSB = noSBCfg.pkgs.nvidia-jetpack.signedFlashScript;
+      noSB = noSBCfg.pkgs.nvidia-jetpack.${flashScriptAttr};
       # Targets that already enable secureboot unconditionally get the identical
       # derivation back from `mkForce true`, so skip the second fixpoint entirely.
       withSB =
@@ -525,7 +529,7 @@ let
                 // nxDiskOverrides
               )
             ];
-          }).pkgs.nvidia-jetpack.signedFlashScript;
+          }).pkgs.nvidia-jetpack.${flashScriptAttr};
     in
     # Single `*-flash-script` entrypoint that picks between two
     # pre-built QSPI firmware variants at flash time.

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -226,6 +226,11 @@ let
           reference.profiles.mvp-orinuser-trial.enable = true;
 
           host.kernel.hardening.hypervisor.enable = true;
+          guest.hardening.protected.enable = true;
+        };
+        vmConfig = {
+          sysvms.netvm.mem = 4096;
+          sysvms.adminvm.mem = 4096;
         };
       })
       // {

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -525,12 +525,6 @@ let
           )
         ];
       };
-      # Read the board name off a fixpoint that is already forced for `noSB`
-      # rather than forcing `t.hostConfiguration` as a third one. The added
-      # modules do not touch `som`/`carrierBoard`, so the string is identical by
-      # construction. Each extra fixpoint is a full re-evaluation -- see
-      # `extendModules` in nixpkgs lib/modules.nix, which shares nothing.
-      innerName = noSBCfg.config.hardware.nvidia-jetpack.name;
       noSB = noSBCfg.pkgs.nvidia-jetpack.${flashScriptAttr};
       # Targets that already enable secureboot unconditionally get the identical
       # derivation back from `mkForce true`, so skip the second fixpoint entirely.
@@ -597,9 +591,9 @@ let
           esac
         done
         if [ "$sb" = 1 ]; then
-          exec ${withSB}/bin/flash-signed-${innerName} "''${args[@]}"
+          exec ${lib.getExe withSB} "''${args[@]}"
         else
-          exec ${noSB}/bin/flash-signed-${innerName} "''${args[@]}"
+          exec ${lib.getExe noSB} "''${args[@]}"
         fi
       '';
     };


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

This PR adds a reference module for the Orin AGX target that allows enabling protected mode separately for each VM.

The option `ghaf.virtualization.microvm.protected-vm` controls whether the given VM boots in protected mode. 
It is currently used in conjunction with the "stable-6-18-pkvm" host kernel and enabled for **net** and **admin** VMs in the `nvidia-jetson-orin-agx64-pvm` target.

The following NixOS configuration options are introduced:
- `config.ghaf.virtualization.microvm.protected-vm` is a per-VM switch to launch the guest in protected mode.
- for the NVIDIA Orin target, 
  - `config.ghaf.host.kernel.hardening.hypervisor.enable` enables the pKVM kernel in the host 
  - `config.ghaf.guest.hardening.protected.enable` turns on protected mode for net and admin VMs.

The PR also adds the following supporting changes:

- the host 6.18 kernel is reused for the guest but compiled with a special config `guest_defconfig`.
- customization options for the crosvm package used by microvm.
- a feature flag to enable/disable the DCE host proxy.

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

- #2143 introduces the host kernel with pKVM support.
This PR adds 4 commits on top.

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

Full device flash is required because the target applies patches to Jetson firmware.

### Test Steps To Verify:

1. Build and flash the `nvidia-jetson-orin-agx64-pvm-debug` target
2. Boot the Orin device
3. Login to the Ghaf host
4. Verify successful boot of all VMs
5. Verify that the net-vm and admin-vm start in protected mode:
```
[ghaf@ghaf-host:~]$ ps aux | grep -i protected
microvm     1578 70.8  1.5 5370580 1007076 ?     SLsl 19:56   2:07 /nix/store/z6ji5my1gi3xfn01jhsd3sxscgw8kw8q-crosvm-aarch64-unknown-linux-gnu-0-develop-2026-07-23-log-level/bin/crosvm --log-level=debug run -m 4096 -c 2 --serial type=stdout,console=true,stdin=true -p console=ttyS0 reboot=k panic=1 audit_backlog_limit=32768 audit_backlog_wait_time=0 systemd.service_watchdogs=false root=fstab loglevel=4 lsm=landlock,yama,bpf audit=1 audit_backlog_limit=32768 init=/nix/store/gnawkj9rynlvr0a7wv68ly9azakms2ph-nixos-system-admin-vm-26.11.20260826.9fbb54b/init regInfo=/nix/store/bgi644lpgbpissfwvakwqqyf2yshyxh0-closure-info/registration --no-balloon -s admin-vm.sock --block /persist/storagevm/img/admin-vm.img,o_direct=false,ro=false --block /persist/storagevm/givc/admin-vm.img,o_direct=false,ro=true --vhost-user type=fs,socket=admin-vm-virtiofs-ghaf-common.sock --vhost-user type=fs,socket=admin-vm-virtiofs-ro-store.sock --net tap-name=tap-admin-vm,mac=02:AD:00:00:00:03 --vsock 3 --initrd /nix/store/6q15r90a1nvn7zwndjp048b46sznw2x9-initrd-linux-pkvm-jetson-aarch64-unknown-linux-gnu-6.18.0/initrd /nix/store/mcd5q61zaisr6m4x94blf2whin95a0vv-linux-pkvm-jetson-aarch64-unknown-linux-gnu-6.18.0/Image --protected-vm-without-firmware --unmap-guest-memory-on-fork --disable-sandbox --smccc-trng --core-scheduling false
microvm     1589 35.3  1.2 5370580 776416 ?      SLsl 19:56   1:03 /nix/store/z6ji5my1gi3xfn01jhsd3sxscgw8kw8q-crosvm-aarch64-unknown-linux-gnu-0-develop-2026-07-23-log-level/bin/crosvm --log-level=debug run -m 4096 -c 2 --serial type=stdout,console=true,stdin=true -p console=ttyS0 reboot=k panic=1 audit_backlog_limit=32768 audit_backlog_wait_time=0 systemd.service_watchdogs=false root=fstab loglevel=4 lsm=landlock,yama,bpf audit=1 audit_backlog_limit=32768 init=/nix/store/dsl4wnqshlc1gv2pfbqyl4m386x6kxj1-nixos-system-net-vm-26.11.20260826.9fbb54b/init regInfo=/nix/store/zgfswr4g6x4l0grqvagszyy27167vjmg-closure-info/registration --no-balloon -s net-vm.sock --block /persist/storagevm/img/net-vm.img,o_direct=false,ro=false --block /persist/storagevm/givc/net-vm.img,o_direct=false,ro=true --vhost-user type=fs,socket=net-vm-virtiofs-ghaf-common.sock --vhost-user type=fs,socket=net-vm-virtiofs-sysupdate.sock --vhost-user type=fs,socket=net-vm-virtiofs-ro-store.sock --net tap-name=tap-net-vm,mac=02:AD:00:00:00:01 --initrd /nix/store/w9ijiy2mrrz0yl3s6xhqz4p1igbrkcsl-initrd-linux-pkvm-jetson-aarch64-unknown-linux-gnu-6.18.0/initrd /nix/store/mcd5q61zaisr6m4x94blf2whin95a0vv-linux-pkvm-jetson-aarch64-unknown-linux-gnu-6.18.0/Image --protected-vm-without-firmware --unmap-guest-memory-on-fork --disable-sandbox --smccc-trng --core-scheduling false
```
6. Verify SSH connectivity to admin and net VMs