### PR TITLE
fix: allow webcams in multiple VMs, fix URL XDG handler

### DIFF
--- a/modules/reference/appvms/business.nix
+++ b/modules/reference/appvms/business.nix
@@ -138,15 +138,6 @@ in
 
       enable = lib.mkDefault true;
 
-      usbPassthrough = [
-        {
-          description = "Internal Webcams for BusinessVM";
-          targetVm = "business-vm";
-          tag = "cam";
-          allow = config.ghaf.reference.passthrough.usb.internalWebcams;
-        }
-      ];
-
       evaluatedConfig = config.ghaf.profiles.laptop-x86.mkAppVm {
         name = "business";
         packages = optionals config.ghaf.profiles.debug.enable [ pkgs.tcpdump ];

--- a/modules/reference/appvms/flatpak.nix
+++ b/modules/reference/appvms/flatpak.nix
@@ -275,7 +275,7 @@ let
               --text="<b>No browser installed through App Store was found in this VM.</b>\n\nFor optimal security and functionality, please install a browser:\n  • Firefox\n  • Chrome\n  • Brave\n  • Chromium\n\nInstall from the App Store and try again.\n\n<i>Alternatively, continue with the standard browser (may malfunction).</i>" \
               --button="Exit:0" \
               --button="Continue:1" \
-              --button-layout=spread \
+              --buttons-layout=spread \
               --center;
           then # user chose to exit
             exit 1

--- a/modules/reference/appvms/google-chrome.nix
+++ b/modules/reference/appvms/google-chrome.nix
@@ -58,24 +58,6 @@ in
 
       enable = lib.mkDefault true;
 
-      usbPassthrough = [
-        {
-          description = "External Webcams for ChromeVM and BusinessVM";
-          allowedVms = [
-            "chrome-vm"
-            "business-vm"
-          ];
-          allow = [
-            {
-              interfaceClass = 14;
-              description = "Video (USB Webcams)";
-            }
-          ];
-          # Ignore internal webcams since they are attached to business-vm
-          deny = config.ghaf.reference.passthrough.usb.internalWebcams;
-        }
-      ];
-
       evaluatedConfig = config.ghaf.profiles.laptop-x86.mkAppVm {
         name = "chrome";
         packages = lib.optional config.ghaf.development.debug.tools.enable pkgs.alsa-utils;

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -144,6 +144,27 @@ in
             }
           ];
         };
+
+        # postpendUsbRules runs after business.nix's own rule, so its silent auto-attach wins first.
+        vhotplug.postpendUsbRules = [
+          {
+            description = "Webcams";
+            tag = "cam";
+            allowedVms = [
+              "business-vm"
+              "chrome-vm"
+              "comms-vm"
+              "flatpak-vm"
+            ];
+            allow = [
+              {
+                interfaceClass = 14;
+                description = "Video (USB Webcams)";
+              }
+            ]
+            ++ config.ghaf.reference.passthrough.usb.internalWebcams;
+          }
+        ];
       };
 
       reference = {

--- a/packages/pkgs-by-name/ghaf-intro/index.html
+++ b/packages/pkgs-by-name/ghaf-intro/index.html
@@ -1761,57 +1761,26 @@
 
         <h3>Camera Isolation</h3>
         <p>
-          Cameras are carefully controlled with different policies for internal
-          and external devices:
+          Both your laptop's built-in webcam and any USB webcam you plug in can
+          only be given to the same fixed set of VMs. No other VM can ever
+          access it:
         </p>
 
-        <div class="two-column">
-          <div class="info-box">
-            <h4>Internal Webcam</h4>
-            <p>
-              Your laptop's built-in camera is passed exclusively to
-              <strong>Business-VM</strong>. This is your trusted environment for
-              corporate video calls. The internal camera is:
-            </p>
-            <ul
-              style="
-                margin-top: 0.75rem;
-                margin-left: 1.5rem;
-                color: var(--text-secondary);
-              "
-            >
-              <li>Identified by physical USB bus/port location</li>
-              <li>Explicitly blocked from Chrome-VM and other VMs</li>
-              <li>Never accessible to untrusted browsing sessions</li>
-            </ul>
-          </div>
-
-          <div class="info-box">
-            <h4>External Webcams</h4>
-            <p>
-              USB webcams you plug in can be shared between
-              <strong>Business-VM</strong> and <strong>Chrome-VM</strong>
-              for flexibility. External cameras are:
-            </p>
-            <ul
-              style="
-                margin-top: 0.75rem;
-                margin-left: 1.5rem;
-                color: var(--text-secondary);
-              "
-            >
-              <li>Detected by USB device class (Video)</li>
-              <li>Dynamically assignable via hot-plug</li>
-              <li>Still isolated from other application VMs</li>
-            </ul>
-          </div>
-        </div>
-
-        <p>
-          This separation means a compromised website in Chrome-VM cannot access
-          your internal webcam to spy on you during a business call — the device
-          literally doesn't exist from Chrome-VM's perspective.
-        </p>
+        <ul
+          style="
+            margin-top: 0.75rem;
+            margin-left: 1.5rem;
+            color: var(--text-secondary);
+          "
+        >
+          <li>
+            Assignable to <strong>Business-VM</strong>,
+            <strong>Chrome-VM</strong>, <strong>Comms-VM</strong>, or
+            <strong>Flatpak-VM</strong> via the USB applet in the taskbar
+          </li>
+          <li>Attached to only one of those VMs at a time</li>
+          <li>Never accessible to any other VM</li>
+        </ul>
 
         <h3>Audio Isolation</h3>
         <p>


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

1. **Fix flatpak URL XDG handler:**
   Fixed notification not appearing due to a mislabeled **yad** (GTK notification) option name.
   This notification only appears when no flatpak browser is detected, when, for example, user sign in via browser is requested.

2. **Allow webcam devices in multiple VMs:**
   Applies only to **mvp-user-trial** profile
   Adjust vhotplug config to allow webcams (internal and external) in the following VMs:
     - business
     - chrome
     - comms
     - flatpak

3. **Bump ghafpkgs to latest for ghaf_usb_applet**

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [x] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

Fixes:
- https://jira.tii.ae/browse/SSRCSP-8852 (was actually fixed by https://github.com/tiiuae/ghaf/commit/b33c0dbbafc322c2f087cd50eefe51bd266dc07c, but this patch fixes the browser notification)
- https://jira.tii.ae/browse/SSRCSP-8870

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation - **vhotplug state file needs to be re-generated**
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Verify internal and external (USB) webcams can be attached to the above-mentioned VMs
2. When plugging in a new USB device, verify a notification appears, letting the user attach it to any allowed VM (e.g. external USB webcam)
3. Verify https://jira.tii.ae/browse/SSRCSP-8852 is fixed and URL XDG handler notification appears as expected:
   - Install e.g. Spotify in flatpak VM
   - Open Spotify and attempt to sign in via browser
   - The URL XDG handler notification should appear, urging the user to install a flatpak browser
   - If a flatpak browser is present, the notification does not appear, and the browser is opened instead (e.g. when Firefox is installed in flatpak VM)
4. Verify https://jira.tii.ae/browse/SSRCSP-8870 is fixed
