### PR TITLE
feat(orin): add secure A/B platform adapter

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -167,6 +167,7 @@ export default defineConfig({
                         "ghaf/dev/guides/extending-targets",
                         "ghaf/dev/guides/downstream-setup",
                         "ghaf/dev/guides/migration",
+                        "ghaf/dev/guides/orin-secure-ab-testing",
                       ],
                     },
                     {

--- a/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
@@ -75,21 +75,21 @@ For every test case record:
 
 ### Pure CI build mode
 
-External trust settings are optional for evaluation and build discovery. With
-`GHAF_DEV_KEY_DIR` unset, evaluate both canaries without `--impure`:
+The repository's default pure flake input is sufficient for evaluation and
+build discovery. Evaluate both debug canaries directly:
 
 ```sh
-env -u GHAF_DEV_KEY_DIR timeout 2h nix eval \
+timeout 2h nix eval \
   '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
 
-env -u GHAF_DEV_KEY_DIR timeout 2h nix eval \
+timeout 2h nix eval \
   '.#nixosConfigurations."nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
 ```
 
 Each evaluation must succeed and emit the target-specific message ending in:
 
 ```text
-GHAF_DEV_KEY_DIR is unset; using repository development public trust for evaluation/build only. Secure A/B deployment and update signing require GHAF_DEV_KEY_DIR from ghaf-dev-keygen.
+using repository CI-only trust from secure-ab-build-config; this image is restricted to debug build coverage and must not be deployed.
 ```
 
 This public fallback is deliberately unsafe for deployment. It exists only so
@@ -102,7 +102,7 @@ and contains the exact warning:
 WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead.
   Requested: <secure-A/B-target>
   Fallback:  <generic-target>
-  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen to flash the secure A/B canary.
+  Rebuild with an external secure-ab-build-config input to flash the secure A/B canary.
 ```
 
 The wrapper does not deploy the CI-only A/B image. It delegates to the existing
@@ -133,24 +133,38 @@ umask 077
 nix run .#ghaf-dev-keygen -- --output "$GHAF_DEV_KEY_DIR"
 ```
 
-Evaluate with the external public trust exposed:
+Choose the candidate generation and export a public-only flake input. This
+directory contains no private keys:
 
 ```sh
-timeout 2h nix eval --impure \
+export SECURE_AB_GENERATION=10
+export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-generation-$SECURE_AB_GENERATION"
+nix run .#ghaf-secure-ab-config -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --generation "$SECURE_AB_GENERATION" \
+  --output "$SECURE_AB_BUILD_CONFIG"
+```
+
+Evaluate with the external public trust and generation pinned by that input:
+
+```sh
+timeout 2h nix eval \
+  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
 ```
 
 It must succeed and emit the target-specific message ending in:
 
 ```text
-using external public trust from GHAF_DEV_KEY_DIR; private signing keys remain outside the Nix store.
+using pure external public trust from secure-ab-build-config; private signing keys remain outside the Nix store.
 ```
 
-Pointing `GHAF_DEV_KEY_DIR` at an incomplete directory must fail evaluation
-with `GHAF_DEV_KEY_DIR is set but missing required public trust files:` followed
-by the exact missing file names. Running a flash script with the variable unset
-must fail with `ERROR: GHAF_DEV_KEY_DIR is required for secure A/B canary
-flashes.`; missing flash/sign files are reported by their exact paths.
+Overriding `secure-ab-build-config` with an incomplete external directory must
+fail pure evaluation with `external secure-ab-build-config is missing required
+public trust files:` followed by the exact missing file names. Running a flash
+script with the runtime key variable unset must fail with `ERROR:
+GHAF_DEV_KEY_DIR is required for secure A/B canary flashes.`; missing flash or
+signing files are reported by their exact paths.
 
 Record `sha256sum PK.crt KEK.crt db.crt update.pub` with the non-secret build
 evidence. Build a flash script with trust directory A, then, with no recovery
@@ -174,23 +188,24 @@ launch the NX and AGX image builds concurrently.
 
 ### Candidate build
 
-Choose a positive generation greater than the target's accepted generation:
+Confirm that `SECURE_AB_GENERATION` is greater than the target's accepted
+generation. If it changes, export a new public build configuration with
+`ghaf-secure-ab-config`; never edit or reuse a published configuration:
 
 ```sh
-export GHAF_UPDATE_GENERATION=10
-
-timeout 2h nix build --impure \
+timeout 2h nix build \
+  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
-  -o result-nx-generation-$GHAF_UPDATE_GENERATION
+  -o result-nx-generation-$SECURE_AB_GENERATION
 ```
 
 Create the signed transport directory:
 
 ```sh
-IMAGE_DIR="result-nx-generation-$GHAF_UPDATE_GENERATION"
+IMAGE_DIR="result-nx-generation-$SECURE_AB_GENERATION"
 MANIFEST="$(find -L "$IMAGE_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
 test -n "$MANIFEST"
-jq -e --argjson generation "$GHAF_UPDATE_GENERATION" '
+jq -e --argjson generation "$SECURE_AB_GENERATION" '
   .system == "aarch64-linux"
   and .target == "nvidia-jetson-orin-nx-verity-luks-debug"
   and .generation == $generation
@@ -199,7 +214,7 @@ jq -e --argjson generation "$GHAF_UPDATE_GENERATION" '
 nix run .#ghaf-sign-update -- \
   --key-dir "$GHAF_DEV_KEY_DIR" \
   --input "$MANIFEST" \
-  --output "signed-nx-generation-$GHAF_UPDATE_GENERATION"
+  --output "signed-nx-generation-$SECURE_AB_GENERATION"
 ```
 
 Verify that the signed output contains one manifest, its detached signature,
@@ -214,7 +229,7 @@ credentials in Git:
 ```sh
 export REGISTRY_ENDPOINT='<registry-dns-name>'
 export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
-export UPDATE_TAG="generation-$GHAF_UPDATE_GENERATION"
+export UPDATE_TAG="generation-$SECURE_AB_GENERATION"
 export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
 read -rsp 'Registry token: ' REGISTRY_TOKEN
 export REGISTRY_TOKEN
@@ -284,7 +299,7 @@ and that registry transport preserves the exact authenticated manifest bytes.
 **Procedure:**
 
 ```sh
-SIGNED_DIR="signed-nx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_DIR="signed-nx-generation-$SECURE_AB_GENERATION"
 SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
 test -s "$SIGNED_MANIFEST"
 test -s "$SIGNED_MANIFEST.sig"
@@ -389,7 +404,7 @@ operator can access both `net-vm` and the Ghaf host.
 **Procedure on the developer machine:**
 
 ```sh
-SIGNED_DIR="signed-nx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_DIR="signed-nx-generation-$SECURE_AB_GENERATION"
 SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
 test -s "$SIGNED_MANIFEST"
 test -s "$SIGNED_MANIFEST.sig"
@@ -427,36 +442,10 @@ curl --fail --silent --show-error \
 
 ```sh
 export UPDATE_HTTP_ORIGIN='http://<developer-interface-address>:<port>'
-export GHAF_UPDATE_GENERATION='<candidate-generation>'
 FETCH_PARENT=/persist/sysupdate
-FINAL_DIR="$FETCH_PARENT/http-generation-$GHAF_UPDATE_GENERATION"
+FINAL_DIR="$FETCH_PARENT/http-generation-$SECURE_AB_GENERATION"
 test ! -e "$FINAL_DIR" || exit 1
-FETCH_DIR="$(mktemp -d "$FETCH_PARENT/.http-generation-$GHAF_UPDATE_GENERATION.XXXXXX")"
-chmod 0755 "$FETCH_DIR"
-
-fetch_file() {
-  file="$1"
-  case "$file" in
-    "" | .* | *[!A-Za-z0-9._-]*) return 1 ;;
-  esac
-  curl --fail --show-error --location \
-    --proto '=http' --proto-redir '=http' \
-    --retry 3 --retry-all-errors \
-    --output "$FETCH_DIR/$file.part" \
-    "$UPDATE_HTTP_ORIGIN/$file"
-  mv -- "$FETCH_DIR/$file.part" "$FETCH_DIR/$file"
-}
-
-fetch_file manifest.json
-fetch_file manifest.json.sig
-for kind in root verity kernel; do
-  artifact="$(jq -er --arg kind "$kind" '.[$kind].file' "$FETCH_DIR/manifest.json")"
-  fetch_file "$artifact"
-done
-touch "$FETCH_DIR/fetch.complete"
-sync "$FETCH_DIR"
-mv -T -- "$FETCH_DIR" "$FINAL_DIR"
-sync "$FETCH_PARENT"
+ghaf-fetch-update "$UPDATE_HTTP_ORIGIN" "$SECURE_AB_GENERATION" "$FETCH_PARENT"
 FETCH_DIR="$FINAL_DIR"
 ```
 
@@ -613,12 +602,17 @@ the inactive fallback and the persist sentinel remains unchanged.
 Build the candidate with the debug-only health failure:
 
 ```sh
-export GHAF_AB_TEST_UNHEALTHY=1
-export GHAF_UPDATE_GENERATION=<newer-generation>
-timeout 2h nix build --impure \
+export SECURE_AB_GENERATION=<newer-generation>
+export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-unhealthy-generation-$SECURE_AB_GENERATION"
+nix run .#ghaf-secure-ab-config -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --generation "$SECURE_AB_GENERATION" \
+  --output "$SECURE_AB_BUILD_CONFIG" \
+  --inject-boot-health-failure
+timeout 2h nix build \
+  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
   -o result-unhealthy
-unset GHAF_AB_TEST_UNHEALTHY
 ```
 
 Sign, validate, and install normally. Reboot without manually selecting entries.
@@ -733,7 +727,8 @@ Keep this terminal running through first boot and rollback tests.
 Build the flash script, sequentially and with the key directory available:
 
 ```sh
-timeout 2h nix build --impure \
+timeout 2h nix build \
+  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-flash-script \
   -o result-nx-flash
 ```
@@ -908,12 +903,19 @@ from panic or service-failure tests.
 ### AGX-001: eMMC canary build
 
 ```sh
-export GHAF_UPDATE_GENERATION=<candidate-generation>
-timeout 2h nix build --impure \
+export SECURE_AB_GENERATION=<candidate-generation>
+export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-agx-generation-$SECURE_AB_GENERATION"
+nix run .#ghaf-secure-ab-config -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --generation "$SECURE_AB_GENERATION" \
+  --output "$SECURE_AB_BUILD_CONFIG"
+timeout 2h nix build \
+  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-ghafImage \
   -o result-agx-update
 
-timeout 2h nix build --impure \
+timeout 2h nix build \
+  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-flash-script \
   -o result-agx-flash
 ```
@@ -926,9 +928,9 @@ Sign and validate the update bundle before connecting it to target storage:
 ```sh
 IMAGE_DIR=result-agx-update
 MANIFEST="$(find -L "$IMAGE_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
-SIGNED_DIR="signed-agx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_DIR="signed-agx-generation-$SECURE_AB_GENERATION"
 
-jq -e --argjson generation "$GHAF_UPDATE_GENERATION" '
+jq -e --argjson generation "$SECURE_AB_GENERATION" '
   .system == "aarch64-linux"
   and .target == "nvidia-jetson-orin-agx-verity-luks-debug"
   and .generation == $generation

