### PR TITLE
fix(yad): drop the optional backends 15.0 turned on

### DIFF
--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -29,5 +29,6 @@
   spire4ghaf = import ./spire4ghaf { inherit prev; };
   udiskie = import ./udiskie { inherit prev; };
   waypipe = import ./waypipe { inherit prev; };
+  yad = import ./yad { inherit prev; };
 })
 # keep-sorted end

--- a/overlays/custom-packages/yad/default.nix
+++ b/overlays/custom-packages/yad/default.nix
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# yad 15.0 turns on four optional backends that 14.1 did not have, and nixpkgs
+# enables all of them. They cost 536 MB of closure on every ghaf image:
+#
+#   --enable-html          webkitgtk_4_1   (the bulk of it, and built from source)
+#   --enable-sourceview    gtksourceview
+#   --enable-spell         gspell
+#   --enable-appindicator  libappindicator
+#
+# Measured on x86_64: 847.1 MB -> 310.8 MB.
+#
+# xdgflatpakurl, the flatpak VM's "no App Store browser" dialog and windows-launcher
+# use yad.
+{ prev }:
+(prev.yad.override {
+  gtksourceview = null;
+  gspell = null;
+  libappindicator = null;
+  webkitgtk_4_1 = null;
+}).overrideAttrs
+  (old: {
+    configureFlags = builtins.filter (
+      flag:
+      !(builtins.elem flag [
+        "--enable-appindicator"
+        "--enable-html"
+        "--enable-sourceview"
+        "--enable-spell"
+      ])
+    ) old.configureFlags;
+  })


### PR DESCRIPTION
nixpkgs' yad went 14.1 -> 15.0, and 15.0 enables four optional backends that 14.1 did not have. All four land in every ghaf image:

    --enable-html          webkitgtk_4_1   (the bulk, and built from source)
    --enable-sourceview    gtksourceview
    --enable-spell         gspell
    --enable-appindicator  libappindicator

Measured on x86_64, yad's closure goes 847.1 MB -> 310.8 MB: 536 MB off every image, for dialogs nothing in the tree opens. Between them xdgflatpakurl, the flatpak VM's "no App Store browser" dialog and windows-launcher use --entry, --file, --image, --text, --title and --button; none of those need any of the four. Nothing uses --html, --text-info, --notification or --tray.

An overlay rather than a per-caller override, deliberately: downstream users of `pkgs.yad` inherit it, and that is where most of the saving lands -- a caller that keeps referencing the stock attribute drags the whole closure back in.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