--- a/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
@@ -1,0 +1,1204 @@
+---
+title: Orin Secure A/B Testing
+---
+{/*
+SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+*/}
+
+# Orin secure A/B testing
+
+This guide defines the downstream development and manual acceptance procedures
+for the [secure A/B image-update architecture](/ghaf/dev/architecture/ab-update).
+It is written for repeatable evidence collection: every case states its
+prerequisites, procedure, expected result, and recovery boundary.
+Implementation-internal validation is intentionally outside this guide's scope.
+
+:::danger[Destructive hardware tests]
+Flashing, corruption, and power-interruption cases destroy data on the selected
+target. Run them only on an explicitly authorized Orin in recovery mode. USB
+VID/PID alone is not authorization. Capture topology and serial identity, require
+exactly one recovery-mode Tegra target, and stop on any ambiguity.
+:::
+
+## Scope and acceptance policy
+
+- Orin NX 16 GB with internal NVMe and Orin AGX with internal eMMC are distinct
+  runtime acceptance targets. Test artifacts and evidence are not transferable
+  between them.
+- QSPI and ESP are outside LUKS; APP, LVM, both system pairs, persist, and swap
+  are in scope.
+- Rollback protects the immutable system pair. Shared `/persist` must survive
+  every successful update, failed trial, and rollback.
+- A trial is accepted only after LUKS, dm-verity, `/persist`, and all configured
+  core Ghaf MicroVMs are healthy.
+- AppVMs and interactive login are not health-gate dependencies.
+- Hard-hang rollback is not accepted until a physical watchdog/reset test passes.
+- A test run is not release acceptance until every required case is recorded
+  against a device identity, build generation, Git revision, and timestamp.
+
+## Test records
+
+Create a directory outside the source tree for each run:
+
+```sh
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-orin-nx-ab"
+EVIDENCE_DIR="$PWD/../test-evidence/$RUN_ID"
+mkdir -p "$EVIDENCE_DIR"
+chmod 0700 "$EVIDENCE_DIR"
+```
+
+Record only public build and device metadata:
+
+```sh
+git rev-parse HEAD > "$EVIDENCE_DIR/ghaf-head.txt"
+git -C ../ghaf-givc rev-parse HEAD > "$EVIDENCE_DIR/givc-head.txt"
+date -u --iso-8601=seconds > "$EVIDENCE_DIR/started-at.txt"
+```
+
+Do not copy private keys or recovery passphrases into the evidence directory.
+For every test case record:
+
+| Field | Required content |
+| --- | --- |
+| Test ID | Stable identifier from this document |
+| Build | Ghaf and ghaf-givc revisions, system, target, version, generation, manifest SHA-256 |
+| Device | Board model, ECID, USB topology path, storage device, serial endpoint |
+| Start/end | UTC timestamps |
+| Preconditions | Active slot, accepted generation, boot entry, persist sentinel |
+| Actions | Exact commands and intentional fault point |
+| Result | Pass, fail, blocked, or not run |
+| Evidence | Serial log, journal, `bootctl`, `lvs`, cryptsetup and verity status |
+| Recovery | Final active slot and whether manual intervention was needed |
+
+## Common setup
+
+### Pure CI build mode
+
+External trust settings are optional for evaluation and build discovery. With
+`GHAF_DEV_KEY_DIR` unset, evaluate both canaries without `--impure`:
+
+```sh
+env -u GHAF_DEV_KEY_DIR timeout 2h nix eval \
+  '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
+
+env -u GHAF_DEV_KEY_DIR timeout 2h nix eval \
+  '.#nixosConfigurations."nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
+```
+
+Each evaluation must succeed and emit the target-specific message ending in:
+
+```text
+GHAF_DEV_KEY_DIR is unset; using repository development public trust for evaluation/build only. Secure A/B deployment and update signing require GHAF_DEV_KEY_DIR from ghaf-dev-keygen.
+```
+
+This public fallback is deliberately unsafe for deployment. It exists only so
+CI can evaluate and build the secure A/B image without access to local secrets.
+Build the exported NX and AGX flash attributes sequentially, then inspect each
+wrapper without running it. Confirm it selects the board-matched generic image
+and contains the exact warning:
+
+```text
+WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead.
+  Requested: <secure-A/B-target>
+  Fallback:  <generic-target>
+  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen to flash the secure A/B canary.
+```
+
+The wrapper does not deploy the CI-only A/B image. It delegates to the existing
+generic unsigned target, which has a different image and partition layout. It
+strips `--secure-boot`, `-u`/`--uki`, and `-s`/`--signed-sd-image` with explicit
+warnings so secure-image-only arguments cannot alter the fallback. Do not
+execute either wrapper during this source-only check; flashing remains a
+separate, explicitly authorized operation.
+
+### Repository and key environment
+
+Use the dedicated Ghaf and ghaf-givc worktrees. Keep the trust directory outside
+both repositories:
+
+```sh
+export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
+test -d "$GHAF_DEV_KEY_DIR"
+test -s "$GHAF_DEV_KEY_DIR/db.key"
+test -s "$GHAF_DEV_KEY_DIR/db.crt"
+test -s "$GHAF_DEV_KEY_DIR/update.key"
+test -s "$GHAF_DEV_KEY_DIR/update.pub"
+```
+
+If the directory does not exist, create it once:
+
+```sh
+umask 077
+nix run .#ghaf-dev-keygen -- --output "$GHAF_DEV_KEY_DIR"
+```
+
+Evaluate with the external public trust exposed:
+
+```sh
+timeout 2h nix eval --impure \
+  '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
+```
+
+It must succeed and emit the target-specific message ending in:
+
+```text
+using external public trust from GHAF_DEV_KEY_DIR; private signing keys remain outside the Nix store.
+```
+
+Pointing `GHAF_DEV_KEY_DIR` at an incomplete directory must fail evaluation
+with `GHAF_DEV_KEY_DIR is set but missing required public trust files:` followed
+by the exact missing file names. Running a flash script with the variable unset
+must fail with `ERROR: GHAF_DEV_KEY_DIR is required for secure A/B canary
+flashes.`; missing flash/sign files are reported by their exact paths.
+
+Record `sha256sum PK.crt KEK.crt db.crt update.pub` with the non-secret build
+evidence. Build a flash script with trust directory A, then, with no recovery
+target attached, invoke it using an independently generated directory B. It must
+exit before work-directory or device preparation with:
+
+```text
+ERROR: GHAF_DEV_KEY_DIR public trust does not match the trust embedded at image evaluation: <file>
+  Rebuild the flash script with this exact GHAF_DEV_KEY_DIR.
+```
+
+Repeat with directory A restored and confirm the trust check passes. Replacing
+only `db.key` or `update.key` with a key from B must fail with the corresponding
+`private key does not match public trust` diagnostic. Never perform these
+negative tests while a recovery-mode target is attached.
+
+### Build resource limits
+
+Run heavy evaluations and builds sequentially, each under `timeout 2h`. Do not
+launch the NX and AGX image builds concurrently.
+
+### Candidate build
+
+Choose a positive generation greater than the target's accepted generation:
+
+```sh
+export GHAF_UPDATE_GENERATION=10
+
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
+  -o result-nx-generation-$GHAF_UPDATE_GENERATION
+```
+
+Create the signed transport directory:
+
+```sh
+IMAGE_DIR="result-nx-generation-$GHAF_UPDATE_GENERATION"
+MANIFEST="$(find -L "$IMAGE_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+test -n "$MANIFEST"
+jq -e --argjson generation "$GHAF_UPDATE_GENERATION" '
+  .system == "aarch64-linux"
+  and .target == "nvidia-jetson-orin-nx-verity-luks-debug"
+  and .generation == $generation
+' "$MANIFEST" >/dev/null
+
+nix run .#ghaf-sign-update -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input "$MANIFEST" \
+  --output "signed-nx-generation-$GHAF_UPDATE_GENERATION"
+```
+
+Verify that the signed output contains one manifest, its detached signature,
+and all three named artifacts. Transfer the directory without changing file
+contents to `/persist/sysupdate/<generation>/` on the target.
+
+### Registry delivery variables
+
+For OCI delivery, configure an HTTPS registry without recording its endpoint or
+credentials in Git:
+
+```sh
+export REGISTRY_ENDPOINT='<registry-dns-name>'
+export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
+export UPDATE_TAG="generation-$GHAF_UPDATE_GENERATION"
+export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
+read -rsp 'Registry token: ' REGISTRY_TOKEN
+export REGISTRY_TOKEN
+REGISTRY_AUTH_ARGS=(--token "$REGISTRY_TOKEN")
+```
+
+The developer credential requires push access. The NX `net-vm` credential must
+be read-only. Use neither a production credential nor `--insecure` for this
+development test.
+
+For the disposable TLS registry procedure in the architecture guide, use its
+short-lived basic credential instead:
+
+```sh
+REGISTRY_AUTH_ARGS=(--username "$REGISTRY_USER" --password "$REGISTRY_PASSWORD")
+export SSL_CERT_FILE='<verified-path-to-disposable-registry-ca.crt>'
+```
+
+Native `htpasswd` authentication does not enforce read-only repository scope;
+record that limitation and tear the registry down after the test.
+
+### Static HTTP delivery variables
+
+For an isolated manual lab test, record placeholders rather than a developer
+machine address in the test plan:
+
+```sh
+export UPDATE_HTTP_BIND='<developer-interface-address>'
+export UPDATE_HTTP_PORT='<non-privileged-port>'
+export UPDATE_HTTP_ORIGIN="http://${UPDATE_HTTP_BIND}:${UPDATE_HTTP_PORT}"
+```
+
+The address must be reachable from the Orin `net-vm` physical uplink. Scope any
+temporary firewall opening to that interface and target network. Plain HTTP is
+only a transport test; host-side signature and policy validation remain
+mandatory.
+
+### REG-000: Disposable local registry setup
+
+**Purpose:** Establish a reproducible OCI Distribution endpoint when no managed
+development registry exists.
+
+**Procedure:** Follow the architecture guide's
+[disposable local HTTPS registry](/ghaf/dev/architecture/ab-update/#disposable-local-https-registry)
+procedure. Before publishing an update, require all of the following:
+
+1. the registry DNS name resolves from the developer host and `net-vm`;
+2. a request without credentials returns `401`;
+3. a request with the disposable basic credential and verified CA returns a
+   successful `/v2/` response;
+4. changing or omitting `SSL_CERT_FILE` makes TLS validation fail; and
+5. the CA SHA-256 copied to `net-vm` equals the developer-host value.
+
+Set `REGISTRY_AUTH_ARGS` to the basic-auth form above, run REG-001 and REG-002,
+then stop the container and delete only its verified temporary data root.
+
+**Expected:** Push, host pull, and device self-fetch all use HTTPS and the
+verified CA. Artifact and signed-manifest validation pass after transport. The
+record states that native `htpasswd` is not a read-only authorization test and
+contains no endpoint, address, password, or CA private key.
+
+### REG-001: Developer-host publish and fetch round trip
+
+**Purpose:** Prove the published OCI artifact includes the detached signature
+and that registry transport preserves the exact authenticated manifest bytes.
+
+**Procedure:**
+
+```sh
+SIGNED_DIR="signed-nx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+test -s "$SIGNED_MANIFEST"
+test -s "$SIGNED_MANIFEST.sig"
+
+nix run 'path:../ghaf-givc#ota-update' -- \
+  registry "${REGISTRY_AUTH_ARGS[@]}" push \
+  --manifest "$SIGNED_MANIFEST" \
+  "$UPDATE_REF"
+
+PULL_ROOT="$(mktemp -d)"
+nix run 'path:../ghaf-givc#ota-update' -- \
+  registry "${REGISTRY_AUTH_ARGS[@]}" pull --validate \
+  --destination "$PULL_ROOT" \
+  "$UPDATE_REF"
+
+PULLED_MANIFEST="$PULL_ROOT/$UPDATE_REPOSITORY_PATH/$UPDATE_TAG/manifest.json"
+cmp "$SIGNED_MANIFEST" "$PULLED_MANIFEST"
+cmp "$SIGNED_MANIFEST.sig" "$PULLED_MANIFEST.sig"
+
+nix run 'path:../ghaf-givc#ota-update' -- image validate \
+  --manifest "$PULLED_MANIFEST" \
+  --trusted-key "$GHAF_DEV_KEY_DIR/update.pub" \
+  --uki-trusted-cert "$GHAF_DEV_KEY_DIR/db.crt" \
+  --target nvidia-jetson-orin-nx-verity-luks-debug \
+  --accepted-generation-file "$PULL_ROOT/accepted-generation"
+```
+
+**Expected:** Push reports an OCI manifest digest. Pull writes
+`manifest.json`, `manifest.json.sig`, the signed UKI, root, and verity files.
+Both `cmp` commands and signed image validation succeed.
+
+**Negative cases:** Remove the signature layer, modify the pulled manifest, or
+modify one artifact. Pull or signed validation must fail as appropriate. No
+target storage is involved in this test.
+
+### REG-002: NX self-fetch through `net-vm`
+
+**Purpose:** Prove the NX fetches its own update over its network-owning VM while
+the host retains exclusive ownership of authentication policy and storage
+mutation.
+
+**Prerequisites:** REG-001 passed; the candidate tag is approved; `net-vm` has
+external registry reachability and a read-only credential; the host and
+`net-vm` both expose `/persist/sysupdate`.
+
+**Procedure in `net-vm`:**
+
+```sh
+export REGISTRY_ENDPOINT='<registry-dns-name>'
+export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
+export UPDATE_TAG='<approved-tag>'
+export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
+read -rsp 'Read-only registry token: ' REGISTRY_TOKEN
+export REGISTRY_TOKEN
+REGISTRY_AUTH_ARGS=(--token "$REGISTRY_TOKEN")
+
+ota-update registry "${REGISTRY_AUTH_ARGS[@]}" discover \
+  "${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}"
+
+ota-update registry "${REGISTRY_AUTH_ARGS[@]}" pull --validate \
+  --destination /persist/sysupdate \
+  "$UPDATE_REF"
+```
+
+Record the OCI digest and printed manifest path. Do not use `--install`.
+
+**Procedure on the Ghaf host:**
+
+```sh
+PULLED_MANIFEST='/persist/sysupdate/<namespace>/ghaf-orin-nx/<approved-tag>/manifest.json'
+test -s "$PULLED_MANIFEST"
+test -s "$PULLED_MANIFEST.sig"
+
+sudo ota-update image validate --manifest "$PULLED_MANIFEST"
+sudo ota-update image --dry-run install --manifest "$PULLED_MANIFEST"
+sudo ota-update image install --manifest "$PULLED_MANIFEST"
+```
+
+Continue with BT-001 for a healthy payload or BT-002 for a health-failure
+payload.
+
+**Expected:** `net-vm` downloads into the shared directory without host network
+access. The host authenticates the manifest and UKI, enforces target and
+generation policy, installs only the inactive pair, and does not reboot
+automatically. The subsequent trial follows the normal health/rollback rules.
+
+**Boundary:** This test is manually initiated on the device. Periodic discovery,
+credential provisioning, approval policy, and unattended installation are not
+enabled by this canary.
+
+### REG-003: Static development HTTP server and device fetch
+
+**Purpose:** Prove a developer machine can expose only a signed payload, the
+Orin device can fetch all five files through `net-vm`, and the Ghaf host rejects
+incomplete or unauthenticated downloads before storage mutation.
+
+**Prerequisites:** A signed NX or AGX candidate exists; its generation is newer
+than the target's accepted generation; the developer machine and Orin uplink
+share a controlled network; `net-vm` exposes `/persist/sysupdate`; and the
+operator can access both `net-vm` and the Ghaf host.
+
+**Procedure on the developer machine:**
+
+```sh
+SIGNED_DIR="signed-nx-generation-$GHAF_UPDATE_GENERATION"
+SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+test -s "$SIGNED_MANIFEST"
+test -s "$SIGNED_MANIFEST.sig"
+
+HTTP_ROOT="$(mktemp -d)"
+install -m 0644 "$SIGNED_MANIFEST" "$HTTP_ROOT/manifest.json"
+install -m 0644 "$SIGNED_MANIFEST.sig" "$HTTP_ROOT/manifest.json.sig"
+
+for kind in root verity kernel; do
+  artifact="$(jq -er --arg kind "$kind" '.[$kind].file' "$SIGNED_MANIFEST")"
+  case "$artifact" in
+    "" | .* | *[!A-Za-z0-9._-]*) exit 1 ;;
+  esac
+  install -m 0644 "$SIGNED_DIR/$artifact" "$HTTP_ROOT/$artifact"
+done
+
+test "$(find "$HTTP_ROOT" -mindepth 1 -maxdepth 1 -type f | wc -l)" -eq 5
+
+python3 -m http.server \
+  --bind "$UPDATE_HTTP_BIND" \
+  --directory "$HTTP_ROOT" \
+  "$UPDATE_HTTP_PORT"
+```
+
+Leave the server in its own terminal. In a second developer terminal, require
+an exact manifest round trip:
+
+```sh
+curl --fail --silent --show-error \
+  "$UPDATE_HTTP_ORIGIN/manifest.json" \
+  | cmp - "$HTTP_ROOT/manifest.json"
+```
+
+**Procedure in `net-vm`:**
+
+```sh
+export UPDATE_HTTP_ORIGIN='http://<developer-interface-address>:<port>'
+export GHAF_UPDATE_GENERATION='<candidate-generation>'
+FETCH_PARENT=/persist/sysupdate
+FINAL_DIR="$FETCH_PARENT/http-generation-$GHAF_UPDATE_GENERATION"
+test ! -e "$FINAL_DIR" || exit 1
+FETCH_DIR="$(mktemp -d "$FETCH_PARENT/.http-generation-$GHAF_UPDATE_GENERATION.XXXXXX")"
+chmod 0755 "$FETCH_DIR"
+
+fetch_file() {
+  file="$1"
+  case "$file" in
+    "" | .* | *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  curl --fail --show-error --location \
+    --proto '=http' --proto-redir '=http' \
+    --retry 3 --retry-all-errors \
+    --output "$FETCH_DIR/$file.part" \
+    "$UPDATE_HTTP_ORIGIN/$file"
+  mv -- "$FETCH_DIR/$file.part" "$FETCH_DIR/$file"
+}
+
+fetch_file manifest.json
+fetch_file manifest.json.sig
+for kind in root verity kernel; do
+  artifact="$(jq -er --arg kind "$kind" '.[$kind].file' "$FETCH_DIR/manifest.json")"
+  fetch_file "$artifact"
+done
+touch "$FETCH_DIR/fetch.complete"
+sync "$FETCH_DIR"
+mv -T -- "$FETCH_DIR" "$FINAL_DIR"
+sync "$FETCH_PARENT"
+FETCH_DIR="$FINAL_DIR"
+```
+
+Record the five filenames, sizes, server request results, and the shared fetch
+directory. Do not record the developer address.
+
+**Procedure on the Ghaf host:**
+
+```sh
+PULLED_MANIFEST="/persist/sysupdate/http-generation-<candidate-generation>/manifest.json"
+test -f "$(dirname "$PULLED_MANIFEST")/fetch.complete"
+test -s "$PULLED_MANIFEST"
+test -s "$PULLED_MANIFEST.sig"
+
+sudo ota-update image validate --manifest "$PULLED_MANIFEST"
+sudo ota-update image --dry-run install --manifest "$PULLED_MANIFEST"
+sudo ota-update image install --manifest "$PULLED_MANIFEST"
+```
+
+Continue with BT-001. Use an AGX signed directory and generation for the AGX;
+the same network flow then installs to the inactive eMMC pair.
+
+**Expected:** The server exposes exactly five public files. `net-vm` performs
+every network request and writes the shared directory. The host performs all
+authentication and target/generation policy checks, preserves the active pair,
+installs the inactive pair, and does not reboot automatically.
+
+**Negative cases:** Stop the server during each download and require that no
+final directory is published and that any hidden temporary directory lacks
+`fetch.complete`. Retry into a newly created temporary directory; never reuse a
+previous final directory or marker. Separately tamper with the manifest,
+signature, and each of the three artifacts; use a signed wrong-target payload;
+and use a signed accepted or older generation. Every host validation must fail before
+LVM or ESP mutation. Do not run `install` after a failed `validate` or dry run.
+
+**Cleanup:** Stop the HTTP server, remove its temporary scoped firewall rule,
+and retain or delete only the exact public staging directory after inspecting
+its contents. Keep private trust material and recovery passphrases outside the
+server root throughout the test.
+
+### Baseline target evidence
+
+Before every mutating target test, capture:
+
+```sh
+sudo ota-update image status
+bootctl status --no-pager
+bootctl list --no-pager
+/run/current-system/systemd/lib/systemd/systemd-bless-boot status || true
+cat /proc/cmdline
+cat /persist/common/ota/accepted-generation
+cryptsetup status cryptroot
+veritysetup status nix-store
+findmnt /nix/store
+findmnt /persist
+sudo pvs
+sudo vgs
+sudo lvs -a -o lv_name,lv_size,lv_attr,devices pool
+systemctl is-active \
+  microvm@admin-vm.service \
+  microvm@disp-vm.service \
+  microvm@gpu-vm.service \
+  microvm@net-vm.service
+```
+
+Create or confirm a non-secret persist sentinel:
+
+```sh
+sudo install -d -m 0700 /persist/common/ota-test
+printf '%s\n' "$RUN_ID" | sudo tee /persist/common/ota-test/sentinel >/dev/null
+sync
+```
+
+The active version/hash from `/proc/cmdline` and `ota-update image status` is
+the protected slot. Stop immediately if it cannot be identified unambiguously.
+
+## Privileged virtual integration
+
+### IT-001: Real LUKS2/LVM/OVMF integration
+
+**Purpose:** Exercise the updater against real loopback-backed LUKS2, LVM,
+root/verity pairs, persist, systemd-boot, and OVMF.
+
+**Procedure (ghaf-givc worktree):**
+
+```sh
+timeout 2h nix build \
+  .#checks.x86_64-linux.vmTests-ota-update-image \
+  --print-build-logs
+```
+
+**Expected:** The test formats LUKS2, opens `cryptpool`, creates VG `pool`,
+installs the signed update, verifies the planned commands, retains the active
+pair, preserves the persist sentinel, removes the inactive pair, recreates the
+missing empty pair, and installs again. The test exits zero.
+
+### IT-002: Repeated A to B to A reuse
+
+**Purpose:** Demonstrate bounded storage use over repeated updates.
+
+**Procedure:** Extend or run the privileged fixture with three strictly
+increasing generations. After each successful health simulation, treat the new
+pair as active and install the next generation.
+
+**Expected:** LV count remains two root and two verity LVs. The pair active at
+the beginning of each install is byte-for-byte unchanged. The inactive physical
+space is reused for the third generation.
+
+### IT-003: Transaction failure matrix
+
+**Purpose:** Exercise every installer boundary without relying only on mocks.
+
+Repeat the integration fixture with failure injected at each boundary:
+
+| Fault point | Required postcondition |
+| --- | --- |
+| Root decompressor exits non-zero | Active pair unchanged; failure reported even if writer exits zero |
+| Root write fails or is short | No final LV names and no boot-default change |
+| Verity decompressor/write fails | Active pair unchanged; staging recoverable |
+| `veritysetup verify` fails | No UKI activation and no boot-default change |
+| First final LV rename succeeds, second fails | Next run recovers incomplete commit without touching active pair |
+| UKI temporary write or sync fails | No partial managed UKI selected |
+| UKI rename succeeds, default selection fails | Old default remains usable; rerun is idempotent |
+| Process killed after default selection | Complete `+3` trial exists; no active-slot data changed |
+
+For every row, capture pre/post LV UUIDs, active LV hashes, ESP directory listing,
+and loader variables. The test fails if the active root or verity LV changes.
+
+## UEFI boot and rollback tests
+
+### BT-001: Healthy three-attempt trial is blessed
+
+**Prerequisites:** A valid signed update newer than the accepted generation and
+all health dependencies configured healthy.
+
+**Procedure:**
+
+1. Validate and dry-run the update.
+2. Record the active pair and exact persistent default.
+3. Install the update.
+4. Confirm a `+3.efi` UKI exists and the default is the matching
+   `ghaf-<version>-<hash>*.efi` candidate glob.
+5. Confirm the installer did not reboot.
+6. Reboot once into the trial.
+7. Wait for `ghaf-boot-health.service` and capture its journal.
+
+**Expected:** The new generation boots, health succeeds, the entry loses its
+counter suffix through blessing, its exact UKI becomes the persistent default,
+and the accepted-generation file advances atomically. The old pair remains as
+the inactive fallback and the persist sentinel remains unchanged.
+
+### BT-002: Core-VM health failure rolls back
+
+Build the candidate with the debug-only health failure:
+
+```sh
+export GHAF_AB_TEST_UNHEALTHY=1
+export GHAF_UPDATE_GENERATION=<newer-generation>
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
+  -o result-unhealthy
+unset GHAF_AB_TEST_UNHEALTHY
+```
+
+Sign, validate, and install normally. Reboot without manually selecting entries.
+
+**Expected:** The trial boots three times. Each run fails because
+`microvm@ab-health-failure-injection.service` is not active, reboots, and
+consumes one attempt. The fourth selection boots the previously blessed pair.
+The accepted generation does not advance and persist remains intact.
+
+### BT-003: Corrupted root or verity rolls back
+
+**Prerequisites:** A valid installed trial, serial capture running, and an
+unambiguous mapping from the trial manifest to its inactive LVs.
+
+**Procedure:**
+
+1. Confirm the trial root LV is not the active root LV.
+2. Record hashes of both active LVs.
+3. After installation but before reboot, corrupt one 4096-byte block in the
+   trial root or verity LV. For a root corruption case, block 256 is suitable:
+
+   ```sh
+   TRIAL_ROOT=/dev/pool/root_<trial-version>_<trial-hash>
+   test -b "$TRIAL_ROOT"
+   sudo dd if=/dev/zero of="$TRIAL_ROOT" \
+     bs=4096 seek=256 count=1 conv=notrunc,fsync status=none
+   ```
+
+4. Reboot and do not interact with the boot menu.
+5. Count trial boots and capture the exact dm-verity failure from serial.
+
+**Expected:** Each trial fails dm-verity, panics or reaches the configured reset
+path, and consumes an attempt. After three failures, systemd-boot selects the
+previously blessed pair. Its root/verity hashes still match the baseline and
+persist is unchanged.
+
+### BT-004: Persistent-state invariant
+
+Run after BT-001, BT-002, and BT-003:
+
+```sh
+test "$(sudo cat /persist/common/ota-test/sentinel)" = "$RUN_ID"
+findmnt --mountpoint /persist
+```
+
+**Expected:** The same Btrfs persist LV is mounted before, during, and after slot
+changes. No rollback procedure reformats or replaces it.
+
+## NX hardware acceptance
+
+### HW-001: Recovery-target authorization
+
+Capture topology before attaching the authorized target:
+
+```sh
+lsusb > "$EVIDENCE_DIR/lsusb-before.txt"
+lsusb -t > "$EVIDENCE_DIR/lsusb-tree-before.txt"
+```
+
+Attach the NX in recovery mode and capture again:
+
+```sh
+lsusb > "$EVIDENCE_DIR/lsusb-after.txt"
+lsusb -t > "$EVIDENCE_DIR/lsusb-tree-after.txt"
+diff -u "$EVIDENCE_DIR/lsusb-before.txt" "$EVIDENCE_DIR/lsusb-after.txt" || true
+```
+
+Required checks:
+
+1. The new device identifies as `0955:7323 NVIDIA Corp. T234 [Orin NX 16GB]`.
+2. Its newly appearing physical USB path is recorded.
+3. Exactly one NVIDIA recovery-mode target remains connected when flash starts.
+4. Any previously observed `0955:7023` APX target is disconnected or otherwise
+   excluded before invoking NVIDIA flash tooling.
+5. The matching serial adapter identity and device node are recorded.
+
+Example fail-closed count check:
+
+```sh
+test "$(lsusb | grep -Ec '0955:(7023|7323)')" -eq 1
+test "$(lsusb -d 0955:7323 | wc -l)" -eq 1
+```
+
+Stop if either assertion fails or if topology does not uniquely identify the
+authorized NX.
+
+### HW-002: Serial capture before flash
+
+Inspect and record the serial endpoint:
+
+```sh
+export SERIAL_DEVICE='<authorized-serial-device>'
+udevadm info --query=property --name="$SERIAL_DEVICE" \
+  > "$EVIDENCE_DIR/serial-udev.txt"
+```
+
+In a dedicated terminal, configure 115200 baud and start a timestamped capture
+before the flash command:
+
+```sh
+sudo stty -F "$SERIAL_DEVICE" 115200 raw -echo
+sudo stdbuf -oL cat "$SERIAL_DEVICE" \
+  | ts '%Y-%m-%dT%H:%M:%.S%z' \
+  | tee "$EVIDENCE_DIR/orin-serial.log"
+```
+
+If `ts` is unavailable, capture without it and record timestamps separately.
+Keep this terminal running through first boot and rollback tests.
+
+### HW-003: Build and flash the NX NVMe canary
+
+Build the flash script, sequentially and with the key directory available:
+
+```sh
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-flash-script \
+  -o result-nx-flash
+```
+
+Immediately before flashing, repeat HW-001's count checks. Then invoke the
+secure-boot variant and UKI path:
+
+```sh
+sudo --preserve-env=GHAF_DEV_KEY_DIR \
+  ./result-nx-flash/bin/flash-ghaf-host --secure-boot -u
+```
+
+**Expected:** The flash script selects the NX NVMe layout, signs EFI binaries
+outside the Nix store, creates LUKS2 APP, records a new recovery passphrase, and
+flashes the authorized NX. Save flash output after redacting the passphrase.
+Do not claim success from the command exit alone; require serial first boot and
+the post-flash checks below.
+
+### HW-004: Secure Boot negative and positive paths
+
+1. Confirm the signed systemd-boot binary and signed UKI boot.
+2. Copy an unsigned UKI to a distinct managed test name on the ESP.
+3. Select it once from firmware or systemd-boot without replacing the blessed
+   signed entry.
+4. Capture the firmware rejection on serial.
+5. Remove the unsigned test artifact and confirm the signed entry still boots.
+
+**Expected:** The unsigned UKI never reaches its kernel. Firmware fallback to
+PXE or the UEFI shell counts only as rejection; separately prove that the signed
+fallback remains selectable. Never replace the only known-good signed UKI.
+
+### HW-005: DUK rotation and recovery unlock
+
+After first boot:
+
+```sh
+sudo cryptsetup status cryptroot
+sudo cryptsetup luksDump /dev/disk/by-uuid/0ada0e5b-0e5b-4e5b-8e5b-0000000000a9
+```
+
+Confirm the manufacturer credential no longer unlocks APP and the recovery
+passphrase from this flash still does. Test recovery from initrd or a controlled
+rescue environment so the already-open mapping cannot create a false positive.
+
+Create a protected header backup after key rotation and before update testing:
+
+```sh
+export APP_DEVICE='<raw-APP-partition>'
+export LUKS_HEADER_BACKUP='<encrypted-offline-staging-path>/app-luks2-header.bin'
+test -b "$APP_DEVICE"
+umask 077
+sudo cryptsetup luksHeaderBackup "$APP_DEVICE" \
+  --header-backup-file "$LUKS_HEADER_BACKUP"
+sudo chmod 0600 "$LUKS_HEADER_BACKUP"
+```
+
+Move the backup into encrypted offline custody and record its non-secret
+inventory identifier with the flash's recovery-passphrase filename. Do not put
+the header backup in the ordinary evidence bundle or leave an unencrypted copy
+on `/persist`.
+
+**Expected:** Normal reboot unlock is unattended through OP-TEE DUK. The old
+manufacturer credential fails. Recovery slot 1 succeeds. Record only pass/fail
+and the recovery file name, never the passphrase.
+
+### HW-006: Encrypted layout and first-boot provisioning
+
+Run the baseline evidence commands. Verify:
+
+- the NVMe APP partition contains LUKS2,
+- `/dev/mapper/cryptroot` is active,
+- VG `pool` is backed by the open mapper rather than raw NVMe,
+- one initial root/verity pair and one reserved inactive capacity exist,
+- persist is Btrfs and mounted read-write,
+- swap is active with random encryption,
+- `nix-store` dm-verity is active, and
+- first-boot resize and persist services succeeded.
+
+Reboot once more and confirm all first-boot operations are idempotent.
+
+On a fresh destructive-test flash, include first-boot interruption points after
+APP expansion, open-LUKS resize, PV resize, swap LV creation, persist LV
+creation, and persist formatting. After each restart, require the service to
+converge without duplicate LVs. In particular, an existing blank persist LV is
+formatted as Btrfs, existing Btrfs is retained with its contents, and an
+unexpected filesystem type stops with an error rather than being reformatted.
+Test the unexpected-filesystem branch only in the disposable integration
+fixture, never by replacing a hardware target's real persist filesystem.
+
+### HW-007: Signed A to B to A update reuse
+
+1. Establish a healthy accepted A generation and persist sentinel.
+2. Install a valid newer B generation and complete BT-001.
+3. Build, sign, and install a third generation.
+4. Complete BT-001 again so physical slot A is reused.
+5. Compare LV counts, LV sizes, boot entries, accepted generation, and persist.
+
+**Expected:** Both updates validate, stage, and bless successfully. The updater
+never writes the pair active at install start. Only two complete pairs remain,
+and persist contains the original sentinel.
+
+### HW-008: Rejection matrix
+
+Run `ota-update image validate` and then `install` where appropriate for these
+payloads:
+
+| Variant | Expected result |
+| --- | --- |
+| Missing signature | Reject before manifest parsing or mutation |
+| Random or wrong-key signature | Reject Ed25519 verification |
+| Manifest changed after signing | Reject Ed25519 verification |
+| Root artifact changed | Reject SHA-256 or size validation |
+| Verity artifact changed | Reject SHA-256 or size validation |
+| Unsigned or wrong-key UKI | Reject UKI signature validation |
+| Signed manifest for AGX on NX | Reject exact target policy |
+| Generation equal to accepted | Reject generation policy |
+| Generation below accepted | Reject generation policy |
+| UKI embeds another root hash | Reject UKI/manifest agreement |
+| UKI embeds another generation | Reject UKI/manifest agreement |
+
+For every row, compare active LV hashes, `lvs`, `/boot/EFI/Linux`, and boot
+default before and after. They must not change.
+
+### HW-009: Core-VM health rollback
+
+Perform BT-002 on the NX. Capture all three `ghaf-boot-health` failures, each
+reboot, counter-name transition, final fallback selection, accepted generation,
+and persist sentinel.
+
+### HW-010: Physical corruption rollback
+
+Perform BT-003 on the NX for root corruption and repeat for verity corruption.
+Require three observed failed trials and an automatic fourth selection of the
+previously blessed pair, without keyboard input.
+
+### HW-011: Physical power-interruption matrix
+
+For each row, begin from a healthy accepted pair, install a fresh generation,
+and remove power only after serial/journal/LV evidence confirms the named phase:
+
+| Phase | Recovery assertion after power restore |
+| --- | --- |
+| Validate, before mutation | Old pair boots; no staging LVs or trial UKI |
+| Staging LV creation | Old pair boots; next install recovers staging |
+| Root decompression/write | Old pair boots; partial root is never selected |
+| Verity decompression/write | Old pair boots; partial pair is never selected |
+| `veritysetup verify` | Old pair boots; uncommitted pair is recoverable |
+| First LV final rename | Old pair boots; incomplete commit is recovered |
+| UKI temporary installation | Old pair boots; no partial UKI is selected |
+| UKI atomic rename | Old pair boots or complete trial is discoverable |
+| Boot-default commit | Either old default or complete `+3` trial; never partial data |
+| First, second, and third trial boot | Counter consumption resumes and ends at fallback |
+| Health blessing before generation-state rename | Rerun converges without lowering accepted generation |
+
+After each interruption, capture state before retrying. The recovery action is
+normally rerunning the same signed install; do not manually rename LVs unless
+the test specifically evaluates the documented rescue procedure.
+
+### HW-012: Hard-hang watchdog acceptance
+
+Inject a controlled hard hang during a counted trial, not merely a service
+failure or clean reboot. Observe the physical Tegra watchdog reset on serial and
+repeat until the three attempt counter is exhausted.
+
+**Expected:** Every hang produces a hardware reset within the configured bound,
+consumes exactly one attempt, and eventually selects the blessed fallback.
+Until this passes, record hard-hang rollback as blocked rather than inferred
+from panic or service-failure tests.
+
+## AGX eMMC hardware acceptance
+
+### AGX-001: eMMC canary build
+
+```sh
+export GHAF_UPDATE_GENERATION=<candidate-generation>
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-ghafImage \
+  -o result-agx-update
+
+timeout 2h nix build --impure \
+  .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-flash-script \
+  -o result-agx-flash
+```
+
+Require manifest system `aarch64-linux`, the exact AGX target, and the intended
+generation, then retain the build logs. Do not flash an NX with AGX artifacts.
+
+Sign and validate the update bundle before connecting it to target storage:
+
+```sh
+IMAGE_DIR=result-agx-update
+MANIFEST="$(find -L "$IMAGE_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+SIGNED_DIR="signed-agx-generation-$GHAF_UPDATE_GENERATION"
+
+jq -e --argjson generation "$GHAF_UPDATE_GENERATION" '
+  .system == "aarch64-linux"
+  and .target == "nvidia-jetson-orin-agx-verity-luks-debug"
+  and .generation == $generation
+' "$MANIFEST" >/dev/null
+
+nix run .#ghaf-sign-update -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input "$MANIFEST" \
+  --output "$SIGNED_DIR"
+
+SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
+nix run 'path:../ghaf-givc#ota-update' -- image validate \
+  --manifest "$SIGNED_MANIFEST" \
+  --trusted-key "$GHAF_DEV_KEY_DIR/update.pub" \
+  --uki-trusted-cert "$GHAF_DEV_KEY_DIR/db.crt" \
+  --target nvidia-jetson-orin-agx-verity-luks-debug \
+  --accepted-generation-file ./accepted-generation
+```
+
+The validation environment must provide `sbverify`. The
+`accepted-generation` file contains the AGX generation accepted before this
+candidate, not the NX value.
+
+### AGX-002: Recovery identity and flash
+
+Capture serial output from the running board before requesting recovery. Verify
+that the device-tree model identifies an AGX developer kit and that APP is on
+internal eMMC. Record the current USB topology, then request forced recovery.
+
+After recovery, require all of the following:
+
+- exactly one authorized Tegra recovery target is present;
+- its USB path is the recovery sibling of the serial-identified AGX operator
+  interface;
+- the recovery query returns the recorded AGX ECID;
+- the serial capture is running before flash starts; and
+- the flash script names `mmcblk0`, never the NX NVMe device.
+
+USB ID `0955:7023` is expected for this AGX generation, but is not sufficient
+authorization by itself. Stop if another APX target is present or topology is
+ambiguous.
+
+```sh
+export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
+
+sudo --preserve-env=GHAF_DEV_KEY_DIR \
+  result-agx-flash/bin/flash-ghaf-host
+```
+
+Store the newly printed recovery passphrase in the protected trust directory.
+Never put it in a shell argument, build log, test record, Git, or the Nix store.
+
+### AGX-003: Encrypted first-boot baseline
+
+Before installing any update, capture the generation-1 baseline over serial:
+
+```sh
+cat /proc/cmdline
+bootctl status --no-pager
+lsblk -o NAME,TYPE,FSTYPE,SIZE,MOUNTPOINTS
+sudo cryptsetup luksDump /dev/mmcblk0p2
+sudo pvs
+sudo vgs
+sudo lvs -a -o lv_name,lv_size,lv_attr,devices
+findmnt / /nix/store /persist /boot
+sudo veritysetup status nix-store
+swapon --show
+systemctl --failed --no-pager
+systemctl is-active microvm@admin-vm.service microvm@net-vm.service
+systemctl is-active microvm@gpu-vm.service microvm@disp-vm.service
+systemctl status ghaf-boot-health.service --no-pager
+cat /persist/common/ota/accepted-generation
+```
+
+Require Secure Boot enabled, one root/verity pair, free LVM space reserved for
+the second pair, read-only verified `/nix/store`, read-write Btrfs `/persist`,
+encrypted swap, healthy configured core VMs, and an accepted generation that
+matches the booted UKI.
+
+Test both remaining credentials explicitly. The manufacturer passphrase must
+fail. Recovery slot 1 must unlock with external tokens disabled. Feed the
+recovery passphrase through a no-echo prompt; do not put it on a command line or
+in the journal.
+
+### AGX-004: DUK reboot and optional fTPM boundary
+
+The AGX secure A/B canary intentionally leaves
+`ghaf.hardware.nvidia.orin.ftpm.enable` disabled. The OP-TEE DUK path remains
+enabled and must unlock APP unattended on every reboot.
+
+```sh
+test ! -e /dev/tpmrm0
+! systemctl cat ghaf-load-ftpm-module.service
+systemctl reboot
+```
+
+Capture the entire shutdown and next boot. Require a prompt reboot, unattended
+LUKS unlock, the same `/persist` contents, no duplicate LVs, the same accepted
+generation, and no `tpm_ftpm_tee` task. A reboot blocked in
+`ftpm_tee_tpm_op_send` is a failure even if the health gate previously passed.
+
+### AGX-005: Signed A to B to A updates
+
+Deliver a correctly signed AGX generation greater than the accepted value by
+the developer-host registry round trip in REG-001 or by AGX self-fetch through
+`net-vm` as described in REG-002. Use the AGX target and a distinct AGX
+repository path. On the host, run validation, dry-run, and install in that
+order. Verify that installation does not reboot automatically.
+
+After manually rebooting, require the candidate to appear as a `+3` UKI. Let
+the health gate bless it, verify the accepted generation advances, then install
+a newer generation to prove B-to-A reuse. At every step assert that the active
+root and verity LVs were not written and that `/persist` retained its sentinel.
+
+Repeat the signed wrong-target, unsigned, tampered, and downgrade cases against
+the AGX. Then repeat health-failure, root-corruption, verity-corruption,
+power-interruption, and hard-hang cases from the common matrix. Record AGX and
+NX results separately.
+
+## Recovery and triage
+
+### Collect an operational evidence bundle
+
+Capture command output before retrying or changing state. Redact network and
+hardware identities before sharing it:
+
+```sh
+sudo ota-update image status
+bootctl status --no-pager
+bootctl list --no-pager
+find /boot/EFI/Linux -maxdepth 1 -type f -printf '%s %f\n' | sort
+sudo lvs -a -o lv_name,lv_size,lv_attr,lv_uuid,devices pool
+sudo pvs -o pv_name,pv_size,pv_free,pv_uuid
+sudo vgs -o vg_name,vg_size,vg_free,vg_uuid pool
+cryptsetup status cryptroot
+veritysetup status nix-store
+findmnt --mountpoint /nix/store
+findmnt --mountpoint /persist
+findmnt --mountpoint /boot
+systemctl --no-pager --full status \
+  firstboot-persist.service ghaf-boot-health.service microvms.target
+journalctl -b --no-pager \
+  -u firstboot-persist.service -u ghaf-boot-health.service
+journalctl -b -1 --no-pager \
+  -u firstboot-persist.service -u ghaf-boot-health.service || true
+```
+
+Also retain the updater's validation, dry-run, and install console output. Record
+the active version/hash, accepted generation, candidate generation, boot-count
+suffix, and whether the persist sentinel is unchanged. Never collect private
+keys or recovery-passphrase contents.
+
+### Rescue decision matrix
+
+| Observed state | Supported action | Boundary |
+| --- | --- | --- |
+| One inactive `root_staging_<id>` or `verity_staging_<id>` beside one active pair | Rerun the exact signed candidate; the missing counterpart is created and both inactive images are rewritten | Automatic only for one-sided staging in the active VG |
+| One final inactive LV and its matching staging peer after interrupted final renames | Rerun the exact signed candidate | Discovery rejoins the inactive pair; ambiguous names stop |
+| Complete candidate LVs but no candidate UKI | Rerun the exact signed candidate | Candidate data is verified and rewritten before UKI activation |
+| Candidate UKI exists but default selection failed | Rerun the exact signed candidate | Updater completes only candidate-specific default selection |
+| Orphan `<candidate>.efi.tmp` | Preserve evidence, then rerun the exact candidate | Atomic install replaces the temporary path; the old default remains |
+| ESP lacks space | Remove only a proven stale `.tmp` or non-active managed UKI, then rerun | Never remove the current or only blessed fallback |
+| VG lacks space for inactive-slot resize | Use a smaller candidate or reflash with a larger layout | Never shrink or delete the active pair manually |
+| Hidden incomplete HTTP fetch directory | Retain for evidence or delete that exact directory; retry into a new temporary directory | Never add a marker or reuse old contents |
+| Existing blank persist LV | Restart `firstboot-persist.service` | It formats the blank LV once |
+| Existing Btrfs persist LV | Restart first boot normally | Contents must be retained |
+| Unexpected filesystem on persist | Stop and investigate | No automatic or forced formatting |
+| Public-trust or private/public key mismatch | Restore the evaluated complete key directory or rebuild | Never mix trust sets |
+| Signature, target, generation, hash, UKI, or verity failure | Reject the candidate and preserve evidence | Do not repair authenticated content in place |
+| Ambiguous active pair, more than two storage groups, or non-staging partial LV | Stop and escalate | No undocumented LV rename/delete procedure |
+| DUK and matching recovery unlock both fail | Stop and use the protected header backup/recovery process | Never delete keyslots or reformat APP |
+
+An unencrypted, raw-root, non-LVM, or otherwise incompatible pre-canary layout
+is not a rescue case; it requires a destructive reflash to establish LUKS2,
+LVM A/B, ESP trust, and recovery material.
+
+### Trial does not roll back
+
+Capture, in this order:
+
+```sh
+bootctl status --no-pager
+bootctl list --no-pager
+/run/current-system/systemd/lib/systemd/systemd-bless-boot status || true
+find /boot/EFI/Linux -maxdepth 1 -type f -printf '%f\n' | sort
+journalctl -b -u ghaf-boot-health.service --no-pager
+cat /proc/cmdline
+```
+
+Check that the trial filename has a boot-count suffix, the persistent default is
+the matching candidate-specific `ghaf-<version>-<hash>*.efi` glob during the
+trial, and the old blessed UKI still exists. A broad `ghaf-*.efi` glob is a
+failure: equal-version UKIs can then be selected by hash ordering instead of by
+update generation. Do not set an exhausted trial as an exact default.
+
+### Update refuses to install
+
+Run `validate` first and preserve its exact error. Check the detached signature,
+target, accepted generation, artifact sizes and hashes, UKI certificate, and UKI
+command line before investigating LVM. Authentication failures are expected to
+occur before runtime mutation.
+
+### Incomplete staging state
+
+Record `ota-update image status`, `lvs -a`, and ESP contents. Match the state to
+the rescue matrix before rerunning the exact same signed update. Automatic
+recovery is intentionally limited to recognizable inactive staging or partial
+commit states. Stop if a name is not in the managed namespace, an LV is in a
+different VG, the active pair is ambiguous, or more than two storage groups
+exist.
+
+### Recovery-key failure
+
+Do not delete any LUKS keyslot. Confirm the recovery file belongs to this exact
+flash and contains no added newline. Preserve a LUKS header backup if one exists,
+then investigate from a controlled rescue environment.
+
+## Validation snapshot and remaining gates
+
+The implementation campaign on 2026-08-19 established the following evidence:
+
+The NX and AGX were each authorized by comparing before/after USB topology,
+recovery identity, board model, storage target, and the matching serial adapter.
+Exact USB paths, ECIDs, serial numbers, device nodes, hostnames, and network
+addresses remain in access-controlled run evidence rather than evergreen
+documentation. No ambiguous or unrelated recovery target was flashed.
+
+| Area | Status | Evidence boundary |
+| --- | --- | --- |
+| Privileged OVMF integration | Passed | focused `vmTests-ota-update-image` build |
+| NX and AGX image builds | Passed | target-matched cross builds, sequential |
+| Static HTTP device fetch | Passed on AGX | `net-vm` fetched a five-file signed payload from a temporary development server into shared persist; host validation/install remained separate |
+| NX encrypted first boot | Passed | LUKS/LVM/verity/persist and core VMs healthy |
+| NX repeated signed updates | Passed | inactive-slot reuse and accepted generation advancement |
+| NX corrupted trial rollback | Passed | generation 9 failed dm-verity three times and generation 7 returned automatically |
+| Persist across rollback | Passed | the run-specific non-secret sentinel remained present |
+| Unsigned UKI rejection | Partial | rejection observed; firmware fell through to network rather than selecting signed fallback automatically |
+| AGX encrypted first boot | Passed | internal eMMC LUKS/LVM/verity/persist, DUK rotation, recovery slot, and core VMs healthy |
+| AGX signed updates | Passed | generations 1 to 2 to 3 proved both physical slots, inactive-slot reuse, active-pair immutability, self-fetch, and accepted-generation advancement |
+| AGX clean reboot | Passed | disabling the optional fTPM removed the OP-TEE probe hang; ordinary shutdown, cold boot, unattended DUK unlock, and health blessing passed repeatedly |
+| AGX trial selection | Passed after fix | a broad default selected the older equal-version UKI; a candidate-specific wildcard selected and blessed generation 3 |
+| All physical power cuts | Not run | HW-011 remains a release gate |
+| Physical hard-hang watchdog | Not run | HW-012 remains a release gate |
+
+The AGX return-slot update ended with generation 3 active and accepted, exactly
+two root/verity pairs, no staging LVs, the generation-2 active pair unchanged
+during installation, both update-fetch sentinels intact on shared persist, and
+the candidate promoted from `+3` to its exact persistent default. The baseline
+fTPM-enabled image required a physical power cycle after the OP-TEE TPM probe
+blocked shutdown; the fTPM-disabled generations completed ordinary reboots.
+
+The validated NX rollback ended on the previously blessed generation, with all
+configured core MicroVM services active, `ghaf-boot-health.service` successful,
+the expected dm-verity root hash, and the persistent default resolving to the
+exact blessed entry.
+These observations are a snapshot, not a substitute for repeating the complete
+matrix on a release candidate.
+
+## Release stop conditions
+
+Do not promote the canaries if any of the following is true:
+
+- the recovery USB target or serial endpoint is ambiguous,
+- the active pair cannot be proven untouched,
+- a negative validation case mutates LVM or ESP state,
+- trial attempts do not decrement exactly once per failed boot,
+- accepted generation advances before successful health blessing,
+- rollback changes or loses shared persist,
+- manufacturer-key rotation removes the recovery keyslot,
+- a physical power interruption requires undocumented manual LV surgery,
+- the watchdog cannot reset a hard-hung counted trial,
+- one board's runtime result is used as evidence for the other, or
+- development-key results are represented as production Secure Boot assurance.

--- a/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
@@ -9,8 +9,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 # Orin secure A/B testing
 
 Use the [shared architecture](/ghaf/dev/architecture/ab-update) for trust,
-manifest, transaction and boot-health contracts. This runbook covers manual
-development and acceptance, not an implemented CI pipeline.
+manifest, transaction and boot-health contracts.
 
 :::danger[Destructive tests]
 Flash, corruption and power-cut cases require an explicitly authorized device.
@@ -27,10 +26,7 @@ only signed fallback.
 | NX 16 GB | `nvidia-jetson-orin-nx-verity-luks-debug` | Internal NVMe | Physical watchdog/reset |
 | AGX | `nvidia-jetson-orin-agx-verity-luks-debug` | Internal eMMC (`mmcblk0`) | DUK reboot with optional fTPM disabled |
 
-Record each board separately; results are not transferable. APP contains LUKS2,
-LVM system pairs, persist and swap; ESP/QSPI are unencrypted. Rollback must retain
-shared persist. Core VMM service activity excludes AppVMs/login and does not
-prove guest-agent readiness.
+APP contains LUKS2, LVM system pairs, persist and swap.
 
 Keep a protected evidence directory outside Git. For each test ID below record
 UTC start/end, Ghaf/GIVC revisions, exact target/generation, manifest digest,
@@ -203,9 +199,8 @@ must not reboot. Reboot manually and observe the health/rollback cases below.
 
 ## Acceptance matrix
 
-Run every applicable row on **each board**. Existing IT IDs denote optional
-GIVC privileged runtime fixtures, not image-build dependencies; this runbook
-does not add a VM to the image build. Hardware results are still required.
+Run each applicable row on NX and AGX. IT IDs identify optional GIVC runtime
+fixtures.
 
 | ID | Procedure | Required result |
 | --- | --- | --- |
@@ -283,8 +278,4 @@ fTPM disablement for clean reboot and candidate-specific selection for
 equal-version trials. Unsigned UKI rejection was partial: firmware fell through
 to networking instead of automatically selecting the signed fallback.
 
-Physical power cuts and hard-hang watchdog tests remained unrun. Repeat the
-matrix per release candidate. Stop promotion on identity ambiguity, active-slot
-mutation, a mutating rejection, incorrect attempt counts, premature acceptance,
-persist loss, recovery-slot loss, undocumented rescue, or unproven hard-hang
-reset. Development-key tests do not establish production Secure Boot assurance.
+Physical power cuts (HW-011) and hard-hang watchdog tests (HW-012) remained unrun.

--- a/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
@@ -8,1164 +8,283 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Orin secure A/B testing
 
-This guide defines the downstream development and manual acceptance procedures
-for the [secure A/B image-update architecture](/ghaf/dev/architecture/ab-update).
-It is written for repeatable evidence collection: every case states its
-prerequisites, procedure, expected result, and recovery boundary.
-Implementation-internal validation is intentionally outside this guide's scope.
+Use the [shared architecture](/ghaf/dev/architecture/ab-update) for trust,
+manifest, transaction and boot-health contracts. This runbook covers manual
+development and acceptance, not an implemented CI pipeline.
 
-:::danger[Destructive hardware tests]
-Flashing, corruption, and power-interruption cases destroy data on the selected
-target. Run them only on an explicitly authorized Orin in recovery mode. USB
-VID/PID alone is not authorization. Capture topology and serial identity, require
-exactly one recovery-mode Tegra target, and stop on any ambiguity.
+:::danger[Destructive tests]
+Flash, corruption and power-cut cases require an explicitly authorized device.
+Match board model, ECID, before/after USB topology, storage and serial endpoint;
+VID/PID alone is insufficient. Require exactly one identified recovery target
+before flashing, and stop on ambiguity. Never overwrite the active pair or the
+only signed fallback.
 :::
 
-## Scope and acceptance policy
+## Scope and records
 
-- Orin NX 16 GB with internal NVMe and Orin AGX with internal eMMC are distinct
-  runtime acceptance targets. Test artifacts and evidence are not transferable
-  between them.
-- QSPI and ESP are outside LUKS; APP, LVM, both system pairs, persist, and swap
-  are in scope.
-- Rollback protects the immutable system pair. Shared `/persist` must survive
-  every successful update, failed trial, and rollback.
-- A trial is accepted only after LUKS, dm-verity, `/persist`, and all configured
-  core Ghaf MicroVMs are healthy.
-- AppVMs and interactive login are not health-gate dependencies.
-- Hard-hang rollback is not accepted until a physical watchdog/reset test passes.
-- A test run is not release acceptance until every required case is recorded
-  against a device identity, build generation, Git revision, and timestamp.
+| Board | Target prefix | APP storage | Additional gate |
+| --- | --- | --- | --- |
+| NX 16 GB | `nvidia-jetson-orin-nx-verity-luks-debug` | Internal NVMe | Physical watchdog/reset |
+| AGX | `nvidia-jetson-orin-agx-verity-luks-debug` | Internal eMMC (`mmcblk0`) | DUK reboot with optional fTPM disabled |
 
-## Test records
+Record each board separately; results are not transferable. APP contains LUKS2,
+LVM system pairs, persist and swap; ESP/QSPI are unencrypted. Rollback must retain
+shared persist. Core VMM service activity excludes AppVMs/login and does not
+prove guest-agent readiness.
 
-Create a directory outside the source tree for each run:
+Keep a protected evidence directory outside Git. For each test ID below record
+UTC start/end, Ghaf/GIVC revisions, exact target/generation, manifest digest,
+device identity, active pair/default/accepted generation before and after,
+commands/fault point, serial/journal evidence, pass/fail/blocked/not-run and any
+manual recovery. Exclude private keys, recovery passphrases and LUKS headers;
+redact network/device identities before sharing.
 
-```sh
-RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-orin-nx-ab"
-EVIDENCE_DIR="$PWD/../test-evidence/$RUN_ID"
-mkdir -p "$EVIDENCE_DIR"
-chmod 0700 "$EVIDENCE_DIR"
-```
+## Build and sign
 
-Record only public build and device metadata:
-
-```sh
-git rev-parse HEAD > "$EVIDENCE_DIR/ghaf-head.txt"
-git -C ../ghaf-givc rev-parse HEAD > "$EVIDENCE_DIR/givc-head.txt"
-date -u --iso-8601=seconds > "$EVIDENCE_DIR/started-at.txt"
-```
-
-Do not copy private keys or recovery passphrases into the evidence directory.
-For every test case record:
-
-| Field | Required content |
-| --- | --- |
-| Test ID | Stable identifier from this document |
-| Build | Ghaf and ghaf-givc revisions, system, target, version, generation, manifest SHA-256 |
-| Device | Board model, ECID, USB topology path, storage device, serial endpoint |
-| Start/end | UTC timestamps |
-| Preconditions | Active slot, accepted generation, boot entry, persist sentinel |
-| Actions | Exact commands and intentional fault point |
-| Result | Pass, fail, blocked, or not run |
-| Evidence | Serial log, journal, `bootctl`, `lvs`, cryptsetup and verity status |
-| Recovery | Final active slot and whether manual intervention was needed |
-
-## Common setup
-
-### Required build configuration
-
-The default input contains no public keys. Secure A/B image and flash-script
-evaluation must fail until an external public configuration is supplied as
-described below. Flash attributes always select the requested target; there is
-no automatic fallback to a generic unsigned image.
-
-CI integration is future work described in the
-[shared architecture guide](/ghaf/dev/architecture/ab-update/#proposed-ci-integration).
-
-### Repository and key environment
-
-Use the dedicated Ghaf and ghaf-givc worktrees. Keep the trust directory outside
-both repositories:
+Generate keys once as described in the shared guide. Set `ORIN=nx` or
+`ORIN=agx` explicitly for the authorized board. Export a new public directory
+for every candidate; never edit an input used for a published image.
 
 ```sh
 export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
-test -d "$GHAF_DEV_KEY_DIR"
-test -s "$GHAF_DEV_KEY_DIR/db.key"
-test -s "$GHAF_DEV_KEY_DIR/db.crt"
-test -s "$GHAF_DEV_KEY_DIR/update.key"
-test -s "$GHAF_DEV_KEY_DIR/update.pub"
+ORIN=nx
+TARGET="nvidia-jetson-orin-$ORIN-verity-luks-debug"
+GENERATION=10
+PUBLIC="$PWD/secure-ab-$ORIN-generation-$GENERATION"
+nix run .#ghaf-secure-ab-config -- --key-dir "$GHAF_DEV_KEY_DIR" \
+  --generation "$GENERATION" --output "$PUBLIC"
+
+# Sequential, bounded evaluations; -from-x86_64 is required on an x86 host.
+for artifact in ghafImage flash-script; do
+  timeout 2h nix build --override-input secure-ab-build-config "path:$PUBLIC" \
+    ".#$TARGET-from-x86_64-$artifact" -o "result-$ORIN-$artifact"
+done
+
+MANIFEST="$(find -L "result-$ORIN-ghafImage" -maxdepth 1 -name '*.manifest' -print -quit)"
+jq -e --arg target "$TARGET" --argjson generation "$GENERATION" \
+  '.system == "aarch64-linux" and .target == $target and .generation == $generation' \
+  "$MANIFEST"
+SIGNED_DIR="signed-$ORIN-generation-$GENERATION"
+nix run .#ghaf-sign-update -- --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input "$MANIFEST" --output "$SIGNED_DIR"
+SIGNED_MANIFEST="$SIGNED_DIR/$(basename "$MANIFEST")"
 ```
 
-If the directory does not exist, create it once:
+Require one manifest, its detached signature and three artifacts. Record public
+certificate/key SHA-256 values. The default keyless input and incomplete public
+directories must fail evaluation; no generic-image fallback is allowed.
+
+With **no recovery target attached**, test the flash script with an unset key
+directory, missing files, an independent trust set, and mismatched `db.key` or
+`update.key`. Each must fail before device/work-directory preparation. Restore
+the evaluated trust set and require the checks to pass. Never run key-negative
+tests while a recovery-mode device is attached.
+
+## Flash and first boot
+
+For HW-001/AGX-002, capture `lsusb` and `lsusb -t` before/after recovery and
+match the returned ECID to the serial-identified board. NX commonly appears as
+`0955:7323`, AGX as `0955:7023`; neither alone authorizes a flash. Exclude other
+APX devices. Confirm NVMe versus eMMC in the selected flash script.
+
+For HW-002, record `udevadm info --query=property --name="$SERIAL_DEVICE"`, set
+115200 baud and start a timestamped serial capture before flashing. Then repeat
+the identity checks immediately before the destructive command:
 
 ```sh
-umask 077
-nix run .#ghaf-dev-keygen -- --output "$GHAF_DEV_KEY_DIR"
+sudo --preserve-env=GHAF_DEV_KEY_DIR \
+  "result-$ORIN-flash-script/bin/flash-ghaf-host" --secure-boot -u
 ```
 
-Choose the candidate generation and export a public-only flake input. This
-directory contains no private keys:
+Keep the new recovery passphrase in protected offline custody, not command
+arguments, ordinary logs or the evidence bundle.
+
+Capture this baseline before every mutating runtime case:
 
 ```sh
-export SECURE_AB_GENERATION=10
-export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-generation-$SECURE_AB_GENERATION"
-nix run .#ghaf-secure-ab-config -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --generation "$SECURE_AB_GENERATION" \
-  --output "$SECURE_AB_BUILD_CONFIG"
+sudo ota-update image status
+bootctl status --no-pager
+bootctl list --no-pager
+cat /proc/cmdline
+cat /persist/common/ota/accepted-generation
+sudo cryptsetup status cryptroot
+sudo veritysetup status nix-store
+sudo lvs -a -o lv_name,lv_size,lv_attr,lv_uuid,devices pool
+findmnt --mountpoint /nix/store
+findmnt --mountpoint /persist
+swapon --show
+systemctl is-active microvm@{admin,disp,gpu,net}-vm.service
+journalctl -b -u firstboot-persist -u ghaf-boot-health --no-pager
 ```
 
-Evaluate with the external public trust and generation pinned by that input:
+Require Secure Boot, LUKS-backed `pool`, verified read-only store, read-write
+Btrfs persist, encrypted swap, healthy configured core VMs and matching accepted
+generation. Initial storage reserves the second pair's capacity. Create a
+non-secret sentinel under `/persist/common/ota-test/`; compare it after every
+update, reboot and rollback. Stop if the active pair cannot be identified.
+
+## Delivery
+
+All network requests belong in `net-vm`; host validation and storage mutation
+remain separate. Never use registry pull's `--install` here.
+
+### OCI: REG-000 through REG-002
+
+Use a managed HTTPS registry or a disposable TLS registry outside Ghaf. Verify
+DNS/reachability from both hosts, unauthenticated `/v2/` rejection, authenticated
+success, CA fingerprint agreement and failure with the wrong CA. Do not use
+`--insecure`. Developer credentials may push; device credentials must be
+read-only. A disposable basic-auth registry without repository authorization
+does not prove read-only access and must be recorded as such.
+
+With `UPDATE_REF=<registry>/<namespace>/<repository>:<approved-tag>` and
+`REGISTRY_AUTH_ARGS` supplied privately (`--token TOKEN` or
+`--username USER --password PASSWORD`), run on the developer host:
 
 ```sh
-timeout 2h nix eval \
-  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
-  '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
-```
-
-It must succeed with the configured generation and public trust. Overriding
-the input with an incomplete directory must fail evaluation and identify the
-missing public file or files. Running a flash
-script with the runtime key variable unset must fail with `ERROR:
-GHAF_DEV_KEY_DIR is required for secure A/B canary flashes.`; missing flash or
-signing files are reported by their exact paths.
-
-Record `sha256sum PK.crt KEK.crt db.crt update.pub` with the non-secret build
-evidence. Build a flash script with trust directory A, then, with no recovery
-target attached, invoke it using an independently generated directory B. It must
-exit before work-directory or device preparation with:
-
-```text
-ERROR: GHAF_DEV_KEY_DIR public trust does not match the trust embedded at image evaluation: <file>
-  Rebuild the flash script with this exact GHAF_DEV_KEY_DIR.
-```
-
-Repeat with directory A restored and confirm the trust check passes. Replacing
-only `db.key` or `update.key` with a key from B must fail with the corresponding
-`private key does not match public trust` diagnostic. Never perform these
-negative tests while a recovery-mode target is attached.
-
-### Build resource limits
-
-Run heavy evaluations and builds sequentially, each under `timeout 2h`. Do not
-launch the NX and AGX image builds concurrently.
-
-### Candidate build
-
-Confirm that `SECURE_AB_GENERATION` is greater than the target's accepted
-generation. If it changes, export a new public build configuration with
-`ghaf-secure-ab-config`; never edit or reuse a published configuration:
-
-```sh
-timeout 2h nix build \
-  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
-  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
-  -o result-nx-generation-$SECURE_AB_GENERATION
-```
-
-Create the signed transport directory:
-
-```sh
-IMAGE_DIR="result-nx-generation-$SECURE_AB_GENERATION"
-MANIFEST="$(find -L "$IMAGE_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
-test -n "$MANIFEST"
-jq -e --argjson generation "$SECURE_AB_GENERATION" '
-  .system == "aarch64-linux"
-  and .target == "nvidia-jetson-orin-nx-verity-luks-debug"
-  and .generation == $generation
-' "$MANIFEST" >/dev/null
-
-nix run .#ghaf-sign-update -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --input "$MANIFEST" \
-  --output "signed-nx-generation-$SECURE_AB_GENERATION"
-```
-
-Verify that the signed output contains one manifest, its detached signature,
-and all three named artifacts. Transfer the directory without changing file
-contents to `/persist/sysupdate/<generation>/` on the target.
-
-### Registry delivery variables
-
-For OCI delivery, configure an HTTPS registry without recording its endpoint or
-credentials in Git:
-
-```sh
-export REGISTRY_ENDPOINT='<registry-dns-name>'
-export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
-export UPDATE_TAG="generation-$SECURE_AB_GENERATION"
-export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
-read -rsp 'Registry token: ' REGISTRY_TOKEN
-export REGISTRY_TOKEN
-REGISTRY_AUTH_ARGS=(--token "$REGISTRY_TOKEN")
-```
-
-The developer credential requires push access. The NX `net-vm` credential must
-be read-only. Use neither a production credential nor `--insecure` for this
-development test.
-
-For the disposable TLS registry procedure in the architecture guide, use its
-short-lived basic credential instead:
-
-```sh
-REGISTRY_AUTH_ARGS=(--username "$REGISTRY_USER" --password "$REGISTRY_PASSWORD")
-export SSL_CERT_FILE='<verified-path-to-disposable-registry-ca.crt>'
-```
-
-Native `htpasswd` authentication does not enforce read-only repository scope;
-record that limitation and tear the registry down after the test.
-
-### Static HTTP delivery variables
-
-For an isolated manual lab test, record placeholders rather than a developer
-machine address in the test plan:
-
-```sh
-export UPDATE_HTTP_BIND='<developer-interface-address>'
-export UPDATE_HTTP_PORT='<non-privileged-port>'
-export UPDATE_HTTP_ORIGIN="http://${UPDATE_HTTP_BIND}:${UPDATE_HTTP_PORT}"
-```
-
-The address must be reachable from the Orin `net-vm` physical uplink. Scope any
-temporary firewall opening to that interface and target network. Plain HTTP is
-only a transport test; host-side signature and policy validation remain
-mandatory.
-
-### REG-000: Disposable local registry setup
-
-**Purpose:** Establish a reproducible OCI Distribution endpoint when no managed
-development registry exists.
-
-**Procedure:** Follow the architecture guide's
-[disposable local HTTPS registry](/ghaf/dev/architecture/ab-update/#disposable-local-https-registry)
-procedure. Before publishing an update, require all of the following:
-
-1. the registry DNS name resolves from the developer host and `net-vm`;
-2. a request without credentials returns `401`;
-3. a request with the disposable basic credential and verified CA returns a
-   successful `/v2/` response;
-4. changing or omitting `SSL_CERT_FILE` makes TLS validation fail; and
-5. the CA SHA-256 copied to `net-vm` equals the developer-host value.
-
-Set `REGISTRY_AUTH_ARGS` to the basic-auth form above, run REG-001 and REG-002,
-then stop the container and delete only its verified temporary data root.
-
-**Expected:** Push, host pull, and device self-fetch all use HTTPS and the
-verified CA. Artifact and signed-manifest validation pass after transport. The
-record states that native `htpasswd` is not a read-only authorization test and
-contains no endpoint, address, password, or CA private key.
-
-### REG-001: Developer-host publish and fetch round trip
-
-**Purpose:** Prove the published OCI artifact includes the detached signature
-and that registry transport preserves the exact authenticated manifest bytes.
-
-**Procedure:**
-
-```sh
-SIGNED_DIR="signed-nx-generation-$SECURE_AB_GENERATION"
-SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
-test -s "$SIGNED_MANIFEST"
-test -s "$SIGNED_MANIFEST.sig"
-
-nix run 'path:../ghaf-givc#ota-update' -- \
-  registry "${REGISTRY_AUTH_ARGS[@]}" push \
-  --manifest "$SIGNED_MANIFEST" \
-  "$UPDATE_REF"
-
+nix run 'path:../ghaf-givc#ota-update' -- registry "${REGISTRY_AUTH_ARGS[@]}" \
+  push --manifest "$SIGNED_MANIFEST" "$UPDATE_REF"
 PULL_ROOT="$(mktemp -d)"
-nix run 'path:../ghaf-givc#ota-update' -- \
-  registry "${REGISTRY_AUTH_ARGS[@]}" pull --validate \
-  --destination "$PULL_ROOT" \
-  "$UPDATE_REF"
-
-PULLED_MANIFEST="$PULL_ROOT/$UPDATE_REPOSITORY_PATH/$UPDATE_TAG/manifest.json"
-cmp "$SIGNED_MANIFEST" "$PULLED_MANIFEST"
-cmp "$SIGNED_MANIFEST.sig" "$PULLED_MANIFEST.sig"
-
-nix run 'path:../ghaf-givc#ota-update' -- image validate \
-  --manifest "$PULLED_MANIFEST" \
-  --trusted-key "$GHAF_DEV_KEY_DIR/update.pub" \
-  --uki-trusted-cert "$GHAF_DEV_KEY_DIR/db.crt" \
-  --target nvidia-jetson-orin-nx-verity-luks-debug \
-  --accepted-generation-file "$PULL_ROOT/accepted-generation"
+nix run 'path:../ghaf-givc#ota-update' -- registry "${REGISTRY_AUTH_ARGS[@]}" \
+  pull --validate --destination "$PULL_ROOT" "$UPDATE_REF"
 ```
 
-**Expected:** Push reports an OCI manifest digest. Pull writes
-`manifest.json`, `manifest.json.sig`, the signed UKI, root, and verity files.
-Both `cmp` commands and signed image validation succeed.
+Record the OCI digest. Compare pulled `<repository>/<tag>/manifest.json` and
+`manifest.json.sig` byte-for-byte with the signed originals; run signed image
+validation with the target's public keys and accepted-generation state.
+Missing signature layers, tampered manifests or altered artifacts must fail.
 
-**Negative cases:** Remove the signature layer, modify the pulled manifest, or
-modify one artifact. Pull or signed validation must fail as appropriate. No
-target storage is involved in this test.
+In `net-vm`, repeat `ota-update registry ... discover <repository>` and
+`ota-update registry ... pull --validate --destination /persist/sysupdate "$UPDATE_REF"`
+using the read-only credential. Record the printed manifest path. This is
+manual self-fetch, not periodic discovery, approval or unattended installation.
 
-### REG-002: NX self-fetch through `net-vm`
+### Static HTTP: REG-003
 
-**Purpose:** Prove the NX fetches its own update over its network-owning VM while
-the host retains exclusive ownership of authentication policy and storage
-mutation.
-
-**Prerequisites:** REG-001 passed; the candidate tag is approved; `net-vm` has
-external registry reachability and a read-only credential; the host and
-`net-vm` both expose `/persist/sysupdate`.
-
-**Procedure in `net-vm`:**
+For an isolated lab only, serve a directory containing exactly five public
+files. Set `UPDATE_HTTP_BIND` and `UPDATE_HTTP_PORT` to a target-reachable
+interface/nonprivileged port; scope any firewall opening to the lab network.
 
 ```sh
-export REGISTRY_ENDPOINT='<registry-dns-name>'
-export UPDATE_REPOSITORY_PATH='<namespace>/ghaf-orin-nx'
-export UPDATE_TAG='<approved-tag>'
-export UPDATE_REF="${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}:${UPDATE_TAG}"
-read -rsp 'Read-only registry token: ' REGISTRY_TOKEN
-export REGISTRY_TOKEN
-REGISTRY_AUTH_ARGS=(--token "$REGISTRY_TOKEN")
-
-ota-update registry "${REGISTRY_AUTH_ARGS[@]}" discover \
-  "${REGISTRY_ENDPOINT}/${UPDATE_REPOSITORY_PATH}"
-
-ota-update registry "${REGISTRY_AUTH_ARGS[@]}" pull --validate \
-  --destination /persist/sysupdate \
-  "$UPDATE_REF"
-```
-
-Record the OCI digest and printed manifest path. Do not use `--install`.
-
-**Procedure on the Ghaf host:**
-
-```sh
-PULLED_MANIFEST='/persist/sysupdate/<namespace>/ghaf-orin-nx/<approved-tag>/manifest.json'
-test -s "$PULLED_MANIFEST"
-test -s "$PULLED_MANIFEST.sig"
-
-sudo ota-update image validate --manifest "$PULLED_MANIFEST"
-sudo ota-update image --dry-run install --manifest "$PULLED_MANIFEST"
-sudo ota-update image install --manifest "$PULLED_MANIFEST"
-```
-
-Continue with BT-001 for a healthy payload or BT-002 for a health-failure
-payload.
-
-**Expected:** `net-vm` downloads into the shared directory without host network
-access. The host authenticates the manifest and UKI, enforces target and
-generation policy, installs only the inactive pair, and does not reboot
-automatically. The subsequent trial follows the normal health/rollback rules.
-
-**Boundary:** This test is manually initiated on the device. Periodic discovery,
-credential provisioning, approval policy, and unattended installation are not
-enabled by this canary.
-
-### REG-003: Static development HTTP server and device fetch
-
-**Purpose:** Prove a developer machine can expose only a signed payload, the
-Orin device can fetch all five files through `net-vm`, and the Ghaf host rejects
-incomplete or unauthenticated downloads before storage mutation.
-
-**Prerequisites:** A signed NX or AGX candidate exists; its generation is newer
-than the target's accepted generation; the developer machine and Orin uplink
-share a controlled network; `net-vm` exposes `/persist/sysupdate`; and the
-operator can access both `net-vm` and the Ghaf host.
-
-**Procedure on the developer machine:**
-
-```sh
-SIGNED_DIR="signed-nx-generation-$SECURE_AB_GENERATION"
-SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
-test -s "$SIGNED_MANIFEST"
-test -s "$SIGNED_MANIFEST.sig"
-
 HTTP_ROOT="$(mktemp -d)"
 install -m 0644 "$SIGNED_MANIFEST" "$HTTP_ROOT/manifest.json"
 install -m 0644 "$SIGNED_MANIFEST.sig" "$HTTP_ROOT/manifest.json.sig"
-
 for kind in root verity kernel; do
   artifact="$(jq -er --arg kind "$kind" '.[$kind].file' "$SIGNED_MANIFEST")"
-  case "$artifact" in
-    "" | .* | *[!A-Za-z0-9._-]*) exit 1 ;;
-  esac
+  case "$artifact" in "" | .* | *[!A-Za-z0-9._-]*) exit 1 ;; esac
   install -m 0644 "$SIGNED_DIR/$artifact" "$HTTP_ROOT/$artifact"
 done
-
-test "$(find "$HTTP_ROOT" -mindepth 1 -maxdepth 1 -type f | wc -l)" -eq 5
-
-python3 -m http.server \
-  --bind "$UPDATE_HTTP_BIND" \
-  --directory "$HTTP_ROOT" \
-  "$UPDATE_HTTP_PORT"
+python3 -m http.server --bind "$UPDATE_HTTP_BIND" \
+  --directory "$HTTP_ROOT" "$UPDATE_HTTP_PORT"
 ```
 
-Leave the server in its own terminal. In a second developer terminal, require
-an exact manifest round trip:
+In `net-vm`, run
+`ghaf-fetch-update http://<developer-interface>:<port> <generation> /persist/sysupdate`.
+It publishes `http-generation-<generation>/manifest.json` with `fetch.complete`.
+Interrupt each download: no final directory/complete marker may appear. Retry
+fresh, never manufacture a marker or reuse old contents. Tamper with every
+bundle component and exercise target/generation rejection on the host.
+Stop the server and remove only its scoped firewall rule and inspected public
+staging directory afterward; never expose keys or recovery material.
+
+### Host installation
+
+Use the manifest path printed by either transport:
 
 ```sh
-curl --fail --silent --show-error \
-  "$UPDATE_HTTP_ORIGIN/manifest.json" \
-  | cmp - "$HTTP_ROOT/manifest.json"
-```
-
-**Procedure in `net-vm`:**
-
-```sh
-export UPDATE_HTTP_ORIGIN='http://<developer-interface-address>:<port>'
-FETCH_PARENT=/persist/sysupdate
-FINAL_DIR="$FETCH_PARENT/http-generation-$SECURE_AB_GENERATION"
-test ! -e "$FINAL_DIR" || exit 1
-ghaf-fetch-update "$UPDATE_HTTP_ORIGIN" "$SECURE_AB_GENERATION" "$FETCH_PARENT"
-FETCH_DIR="$FINAL_DIR"
-```
-
-Record the five filenames, sizes, server request results, and the shared fetch
-directory. Do not record the developer address.
-
-**Procedure on the Ghaf host:**
-
-```sh
-PULLED_MANIFEST="/persist/sysupdate/http-generation-<candidate-generation>/manifest.json"
-test -f "$(dirname "$PULLED_MANIFEST")/fetch.complete"
-test -s "$PULLED_MANIFEST"
-test -s "$PULLED_MANIFEST.sig"
-
 sudo ota-update image validate --manifest "$PULLED_MANIFEST"
 sudo ota-update image --dry-run install --manifest "$PULLED_MANIFEST"
 sudo ota-update image install --manifest "$PULLED_MANIFEST"
 ```
 
-Continue with BT-001. Use an AGX signed directory and generation for the AGX;
-the same network flow then installs to the inactive eMMC pair.
-
-**Expected:** The server exposes exactly five public files. `net-vm` performs
-every network request and writes the shared directory. The host performs all
-authentication and target/generation policy checks, preserves the active pair,
-installs the inactive pair, and does not reboot automatically.
-
-**Negative cases:** Stop the server during each download and require that no
-final directory is published and that any hidden temporary directory lacks
-`fetch.complete`. Retry into a newly created temporary directory; never reuse a
-previous final directory or marker. Separately tamper with the manifest,
-signature, and each of the three artifacts; use a signed wrong-target payload;
-and use a signed accepted or older generation. Every host validation must fail before
-LVM or ESP mutation. Do not run `install` after a failed `validate` or dry run.
-
-**Cleanup:** Stop the HTTP server, remove its temporary scoped firewall rule,
-and retain or delete only the exact public staging directory after inspecting
-its contents. Keep private trust material and recovery passphrases outside the
-server root throughout the test.
-
-### Baseline target evidence
-
-Before every mutating target test, capture:
-
-```sh
-sudo ota-update image status
-bootctl status --no-pager
-bootctl list --no-pager
-/run/current-system/systemd/lib/systemd/systemd-bless-boot status || true
-cat /proc/cmdline
-cat /persist/common/ota/accepted-generation
-cryptsetup status cryptroot
-veritysetup status nix-store
-findmnt /nix/store
-findmnt /persist
-sudo pvs
-sudo vgs
-sudo lvs -a -o lv_name,lv_size,lv_attr,devices pool
-systemctl is-active \
-  microvm@admin-vm.service \
-  microvm@disp-vm.service \
-  microvm@gpu-vm.service \
-  microvm@net-vm.service
-```
-
-Create or confirm a non-secret persist sentinel:
-
-```sh
-sudo install -d -m 0700 /persist/common/ota-test
-printf '%s\n' "$RUN_ID" | sudo tee /persist/common/ota-test/sentinel >/dev/null
-sync
-```
-
-The active version/hash from `/proc/cmdline` and `ota-update image status` is
-the protected slot. Stop immediately if it cannot be identified unambiguously.
-
-## Privileged virtual integration
-
-### IT-001: Real LUKS2/LVM/OVMF integration
-
-**Purpose:** Exercise the updater against real loopback-backed LUKS2, LVM,
-root/verity pairs, persist, systemd-boot, and OVMF.
-
-**Procedure (ghaf-givc worktree):**
-
-```sh
-timeout 2h nix build \
-  .#checks.x86_64-linux.vmTests-ota-update-image \
-  --print-build-logs
-```
-
-**Expected:** The test formats LUKS2, opens `cryptpool`, creates VG `pool`,
-installs the signed update, verifies the planned commands, retains the active
-pair, preserves the persist sentinel, removes the inactive pair, recreates the
-missing empty pair, and installs again. The test exits zero.
-
-### IT-002: Repeated A to B to A reuse
-
-**Purpose:** Demonstrate bounded storage use over repeated updates.
-
-**Procedure:** Extend or run the privileged fixture with three strictly
-increasing generations. After each successful health simulation, treat the new
-pair as active and install the next generation.
-
-**Expected:** LV count remains two root and two verity LVs. The pair active at
-the beginning of each install is byte-for-byte unchanged. The inactive physical
-space is reused for the third generation.
-
-### IT-003: Transaction failure matrix
-
-**Purpose:** Exercise every installer boundary without relying only on mocks.
-
-Repeat the integration fixture with failure injected at each boundary:
-
-| Fault point | Required postcondition |
-| --- | --- |
-| Root decompressor exits non-zero | Active pair unchanged; failure reported even if writer exits zero |
-| Root write fails or is short | No final LV names and no boot-default change |
-| Verity decompressor/write fails | Active pair unchanged; staging recoverable |
-| `veritysetup verify` fails | No UKI activation and no boot-default change |
-| First final LV rename succeeds, second fails | Next run recovers incomplete commit without touching active pair |
-| UKI temporary write or sync fails | No partial managed UKI selected |
-| UKI rename succeeds, default selection fails | Old default remains usable; rerun is idempotent |
-| Process killed after default selection | Complete `+3` trial exists; no active-slot data changed |
-
-For every row, capture pre/post LV UUIDs, active LV hashes, ESP directory listing,
-and loader variables. The test fails if the active root or verity LV changes.
-
-## UEFI boot and rollback tests
-
-### BT-001: Healthy three-attempt trial is blessed
-
-**Prerequisites:** A valid signed update newer than the accepted generation and
-all health dependencies configured healthy.
-
-**Procedure:**
-
-1. Validate and dry-run the update.
-2. Record the active pair and exact persistent default.
-3. Install the update.
-4. Confirm a `+3.efi` UKI exists and the default is the matching
-   `ghaf-<version>-<hash>*.efi` candidate glob.
-5. Confirm the installer did not reboot.
-6. Reboot once into the trial.
-7. Wait for `ghaf-boot-health.service` and capture its journal.
-
-**Expected:** The new generation boots, health succeeds, the entry loses its
-counter suffix through blessing, its exact UKI becomes the persistent default,
-and the accepted-generation file advances atomically. The old pair remains as
-the inactive fallback and the persist sentinel remains unchanged.
-
-### BT-002: Core-VM health failure rolls back
-
-Build the candidate with the debug-only health failure:
-
-```sh
-export SECURE_AB_GENERATION=<newer-generation>
-export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-unhealthy-generation-$SECURE_AB_GENERATION"
-nix run .#ghaf-secure-ab-config -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --generation "$SECURE_AB_GENERATION" \
-  --output "$SECURE_AB_BUILD_CONFIG" \
-  --inject-boot-health-failure
-timeout 2h nix build \
-  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
-  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-ghafImage \
-  -o result-unhealthy
-```
-
-Sign, validate, and install normally. Reboot without manually selecting entries.
-
-**Expected:** The trial boots three times. Each run fails because
-`microvm@ghaf-boot-health-injection-probe.service` is not active, reboots, and
-consumes one attempt. The fourth selection boots the previously blessed pair.
-The accepted generation does not advance and persist remains intact.
-
-### BT-003: Corrupted root or verity rolls back
-
-**Prerequisites:** A valid installed trial, serial capture running, and an
-unambiguous mapping from the trial manifest to its inactive LVs.
-
-**Procedure:**
-
-1. Confirm the trial root LV is not the active root LV.
-2. Record hashes of both active LVs.
-3. After installation but before reboot, corrupt one 4096-byte block in the
-   trial root or verity LV. For a root corruption case, block 256 is suitable:
-
-   ```sh
-   TRIAL_ROOT=/dev/pool/root_<trial-version>_<trial-hash>
-   test -b "$TRIAL_ROOT"
-   sudo dd if=/dev/zero of="$TRIAL_ROOT" \
-     bs=4096 seek=256 count=1 conv=notrunc,fsync status=none
-   ```
-
-4. Reboot and do not interact with the boot menu.
-5. Count trial boots and capture the exact dm-verity failure from serial.
-
-**Expected:** Each trial fails dm-verity, panics or reaches the configured reset
-path, and consumes an attempt. After three failures, systemd-boot selects the
-previously blessed pair. Its root/verity hashes still match the baseline and
-persist is unchanged.
-
-### BT-004: Persistent-state invariant
-
-Run after BT-001, BT-002, and BT-003:
-
-```sh
-test "$(sudo cat /persist/common/ota-test/sentinel)" = "$RUN_ID"
-findmnt --mountpoint /persist
-```
-
-**Expected:** The same Btrfs persist LV is mounted before, during, and after slot
-changes. No rollback procedure reformats or replaces it.
-
-## NX hardware acceptance
-
-### HW-001: Recovery-target authorization
-
-Capture topology before attaching the authorized target:
-
-```sh
-lsusb > "$EVIDENCE_DIR/lsusb-before.txt"
-lsusb -t > "$EVIDENCE_DIR/lsusb-tree-before.txt"
-```
-
-Attach the NX in recovery mode and capture again:
-
-```sh
-lsusb > "$EVIDENCE_DIR/lsusb-after.txt"
-lsusb -t > "$EVIDENCE_DIR/lsusb-tree-after.txt"
-diff -u "$EVIDENCE_DIR/lsusb-before.txt" "$EVIDENCE_DIR/lsusb-after.txt" || true
-```
-
-Required checks:
-
-1. The new device identifies as `0955:7323 NVIDIA Corp. T234 [Orin NX 16GB]`.
-2. Its newly appearing physical USB path is recorded.
-3. Exactly one NVIDIA recovery-mode target remains connected when flash starts.
-4. Any previously observed `0955:7023` APX target is disconnected or otherwise
-   excluded before invoking NVIDIA flash tooling.
-5. The matching serial adapter identity and device node are recorded.
-
-Example fail-closed count check:
-
-```sh
-test "$(lsusb | grep -Ec '0955:(7023|7323)')" -eq 1
-test "$(lsusb -d 0955:7323 | wc -l)" -eq 1
-```
-
-Stop if either assertion fails or if topology does not uniquely identify the
-authorized NX.
-
-### HW-002: Serial capture before flash
-
-Inspect and record the serial endpoint:
-
-```sh
-export SERIAL_DEVICE='<authorized-serial-device>'
-udevadm info --query=property --name="$SERIAL_DEVICE" \
-  > "$EVIDENCE_DIR/serial-udev.txt"
-```
-
-In a dedicated terminal, configure 115200 baud and start a timestamped capture
-before the flash command:
-
-```sh
-sudo stty -F "$SERIAL_DEVICE" 115200 raw -echo
-sudo stdbuf -oL cat "$SERIAL_DEVICE" \
-  | ts '%Y-%m-%dT%H:%M:%.S%z' \
-  | tee "$EVIDENCE_DIR/orin-serial.log"
-```
-
-If `ts` is unavailable, capture without it and record timestamps separately.
-Keep this terminal running through first boot and rollback tests.
-
-### HW-003: Build and flash the NX NVMe canary
-
-Build the flash script, sequentially and with the key directory available:
-
-```sh
-timeout 2h nix build \
-  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
-  .#nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64-flash-script \
-  -o result-nx-flash
-```
-
-Immediately before flashing, repeat HW-001's count checks. Then invoke the
-secure-boot variant and UKI path:
-
-```sh
-sudo --preserve-env=GHAF_DEV_KEY_DIR \
-  ./result-nx-flash/bin/flash-ghaf-host --secure-boot -u
-```
-
-**Expected:** The flash script selects the NX NVMe layout, signs EFI binaries
-outside the Nix store, creates LUKS2 APP, records a new recovery passphrase, and
-flashes the authorized NX. Save flash output after redacting the passphrase.
-Do not claim success from the command exit alone; require serial first boot and
-the post-flash checks below.
-
-### HW-004: Secure Boot negative and positive paths
-
-1. Confirm the signed systemd-boot binary and signed UKI boot.
-2. Copy an unsigned UKI to a distinct managed test name on the ESP.
-3. Select it once from firmware or systemd-boot without replacing the blessed
-   signed entry.
-4. Capture the firmware rejection on serial.
-5. Remove the unsigned test artifact and confirm the signed entry still boots.
-
-**Expected:** The unsigned UKI never reaches its kernel. Firmware fallback to
-PXE or the UEFI shell counts only as rejection; separately prove that the signed
-fallback remains selectable. Never replace the only known-good signed UKI.
-
-### HW-005: DUK rotation and recovery unlock
-
-After first boot:
-
-```sh
-sudo cryptsetup status cryptroot
-sudo cryptsetup luksDump /dev/disk/by-uuid/0ada0e5b-0e5b-4e5b-8e5b-0000000000a9
-```
-
-Confirm the manufacturer credential no longer unlocks APP and the recovery
-passphrase from this flash still does. Test recovery from initrd or a controlled
-rescue environment so the already-open mapping cannot create a false positive.
-
-Create a protected header backup after key rotation and before update testing:
-
-```sh
-export APP_DEVICE='<raw-APP-partition>'
-export LUKS_HEADER_BACKUP='<encrypted-offline-staging-path>/app-luks2-header.bin'
-test -b "$APP_DEVICE"
-umask 077
-sudo cryptsetup luksHeaderBackup "$APP_DEVICE" \
-  --header-backup-file "$LUKS_HEADER_BACKUP"
-sudo chmod 0600 "$LUKS_HEADER_BACKUP"
-```
-
-Move the backup into encrypted offline custody and record its non-secret
-inventory identifier with the flash's recovery-passphrase filename. Do not put
-the header backup in the ordinary evidence bundle or leave an unencrypted copy
-on `/persist`.
-
-**Expected:** Normal reboot unlock is unattended through OP-TEE DUK. The old
-manufacturer credential fails. Recovery slot 1 succeeds. Record only pass/fail
-and the recovery file name, never the passphrase.
-
-### HW-006: Encrypted layout and first-boot provisioning
-
-Run the baseline evidence commands. Verify:
-
-- the NVMe APP partition contains LUKS2,
-- `/dev/mapper/cryptroot` is active,
-- VG `pool` is backed by the open mapper rather than raw NVMe,
-- one initial root/verity pair and one reserved inactive capacity exist,
-- persist is Btrfs and mounted read-write,
-- swap is active with random encryption,
-- `nix-store` dm-verity is active, and
-- first-boot resize and persist services succeeded.
-
-Reboot once more and confirm all first-boot operations are idempotent.
-
-On a fresh destructive-test flash, include first-boot interruption points after
-APP expansion, open-LUKS resize, PV resize, swap LV creation, persist LV
-creation, and persist formatting. After each restart, require the service to
-converge without duplicate LVs. In particular, an existing blank persist LV is
-formatted as Btrfs, existing Btrfs is retained with its contents, and an
-unexpected filesystem type stops with an error rather than being reformatted.
-Test the unexpected-filesystem branch only in the disposable integration
-fixture, never by replacing a hardware target's real persist filesystem.
-
-### HW-007: Signed A to B to A update reuse
-
-1. Establish a healthy accepted A generation and persist sentinel.
-2. Install a valid newer B generation and complete BT-001.
-3. Build, sign, and install a third generation.
-4. Complete BT-001 again so physical slot A is reused.
-5. Compare LV counts, LV sizes, boot entries, accepted generation, and persist.
-
-**Expected:** Both updates validate, stage, and bless successfully. The updater
-never writes the pair active at install start. Only two complete pairs remain,
-and persist contains the original sentinel.
-
-### HW-008: Rejection matrix
-
-Run `ota-update image validate` and then `install` where appropriate for these
-payloads:
-
-| Variant | Expected result |
-| --- | --- |
-| Missing signature | Reject before manifest parsing or mutation |
-| Random or wrong-key signature | Reject Ed25519 verification |
-| Manifest changed after signing | Reject Ed25519 verification |
-| Root artifact changed | Reject SHA-256 or size validation |
-| Verity artifact changed | Reject SHA-256 or size validation |
-| Unsigned or wrong-key UKI | Reject UKI signature validation |
-| Signed manifest for AGX on NX | Reject exact target policy |
-| Generation equal to accepted | Reject generation policy |
-| Generation below accepted | Reject generation policy |
-| UKI embeds another root hash | Reject UKI/manifest agreement |
-| UKI embeds another generation | Reject UKI/manifest agreement |
-
-For every row, compare active LV hashes, `lvs`, `/boot/EFI/Linux`, and boot
-default before and after. They must not change.
-
-### HW-009: Core-VM health rollback
-
-Perform BT-002 on the NX. Capture all three `ghaf-boot-health` failures, each
-reboot, counter-name transition, final fallback selection, accepted generation,
-and persist sentinel.
-
-### HW-010: Physical corruption rollback
-
-Perform BT-003 on the NX for root corruption and repeat for verity corruption.
-Require three observed failed trials and an automatic fourth selection of the
-previously blessed pair, without keyboard input.
-
-### HW-011: Physical power-interruption matrix
-
-For each row, begin from a healthy accepted pair, install a fresh generation,
-and remove power only after serial/journal/LV evidence confirms the named phase:
-
-| Phase | Recovery assertion after power restore |
-| --- | --- |
-| Validate, before mutation | Old pair boots; no staging LVs or trial UKI |
-| Staging LV creation | Old pair boots; next install recovers staging |
-| Root decompression/write | Old pair boots; partial root is never selected |
-| Verity decompression/write | Old pair boots; partial pair is never selected |
-| `veritysetup verify` | Old pair boots; uncommitted pair is recoverable |
-| First LV final rename | Old pair boots; incomplete commit is recovered |
-| UKI temporary installation | Old pair boots; no partial UKI is selected |
-| UKI atomic rename | Old pair boots or complete trial is discoverable |
-| Boot-default commit | Either old default or complete `+3` trial; never partial data |
-| First, second, and third trial boot | Counter consumption resumes and ends at fallback |
-| Health blessing before generation-state rename | Rerun converges without lowering accepted generation |
-
-After each interruption, capture state before retrying. The recovery action is
-normally rerunning the same signed install; do not manually rename LVs unless
-the test specifically evaluates the documented rescue procedure.
-
-### HW-012: Hard-hang watchdog acceptance
-
-Inject a controlled hard hang during a counted trial, not merely a service
-failure or clean reboot. Observe the physical Tegra watchdog reset on serial and
-repeat until the three attempt counter is exhausted.
-
-**Expected:** Every hang produces a hardware reset within the configured bound,
-consumes exactly one attempt, and eventually selects the blessed fallback.
-Until this passes, record hard-hang rollback as blocked rather than inferred
-from panic or service-failure tests.
-
-## AGX eMMC hardware acceptance
-
-### AGX-001: eMMC canary build
-
-```sh
-export SECURE_AB_GENERATION=<candidate-generation>
-export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-agx-generation-$SECURE_AB_GENERATION"
-nix run .#ghaf-secure-ab-config -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --generation "$SECURE_AB_GENERATION" \
-  --output "$SECURE_AB_BUILD_CONFIG"
-timeout 2h nix build \
-  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
-  .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-ghafImage \
-  -o result-agx-update
-
-timeout 2h nix build \
-  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
-  .#nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64-flash-script \
-  -o result-agx-flash
-```
-
-Require manifest system `aarch64-linux`, the exact AGX target, and the intended
-generation, then retain the build logs. Do not flash an NX with AGX artifacts.
-
-Sign and validate the update bundle before connecting it to target storage:
-
-```sh
-IMAGE_DIR=result-agx-update
-MANIFEST="$(find -L "$IMAGE_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
-SIGNED_DIR="signed-agx-generation-$SECURE_AB_GENERATION"
-
-jq -e --argjson generation "$SECURE_AB_GENERATION" '
-  .system == "aarch64-linux"
-  and .target == "nvidia-jetson-orin-agx-verity-luks-debug"
-  and .generation == $generation
-' "$MANIFEST" >/dev/null
-
-nix run .#ghaf-sign-update -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --input "$MANIFEST" \
-  --output "$SIGNED_DIR"
-
-SIGNED_MANIFEST="$(find "$SIGNED_DIR" -maxdepth 1 -name '*.manifest' -print -quit)"
-nix run 'path:../ghaf-givc#ota-update' -- image validate \
-  --manifest "$SIGNED_MANIFEST" \
-  --trusted-key "$GHAF_DEV_KEY_DIR/update.pub" \
-  --uki-trusted-cert "$GHAF_DEV_KEY_DIR/db.crt" \
-  --target nvidia-jetson-orin-agx-verity-luks-debug \
-  --accepted-generation-file ./accepted-generation
-```
-
-The validation environment must provide `sbverify`. The
-`accepted-generation` file contains the AGX generation accepted before this
-candidate, not the NX value.
-
-### AGX-002: Recovery identity and flash
-
-Capture serial output from the running board before requesting recovery. Verify
-that the device-tree model identifies an AGX developer kit and that APP is on
-internal eMMC. Record the current USB topology, then request forced recovery.
-
-After recovery, require all of the following:
-
-- exactly one authorized Tegra recovery target is present;
-- its USB path is the recovery sibling of the serial-identified AGX operator
-  interface;
-- the recovery query returns the recorded AGX ECID;
-- the serial capture is running before flash starts; and
-- the flash script names `mmcblk0`, never the NX NVMe device.
-
-USB ID `0955:7023` is expected for this AGX generation, but is not sufficient
-authorization by itself. Stop if another APX target is present or topology is
-ambiguous.
-
-```sh
-export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
-
-sudo --preserve-env=GHAF_DEV_KEY_DIR \
-  result-agx-flash/bin/flash-ghaf-host
-```
-
-Store the newly printed recovery passphrase in the protected trust directory.
-Never put it in a shell argument, build log, test record, Git, or the Nix store.
-
-### AGX-003: Encrypted first-boot baseline
-
-Before installing any update, capture the generation-1 baseline over serial:
-
-```sh
-cat /proc/cmdline
-bootctl status --no-pager
-lsblk -o NAME,TYPE,FSTYPE,SIZE,MOUNTPOINTS
-sudo cryptsetup luksDump /dev/mmcblk0p2
-sudo pvs
-sudo vgs
-sudo lvs -a -o lv_name,lv_size,lv_attr,devices
-findmnt / /nix/store /persist /boot
-sudo veritysetup status nix-store
-swapon --show
-systemctl --failed --no-pager
-systemctl is-active microvm@admin-vm.service microvm@net-vm.service
-systemctl is-active microvm@gpu-vm.service microvm@disp-vm.service
-systemctl status ghaf-boot-health.service --no-pager
-cat /persist/common/ota/accepted-generation
-```
-
-Require Secure Boot enabled, one root/verity pair, free LVM space reserved for
-the second pair, read-only verified `/nix/store`, read-write Btrfs `/persist`,
-encrypted swap, healthy configured core VMs, and an accepted generation that
-matches the booted UKI.
-
-Test both remaining credentials explicitly. The manufacturer passphrase must
-fail. Recovery slot 1 must unlock with external tokens disabled. Feed the
-recovery passphrase through a no-echo prompt; do not put it on a command line or
-in the journal.
-
-### AGX-004: DUK reboot and optional fTPM boundary
-
-The AGX secure A/B canary intentionally leaves
-`ghaf.hardware.nvidia.orin.ftpm.enable` disabled. The OP-TEE DUK path remains
-enabled and must unlock APP unattended on every reboot.
-
-```sh
-test ! -e /dev/tpmrm0
-! systemctl cat ghaf-load-ftpm-module.service
-systemctl reboot
-```
-
-Capture the entire shutdown and next boot. Require a prompt reboot, unattended
-LUKS unlock, the same `/persist` contents, no duplicate LVs, the same accepted
-generation, and no `tpm_ftpm_tee` task. A reboot blocked in
-`ftpm_tee_tpm_op_send` is a failure even if the health gate previously passed.
-
-### AGX-005: Signed A to B to A updates
-
-Deliver a correctly signed AGX generation greater than the accepted value by
-the developer-host registry round trip in REG-001 or by AGX self-fetch through
-`net-vm` as described in REG-002. Use the AGX target and a distinct AGX
-repository path. On the host, run validation, dry-run, and install in that
-order. Verify that installation does not reboot automatically.
-
-After manually rebooting, require the candidate to appear as a `+3` UKI. Let
-the health gate bless it, verify the accepted generation advances, then install
-a newer generation to prove B-to-A reuse. At every step assert that the active
-root and verity LVs were not written and that `/persist` retained its sentinel.
-
-Repeat the signed wrong-target, unsigned, tampered, and downgrade cases against
-the AGX. Then repeat health-failure, root-corruption, verity-corruption,
-power-interruption, and hard-hang cases from the common matrix. Record AGX and
-NX results separately.
+Stop on any error. Confirm the active pair/default against the baseline,
+a complete `+3.efi` trial and its candidate-specific default glob; installation
+must not reboot. Reboot manually and observe the health/rollback cases below.
+
+## Acceptance matrix
+
+Run every applicable row on **each board**. Existing IT IDs denote optional
+GIVC privileged runtime fixtures, not image-build dependencies; this runbook
+does not add a VM to the image build. Hardware results are still required.
+
+| ID | Procedure | Required result |
+| --- | --- | --- |
+| IT-001 | Exercise signed install against real disposable LUKS/LVM/verity storage | Active pair retained, staged pair verified, persist retained |
+| IT-002 / HW-007 / AGX-005 | Install three strictly increasing generations A→B→A | Two bounded system pairs, inactive space reused, active hashes unchanged, acceptance advances |
+| IT-003 | Inject each transaction failure listed below | Active hashes/UUIDs unchanged; no partial UKI selected; retry converges |
+| BT-001 | Reboot a valid installed trial with healthy dependencies | Exact candidate default, counter removed, accepted generation advances, persist intact |
+| BT-002 / HW-009 | Export a newer public config with `--inject-boot-health-failure`; build/sign/install normally | Three probe-service failures/reboots, one attempt consumed each time, then blessed fallback; acceptance unchanged |
+| BT-003 / HW-010 | With serial and explicit LV identity, corrupt one 4096-byte block of the **inactive trial** root; repeat for verity | Three dm-verity failures, automatic fourth selection of blessed pair; active hashes unchanged |
+| BT-004 | Compare sentinel and persist identity after each case | Same Btrfs LV and contents, no reformat |
+| HW-003 / AGX-001 | Build/flash the board-matched artifacts above | Intended NVMe/eMMC target, signed boot, complete baseline |
+| HW-004 | Select a separate unsigned test UKI without replacing signed fallback | Kernel never runs; signed fallback remains selectable. PXE/shell fallback proves rejection only |
+| HW-005 / AGX-003 | Test manufacturer rejection, recovery slot 1 with external tokens disabled, then unattended DUK reboot | Manufacturer fails; recovery succeeds; no false positive from an already-open mapping |
+| HW-006 | Interrupt first boot after APP/LUKS/PV growth, swap/persist creation and persist formatting | Restart converges, no duplicate LVs; blank persist formats once, Btrfs retained, unexpected filesystem rejects |
+| HW-008 | Apply every rejection variant below | No active hash, LV, ESP or boot-default mutation |
+| HW-011 | Physically cut power at every named phase below | Old blessed boot or complete trial, recoverable staging, persist intact |
+| HW-012 | Hard-hang a counted trial repeatedly | Bounded physical watchdog reset each time, exactly one attempt consumed, eventual fallback |
+| AGX-004 | Verify fTPM disabled and perform ordinary shutdown/reboot | No `/dev/tpmrm0`, load service or `tpm_ftpm_tee` task; prompt reboot, unattended DUK unlock and unchanged persist |
+
+For HW-005, make a protected `cryptsetup luksHeaderBackup` after key rotation
+and before faults. Move it into encrypted offline custody; keep only its
+inventory identifier with the run record. Prompt for recovery secrets without
+echo. Never delete slots to investigate recovery failure. Test unexpected
+persist filesystems only in a disposable fixture, not by replacing real data.
+
+### Rejection and interruption cases
+
+HW-008: missing/random/wrong-key signature; manifest changed after signing;
+root or verity size/hash mismatch; unsigned/wrong-key UKI; opposite-board target;
+equal/older generation; UKI root hash or generation disagreeing with manifest.
+Validate first and do not continue to installation after a failed preflight.
+
+IT-003: root decoder failure (including writer success), short/failed root
+write, verity decoder/write failure, failed `veritysetup verify`, second final
+LV rename failure, UKI temporary write/sync failure, default-selection failure
+after UKI rename, and process termination after default selection. Record
+pre/post active hashes, LV UUIDs, ESP listing and loader variables.
+
+HW-011: validation before mutation; staging creation; root write; verity write;
+verity verification; first final LV rename; UKI temporary installation; UKI
+atomic rename; boot-default commit; each of the three trial boots; acceptance
+persistence before blessing. Confirm the phase from live evidence before cutting
+power, collect state before retry, then rerun the exact signed candidate.
+Before boot commit the old pair must boot; afterward only the old pair or
+complete trial may boot. Health retries must converge without lowering accepted
+generation. No undocumented LV surgery is an acceptable recovery.
 
 ## Recovery and triage
 
-### Collect an operational evidence bundle
+Capture the baseline commands, `systemd-bless-boot status`, ESP filenames,
+current/previous boot journals and updater output **before** retrying.
 
-Capture command output before retrying or changing state. Redact network and
-hardware identities before sharing it:
+| State | Action and boundary |
+| --- | --- |
+| Recognizable one-sided inactive staging, partial final rename, complete LVs without UKI, or failed candidate default selection | Rerun the exact signed candidate; never rename/delete the active pair |
+| Orphan UKI `.tmp` or ESP full | Preserve evidence; remove only proven stale managed files, never current/only blessed fallback; retry |
+| Candidate exceeds fixed slots or pre-canary layout is incompatible | Intentional destructive reflash with suitable layout, not shrinking persist |
+| Incomplete HTTP fetch | Inspect/retain or delete only that temporary directory; retry fresh |
+| Blank/Btrfs/unexpected persist | Restart to format blank/retain Btrfs; stop on any other filesystem |
+| Trust/key mismatch or authentication/policy failure | Restore matching evaluated trust or reject/rebuild; never repair signed contents in place |
+| Ambiguous active pair, unmanaged/non-staging partial LV, different VG or more than two groups | Stop and escalate |
+| DUK and matching recovery both fail | Preserve header/slots; use controlled rescue and protected backup, never reformat APP |
 
-```sh
-sudo ota-update image status
-bootctl status --no-pager
-bootctl list --no-pager
-find /boot/EFI/Linux -maxdepth 1 -type f -printf '%s %f\n' | sort
-sudo lvs -a -o lv_name,lv_size,lv_attr,lv_uuid,devices pool
-sudo pvs -o pv_name,pv_size,pv_free,pv_uuid
-sudo vgs -o vg_name,vg_size,vg_free,vg_uuid pool
-cryptsetup status cryptroot
-veritysetup status nix-store
-findmnt --mountpoint /nix/store
-findmnt --mountpoint /persist
-findmnt --mountpoint /boot
-systemctl --no-pager --full status \
-  firstboot-persist.service ghaf-boot-health.service microvms.target
-journalctl -b --no-pager \
-  -u firstboot-persist.service -u ghaf-boot-health.service
-journalctl -b -1 --no-pager \
-  -u firstboot-persist.service -u ghaf-boot-health.service || true
-```
+For rollback failures, check counter suffixes, the candidate-specific
+`ghaf-<version>-<hash>*.efi` glob and surviving blessed UKI. Broad `ghaf-*.efi`
+can pick an older equal-version image by hash order; an exhausted trial must
+not be pinned as an exact default.
 
-Also retain the updater's validation, dry-run, and install console output. Record
-the active version/hash, accepted generation, candidate generation, boot-count
-suffix, and whether the persist sentinel is unchanged. Never collect private
-keys or recovery-passphrase contents.
+## Historical evidence and release gates
 
-### Rescue decision matrix
+The 2026-08-19 campaign recorded sequential NX/AGX builds and encrypted first
+boot, NX signed slot reuse and three-failure corruption rollback, AGX static-HTTP
+self-fetch and generations 1→2→3, and persist retention. AGX required optional
+fTPM disablement for clean reboot and candidate-specific selection for
+equal-version trials. Unsigned UKI rejection was partial: firmware fell through
+to networking instead of automatically selecting the signed fallback.
 
-| Observed state | Supported action | Boundary |
-| --- | --- | --- |
-| One inactive `root_staging_<id>` or `verity_staging_<id>` beside one active pair | Rerun the exact signed candidate; the missing counterpart is created and both inactive images are rewritten | Automatic only for one-sided staging in the active VG |
-| One final inactive LV and its matching staging peer after interrupted final renames | Rerun the exact signed candidate | Discovery rejoins the inactive pair; ambiguous names stop |
-| Complete candidate LVs but no candidate UKI | Rerun the exact signed candidate | Candidate data is verified and rewritten before UKI activation |
-| Candidate UKI exists but default selection failed | Rerun the exact signed candidate | Updater completes only candidate-specific default selection |
-| Orphan `<candidate>.efi.tmp` | Preserve evidence, then rerun the exact candidate | Atomic install replaces the temporary path; the old default remains |
-| ESP lacks space | Remove only a proven stale `.tmp` or non-active managed UKI, then rerun | Never remove the current or only blessed fallback |
-| Candidate exceeds the fixed root or verity slot capacity | Reflash with an intentionally larger platform layout | Never shrink persist or delete the active pair manually |
-| Hidden incomplete HTTP fetch directory | Retain for evidence or delete that exact directory; retry into a new temporary directory | Never add a marker or reuse old contents |
-| Existing blank persist LV | Restart `firstboot-persist.service` | It formats the blank LV once |
-| Existing Btrfs persist LV | Restart first boot normally | Contents must be retained |
-| Unexpected filesystem on persist | Stop and investigate | No automatic or forced formatting |
-| Public-trust or private/public key mismatch | Restore the evaluated complete key directory or rebuild | Never mix trust sets |
-| Signature, target, generation, hash, UKI, or verity failure | Reject the candidate and preserve evidence | Do not repair authenticated content in place |
-| Ambiguous active pair, more than two storage groups, or non-staging partial LV | Stop and escalate | No undocumented LV rename/delete procedure |
-| DUK and matching recovery unlock both fail | Stop and use the protected header backup/recovery process | Never delete keyslots or reformat APP |
-
-An unencrypted, raw-root, non-LVM, or otherwise incompatible pre-canary layout
-is not a rescue case; it requires a destructive reflash to establish LUKS2,
-LVM A/B, ESP trust, and recovery material.
-
-### Trial does not roll back
-
-Capture, in this order:
-
-```sh
-bootctl status --no-pager
-bootctl list --no-pager
-/run/current-system/systemd/lib/systemd/systemd-bless-boot status || true
-find /boot/EFI/Linux -maxdepth 1 -type f -printf '%f\n' | sort
-journalctl -b -u ghaf-boot-health.service --no-pager
-cat /proc/cmdline
-```
-
-Check that the trial filename has a boot-count suffix, the persistent default is
-the matching candidate-specific `ghaf-<version>-<hash>*.efi` glob during the
-trial, and the old blessed UKI still exists. A broad `ghaf-*.efi` glob is a
-failure: equal-version UKIs can then be selected by hash ordering instead of by
-update generation. Do not set an exhausted trial as an exact default.
-
-### Update refuses to install
-
-Run `validate` first and preserve its exact error. Check the detached signature,
-target, accepted generation, artifact sizes and hashes, UKI certificate, and UKI
-command line before investigating LVM. Authentication failures are expected to
-occur before runtime mutation.
-
-### Incomplete staging state
-
-Record `ota-update image status`, `lvs -a`, and ESP contents. Match the state to
-the rescue matrix before rerunning the exact same signed update. Automatic
-recovery is intentionally limited to recognizable inactive staging or partial
-commit states. Stop if a name is not in the managed namespace, an LV is in a
-different VG, the active pair is ambiguous, or more than two storage groups
-exist.
-
-### Recovery-key failure
-
-Do not delete any LUKS keyslot. Confirm the recovery file belongs to this exact
-flash and contains no added newline. Preserve a LUKS header backup if one exists,
-then investigate from a controlled rescue environment.
-
-## Validation snapshot and remaining gates
-
-The implementation campaign on 2026-08-19 established the following evidence:
-
-The NX and AGX were each authorized by comparing before/after USB topology,
-recovery identity, board model, storage target, and the matching serial adapter.
-Exact USB paths, ECIDs, serial numbers, device nodes, hostnames, and network
-addresses remain in access-controlled run evidence rather than evergreen
-documentation. No ambiguous or unrelated recovery target was flashed.
-
-| Area | Status | Evidence boundary |
-| --- | --- | --- |
-| Privileged OVMF integration | Passed | focused `vmTests-ota-update-image` build |
-| NX and AGX image builds | Passed | target-matched cross builds, sequential |
-| Static HTTP device fetch | Passed on AGX | `net-vm` fetched a five-file signed payload from a temporary development server into shared persist; host validation/install remained separate |
-| NX encrypted first boot | Passed | LUKS/LVM/verity/persist and core VMs healthy |
-| NX repeated signed updates | Passed | inactive-slot reuse and accepted generation advancement |
-| NX corrupted trial rollback | Passed | generation 9 failed dm-verity three times and generation 7 returned automatically |
-| Persist across rollback | Passed | the run-specific non-secret sentinel remained present |
-| Unsigned UKI rejection | Partial | rejection observed; firmware fell through to network rather than selecting signed fallback automatically |
-| AGX encrypted first boot | Passed | internal eMMC LUKS/LVM/verity/persist, DUK rotation, recovery slot, and core VMs healthy |
-| AGX signed updates | Passed | generations 1 to 2 to 3 proved both physical slots, inactive-slot reuse, active-pair immutability, self-fetch, and accepted-generation advancement |
-| AGX clean reboot | Passed | disabling the optional fTPM removed the OP-TEE probe hang; ordinary shutdown, cold boot, unattended DUK unlock, and health blessing passed repeatedly |
-| AGX trial selection | Passed after fix | a broad default selected the older equal-version UKI; a candidate-specific wildcard selected and blessed generation 3 |
-| All physical power cuts | Not run | HW-011 remains a release gate |
-| Physical hard-hang watchdog | Not run | HW-012 remains a release gate |
-
-The AGX return-slot update ended with generation 3 active and accepted, exactly
-two root/verity pairs, no staging LVs, the generation-2 active pair unchanged
-during installation, both update-fetch sentinels intact on shared persist, and
-the candidate promoted from `+3` to its exact persistent default. The baseline
-fTPM-enabled image required a physical power cycle after the OP-TEE TPM probe
-blocked shutdown; the fTPM-disabled generations completed ordinary reboots.
-
-The validated NX rollback ended on the previously blessed generation, with all
-configured core MicroVM services active, `ghaf-boot-health.service` successful,
-the expected dm-verity root hash, and the persistent default resolving to the
-exact blessed entry.
-These observations are a snapshot, not a substitute for repeating the complete
-matrix on a release candidate.
-
-## Release stop conditions
-
-Do not promote the canaries if any of the following is true:
-
-- the recovery USB target or serial endpoint is ambiguous,
-- the active pair cannot be proven untouched,
-- a negative validation case mutates LVM or ESP state,
-- trial attempts do not decrement exactly once per failed boot,
-- accepted generation advances before successful health blessing,
-- rollback changes or loses shared persist,
-- manufacturer-key rotation removes the recovery keyslot,
-- a physical power interruption requires undocumented manual LV surgery,
-- the watchdog cannot reset a hard-hung counted trial,
-- one board's runtime result is used as evidence for the other, or
-- development-key results are represented as production Secure Boot assurance.
+Physical power cuts and hard-hang watchdog tests remained unrun. Repeat the
+matrix per release candidate. Stop promotion on identity ambiguity, active-slot
+mutation, a mutating rejection, incorrect attempt counts, premature acceptance,
+persist loss, recovery-slot loss, undocumented rescue, or unproven hard-hang
+reset. Development-key tests do not establish production Secure Boot assurance.

--- a/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
@@ -73,44 +73,15 @@ For every test case record:
 
 ## Common setup
 
-### Pure CI build mode
+### Required build configuration
 
-The repository's default pure flake input is sufficient for evaluation and
-build discovery. Evaluate both debug canaries directly:
+The default input contains no public keys. Secure A/B image and flash-script
+evaluation must fail until an external public configuration is supplied as
+described below. Flash attributes always select the requested target; there is
+no automatic fallback to a generic unsigned image.
 
-```sh
-timeout 2h nix eval \
-  '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
-
-timeout 2h nix eval \
-  '.#nixosConfigurations."nvidia-jetson-orin-agx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
-```
-
-Each evaluation must succeed and emit the target-specific message ending in:
-
-```text
-using repository CI-only trust from secure-ab-build-config; this image is restricted to debug build coverage and must not be deployed.
-```
-
-This public fallback is deliberately unsafe for deployment. It exists only so
-CI can evaluate and build the secure A/B image without access to local secrets.
-Build the exported NX and AGX flash attributes sequentially, then inspect each
-wrapper without running it. Confirm it selects the board-matched generic image
-and contains the exact warning:
-
-```text
-WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead.
-  Requested: <secure-A/B-target>
-  Fallback:  <generic-target>
-  Rebuild with an external secure-ab-build-config input to flash the secure A/B canary.
-```
-
-The wrapper does not deploy the CI-only A/B image. It delegates to the existing
-generic unsigned target, which has a different image and partition layout. It
-strips `--secure-boot`, `-u`/`--uki`, and `-s`/`--signed-sd-image` with explicit
-warnings so secure-image-only arguments cannot alter the fallback. Do not
-execute either wrapper during this source-only check; flashing remains a
-separate, explicitly authorized operation.
+CI integration is future work described in the
+[shared architecture guide](/ghaf/dev/architecture/ab-update/#proposed-ci-integration).
 
 ### Repository and key environment
 
@@ -153,15 +124,9 @@ timeout 2h nix eval \
   '.#nixosConfigurations."nvidia-jetson-orin-nx-verity-luks-debug-from-x86_64".config.system.build.ghafImage.drvPath'
 ```
 
-It must succeed and emit the target-specific message ending in:
-
-```text
-using pure external public trust from secure-ab-build-config; private signing keys remain outside the Nix store.
-```
-
-Overriding `secure-ab-build-config` with an incomplete external directory must
-fail pure evaluation with `external secure-ab-build-config is missing required
-public trust files:` followed by the exact missing file names. Running a flash
+It must succeed with the configured generation and public trust. Overriding
+the input with an incomplete directory must fail evaluation and identify the
+missing public file or files. Running a flash
 script with the runtime key variable unset must fail with `ERROR:
 GHAF_DEV_KEY_DIR is required for secure A/B canary flashes.`; missing flash or
 signing files are reported by their exact paths.

--- a/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
@@ -618,7 +618,7 @@ timeout 2h nix build \
 Sign, validate, and install normally. Reboot without manually selecting entries.
 
 **Expected:** The trial boots three times. Each run fails because
-`microvm@ab-health-failure-injection.service` is not active, reboots, and
+`microvm@ghaf-boot-health-injection-probe.service` is not active, reboots, and
 consumes one attempt. The fourth selection boots the previously blessed pair.
 The accepted generation does not advance and persist remains intact.
 

--- a/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/orin-secure-ab-testing.mdx
@@ -1091,7 +1091,7 @@ keys or recovery-passphrase contents.
 | Candidate UKI exists but default selection failed | Rerun the exact signed candidate | Updater completes only candidate-specific default selection |
 | Orphan `<candidate>.efi.tmp` | Preserve evidence, then rerun the exact candidate | Atomic install replaces the temporary path; the old default remains |
 | ESP lacks space | Remove only a proven stale `.tmp` or non-active managed UKI, then rerun | Never remove the current or only blessed fallback |
-| VG lacks space for inactive-slot resize | Use a smaller candidate or reflash with a larger layout | Never shrink or delete the active pair manually |
+| Candidate exceeds the fixed root or verity slot capacity | Reflash with an intentionally larger platform layout | Never shrink persist or delete the active pair manually |
 | Hidden incomplete HTTP fetch directory | Retain for evidence or delete that exact directory; retry into a new temporary directory | Never add a marker or reuse old contents |
 | Existing blank persist LV | Restart `firstboot-persist.service` | It formats the blank LV once |
 | Existing Btrfs persist LV | Restart first boot normally | Contents must be retained |

--- a/modules/partitioning/firstboot-persist.nix
+++ b/modules/partitioning/firstboot-persist.nix
@@ -8,8 +8,8 @@
 # boot this service:
 #
 #   1. Expands the LVM PV after initrd has grown APP and the open LUKS mapping
-#   2. Creates swap and persist LVs from the free space, reserving
-#      enough room for a future B-slot root+verity pair (OTA updates)
+#   2. Creates the fixed-capacity empty B-slot root and verity LVs
+#   3. Creates swap and persist LVs from the remaining free space
 #
 # Every step is idempotent — the service can be interrupted and re-run
 # safely (e.g. after a power loss during first boot).
@@ -55,15 +55,28 @@ let
       echo "Resizing PV..."
       pvresize "$PV_PATH"
 
-      # --- Compute B-slot reservation ---
+      # --- Provision the fixed-capacity B slot before persist takes the rest ---
 
-      A_ROOT_MIB=$(lvs --noheadings -o lv_size --nosuffix --units m -S "vg_name=pool && lv_name=~^root_" | head -1 | tr -d '[:space:]')
-      A_VERITY_MIB=$(lvs --noheadings -o lv_size --nosuffix --units m -S "vg_name=pool && lv_name=~^verity_" | head -1 | tr -d '[:space:]')
-      # Reserve 50% headroom on top of the current A-slot sizes so the
-      # B-slot can accommodate a significantly larger image after OTA
-      # updates that add packages or data.
-      RESERVE_MIB=$(awk "BEGIN { printf \"%d\", (''${A_ROOT_MIB:-0} + ''${A_VERITY_MIB:-0}) * 1.5 + 64 }")
-      echo "B-slot reservation: $RESERVE_MIB MiB (1.5 * (root=$A_ROOT_MIB + verity=$A_VERITY_MIB) + 64)"
+      ensure_empty_lv() {
+        name="$1"
+        expected_mib="$2"
+        if lvs "pool/$name" >/dev/null 2>&1; then
+          actual_mib=$(lvs --noheadings -o lv_size --nosuffix --units m "pool/$name" \
+            | awk '{ sub(/^</, "", $1); printf "%d", $1 }')
+          if [ "$actual_mib" -ne "$expected_mib" ]; then
+            echo "ERROR: pool/$name is $actual_mib MiB, expected $expected_mib MiB" >&2
+            exit 1
+          fi
+          echo "pool/$name already has the required $expected_mib MiB capacity."
+        else
+          echo "Creating pool/$name ($expected_mib MiB)..."
+          DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n "$name" -L "''${expected_mib}M" pool
+        fi
+      }
+
+      ensure_empty_lv root_empty ${toString cfg.rootSlotSizeMiB}
+      ensure_empty_lv verity_empty ${toString cfg.veritySlotSizeMiB}
+      vgmknodes pool
 
       # --- Create swap LV (skip if already exists) ---
 
@@ -77,16 +90,16 @@ let
       # --- Create persist LV and finish an interrupted format if needed ---
 
       if [ ! -e /dev/pool/persist ]; then
-        VG_FREE_MIB=$(vgs --noheadings -o vg_free --nosuffix --units m pool | tr -d '[:space:]')
-        VG_FREE_INT=$(awk "BEGIN { printf \"%d\", $VG_FREE_MIB }")
-        PERSIST_MIB=$(( VG_FREE_INT - RESERVE_MIB ))
+        VG_FREE_INT=$(vgs --noheadings -o vg_free --nosuffix --units m pool \
+          | awk '{ sub(/^</, "", $1); printf "%d", $1 }')
+        PERSIST_MIB=$VG_FREE_INT
 
         if [ "$PERSIST_MIB" -le 0 ]; then
-          echo "ERROR: not enough free space (free=$VG_FREE_INT, reserve=$RESERVE_MIB)"
+          echo "ERROR: no free space remains for persist after fixed slots and swap"
           exit 1
         fi
 
-        echo "Creating persist LV: $PERSIST_MIB MiB (leaving $RESERVE_MIB MiB for B-slot)"
+        echo "Creating persist LV from the remaining $PERSIST_MIB MiB..."
         lvcreate -L "''${PERSIST_MIB}M" -n persist pool
 
       else
@@ -119,7 +132,7 @@ in
 
     # --- First-boot service ---
     systemd.services.firstboot-persist = {
-      description = "Create swap and persist LVs on first boot";
+      description = "Create inactive system slot, swap, and persist LVs on first boot";
       wantedBy = [ "local-fs-pre.target" ];
       before = [ "local-fs-pre.target" ];
       after = [

--- a/modules/partitioning/firstboot-persist.nix
+++ b/modules/partitioning/firstboot-persist.nix
@@ -7,9 +7,8 @@
 # to minimize flash image size (~5.5 GiB instead of ~16 GiB). On first
 # boot this service:
 #
-#   1. Resizes the GPT and APP partition to fill the eMMC
-#   2. Expands the LVM PV to match
-#   3. Creates swap and persist LVs from the free space, reserving
+#   1. Expands the LVM PV after initrd has grown APP and the open LUKS mapping
+#   2. Creates swap and persist LVs from the free space, reserving
 #      enough room for a future B-slot root+verity pair (OTA updates)
 #
 # Every step is idempotent — the service can be interrupted and re-run
@@ -35,36 +34,22 @@ let
     runtimeInputs = with pkgs; [
       gnugrep
       gawk
-      util-linux
-      gptfdisk
-      parted
       lvm2
       coreutils
       btrfs-progs
+      util-linux
     ];
     text = ''
       set -euo pipefail
       echo "firstboot-persist: starting at $(date)"
 
-      # --- Resize APP partition to fill the eMMC (idempotent) ---
+      # Initrd grows APP and the open LUKS mapping while the OP-TEE DUK is
+      # still available in its shared keyring.  Only the PV and new LVs are
+      # safe to grow here after switch-root.
 
       PV_PATH=$(pvdisplay -C -o pv_name --noheadings -S vg_name=pool | head -n1 | tr -d '[:space:]')
-      P_DEVPATH=$(readlink -f "$PV_PATH")
-      echo "PV: $PV_PATH -> $P_DEVPATH"
-
-      if [[ "$P_DEVPATH" =~ [0-9]+$ ]]; then
-        PARTNUM=$(echo "$P_DEVPATH" | grep -o '[0-9]*$')
-        PARENT_DISK=/dev/$(lsblk --nodeps --noheadings -o pkname "$P_DEVPATH")
-      else
-        echo "ERROR: cannot determine partition number from $P_DEVPATH"
-        exit 1
-      fi
-
-      echo "Fixing GPT and resizing partition $PARTNUM on $PARENT_DISK..."
-      sgdisk "$PARENT_DISK" -e || true
-      # parted resizepart updates the kernel's partition size synchronously
-      # via BLKPG_RESIZE_PARTITION ioctl, so no partprobe/udevadm needed.
-      parted -s -a opt "$PARENT_DISK" "resizepart $PARTNUM 100%" || true
+      [[ -n "$PV_PATH" ]] || { echo "ERROR: pool PV not found"; exit 1; }
+      echo "PV: $PV_PATH -> $(readlink -f "$PV_PATH")"
 
       # pvresize is idempotent — no-op if PV already matches partition
       echo "Resizing PV..."
@@ -89,7 +74,7 @@ let
         echo "swap LV already exists, skipping."
       fi
 
-      # --- Create persist LV (skip if already exists) ---
+      # --- Create persist LV and finish an interrupted format if needed ---
 
       if [ ! -e /dev/pool/persist ]; then
         VG_FREE_MIB=$(vgs --noheadings -o vg_free --nosuffix --units m pool | tr -d '[:space:]')
@@ -104,11 +89,24 @@ let
         echo "Creating persist LV: $PERSIST_MIB MiB (leaving $RESERVE_MIB MiB for B-slot)"
         lvcreate -L "''${PERSIST_MIB}M" -n persist pool
 
-        echo "Formatting persist as btrfs..."
-        mkfs.btrfs -L persist /dev/pool/persist
       else
-        echo "persist LV already exists, skipping."
+        echo "persist LV already exists."
       fi
+
+      PERSIST_TYPE=$(blkid -o value -s TYPE /dev/pool/persist 2>/dev/null || true)
+      case "$PERSIST_TYPE" in
+        "")
+          echo "Formatting uninitialized persist LV as btrfs..."
+          mkfs.btrfs -L persist /dev/pool/persist
+          ;;
+        btrfs)
+          echo "persist LV already contains btrfs, retaining it."
+          ;;
+        *)
+          echo "ERROR: persist LV has unexpected filesystem type: $PERSIST_TYPE"
+          exit 1
+          ;;
+      esac
 
       echo "firstboot-persist: done."
     '';

--- a/modules/partitioning/firstboot-persist.nix
+++ b/modules/partitioning/firstboot-persist.nix
@@ -3,13 +3,11 @@
 #
 # First-boot service for Jetson Orin A/B verity boot.
 #
-# The pre-built LVM image only contains the A-slot root and verity LVs
-# to minimize flash image size (~5.5 GiB instead of ~16 GiB). On first
+# The pre-built LVM image contains both fixed-capacity system slots. On first
 # boot this service:
 #
 #   1. Expands the LVM PV after initrd has grown APP and the open LUKS mapping
-#   2. Creates the fixed-capacity empty B-slot root and verity LVs
-#   3. Creates swap and persist LVs from the remaining free space
+#   2. Creates swap and persist LVs from the remaining free space
 #
 # Every step is idempotent — the service can be interrupted and re-run
 # safely (e.g. after a power loss during first boot).
@@ -55,27 +53,8 @@ let
       echo "Resizing PV..."
       pvresize "$PV_PATH"
 
-      # --- Provision the fixed-capacity B slot before persist takes the rest ---
-
-      ensure_empty_lv() {
-        name="$1"
-        expected_mib="$2"
-        if lvs "pool/$name" >/dev/null 2>&1; then
-          actual_mib=$(lvs --noheadings -o lv_size --nosuffix --units m "pool/$name" \
-            | awk '{ sub(/^</, "", $1); printf "%d", $1 }')
-          if [ "$actual_mib" -ne "$expected_mib" ]; then
-            echo "ERROR: pool/$name is $actual_mib MiB, expected $expected_mib MiB" >&2
-            exit 1
-          fi
-          echo "pool/$name already has the required $expected_mib MiB capacity."
-        else
-          echo "Creating pool/$name ($expected_mib MiB)..."
-          DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n "$name" -L "''${expected_mib}M" pool
-        fi
-      }
-
-      ensure_empty_lv root_empty ${toString cfg.rootSlotSizeMiB}
-      ensure_empty_lv verity_empty ${toString cfg.veritySlotSizeMiB}
+      # The image builder owns the two system pairs. Their names change during
+      # updates, so provisioning must not recreate the initial empty names.
       vgmknodes pool
 
       # --- Create swap LV (skip if already exists) ---
@@ -132,7 +111,7 @@ in
 
     # --- First-boot service ---
     systemd.services.firstboot-persist = {
-      description = "Create inactive system slot, swap, and persist LVs on first boot";
+      description = "Grow the storage pool and provision swap and persist";
       wantedBy = [ "local-fs-pre.target" ];
       before = [ "local-fs-pre.target" ];
       after = [

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/jetson-orin.nix
@@ -513,9 +513,16 @@ let
         uniqueKeyDescription=$1
         defaultKey=$2
         luksDev=$3
+        # The flash image reserves slot 1 for the printable recovery
+        # passphrase. Put the DUK in a known, separate slot so manufacturer
+        # removal cannot remove or rewrite recovery.
+        uniqueKeySlot=2
 
         printf "Switching to use device unique key. This might take a bit..\n"
-        if ! printf "%s" "$defaultKey" | cryptsetup luksAddKey --new-key-description "$uniqueKeyDescription" --key-file=- "$luksDev"; then
+        if ! printf "%s" "$defaultKey" | cryptsetup luksAddKey \
+          --new-key-description "$uniqueKeyDescription" \
+          --new-key-slot "$uniqueKeySlot" \
+          --key-file=- "$luksDev"; then
           printf "error: Failed to set unique key\n"
           handle_error
         fi
@@ -525,15 +532,11 @@ let
           handle_error
         fi
 
-        # luksAddKey/luksRemoveKey only swap keyslots; the volume key that
-        # actually encrypts the data is still the one the manufacturing
-        # passphrase protected. Reencrypt derives a fresh volume key from the
-        # device-unique key, so a leaked manufacturing passphrase grants nothing.
-        printf "Note: Re-encryption may take 1 minute for every 1 GB of data ...\n"
-        if ! cryptsetup reencrypt --key-description "$uniqueKeyDescription" "$luksDev"; then
-           printf "error: Re-encryption failed\n"
-           handle_error
-        fi
+        # Do not rotate the volume key here.  cryptsetup cannot re-wrap a
+        # recovery keyslot without knowing its passphrase, so volume-key
+        # re-encryption would discard the offline recovery credential.  Removing
+        # the manufacturer keyslot is sufficient to revoke that passphrase: it
+        # never exposed the random volume key itself.
       }
 
       # Resolve the LUKS partition by its pinned header UUID and verify it is a
@@ -591,6 +594,94 @@ let
         printf "error: Unable to add cryptrsetup token\n"
         handle_error
       fi
+    '';
+  };
+
+  # APP must be grown while the OP-TEE-derived key is still present in the
+  # initrd's shared keyring.  After switch-root that keyring is intentionally
+  # unreachable, so cryptsetup resize would otherwise prompt for a passphrase.
+  # The real-root firstboot service grows the PV and creates the remaining LVs.
+  resizeVerityLuksScript = pkgs.writeShellApplication {
+    name = "resize-verity-luks";
+    runtimeInputs = with pkgs; [
+      coreutils
+      cryptsetup
+      gptfdisk
+      parted
+      util-linux
+    ];
+    text = ''
+      set -euo pipefail
+
+      luks_dev=""
+      for dev in $(blkid -o device -t UUID=${luksUuid} 2>/dev/null); do
+        [ "$(blkid -o value -s TYPE "$dev" 2>/dev/null)" = "crypto_LUKS" ] || continue
+        luks_dev="$dev"
+        break
+      done
+      [ -n "$luks_dev" ] || { echo "ERROR: LUKS APP partition not found"; exit 1; }
+
+      real_dev=$(readlink -f "$luks_dev")
+      base_dev=$(basename "$real_dev")
+      part_num=$(cat "/sys/class/block/$base_dev/partition")
+      disk="/dev/$(basename "$(readlink -f "/sys/class/block/$base_dev/..")")"
+
+      echo "Growing APP partition $part_num on $disk..."
+      sgdisk -e "$disk" || true
+
+      # Grow to the largest partition size that is an exact multiple of the
+      # LUKS data-sector size.  A raw `resizepart 100%` can leave APP a few
+      # 512-byte sectors too long on NVMe; cryptsetup then refuses to grow a
+      # mapping whose data sector is 4096 bytes.
+      part_start=$(cat "/sys/class/block/$base_dev/start")
+      last_usable=""
+      while IFS= read -r line; do
+        if [[ "$line" =~ last\ usable\ sector\ is\ ([0-9]+) ]]; then
+          last_usable="''${BASH_REMATCH[1]}"
+          break
+        fi
+      done < <(sgdisk -p "$disk")
+      logical_sector_bytes=$(blockdev --getss "$disk")
+      luks_sector_bytes=""
+      while read -r field value _; do
+        if [ "$field" = "sector:" ]; then
+          luks_sector_bytes="$value"
+          break
+        fi
+      done < <(cryptsetup luksDump "$real_dev")
+
+      [[ "$part_start" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid APP start sector"; exit 1; }
+      [[ "$last_usable" =~ ^[0-9]+$ ]] || { echo "ERROR: GPT last usable sector not found"; exit 1; }
+      [[ "$logical_sector_bytes" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid disk sector size"; exit 1; }
+      [[ "$luks_sector_bytes" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid LUKS sector size"; exit 1; }
+      (( luks_sector_bytes >= logical_sector_bytes )) || { echo "ERROR: LUKS sector is smaller than disk sector"; exit 1; }
+      (( luks_sector_bytes % logical_sector_bytes == 0 )) || { echo "ERROR: incompatible LUKS and disk sector sizes"; exit 1; }
+
+      alignment=$((luks_sector_bytes / logical_sector_bytes))
+      max_part_sectors=$((last_usable - part_start + 1))
+      aligned_part_sectors=$((max_part_sectors / alignment * alignment))
+      aligned_end=$((part_start + aligned_part_sectors - 1))
+      (( aligned_part_sectors > 0 )) || { echo "ERROR: no usable aligned APP space"; exit 1; }
+
+      # NVIDIA's generated GPT can leave a handful of sectors outside the
+      # usable range.  --fix answers that repair prompt noninteractively.
+      parted -s -f -a none "$disk" unit s resizepart "$part_num" "''${aligned_end}s"
+      udevadm settle
+
+      # Do not race cryptsetup against the kernel's partition-table update.
+      for _ in $(seq 1 50); do
+        [ "$(cat "/sys/class/block/$base_dev/size")" -eq "$aligned_part_sectors" ] && break
+        sleep 0.1
+      done
+      [ "$(cat "/sys/class/block/$base_dev/size")" -eq "$aligned_part_sectors" ] || {
+        echo "ERROR: kernel did not observe the aligned APP size"
+        exit 1
+      }
+
+      echo "Growing open LUKS mapping ${cfg.diskEncryption.mapperName}..."
+      cryptsetup resize \
+        --key-description ${luksDiskKeyDescription} \
+        ${cfg.diskEncryption.mapperName}
     '';
   };
 
@@ -719,6 +810,15 @@ in
       defaultText = lib.literalExpression "config.ghaf.profiles.debug.enable";
     };
 
+    ftpm.enable = mkOption {
+      description = ''
+        Load the OP-TEE-backed firmware TPM during stage 2. This is independent
+        of the OP-TEE device-unique-key service used for disk encryption.
+      '';
+      type = types.bool;
+      default = true;
+    };
+
     diskEncryption = {
       enable = mkEnableOption "generic LUKS root filesystem encryption for eMMC APP partition";
 
@@ -835,12 +935,10 @@ in
         '';
       }
       {
-        assertion = !(cfg.diskEncryption.enable && verityEnabled);
+        assertion = !cfg.runtimeEkProvision.enable || cfg.ftpm.enable;
         message = ''
-          ghaf.hardware.nvidia.orin.diskEncryption.enable and
-          ghaf.partitioning.verity.enable are mutually exclusive root strategies:
-          verity owns fileSystems."/" as a tmpfs overlay, LUKS as an ext4 root on
-          /dev/mapper/${cfg.diskEncryption.mapperName}. Enable at most one.
+          ghaf.hardware.nvidia.orin.runtimeEkProvision.enable requires
+          ghaf.hardware.nvidia.orin.ftpm.enable.
         '';
       }
     ];
@@ -1041,6 +1139,7 @@ in
         ]
         ++ lib.optionals cfg.diskEncryption.deviceUniqueKey.enable [
           preDiskUniqueKeyScript
+          resizeVerityLuksScript
           postDiskUniqueKeyScript
         ];
 
@@ -1099,12 +1198,35 @@ in
           };
         };
 
+        resize-verity-luks = lib.mkIf verityEnabled {
+          description = "Grow verity APP and LUKS mapping before DUK cleanup";
+          wantedBy = [ "initrd-root-fs.target" ];
+          after = [
+            "systemd-cryptsetup@${cfg.diskEncryption.mapperName}.service"
+          ];
+          before = [
+            "initrd-root-fs.target"
+            "post-disk-unique-key.service"
+          ];
+          unitConfig = {
+            DefaultDependencies = false;
+          };
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${resizeVerityLuksScript}/bin/resize-verity-luks";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+            KeyringMode = "shared";
+          };
+        };
+
         post-disk-unique-key = {
           description = "Cleanup service for device unique key disk encryption";
           wantedBy = [ "initrd-switch-root.target" ];
-          after = [
-            "resize-partitions.service"
-          ];
+          after =
+            lib.optionals (!verityEnabled) [ "resize-partitions.service" ]
+            ++ lib.optionals verityEnabled [ "resize-verity-luks.service" ];
           unitConfig = {
             DefaultDependencies = false;
           };
@@ -1155,7 +1277,7 @@ in
       };
     };
 
-    systemd.services.ghaf-load-ftpm-module = {
+    systemd.services.ghaf-load-ftpm-module = mkIf cfg.ftpm.enable {
       description = "Load fTPM module after stage-2 OP-TEE readiness";
       wantedBy = [ "multi-user.target" ];
       wants = [
@@ -1180,7 +1302,7 @@ in
       };
     };
 
-    systemd.services.ghaf-provision-ek-certs = mkIf cfg.runtimeEkProvision.enable {
+    systemd.services.ghaf-provision-ek-certs = mkIf (cfg.ftpm.enable && cfg.runtimeEkProvision.enable) {
       description = "Provision fTPM EK certificates into standard NV indices";
       wantedBy = [ "multi-user.target" ];
       wants = [ "tee-supplicant.service" ];
@@ -1202,7 +1324,7 @@ in
       };
     };
 
-    systemd.services.ghaf-export-ek-endorsement-bundle = {
+    systemd.services.ghaf-export-ek-endorsement-bundle = mkIf cfg.ftpm.enable {
       description = "Export EK certs and build endorsement CA bundle";
       wantedBy = [ "multi-user.target" ];
       wants = [ "tee-supplicant.service" ];

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
@@ -223,31 +223,12 @@ let
     cp "$_boot_src" "$_sign_dir/BOOTAA64.efi"
     cp "$_uki_src" "$_sign_dir/$_uki_name"
 
-    # Sign EFI binaries if secure boot keys are available
-    _sb_key_dir="$GHAF_DEV_KEY_DIR"
-    if [ -n "$_sb_key_dir" ] && [ -f "$_sb_key_dir/db.key" ] && [ -f "$_sb_key_dir/db.crt" ]; then
-      echo "Signing EFI binaries with $_sb_key_dir/db.crt ..."
-      for _efi in "$_sign_dir"/*.efi; do
-        echo "  Signing: $(basename "$_efi")"
-        "${pkgs.pkgsBuildBuild.sbsigntool}/bin/sbsign" \
-          --key "$_sb_key_dir/db.key" --cert "$_sb_key_dir/db.crt" \
-          --output "$_efi" "$_efi"
-      done
-    ${
-      if config.ghaf.hardware.nvidia.orin.secureboot.enable then
-        ''
-          else
-            echo "ERROR: Secure Boot is enabled but no signing keys found." >&2
-            echo "  Set GHAF_DEV_KEY_DIR to a directory from ghaf-dev-keygen." >&2
-            exit 1
-        ''
-      else
-        ''
-          else
-            echo "Secure Boot signing skipped (no keys found)."
-        ''
-    }
-    fi
+    # Trust and both signing keys were checked before preparing any images.
+    for _efi in "$_sign_dir"/*.efi; do
+      "${pkgs.pkgsBuildBuild.sbsigntool}/bin/sbsign" \
+        --key "$GHAF_DEV_KEY_DIR/db.key" --cert "$GHAF_DEV_KEY_DIR/db.crt" \
+        --output "$_efi" "$_efi"
+    done
 
     # Create 512M FAT32 ESP image
     "${pkgs.pkgsBuildBuild.dosfstools}/bin/mkfs.vfat" -F 32 -n ESP -C "$_esp" $((512 * 1024))

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
@@ -32,8 +32,8 @@ let
   # <device type="sdmmc_user"> or NVMe <device type="nvme"> children.
   # This avoids fragile line-count splicing.
   #
-  # All values are fully resolved at Nix build time (the APP partition
-  # size is read from the LVM image derivation via --set).
+  # All values are fully resolved at Nix build time (the APP partition size is
+  # derived from the exported slot capacities via --set).
   partitionsStorage = [
     {
       name = "master_boot_record";
@@ -87,7 +87,7 @@ let
         percent_reserved = "0x808";
         unique_guid = "APPUUID";
         filename = "system.img";
-        description = "LUKS2 cryptpool containing an LVM PV with A/B root+verity, swap, persist.";
+        description = "Prebuilt LVM payload for A/B root and verity slots.";
       };
     }
     {
@@ -268,9 +268,10 @@ let
     rm -rf "$_sign_dir"
     echo "ESP image built: $_esp"
 
-    echo "Decompressing pre-built LVM payload..."
-    _plain="$WORKDIR/bootloader/system.lvm"
-    "${pkgs.pkgsBuildBuild.zstd}/bin/zstd" -f -d "${verityImages}/system.img.zst" -o "$_plain"
+    echo "Installing prebuilt LVM payload..."
+    _outer="$WORKDIR/bootloader/system.img"
+    "${lib.getExe pkgs.pkgsBuildBuild.zstd}" --decompress --force \
+      "${verityImages}/system.img.zst" -o "$_outer"
     ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
       _recovery_dir="$GHAF_DEV_KEY_DIR/recovery-passphrases"
       mkdir -p "$_recovery_dir"
@@ -282,32 +283,16 @@ let
         | "${pkgs.pkgsBuildBuild.coreutils}/bin/tr" -d '\n' > "$_recovery"
       chmod 0600 "$_recovery"
 
-      _outer="$WORKDIR/bootloader/system.img"
-      truncate -s "$(cat ${verityImages}/system.raw_size)" "$_outer"
-      printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
-        | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" luksFormat --batch-mode \
-          --type luks2 --uuid ${config.ghaf.hardware.nvidia.orin.diskEncryption.luksUuid} \
-          --key-slot 0 \
-          --key-file=- "$_outer"
       printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
         | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" luksAddKey \
           --new-key-slot 1 \
           --key-file=- "$_outer" "$_recovery"
-      _mapper="ghaf-flash-$PPID"
-      printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
-        | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" open --key-file=- "$_outer" "$_mapper"
-      "${pkgs.pkgsBuildBuild.coreutils}/bin/dd" if="$_plain" of="/dev/mapper/$_mapper" bs=4M conv=fsync,notrunc status=progress
-      "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" close "$_mapper"
-      rm -f "$_plain"
       echo "============================================================"
       echo "RECOVERY PASSPHRASE (store securely; generated for this flash):"
       cat "$_recovery"
       printf '\n'
       echo "Saved at: $_recovery"
       echo "============================================================"
-    ''}
-    ${lib.optionalString (!config.ghaf.hardware.nvidia.orin.diskEncryption.enable) ''
-      mv "$_plain" "$WORKDIR/bootloader/system.img"
     ''}
     # flash.sh -k APP looks for system.img relative to $WORKDIR
     ln -sf "$WORKDIR/bootloader/system.img" "$WORKDIR/system.img"

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Partition template for A/B verity boot on NVIDIA Jetson Orin AGX.
+# Partition template for A/B verity boot on NVIDIA Jetson Orin.
 #
-# Produces a flash.xml with two partitions on eMMC:
+# Produces a flash.xml with two partitions on the target storage device:
 #   - ESP (512M, vfat) with systemd-boot + UKI
 #   - APP (LVM PV) with A/B root+verity slots, swap, persist
 #
@@ -18,17 +18,23 @@
 }:
 let
   cfg = config.ghaf.hardware.nvidia.orin;
+  trustDigests = cfg.secureboot.publicTrustDigests;
+  expectedPkDigest = trustDigests."PK.crt" or "";
+  expectedKekDigest = trustDigests."KEK.crt" or "";
+  expectedDbDigest = trustDigests."db.crt" or "";
+  expectedUpdateDigest = trustDigests."update.pub" or "";
 
   inherit (config.system.build) verityImages;
 
-  # eMMC partition layout as structured Nix data.
+  # Root storage partition layout as structured Nix data.
   # Serialized to JSON and spliced into NVIDIA's flash XML by
-  # splice-flash-xml.py, which replaces the <device type="sdmmc_user">
-  # children. This avoids fragile line-count splicing.
+  # splice-flash-xml.py, which replaces either the eMMC
+  # <device type="sdmmc_user"> or NVMe <device type="nvme"> children.
+  # This avoids fragile line-count splicing.
   #
   # All values are fully resolved at Nix build time (the APP partition
   # size is read from the LVM image derivation via --set).
-  partitionsEmmc = [
+  partitionsStorage = [
     {
       name = "master_boot_record";
       type = "protective_master_boot_record";
@@ -81,7 +87,7 @@ let
         percent_reserved = "0x808";
         unique_guid = "APPUUID";
         filename = "system.img";
-        description = "LVM PV containing A/B root+verity slots, swap, persist.";
+        description = "LUKS2 cryptpool containing an LVM PV with A/B root+verity, swap, persist.";
       };
     }
     {
@@ -98,15 +104,23 @@ let
     }
   ];
 
-  # Build the final flash.xml by replacing the sdmmc_user partitions
+  # Build the final flash.xml by replacing the storage-device partitions
   # in NVIDIA's template with our layout using XML-aware splicing.
+  #
+  # Orin NX has no eMMC. Its p3768 devkit must use NVIDIA's NVMe template;
+  # using the SDMMC template makes MB2 probe SDMMC instance 3, fail with
+  # "Secondary storage init failed", and hang in Busy Spin before flashing.
   partitionTemplate =
     let
       inherit (pkgs.nvidia-jetpack) bspSrc;
-      isIndustrial = config.hardware.nvidia-jetpack.som == "orin-agx-industrial";
+      inherit (config.hardware.nvidia-jetpack) som;
+      isIndustrial = som == "orin-agx-industrial";
+      isNvme = som == "orin-nx";
       xmlFile =
         if isIndustrial then
           "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_sdmmc_industrial.xml"
+        else if isNvme then
+          "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_nvme.xml"
         else
           "${bspSrc}/bootloader/generic/cfg/flash_t234_qspi_sdmmc.xml";
     in
@@ -116,9 +130,11 @@ let
       }
       ''
         python3 ${./splice-flash-xml.py} \
+          --device-type "${if isNvme then "nvme" else "sdmmc_user"}" \
+          ${lib.optionalString cfg.flashScriptOverrides.onlyQSPI "--remove-device"} \
           --set "APP.size=$(cat ${verityImages}/system.raw_size)" \
           ${xmlFile} \
-          ${pkgs.writeText "sdmmc-verity.json" (builtins.toJSON partitionsEmmc)} \
+          ${pkgs.writeText "verity-storage.json" (builtins.toJSON partitionsStorage)} \
           "$out"
       '';
 
@@ -132,6 +148,71 @@ let
     echo "Carrier board: ${config.hardware.nvidia-jetpack.carrierBoard}"
     echo "============================================================"
     echo ""
+
+    _external_public_trust=${
+      if config.ghaf.hardware.nvidia.orin.secureboot.externalPublicTrustConfigured then "1" else "0"
+    }
+    if [ "$_external_public_trust" != 1 ]; then
+      echo "ERROR: this flash script was built with CI-only public trust and cannot flash a secure A/B canary." >&2
+      echo "  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen." >&2
+      exit 1
+    fi
+
+    if [ -z "''${GHAF_DEV_KEY_DIR:-}" ]; then
+      echo "ERROR: GHAF_DEV_KEY_DIR is required for secure A/B canary flashes." >&2
+      exit 1
+    fi
+    for _required in PK.crt KEK.crt db.crt db.key update.pub update.key; do
+      if [ ! -s "$GHAF_DEV_KEY_DIR/$_required" ]; then
+        echo "ERROR: missing $GHAF_DEV_KEY_DIR/$_required" >&2
+        exit 1
+      fi
+    done
+
+    _check_public_trust() {
+      _trust_name="$1"
+      _expected_digest="$2"
+      _actual_digest=$("${pkgs.pkgsBuildBuild.coreutils}/bin/sha256sum" "$GHAF_DEV_KEY_DIR/$_trust_name")
+      _actual_digest="''${_actual_digest%% *}"
+      if [ -z "$_expected_digest" ] || [ "$_actual_digest" != "$_expected_digest" ]; then
+        echo "ERROR: GHAF_DEV_KEY_DIR public trust does not match the trust embedded at image evaluation: $_trust_name" >&2
+        echo "  Rebuild the flash script with this exact GHAF_DEV_KEY_DIR." >&2
+        exit 1
+      fi
+    }
+    _check_public_trust PK.crt ${lib.escapeShellArg expectedPkDigest}
+    _check_public_trust KEK.crt ${lib.escapeShellArg expectedKekDigest}
+    _check_public_trust db.crt ${lib.escapeShellArg expectedDbDigest}
+    _check_public_trust update.pub ${lib.escapeShellArg expectedUpdateDigest}
+
+    _trust_check_dir=$(mktemp -d)
+    "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" pkey \
+      -in "$GHAF_DEV_KEY_DIR/db.key" -pubout -outform DER \
+      -out "$_trust_check_dir/db-key.der"
+    "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" x509 \
+      -in "$GHAF_DEV_KEY_DIR/db.crt" -pubkey -noout \
+      -out "$_trust_check_dir/db-cert.pem"
+    "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" pkey \
+      -pubin -in "$_trust_check_dir/db-cert.pem" -outform DER \
+      -out "$_trust_check_dir/db-cert.der"
+    if ! "${pkgs.pkgsBuildBuild.diffutils}/bin/cmp" -s \
+      "$_trust_check_dir/db-key.der" "$_trust_check_dir/db-cert.der"; then
+      echo "ERROR: GHAF_DEV_KEY_DIR private key does not match public trust: db.key/db.crt" >&2
+      exit 1
+    fi
+
+    "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" pkey \
+      -in "$GHAF_DEV_KEY_DIR/update.key" -pubout -outform DER \
+      -out "$_trust_check_dir/update-key.der"
+    "${pkgs.pkgsBuildBuild.coreutils}/bin/tail" -c 32 \
+      "$_trust_check_dir/update-key.der" > "$_trust_check_dir/update-key.raw"
+    if [ "$("${pkgs.pkgsBuildBuild.coreutils}/bin/wc" -c < "$GHAF_DEV_KEY_DIR/update.pub")" -ne 32 ] \
+      || ! "${pkgs.pkgsBuildBuild.diffutils}/bin/cmp" -s \
+        "$_trust_check_dir/update-key.raw" "$GHAF_DEV_KEY_DIR/update.pub"; then
+      echo "ERROR: GHAF_DEV_KEY_DIR private key does not match public trust: update.key/update.pub" >&2
+      exit 1
+    fi
+    rm -rf "$_trust_check_dir"
 
     mkdir -pv "$WORKDIR/bootloader"
 
@@ -152,12 +233,7 @@ let
     cp "$_uki_src" "$_sign_dir/$_uki_name"
 
     # Sign EFI binaries if secure boot keys are available
-    _sb_key_dir="''${SECURE_BOOT_SIGNING_KEY_DIR:-${
-      if config.ghaf.hardware.nvidia.orin.secureboot.enable then
-        config.ghaf.hardware.nvidia.orin.secureboot.signingKeyDir
-      else
-        ""
-    }}"
+    _sb_key_dir="$GHAF_DEV_KEY_DIR"
     if [ -n "$_sb_key_dir" ] && [ -f "$_sb_key_dir/db.key" ] && [ -f "$_sb_key_dir/db.crt" ]; then
       echo "Signing EFI binaries with $_sb_key_dir/db.crt ..."
       for _efi in "$_sign_dir"/*.efi; do
@@ -171,8 +247,7 @@ let
         ''
           else
             echo "ERROR: Secure Boot is enabled but no signing keys found." >&2
-            echo "  Set SECURE_BOOT_SIGNING_KEY_DIR or place db.key + db.crt in:" >&2
-            echo "  $_sb_key_dir" >&2
+            echo "  Set GHAF_DEV_KEY_DIR to a directory from ghaf-dev-keygen." >&2
             exit 1
         ''
       else
@@ -193,11 +268,50 @@ let
     rm -rf "$_sign_dir"
     echo "ESP image built: $_esp"
 
-    echo "Decompressing pre-built system (LVM) sparse image..."
-    "${pkgs.pkgsBuildBuild.zstd}/bin/zstd" -f -d "${verityImages}/system.img.zst" -o "$WORKDIR/bootloader/system.img"
+    echo "Decompressing pre-built LVM payload..."
+    _plain="$WORKDIR/bootloader/system.lvm"
+    "${pkgs.pkgsBuildBuild.zstd}/bin/zstd" -f -d "${verityImages}/system.img.zst" -o "$_plain"
+    ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
+      _recovery_dir="$GHAF_DEV_KEY_DIR/recovery-passphrases"
+      mkdir -p "$_recovery_dir"
+      _recovery="$_recovery_dir/recovery-$(date -u +%Y%m%dT%H%M%SZ).txt"
+      # Store exactly the printable passphrase bytes that an operator types.
+      # A trailing newline would become part of a cryptsetup key file during
+      # enrollment and make the printed value fail interactive recovery.
+      "${pkgs.pkgsBuildBuild.openssl}/bin/openssl" rand -base64 24 \
+        | "${pkgs.pkgsBuildBuild.coreutils}/bin/tr" -d '\n' > "$_recovery"
+      chmod 0600 "$_recovery"
+
+      _outer="$WORKDIR/bootloader/system.img"
+      truncate -s "$(cat ${verityImages}/system.raw_size)" "$_outer"
+      printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
+        | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" luksFormat --batch-mode \
+          --type luks2 --uuid ${config.ghaf.hardware.nvidia.orin.diskEncryption.luksUuid} \
+          --key-slot 0 \
+          --key-file=- "$_outer"
+      printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
+        | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" luksAddKey \
+          --new-key-slot 1 \
+          --key-file=- "$_outer" "$_recovery"
+      _mapper="ghaf-flash-$PPID"
+      printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
+        | "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" open --key-file=- "$_outer" "$_mapper"
+      "${pkgs.pkgsBuildBuild.coreutils}/bin/dd" if="$_plain" of="/dev/mapper/$_mapper" bs=4M conv=fsync,notrunc status=progress
+      "${pkgs.pkgsBuildBuild.cryptsetup}/bin/cryptsetup" close "$_mapper"
+      rm -f "$_plain"
+      echo "============================================================"
+      echo "RECOVERY PASSPHRASE (store securely; generated for this flash):"
+      cat "$_recovery"
+      printf '\n'
+      echo "Saved at: $_recovery"
+      echo "============================================================"
+    ''}
+    ${lib.optionalString (!config.ghaf.hardware.nvidia.orin.diskEncryption.enable) ''
+      mv "$_plain" "$WORKDIR/bootloader/system.img"
+    ''}
     # flash.sh -k APP looks for system.img relative to $WORKDIR
     ln -sf "$WORKDIR/bootloader/system.img" "$WORKDIR/system.img"
-    echo "LVM image: $("${pkgs.pkgsBuildBuild.coreutils}/bin/stat" -c%s "$WORKDIR/bootloader/system.img") bytes (compressed)"
+    echo "APP image: $("${pkgs.pkgsBuildBuild.coreutils}/bin/stat" -c%s "$WORKDIR/bootloader/system.img") bytes"
 
     # Ensure all DTB variants in kernel/dtb/ have NixOS overlays applied.
     # NixOS only applies deviceTree.overlays to the DTB named in

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
@@ -154,7 +154,7 @@ let
     }
     if [ "$_external_public_trust" != 1 ]; then
       echo "ERROR: this flash script was built with CI-only public trust and cannot flash a secure A/B canary." >&2
-      echo "  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen." >&2
+      echo "  Rebuild with an external secure-ab-build-config input." >&2
       exit 1
     fi
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
@@ -149,15 +149,6 @@ let
     echo "============================================================"
     echo ""
 
-    _external_public_trust=${
-      if config.ghaf.hardware.nvidia.orin.secureboot.externalPublicTrustConfigured then "1" else "0"
-    }
-    if [ "$_external_public_trust" != 1 ]; then
-      echo "ERROR: this flash script was built with CI-only public trust and cannot flash a secure A/B canary." >&2
-      echo "  Rebuild with an external secure-ab-build-config input." >&2
-      exit 1
-    fi
-
     if [ -z "''${GHAF_DEV_KEY_DIR:-}" ]; then
       echo "ERROR: GHAF_DEV_KEY_DIR is required for secure A/B canary flashes." >&2
       exit 1

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/sdimage.nix
@@ -162,6 +162,10 @@ in
               # Minimal loader configuration
               cat > firmware/loader/loader.conf << EOF
               timeout 0
+              # Keep legacy ghaf_kernel_* images outside A/B selection. A
+              # boot-counted ghaf-* trial sorts ahead of the blessed entry
+              # until its attempts are exhausted, then sorts behind it.
+              default ghaf-*.efi
               editor no
               console-mode keep
               EOF

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/secureboot.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/secureboot.nix
@@ -95,19 +95,6 @@ in
       '';
     };
 
-    externalPublicTrustConfigured = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      internal = true;
-      description = ''
-        Whether the image was evaluated with a complete external public trust
-        set. The exported flake flash entry point uses this marker to select
-        either the secure A/B implementation or the board-matched generic
-        unsigned fallback. The secure A/B implementation itself remains
-        fail-closed for CI-only images.
-      '';
-    };
-
     publicTrustDigests = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
       default = { };

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/secureboot.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/secureboot.nix
@@ -33,15 +33,26 @@ let
 
   keysDir = cfg.keysSource;
 
-  requiredCertFiles = [
-    (keysDir + "/PK.crt")
-    (keysDir + "/KEK.crt")
-    (keysDir + "/db.crt")
-  ];
+  certFile =
+    name:
+    if cfg.certificateContents == null then
+      keysDir + "/${name}.crt"
+    else
+      pkgs.writeText "ghaf-secureboot-${name}.crt" cfg.certificateContents.${name};
 
-  pkEsl = eslFromCert "PK.esl" (keysDir + "/PK.crt");
-  kekEsl = eslFromCert "KEK.esl" (keysDir + "/KEK.crt");
-  dbEsl = eslFromCert "db.esl" (keysDir + "/db.crt");
+  requiredCertFiles =
+    if cfg.certificateContents == null then
+      [
+        (keysDir + "/PK.crt")
+        (keysDir + "/KEK.crt")
+        (keysDir + "/db.crt")
+      ]
+    else
+      [ ];
+
+  pkEsl = eslFromCert "PK.esl" (certFile "PK");
+  kekEsl = eslFromCert "KEK.esl" (certFile "KEK");
+  dbEsl = eslFromCert "db.esl" (certFile "db");
 in
 {
   options.ghaf.hardware.nvidia.orin.secureboot = {
@@ -53,9 +64,26 @@ in
       description = "Directory containing PK.crt, KEK.crt and db.crt used to generate ESLs.";
     };
 
+    certificateContents = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.submodule {
+          options = {
+            PK = lib.mkOption { type = lib.types.lines; };
+            KEK = lib.mkOption { type = lib.types.lines; };
+            db = lib.mkOption { type = lib.types.lines; };
+          };
+        }
+      );
+      default = null;
+      description = ''
+        Public UEFI certificates supplied as text. This imports only public
+        material when a development trust directory also contains private keys.
+      '';
+    };
+
     signingKeyDir = lib.mkOption {
       type = lib.types.str;
-      default = toString ../../../../secureboot/dev-keys;
+      default = "";
       description = ''
         Path to directory containing db.key and db.crt for signing EFI
         binaries at flash time (on the build host). This is intentionally
@@ -64,6 +92,30 @@ in
 
         Can be overridden at flash time via the SECURE_BOOT_SIGNING_KEY_DIR
         environment variable.
+      '';
+    };
+
+    externalPublicTrustConfigured = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      internal = true;
+      description = ''
+        Whether the image was evaluated with a complete external public trust
+        set. The exported flake flash entry point uses this marker to select
+        either the secure A/B implementation or the board-matched generic
+        unsigned fallback. The secure A/B implementation itself remains
+        fail-closed for CI-only images.
+      '';
+    };
+
+    publicTrustDigests = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      internal = true;
+      description = ''
+        SHA-256 digests of the external public trust files embedded during
+        evaluation. Flash scripts compare these with the runtime key directory
+        before signing or preparing images.
       '';
     };
   };

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/secureboot.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/secureboot.nix
@@ -33,22 +33,12 @@ let
 
   keysDir = cfg.keysSource;
 
-  certFile =
-    name:
-    if cfg.certificateContents == null then
-      keysDir + "/${name}.crt"
-    else
-      pkgs.writeText "ghaf-secureboot-${name}.crt" cfg.certificateContents.${name};
-
-  requiredCertFiles =
-    if cfg.certificateContents == null then
-      [
-        (keysDir + "/PK.crt")
-        (keysDir + "/KEK.crt")
-        (keysDir + "/db.crt")
-      ]
-    else
-      [ ];
+  certFile = name: keysDir + "/${name}.crt";
+  requiredCertFiles = map certFile [
+    "PK"
+    "KEK"
+    "db"
+  ];
 
   pkEsl = eslFromCert "PK.esl" (certFile "PK");
   kekEsl = eslFromCert "KEK.esl" (certFile "KEK");
@@ -62,23 +52,6 @@ in
       type = lib.types.path;
       default = ../../../../secureboot/keys;
       description = "Directory containing PK.crt, KEK.crt and db.crt used to generate ESLs.";
-    };
-
-    certificateContents = lib.mkOption {
-      type = lib.types.nullOr (
-        lib.types.submodule {
-          options = {
-            PK = lib.mkOption { type = lib.types.lines; };
-            KEK = lib.mkOption { type = lib.types.lines; };
-            db = lib.mkOption { type = lib.types.lines; };
-          };
-        }
-      );
-      default = null;
-      description = ''
-        Public UEFI certificates supplied as text. This imports only public
-        material when a development trust directory also contains private keys.
-      '';
     };
 
     signingKeyDir = lib.mkOption {

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
@@ -25,12 +25,12 @@
 let
   cfg = config.ghaf.partitioning.verity;
 
-  # The ghafImage derivation from verity-volume.nix produces:
+  # The ghafUpdateImage derivation from verity-volume.nix produces:
   #   ghaf_root_<ver>_<hash>.raw.zst   — erofs nix-store image (compressed)
   #   ghaf_verity_<ver>_<hash>.raw.zst — dm-verity hash tree (compressed)
   #   ghaf_kernel_<ver>_<hash>.efi     — UKI with real roothash
   #   ghaf_<ver>_<hash>.manifest       — JSON manifest
-  inherit (config.system.build) ghafImage;
+  inherit (config.system.build) ghafUpdateImage verityLvmImage;
 
   # The ESP FAT image is built at flash time (not here) so that
   # EFI binaries can be signed with a private key that never enters
@@ -39,181 +39,39 @@ let
     mkdir -p $out
 
     # UKI (roothash-patched)
-    uki=$(find ${ghafImage} -name '*.efi' | head -1)
+    uki=$(find ${ghafUpdateImage} -name '*.efi' | head -1)
     if [ -z "$uki" ]; then
       echo "ERROR: No UKI (.efi) found in ghafImage output"
-      ls -la ${ghafImage}/
+      ls -la ${ghafUpdateImage}/
       exit 1
     fi
     ln -s "$uki" "$out/uki.efi"
-    basename "$uki" > "$out/uki-filename"
+
+    # The image artifact keeps its manifest-facing ghaf_kernel_* name, but
+    # systemd-boot and ota-update use ghaf-<version>-<hash>.efi as the stable
+    # managed entry ID.  Flash the initial UKI under that same name so the
+    # first slot participates in normal A/B discovery and is removed when its
+    # physical slot is reused.
+    manifest=$(find ${ghafUpdateImage} -name '*.manifest' | head -1)
+    version=$(${pkgs.buildPackages.jq}/bin/jq -er '.version' "$manifest")
+    root_hash=$(${pkgs.buildPackages.jq}/bin/jq -er '.root_verity_hash' "$manifest")
+    printf 'ghaf-%s-%s.efi\n' "$version" "''${root_hash:0:16}" > "$out/uki-filename"
 
     # systemd-boot
     ln -s "${config.systemd.package}/lib/systemd/boot/efi/systemd-bootaa64.efi" \
       "$out/systemd-bootaa64.efi"
   '';
 
-  # LVM image: must be built in a VM because LVM needs block devices.
-  # Reads the manifest from ghafImage to determine LV names, then writes
-  # the erofs and verity raw data directly into correctly-named LVs.
-  #
-  # Use pkgsBuildBuild (native build platform) for the VM tools.
-  # The VM runs on the build host and only writes raw data into LVs.
-  buildPkgs = pkgs.pkgsBuildBuild;
-
-  # LVM config for the VM — disable udev integration since the minimal
-  # VM has no udev daemon; LVM will create device nodes directly.
-  lvmConf = buildPkgs.writeText "lvm.conf" ''
-    devices {
-      dir = "/dev"
-      scan = [ "/dev" ]
-    }
-    activation {
-      udev_sync = 0
-      udev_rules = 0
-    }
-  '';
-
-  vmTools = buildPkgs.vmTools.override {
-    rootModules = [
-      "virtiofs"
-      "virtio_pci"
-      "virtio_blk"
-      "virtio_balloon"
-      "virtio_rng"
-      "dm_mod" # LVM needs device-mapper
-    ];
-  };
-  lvmImage = vmTools.runInLinuxVM (
-    buildPkgs.stdenvNoCC.mkDerivation {
-      name = "lvm-image";
-
-      # runInLinuxVM uses overrideDerivation + stage2Init which doesn't
-      # support structuredAttrs (origArgs becomes a flat string instead
-      # of a bash array, causing the builder invocation to fail silently)
-      __structuredAttrs = false;
-
-      buildInputs = with buildPkgs; [
-        lvm2
-        util-linux
-        zstd
-        jq
-      ];
-
-      memSize = 4096; # 4G RAM for the VM
-
-      preVM = ''
-        set -efx
-        mkdir -p $out
-
-        # Compute slot sizes from actual images (+ headroom)
-        manifest=$(find ${ghafImage} -name '*.manifest' | head -1)
-        root_file=$(${buildPkgs.jq}/bin/jq -r '.root.file' "$manifest")
-        verity_file=$(${buildPkgs.jq}/bin/jq -r '.verity.file' "$manifest")
-
-        # Get uncompressed sizes in bytes from zstd verbose listing
-        # Output line: "Decompressed Size: 9.37 GiB (10058227712 B)"
-        get_decompressed_size() {
-          ${buildPkgs.zstd}/bin/zstd --list -v "$1" 2>/dev/null \
-            | awk '/Decompressed Size/ { match($0, /\(([0-9]+) B\)/, m); print m[1] }'
-        }
-
-        root_bytes=$(get_decompressed_size "${ghafImage}/$root_file")
-        verity_bytes=$(get_decompressed_size "${ghafImage}/$verity_file")
-
-        # Round up to MiB + headroom
-        root_mib=$(( (root_bytes + 1048575) / 1048576 + 512 ))
-        verity_mib=$(( (verity_bytes + 1048575) / 1048576 + 16 ))
-        echo "Root image: $root_bytes bytes -> LV size: $root_mib MiB"
-        echo "Verity image: $verity_bytes bytes -> LV size: $verity_mib MiB"
-
-        # Only A-slot: root + verity + 64M LVM metadata overhead.
-        # B-slot, swap and persist are created on first boot by
-        # firstboot-persist.nix after the APP partition is resized.
-        lvm_mib=$(( root_mib + verity_mib + 64 ))
-        echo "LVM PV size: $lvm_mib MiB"
-
-        ${buildPkgs.qemu}/bin/qemu-img create -f raw "$out/system.img" ''${lvm_mib}M
-
-        # Pass computed sizes to buildCommand via xchg
-        mkdir -p xchg
-        echo "$root_mib" > xchg/root_size_mib
-        echo "$verity_mib" > xchg/verity_size_mib
-      '';
-
-      QEMU_OPTS = ''-drive file="$out"/system.img,if=virtio,cache=unsafe,werror=report,format=raw'';
-
-      # postVM runs on the build host after the VM exits.
-      # The image is small (only A-slot, ~5.5 GiB) so we just
-      # zstd-compress the raw image directly — no sparse conversion needed.
-      postVM = ''
-        ${buildPkgs.coreutils}/bin/stat -c%s "$out/system.img" > "$out/system.raw_size"
-        ${buildPkgs.zstd}/bin/zstd --compress --rm "$out/system.img" -o "$out/system.img.zst"
-      '';
-
-      buildCommand = ''
-        # Configure LVM to create device nodes directly (no udev in this VM)
-        export LVM_SYSTEM_DIR=/tmp/lvm
-        mkdir -p /tmp/lvm
-        cp ${lvmConf} /tmp/lvm/lvm.conf
-
-        LVM_DEV=/dev/vda
-
-        # Parse the manifest to get LV names
-        manifest=$(find ${ghafImage} -name '*.manifest' | head -1)
-        if [ -z "$manifest" ]; then
-          echo "ERROR: No manifest found in ghafImage output"
-          ls -la ${ghafImage}/
-          exit 1
-        fi
-        echo "Using manifest: $manifest"
-
-        # Extract the root and verity filenames (which encode version+hash)
-        root_file=$(jq -r '.root.file' "$manifest")
-        verity_file=$(jq -r '.verity.file' "$manifest")
-        echo "Root file: $root_file"
-        echo "Verity file: $verity_file"
-
-        # Extract LV name suffix from filename: ghaf_root_<ver>_<hash>.raw.zst -> <ver>_<hash>
-        # Pattern: ghaf_root_VERSION_HASH.raw.zst
-        lv_suffix=$(echo "$root_file" | sed 's/^ghaf_root_//; s/\.raw\.zst$//')
-        echo "LV suffix: $lv_suffix"
-
-        # Create LVM PV and VG on the raw disk
-        pvcreate "$LVM_DEV"
-        vgcreate pool "$LVM_DEV"
-
-        # Read slot sizes computed by preVM from actual images
-        root_mib=$(cat /tmp/xchg/root_size_mib)
-        verity_mib=$(cat /tmp/xchg/verity_size_mib)
-        echo "Root slot size: $root_mib MiB, Verity slot size: $verity_mib MiB"
-
-        # Create A-slot logical volumes only. B-slot, swap and persist
-        # are created on first boot by firstboot-persist.nix.
-        lvcreate -L "''${root_mib}M"   -n "root_$lv_suffix"   pool
-        lvcreate -L "''${verity_mib}M" -n "verity_$lv_suffix" pool
-
-        # Decompress and write erofs image into root LV
-        echo "Writing erofs image to root_$lv_suffix..."
-        zstd -d "${ghafImage}/$root_file" --stdout | dd of="/dev/pool/root_$lv_suffix" bs=4M conv=notrunc status=progress
-
-        # Decompress and write verity hash tree into verity LV
-        echo "Writing verity data to verity_$lv_suffix..."
-        zstd -d "${ghafImage}/$verity_file" --stdout | dd of="/dev/pool/verity_$lv_suffix" bs=4M conv=notrunc status=progress
-
-        # Deactivate VG before finishing
-        vgchange -an pool
-      '';
-    }
-  );
 in
 {
   config = lib.mkIf cfg.enable {
     system.build.verityImages = pkgs.runCommand "verity-images" { } ''
       mkdir -p $out
       ln -s ${espFiles} $out/esp-files
-      ln -s ${lvmImage}/system.img.zst $out/system.img.zst
-      ln -s ${lvmImage}/system.raw_size $out/system.raw_size
+      ln -s ${verityLvmImage}/system.img.zst $out/system.img.zst
+      # NVIDIA's flash-time outer LUKS container needs header headroom.
+      lvm_size=$(cat ${verityLvmImage}/system.raw_size)
+      echo $((lvm_size + 32 * 1024 * 1024)) > $out/system.raw_size
     '';
 
     # Configure filesystem mounts for the verity layout.

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
@@ -9,7 +9,7 @@
 #            sd-stub skips fixup and the kernel uses the firmware's DTB
 #            already in the EFI Configuration Table (installed by DtPlatformDxe).
 #
-# LVM image: PV containing volume group "pool" with only the A-slot:
+# LVM payload: the image builder creates volume group "pool" with:
 #   - root_<ver>_<hash>  (erofs nix-store image from ghafImage)
 #   - verity_<ver>_<hash> (dm-verity hash tree from ghafImage)
 #
@@ -30,11 +30,13 @@ let
   #   ghaf_verity_<ver>_<hash>.raw.zst — dm-verity hash tree (compressed)
   #   ghaf_kernel_<ver>_<hash>.efi     — UKI with real roothash
   #   ghaf_<ver>_<hash>.manifest       — JSON manifest
-  inherit (config.system.build) ghafUpdateImage verityLvmImage;
+  inherit (config.system.build) ghafUpdateImage;
+  fixedSlotSizes = cfg.rootSlotSizeMiB != null && cfg.veritySlotSizeMiB != null;
+  luksHeaderSizeMiB = if config.ghaf.hardware.nvidia.orin.diskEncryption.enable then 32 else 0;
 
-  # The ESP FAT image is built at flash time (not here) so that
-  # EFI binaries can be signed with a private key that never enters
-  # the Nix store.  We only export the individual files needed.
+  # The ESP is assembled at flash time because its EFI binaries need private
+  # signing keys. The LVM/LUKS payload is built here using regular-file-only
+  # userspace tools; no loop device, device mapper, VM, or privilege is needed.
   espFiles = pkgs.runCommand "esp-files" { } ''
     mkdir -p $out
 
@@ -68,10 +70,47 @@ in
     system.build.verityImages = pkgs.runCommand "verity-images" { } ''
       mkdir -p $out
       ln -s ${espFiles} $out/esp-files
-      ln -s ${verityLvmImage}/system.img.zst $out/system.img.zst
-      # NVIDIA's flash-time outer LUKS container needs header headroom.
-      lvm_size=$(cat ${verityLvmImage}/system.raw_size)
-      echo $((lvm_size + 32 * 1024 * 1024)) > $out/system.raw_size
+      ln -s ${ghafUpdateImage} $out/update
+      manifest=$(find ${ghafUpdateImage} -maxdepth 1 -name '*.manifest' -print -quit)
+      ${
+        if fixedSlotSizes then
+          ''
+            root_mib=${toString cfg.rootSlotSizeMiB}
+            verity_mib=${toString cfg.veritySlotSizeMiB}
+          ''
+        else
+          ''
+            root_bytes=$(${pkgs.buildPackages.jq}/bin/jq -er '.root.unpacked_size' "$manifest")
+            verity_bytes=$(${pkgs.buildPackages.jq}/bin/jq -er '.verity.unpacked_size' "$manifest")
+            root_mib=$(( (root_bytes + 1048575) / 1048576 + 512 ))
+            verity_mib=$(( (verity_bytes + 1048575) / 1048576 + 16 ))
+          ''
+      }
+      printf '%s\n' "$root_mib" > $out/root_size_mib
+      printf '%s\n' "$verity_mib" > $out/verity_size_mib
+      # One populated A-slot and LVM metadata headroom. In encrypted builds the
+      # regular-file LUKS conversion adds its header without shrinking payload.
+      payload_mib=$((root_mib + verity_mib + 64))
+      image=system.img
+      truncate -s "$((payload_mib * 1024 * 1024))" "$image"
+      "${lib.getExe pkgs.buildPackages.ghaf-initialize-verity-lvm}" \
+        --image "$image" \
+        --update-dir ${ghafUpdateImage} \
+        --root-size-mib "$root_mib" \
+        --verity-size-mib "$verity_mib"
+      ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
+        printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
+          > manufacturer.key
+        "${lib.getExe pkgs.buildPackages.ghaf-wrap-luks-image}" \
+          --image "$image" \
+          --uuid ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.luksUuid} \
+          --key-file manufacturer.key \
+          --header-size-mib ${toString luksHeaderSizeMiB}
+        rm -f manufacturer.key
+      ''}
+      stat -c%s "$image" > $out/system.raw_size
+      "${lib.getExe pkgs.buildPackages.zstd}" --compress --threads=0 \
+        "$image" -o $out/system.img.zst
     '';
 
     # Configure filesystem mounts for the verity layout.

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
@@ -32,7 +32,6 @@ let
   #   ghaf_<ver>_<hash>.manifest       — JSON manifest
   inherit (config.system.build) ghafUpdateImage;
   fixedSlotSizes = cfg.rootSlotSizeMiB != null && cfg.veritySlotSizeMiB != null;
-  luksHeaderSizeMiB = if config.ghaf.hardware.nvidia.orin.diskEncryption.enable then 32 else 0;
 
   # The ESP is assembled at flash time because its EFI binaries need private
   # signing keys. The LVM/LUKS payload is built here using regular-file-only
@@ -71,7 +70,9 @@ in
       mkdir -p $out
       ln -s ${espFiles} $out/esp-files
       ln -s ${ghafUpdateImage} $out/update
-      manifest=$(find ${ghafUpdateImage} -maxdepth 1 -name '*.manifest' -print -quit)
+      mapfile -t manifests < <(find ${ghafUpdateImage} -maxdepth 1 -type f -name '*.manifest')
+      [ "''${#manifests[@]}" -eq 1 ] || { echo "Expected exactly one update manifest" >&2; exit 1; }
+      manifest="''${manifests[0]}"
       ${
         if fixedSlotSizes then
           ''
@@ -95,7 +96,7 @@ in
       truncate -s "$((payload_mib * 1024 * 1024))" "$image"
       "${lib.getExe pkgs.buildPackages.ghaf-initialize-verity-lvm}" \
         --image "$image" \
-        --update-dir ${ghafUpdateImage} \
+        --manifest "$manifest" \
         --root-size-mib "$root_mib" \
         --verity-size-mib "$verity_mib"
       ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
@@ -104,8 +105,7 @@ in
         "${lib.getExe pkgs.buildPackages.ghaf-wrap-luks-image}" \
           --image "$image" \
           --uuid ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.luksUuid} \
-          --key-file manufacturer.key \
-          --header-size-mib ${toString luksHeaderSizeMiB}
+          --key-file manufacturer.key
         rm -f manufacturer.key
       ''}
       stat -c%s "$image" > $out/system.raw_size

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
@@ -25,6 +25,8 @@
 }:
 let
   cfg = config.ghaf.partitioning.verity;
+  buildPkgs = pkgs.pkgsBuildBuild;
+  runVM = import ../../../../../lib/image-builder-vm.nix { pkgs = buildPkgs; };
 
   # The ghafUpdateImage derivation from verity-volume.nix produces:
   #   ghaf_root_<ver>_<hash>.raw.zst   — erofs nix-store image (compressed)
@@ -35,8 +37,8 @@ let
   fixedSlotSizes = cfg.rootSlotSizeMiB != null && cfg.veritySlotSizeMiB != null;
 
   # The ESP is assembled at flash time because its EFI binaries need private
-  # signing keys. The LVM/LUKS payload is built here using regular-file-only
-  # userspace tools; no loop device, device mapper, VM, or privilege is needed.
+  # signing keys. The LVM/LUKS payload is created on a disposable build-VM disk
+  # using stock cryptsetup and LVM tools.
   espFiles = pkgs.runCommand "esp-files" { } ''
     mkdir -p $out
 
@@ -67,54 +69,58 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
-    system.build.verityImages = pkgs.runCommand "verity-images" { } ''
-      mkdir -p $out
-      ln -s ${espFiles} $out/esp-files
-      ln -s ${ghafUpdateImage} $out/update
-      mapfile -t manifests < <(find ${ghafUpdateImage} -maxdepth 1 -type f -name '*.manifest')
-      [ "''${#manifests[@]}" -eq 1 ] || { echo "Expected exactly one update manifest" >&2; exit 1; }
-      manifest="''${manifests[0]}"
-      ${
-        if fixedSlotSizes then
-          ''
-            root_mib=${toString cfg.rootSlotSizeMiB}
-            verity_mib=${toString cfg.veritySlotSizeMiB}
-          ''
-        else
-          ''
-            root_bytes=$(${pkgs.buildPackages.jq}/bin/jq -er '.root.unpacked_size' "$manifest")
-            verity_bytes=$(${pkgs.buildPackages.jq}/bin/jq -er '.verity.unpacked_size' "$manifest")
-            root_mib=$(( (root_bytes + 1048575) / 1048576 + 512 ))
-            verity_mib=$(( (verity_bytes + 1048575) / 1048576 + 16 ))
-          ''
-      }
-      printf '%s\n' "$root_mib" > $out/root_size_mib
-      printf '%s\n' "$verity_mib" > $out/verity_size_mib
-      # Both fixed system pairs and LVM metadata headroom. Empty B-slot extents
-      # remain sparse. In encrypted builds the
-      # regular-file LUKS conversion adds its header without shrinking payload.
-      payload_mib=$((2 * (root_mib + verity_mib) + 64))
-      image=system.img
-      truncate -s "$((payload_mib * 1024 * 1024))" "$image"
-      "${lib.getExe pkgs.buildPackages.ghaf-initialize-verity-lvm}" \
-        --image "$image" \
-        --manifest "$manifest" \
-        --create-inactive-slots \
-        --root-size-mib "$root_mib" \
-        --verity-size-mib "$verity_mib"
-      ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
-        printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} \
-          > manufacturer.key
-        "${lib.getExe pkgs.buildPackages.ghaf-wrap-luks-image}" \
-          --image "$image" \
-          --uuid ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.luksUuid} \
-          --key-file manufacturer.key
-        rm -f manufacturer.key
-      ''}
-      stat -c%s "$image" > $out/system.raw_size
-      "${lib.getExe pkgs.buildPackages.zstd}" --compress --threads=0 \
-        "$image" -o $out/system.img.zst
-    '';
+    system.build.verityImages = runVM (
+      buildPkgs.runCommand "verity-images"
+        {
+          preVM = ''
+            mapfile -t manifests < <(find ${ghafUpdateImage} -maxdepth 1 -type f -name '*.manifest')
+            [ "''${#manifests[@]}" -eq 1 ] || { echo "Expected exactly one update manifest" >&2; exit 1; }
+            manifest="''${manifests[0]}"
+            printf '%s' "$manifest" > xchg/manifest-path
+            ${
+              if fixedSlotSizes then
+                ''
+                  root_mib=${toString cfg.rootSlotSizeMiB}
+                  verity_mib=${toString cfg.veritySlotSizeMiB}
+                ''
+              else
+                ''
+                  root_bytes=$(${buildPkgs.jq}/bin/jq -er '.root.unpacked_size' "$manifest")
+                  verity_bytes=$(${buildPkgs.jq}/bin/jq -er '.verity.unpacked_size' "$manifest")
+                  root_mib=$(( (root_bytes + 1048575) / 1048576 + 512 ))
+                  verity_mib=$(( (verity_bytes + 1048575) / 1048576 + 16 ))
+                ''
+            }
+            printf '%s\n' "$root_mib" > xchg/root_size_mib
+            printf '%s\n' "$verity_mib" > xchg/verity_size_mib
+            diskImage=$PWD/system.img
+            truncate -s "$(( (2 * (root_mib + verity_mib) + 64 + ${
+              if config.ghaf.hardware.nvidia.orin.diskEncryption.enable then "32" else "0"
+            }) * 1048576 ))" "$diskImage"
+          '';
+          postVM = ''
+            mkdir -p "$out"
+            ln -s ${espFiles} "$out/esp-files"
+            ln -s ${ghafUpdateImage} "$out/update"
+            cp xchg/root_size_mib xchg/verity_size_mib "$out/"
+            stat -c%s "$diskImage" > "$out/system.raw_size"
+            ${lib.getExe buildPkgs.zstd} --compress --threads=0 "$diskImage" -o "$out/system.img.zst"
+          '';
+        }
+        ''
+          encryption=()
+          ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''
+            umask 077
+            printf '%s' ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.deviceUniqueKey.deviceManufacturerPassphrase} > manufacturer.key
+            encryption=(--luks-uuid ${lib.escapeShellArg config.ghaf.hardware.nvidia.orin.diskEncryption.luksUuid} --key-file manufacturer.key)
+          ''}
+          ${lib.getExe buildPkgs.ghaf-initialize-verity-lvm} \
+            --image /dev/vda --manifest "$(cat manifest-path)" --create-inactive-slots \
+            --root-size-mib "$(cat root_size_mib)" --verity-size-mib "$(cat verity_size_mib)" \
+            "''${encryption[@]}"
+          rm -f manufacturer.key
+        ''
+    );
 
     # Configure filesystem mounts for the verity layout.
     # /persist and swap are declared in firstboot-persist.nix.

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
@@ -12,8 +12,9 @@
 # LVM payload: the image builder creates volume group "pool" with:
 #   - root_<ver>_<hash>  (erofs nix-store image from ghafImage)
 #   - verity_<ver>_<hash> (dm-verity hash tree from ghafImage)
+#   - root_empty / verity_empty (reserved inactive system pair)
 #
-# Swap, persist and B-slot LVs are created on first boot by
+# Swap and persist LVs are created on first boot by
 # firstboot-persist.nix, which resizes the APP partition to fill the
 # eMMC and uses the free VG space.
 {
@@ -89,14 +90,16 @@ in
       }
       printf '%s\n' "$root_mib" > $out/root_size_mib
       printf '%s\n' "$verity_mib" > $out/verity_size_mib
-      # One populated A-slot and LVM metadata headroom. In encrypted builds the
+      # Both fixed system pairs and LVM metadata headroom. Empty B-slot extents
+      # remain sparse. In encrypted builds the
       # regular-file LUKS conversion adds its header without shrinking payload.
-      payload_mib=$((root_mib + verity_mib + 64))
+      payload_mib=$((2 * (root_mib + verity_mib) + 64))
       image=system.img
       truncate -s "$((payload_mib * 1024 * 1024))" "$image"
       "${lib.getExe pkgs.buildPackages.ghaf-initialize-verity-lvm}" \
         --image "$image" \
         --manifest "$manifest" \
+        --create-inactive-slots \
         --root-size-mib "$root_mib" \
         --verity-size-mib "$verity_mib"
       ${lib.optionalString config.ghaf.hardware.nvidia.orin.diskEncryption.enable ''

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -13,14 +13,6 @@ let
   inherit (inputs) jetpack-nixos nixpkgs;
   system = "aarch64-linux";
   pkgsX86 = nixpkgs.legacyPackages.x86_64-linux;
-  updateHealthFailureText = builtins.getEnv "GHAF_AB_TEST_UNHEALTHY";
-  updateHealthFailure =
-    if updateHealthFailureText == "" then
-      false
-    else if updateHealthFailureText == "1" then
-      true
-    else
-      throw "GHAF_AB_TEST_UNHEALTHY must be unset or 1";
   lazyPackage =
     name: drv:
     (lib.lazyDerivation {
@@ -150,6 +142,8 @@ let
           enable = true;
           inherit target;
         };
+        boot-health.debugUnhealthyMicrovm =
+          if config.ghaf.secureUpdate.injectBootHealthFailure then "ab-health-failure-injection" else null;
         hardware.nvidia.orin.secureboot = {
           inherit (config.ghaf.secureUpdate)
             externalPublicTrustConfigured
@@ -542,7 +536,6 @@ let
             boot-health = {
               enable = true;
               luksMapper = "cryptroot";
-              debugUnhealthyMicrovm = if updateHealthFailure then "ab-health-failure-injection" else null;
             };
           };
         })
@@ -773,7 +766,7 @@ let
           echo "WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead." >&2
           echo "  Requested: ${t.name}" >&2
           echo "  Fallback:  ${fallback.name}" >&2
-          echo "  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen to flash the secure A/B canary." >&2
+          echo "  Rebuild with an external secure-ab-build-config input to flash the secure A/B canary." >&2
 
           args=()
           while (($#)); do

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -139,6 +139,13 @@ let
     }:
     {
       ghaf = {
+        partitioning.verity = {
+          # Both Orin variants have room for two 12 GiB roots on the 64 GB AGX
+          # eMMC while retaining roughly 30 GiB for persist. Current signed
+          # canaries use less than 5 GiB of root data and 40 MiB of verity data.
+          rootSlotSizeMiB = 12 * 1024;
+          veritySlotSizeMiB = 256;
+        };
         secureUpdate = {
           enable = true;
           inherit target;

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -142,8 +142,6 @@ let
           enable = true;
           inherit target;
         };
-        boot-health.debugUnhealthyMicrovm =
-          if config.ghaf.secureUpdate.injectBootHealthFailure then "ab-health-failure-injection" else null;
         hardware.nvidia.orin.secureboot = {
           inherit (config.ghaf.secureUpdate)
             externalPublicTrustConfigured
@@ -526,7 +524,7 @@ let
             partitioning.verity.enable = true;
             # Linux 6.6 on Orin supports LZ4HC EROFS images but not the zstd
             # format emitted by the current erofs-utils.
-            partitioning.verity.erofsCompression = "lz4hc";
+            partitioning.verity.erofsCompression.algorithm = "lz4hc";
             hardware.nvidia.orin.secureboot.enable = true;
             hardware.nvidia.orin.diskEncryption.enable = true;
             hardware.nvidia.orin.diskEncryption.deviceUniqueKey.enable = true;

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -13,6 +13,14 @@ let
   inherit (inputs) jetpack-nixos nixpkgs;
   system = "aarch64-linux";
   pkgsX86 = nixpkgs.legacyPackages.x86_64-linux;
+  updateHealthFailureText = builtins.getEnv "GHAF_AB_TEST_UNHEALTHY";
+  updateHealthFailure =
+    if updateHealthFailureText == "" then
+      false
+    else if updateHealthFailureText == "1" then
+      true
+    else
+      throw "GHAF_AB_TEST_UNHEALTHY must be unset or 1";
   lazyPackage =
     name: drv:
     (lib.lazyDerivation {
@@ -103,8 +111,7 @@ let
     self.nixosModules.profiles
     ../../modules/reference/hardware/jetpack/nvidia-jetson-orin/verity-image.nix
     ../../modules/reference/hardware/jetpack/nvidia-jetson-orin/partition-template-verity.nix
-    inputs.nix-store-veritysetup-generator.nixosModules.ghaf-store-veritysetup-generator
-    ../../modules/partitioning/verity-volume.nix
+    self.nixosModules.secure-ab-core
     ../../modules/partitioning/firstboot-persist.nix
     # Enable dm-verity and erofs in the kernel (not in the BSP default config)
     {
@@ -123,6 +130,112 @@ let
       ];
     }
   ];
+
+  mkOrinSecureUpdateModule =
+    target:
+    {
+      config,
+      ...
+    }:
+    {
+      ghaf = {
+        secureUpdate = {
+          enable = true;
+          inherit target;
+        };
+        hardware.nvidia.orin.secureboot = {
+          inherit (config.ghaf.secureUpdate)
+            externalPublicTrustConfigured
+            publicTrustDigests
+            ;
+          certificateContents = config.ghaf.secureUpdate.uefiCertificateContents;
+        };
+      };
+    };
+
+  orinLocalBootFirstModule =
+    { pkgs, ... }:
+    {
+      # NVIDIA's development firmware can put HTTP/PXE entries before the
+      # internal storage entry. That turns every watchdog reset into a
+      # multi-minute network-boot timeout and, more importantly, delays A/B
+      # attempt consumption. Promote only the storage entry that successfully
+      # booted this system; never promote a shell, setup, or network entry.
+      systemd.services.ghaf-promote-local-uefi-boot = {
+        description = "Promote the booted internal storage UEFI entry";
+        after = [
+          "boot.mount"
+          "setup-jetson-efi-variables.service"
+        ];
+        requires = [ "boot.mount" ];
+        wantedBy = [ "multi-user.target" ];
+        path = with pkgs; [
+          coreutils
+          efibootmgr
+          gnugrep
+          gnused
+        ];
+        script = ''
+          state="$(efibootmgr)"
+          current="$(printf '%s\n' "$state" | sed -n 's/^BootCurrent:[[:space:]]*//p')"
+          order="$(printf '%s\n' "$state" | sed -n 's/^BootOrder:[[:space:]]*//p')"
+
+          if ! printf '%s\n' "$current" | grep -Eq '^[0-9A-Fa-f]{4}$'; then
+            echo "Cannot identify current UEFI boot entry: $current" >&2
+            exit 1
+          fi
+
+          label="$(
+            printf '%s\n' "$state" \
+              | sed -n "s/^Boot''${current}\\*\{0,1\}[[:space:]]*//p" \
+              | head -n1
+          )"
+          case "$label" in
+          "UEFI HTTP"* | "UEFI PXE"* | "UEFI Shell"* | "Enter Setup"* | "BootManagerMenuApp"* | "")
+            echo "Refusing to promote non-storage UEFI entry Boot$current: $label" >&2
+            exit 1
+            ;;
+          "UEFI "*) ;;
+          *)
+            echo "Refusing to promote unrecognized UEFI entry Boot$current: $label" >&2
+            exit 1
+            ;;
+          esac
+
+          first="''${order%%,*}"
+          if [ "$first" = "$current" ]; then
+            echo "Boot$current ($label) is already first in BootOrder"
+            exit 0
+          fi
+
+          newOrder="$current"
+          oldIFS="$IFS"
+          IFS=,
+          for entry in $order; do
+            if [ "$entry" != "$current" ]; then
+              newOrder="$newOrder,$entry"
+            fi
+          done
+          IFS="$oldIFS"
+
+          efibootmgr --bootorder "$newOrder"
+          echo "Promoted Boot$current ($label) ahead of network boot entries"
+        '';
+        serviceConfig.Type = "oneshot";
+      };
+    };
+
+  # Static HTTP is a deliberately manual development transport. Keep its
+  # download/parsing tools in the secure canary net-vm, which owns external
+  # networking, rather than giving the Ghaf host direct network access.
+  orinUpdateHttpFetchModule =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [
+        curl
+        jq
+      ];
+    };
 
   # Shared by the AGX and NX accelerated-guivm variants.
   acceleratedGuivmUsbRules = [
@@ -362,30 +475,68 @@ let
 
   ];
 
-  # A/B Verity Boot Configurations (AGX only)
+  # Secure A/B verity+LUKS canaries. The AGX canary leaves the firmware TPM
+  # disabled: its OP-TEE fTPM probe can remain uninterruptibly blocked and
+  # prevent reboot. This does not disable the separate OP-TEE DUK path used to
+  # unlock APP.
   verity-target-configs =
     map
       (
-        variant:
+        board:
         (ghaf-configuration {
-          name = "nvidia-jetson-orin-agx-verity";
+          name = "${board.name}-verity-luks";
           inherit system;
           profile = "orin";
-          hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-agx;
-          inherit variant;
-          extraModules = orinVerityModules;
+          inherit (board) hardwareModule;
+          variant = "debug";
+          extraModules = orinVerityModules ++ [
+            (mkOrinSecureUpdateModule "${board.name}-verity-luks-debug")
+            orinLocalBootFirstModule
+            {
+              # The Tegra186 watchdog used by Orin accepts timeouts up to
+              # 255s. Arm it in both initrd and stage 2 so verity panics,
+              # early boot hangs, and shutdown hangs can consume a
+              # boot-counting attempt. systemd's 10 minute reboot-watchdog
+              # default is rejected by this device, so keep all configured
+              # timeouts within its range.
+              # NixOS' initrd panic-on-fail service triggers a SysRq crash
+              # when emergency.target is reached. Together with panic=10,
+              # this makes an unmountable or corrupted trial consume its
+              # systemd-boot attempt instead of waiting in an emergency
+              # shell while PID 1 continues to feed the watchdog.
+              boot.kernelParams = [
+                "boot.panic_on_fail"
+                "panic=10"
+              ];
+              boot.initrd.systemd.settings.Manager = {
+                WatchdogDevice = "/dev/watchdog0";
+                RuntimeWatchdogSec = "30s";
+                RebootWatchdogSec = "2min";
+              };
+              systemd.settings.Manager = {
+                WatchdogDevice = "/dev/watchdog0";
+                RuntimeWatchdogSec = "30s";
+                RebootWatchdogSec = "2min";
+              };
+            }
+          ];
           extraConfig = {
             reference.profiles.mvp-orinuser-trial.enable = true;
             partitioning.verity.enable = true;
-            partitioning.verity.uki-signing-key-dir = lib.mkIf (
-              variant == "debug"
-            ) ../../modules/secureboot/dev-keys;
+            # Linux 6.6 on Orin supports LZ4HC EROFS images but not the zstd
+            # format emitted by the current erofs-utils.
+            partitioning.verity.erofsCompression = "lz4hc";
             hardware.nvidia.orin.secureboot.enable = true;
-            # Debug builds enroll the dev certs so they match the dev signing
-            # keys; release builds keep the production certs from keysSource.
-            hardware.nvidia.orin.secureboot.keysSource = lib.mkIf (
-              variant == "debug"
-            ) ../../modules/secureboot/dev-keys;
+            hardware.nvidia.orin.diskEncryption.enable = true;
+            hardware.nvidia.orin.diskEncryption.deviceUniqueKey.enable = true;
+            hardware.nvidia.orin.ftpm.enable = board.enableFtpm;
+            hardware.nvidia.orin.runtimeEkProvision.enable = board.enableFtpm;
+            virtualization.vmConfig.sysvms.netvm.extraModules = [ orinUpdateHttpFetchModule ];
+            boot-health = {
+              enable = true;
+              luksMapper = "cryptroot";
+              debugUnhealthyMicrovm = if updateHealthFailure then "ab-health-failure-injection" else null;
+            };
           };
         })
         // {
@@ -398,8 +549,16 @@ let
         }
       )
       [
-        "debug"
-        "release"
+        {
+          name = "nvidia-jetson-orin-nx";
+          hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-nx;
+          enableFtpm = true;
+        }
+        {
+          name = "nvidia-jetson-orin-agx";
+          hardwareModule = self.nixosModules.hardware-nvidia-jetson-orin-agx;
+          enableFtpm = false;
+        }
       ];
   all-target-configs = target-configs ++ verity-target-configs;
 
@@ -469,8 +628,8 @@ let
       package = hostConfiguration.config.system.build.ghafImage;
     };
 
-  # LUKS and dm-verity are mutually exclusive root strategies (see the assertion
-  # in jetson-orin.nix), so the verity targets get no -luks variant.
+  # Secure verity canaries already contain the outer LUKS cryptpool, so do not
+  # generate duplicate synthetic -luks or -luks-uki variants for them.
   luksable-target-configs = builtins.filter (t: !isVerityTarget t) all-target-configs;
 
   # Add nodemoapps targets
@@ -482,6 +641,16 @@ let
     ++ (map (t: generate-luks (generate-nodemoapps t)) luksable-target-configs)
     ++ (map (t: generate-luks-uki (generate-nodemoapps t)) luksable-target-configs);
   crossTargets = map generate-cross-from-x86_64 targets;
+
+  genericUnsignedTarget =
+    t:
+    let
+      fallbackName = lib.replaceStrings [ "-verity-luks" ] [ "" ] t.name;
+    in
+    lib.findFirst (candidate: candidate.name == fallbackName)
+      (throw "No generic unsigned fallback target `${fallbackName}` for secure A/B target `${t.name}`")
+      crossTargets;
+
   flashTarget =
     t: qspiOnly:
     let
@@ -581,6 +750,55 @@ let
       '';
     };
 
+  exportedFlashTarget =
+    t:
+    if
+      isVerityTarget t
+      && !t.hostConfiguration.config.ghaf.hardware.nvidia.orin.secureboot.externalPublicTrustConfigured
+    then
+      let
+        fallback = genericUnsignedTarget t;
+        fallbackFlash = flashTarget fallback false;
+      in
+      pkgsX86.writeShellApplication {
+        name = "flash-ghaf-host";
+        text = ''
+          echo "WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead." >&2
+          echo "  Requested: ${t.name}" >&2
+          echo "  Fallback:  ${fallback.name}" >&2
+          echo "  Rebuild with --impure and GHAF_DEV_KEY_DIR from ghaf-dev-keygen to flash the secure A/B canary." >&2
+
+          args=()
+          while (($#)); do
+            case "$1" in
+              --secure-boot)
+                echo "WARNING: ignoring --secure-boot because the CI-only fallback is explicitly unsigned." >&2
+                shift
+                ;;
+              -u|--uki)
+                echo "WARNING: ignoring $1 because the generic fallback does not use a UKI image." >&2
+                shift
+                ;;
+              -s|--signed-sd-image)
+                if (($# < 2)); then
+                  echo "ERROR: $1 requires an image directory argument." >&2
+                  exit 2
+                fi
+                echo "WARNING: ignoring $1 and its argument because the fallback uses its built-in generic unsigned image." >&2
+                shift 2
+                ;;
+              *)
+                args+=("$1")
+                shift
+                ;;
+            esac
+          done
+          exec ${fallbackFlash}/bin/flash-ghaf-host "''${args[@]}"
+        '';
+      }
+    else
+      flashTarget t false;
+
   # Filter verity targets without forcing every hostConfiguration.config during
   # package-set evaluation.
   isVerityTarget = t: t.isVerity or false;
@@ -616,7 +834,7 @@ in
             t:
             #Note: secureTarget does not toggle between secureboot on/off!!
             lib.nameValuePair "${t.name}-flash-script" (
-              lazyPackage "${t.name}-flash-script" (flashTarget t false)
+              lazyPackage "${t.name}-flash-script" (exportedFlashTarget t)
             )
           ) flashCrossTargets
         )

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -143,10 +143,7 @@ let
           inherit target;
         };
         hardware.nvidia.orin.secureboot = {
-          inherit (config.ghaf.secureUpdate)
-            externalPublicTrustConfigured
-            publicTrustDigests
-            ;
+          inherit (config.ghaf.secureUpdate) publicTrustDigests;
           certificateContents = config.ghaf.secureUpdate.uefiCertificateContents;
         };
       };
@@ -640,15 +637,6 @@ let
     ++ (map (t: generate-luks-uki (generate-nodemoapps t)) luksable-target-configs);
   crossTargets = map generate-cross-from-x86_64 targets;
 
-  genericUnsignedTarget =
-    t:
-    let
-      fallbackName = lib.replaceStrings [ "-verity-luks" ] [ "" ] t.name;
-    in
-    lib.findFirst (candidate: candidate.name == fallbackName)
-      (throw "No generic unsigned fallback target `${fallbackName}` for secure A/B target `${t.name}`")
-      crossTargets;
-
   flashTarget =
     t: qspiOnly:
     let
@@ -748,55 +736,6 @@ let
       '';
     };
 
-  exportedFlashTarget =
-    t:
-    if
-      isVerityTarget t
-      && !t.hostConfiguration.config.ghaf.hardware.nvidia.orin.secureboot.externalPublicTrustConfigured
-    then
-      let
-        fallback = genericUnsignedTarget t;
-        fallbackFlash = flashTarget fallback false;
-      in
-      pkgsX86.writeShellApplication {
-        name = "flash-ghaf-host";
-        text = ''
-          echo "WARNING: secure A/B development trust was unavailable at evaluation; flashing the generic unsigned target instead." >&2
-          echo "  Requested: ${t.name}" >&2
-          echo "  Fallback:  ${fallback.name}" >&2
-          echo "  Rebuild with an external secure-ab-build-config input to flash the secure A/B canary." >&2
-
-          args=()
-          while (($#)); do
-            case "$1" in
-              --secure-boot)
-                echo "WARNING: ignoring --secure-boot because the CI-only fallback is explicitly unsigned." >&2
-                shift
-                ;;
-              -u|--uki)
-                echo "WARNING: ignoring $1 because the generic fallback does not use a UKI image." >&2
-                shift
-                ;;
-              -s|--signed-sd-image)
-                if (($# < 2)); then
-                  echo "ERROR: $1 requires an image directory argument." >&2
-                  exit 2
-                fi
-                echo "WARNING: ignoring $1 and its argument because the fallback uses its built-in generic unsigned image." >&2
-                shift 2
-                ;;
-              *)
-                args+=("$1")
-                shift
-                ;;
-            esac
-          done
-          exec ${fallbackFlash}/bin/flash-ghaf-host "''${args[@]}"
-        '';
-      }
-    else
-      flashTarget t false;
-
   # Filter verity targets without forcing every hostConfiguration.config during
   # package-set evaluation.
   isVerityTarget = t: t.isVerity or false;
@@ -832,7 +771,7 @@ in
             t:
             #Note: secureTarget does not toggle between secureboot on/off!!
             lib.nameValuePair "${t.name}-flash-script" (
-              lazyPackage "${t.name}-flash-script" (exportedFlashTarget t)
+              lazyPackage "${t.name}-flash-script" (flashTarget t false)
             )
           ) flashCrossTargets
         )

--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -144,7 +144,7 @@ let
         };
         hardware.nvidia.orin.secureboot = {
           inherit (config.ghaf.secureUpdate) publicTrustDigests;
-          certificateContents = config.ghaf.secureUpdate.uefiCertificateContents;
+          keysSource = inputs.secure-ab-build-config;
         };
       };
     };


### PR DESCRIPTION
## Summary

NVIDIA Jetson Orin adapter on #2199; independent of sibling #2201.

- NX NVMe and AGX eMMC secure verity/LUKS targets.
- Shared regular-file image builders; flash-time signing and recovery enrollment.
- OP-TEE DUK unlock, aligned APP growth and idempotent persist provisioning.
- External public trust bound to NVIDIA Secure Boot, fixed-capacity system
  slots and shared three-attempt boot health.
- Uses the Rust LVM writer from tiiuae/ghafpkgs#378 through the shared pin,
  selecting exactly one manifest explicitly and using the fixed LUKS header.

The runbook retains test IDs, fault points, device checks and recovery limits.
Mandatory signing-key validation eliminates the unsigned-signing branch.

## Validation

Pure NX/AGX trust evaluation and generated NX pre-flash shell syntax checks
pass. The latest shared pin and CLI changes pass pure AGX secure-image
build-command evaluation, formatting, REUSE and whitespace checks.
