### PR TITLE
feat(x86): add secure A/B platform adapter

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -167,6 +167,7 @@ export default defineConfig({
                         "ghaf/dev/guides/extending-targets",
                         "ghaf/dev/guides/downstream-setup",
                         "ghaf/dev/guides/migration",
+                        "ghaf/dev/guides/x86-secure-ab-testing",
                       ],
                     },
                     {

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -33,9 +33,15 @@ Generate one external development trust directory and keep it outside Git:
 ```sh
 nix run .#ghaf-dev-keygen -- --output /secure/local/ghaf-dev-keys
 export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
-export GHAF_UPDATE_GENERATION=1
+export SECURE_AB_GENERATION=1
+export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-x86-generation-$SECURE_AB_GENERATION"
+nix run .#ghaf-secure-ab-config -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --generation "$SECURE_AB_GENERATION" \
+  --output "$SECURE_AB_BUILD_CONFIG"
 
-timeout 2h nix build --impure \
+timeout 2h nix build \
+  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   .#intel-laptop-debug-secure-ab \
   -o result-x86-initial
 ```
@@ -74,11 +80,18 @@ production manufacturing credential flow.
 
 ## Build and sign an update
 
-Increment the generation for every candidate:
+Increment the generation and export a new public-only build configuration for
+every candidate. Never edit or reuse a configuration that produced an image:
 
 ```sh
-export GHAF_UPDATE_GENERATION=2
-timeout 2h nix build --impure \
+export SECURE_AB_GENERATION=2
+export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-x86-generation-$SECURE_AB_GENERATION"
+nix run .#ghaf-secure-ab-config -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --generation "$SECURE_AB_GENERATION" \
+  --output "$SECURE_AB_BUILD_CONFIG"
+timeout 2h nix build \
+  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   .#intel-laptop-debug-secure-ab-sysupdate \
   -o result-x86-update
 

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -20,6 +20,12 @@ The initial target contains a Type-2-only ESP, one active root/verity pair, one
 empty pair, Btrfs persist, swap, and a LUKS2 container. EFI executables remain
 unsigned in the Nix result so private keys never enter the store.
 
+Both system pairs use the established x86 capacities: 50 GiB for each root LV
+and 1 GiB for each verity LV. With the default 12 GiB swap and 2 GiB initial
+persist volume, the initial image and destination disk require approximately
+121 GiB. The build rejects a smaller configured image instead of silently
+producing a system without a usable inactive slot.
+
 ## Build and sign the initial disk
 
 Generate one external development trust directory and keep it outside Git:

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -13,12 +13,14 @@ replace the normal `intel-laptop-*` targets. The secure family is additive:
 
 | Artifact | Flake target |
 | --- | --- |
-| Initial encrypted, verity-backed disk | `intel-laptop-debug-secure-ab` |
+| Initial disk image | `intel-laptop-debug-secure-ab` |
 | A/B update payload | `intel-laptop-debug-secure-ab-sysupdate` |
 
-The initial target contains a Type-2-only ESP, one active root/verity pair, one
-empty pair, Btrfs persist, swap, and a LUKS2 container. EFI executables remain
-unsigned in the Nix result so private keys never enter the store.
+The initial target builds the complete unsigned disk image in the Nix sandbox.
+Regular-file tools create its GPT, Type-2-only ESP, one active root/verity pair,
+one empty pair, Btrfs persist, swap, and LUKS2 container. The build uses no VM,
+loop device, device-mapper mapping, mount, or privilege. EFI executables remain
+unsigned so private keys never enter the store.
 
 Both system pairs use the established x86 capacities: 50 GiB for each root LV
 and 1 GiB for each verity LV. With the default 12 GiB swap and 2 GiB initial
@@ -26,7 +28,7 @@ persist volume, the initial image and destination disk require approximately
 121 GiB. The build rejects a smaller configured image instead of silently
 producing a system without a usable inactive slot.
 
-## Build and sign the initial disk
+## Build, prepare, and sign the initial disk
 
 Generate one external development trust directory and keep it outside Git:
 
@@ -43,17 +45,18 @@ nix run .#ghaf-secure-ab-config -- \
 timeout 2h nix build \
   --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
   .#intel-laptop-debug-secure-ab \
-  -o result-x86-initial
+  -o result-x86-unsigned
 ```
 
-Sign the ESP into a new output directory. The signer refuses CI-only images,
-checks that all four public trust files match the evaluation inventory, signs
-both systemd-boot paths and every UKI, and regenerates the bmap:
+The result is the unsigned disk image. Sign its ESP into another new output directory.
+The signer refuses CI-only images, checks that all four public trust files match
+the evaluation inventory, signs both systemd-boot paths and every UKI, and
+regenerates the bmap:
 
 ```sh
 sudo nix run .#ghaf-sign-x86-image -- \
   --key-dir "$GHAF_DEV_KEY_DIR" \
-  --input result-x86-initial \
+  --input result-x86-unsigned \
   --output /var/tmp/ghaf-x86-signed
 ```
 
@@ -107,9 +110,10 @@ boot-counted trial, health gate, and rollback are shared with NVIDIA.
 
 ## Acceptance boundary
 
-A successful Nix build proves artifact construction only. Hardware acceptance
-still requires Secure Boot enabled, the empty bootstrap slot removed, signed
-A→B→A updates, wrong-target and downgrade rejection, corrupt-root rollback,
-power interruption at each transaction phase, and verification that the
-machine resets after an early boot failure. A kernel `panic=10` fallback is
-configured; a platform watchdog is not claimed until it is tested per laptop.
+A successful Nix build proves payload and disk construction, but not hardware
+acceptance. Hardware acceptance still requires Secure Boot enabled, the empty
+bootstrap slot removed, signed A→B→A updates, wrong-target and downgrade
+rejection, corrupt-root rollback, power interruption at each transaction phase,
+and verification that the machine resets after an early boot failure. A kernel
+`panic=10` fallback is configured; a platform watchdog is not claimed until it
+is tested per laptop.

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -8,112 +8,71 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # x86 secure A/B testing
 
-This guide covers the Intel laptop secure A/B development canary. It does not
-replace the normal `intel-laptop-*` targets. The secure family is additive:
+The Intel development canary is additive; normal laptop targets are unchanged.
+See the [shared architecture](/ghaf/dev/architecture/ab-update) for trust,
+signing, transactions and acceptance rules.
 
-| Artifact | Flake target |
+| Artifact | Target |
 | --- | --- |
-| Initial disk image | `intel-laptop-debug-secure-ab` |
-| A/B update payload | `intel-laptop-debug-secure-ab-sysupdate` |
+| Initial unsigned disk | `intel-laptop-debug-secure-ab` |
+| Update payload | `intel-laptop-debug-secure-ab-sysupdate` |
 
-The initial target builds the complete unsigned disk image in the Nix sandbox.
-Regular-file tools create its GPT, Type-2-only ESP, one active root/verity pair,
-one empty pair, Btrfs persist, swap, and LUKS2 container. The build uses no VM,
-loop device, device-mapper mapping, mount, or privilege. EFI executables remain
-unsigned so private keys never enter the store.
+The initial build creates GPT, a Type-2-only ESP, active and empty root/verity
+pairs, Btrfs persist, swap and LUKS2 using regular files: no VM, root, mount,
+loop device or device mapper. EFI signing is separate so keys stay outside the
+store. Each root is 50 GiB and each verity LV 1 GiB; with 12 GiB swap and 2 GiB
+persist the default disk needs approximately 121 GiB. Smaller images reject.
 
-Both system pairs use the established x86 capacities: 50 GiB for each root LV
-and 1 GiB for each verity LV. With the default 12 GiB swap and 2 GiB initial
-persist volume, the initial image and destination disk require approximately
-121 GiB. The build rejects a smaller configured image instead of silently
-producing a system without a usable inactive slot.
+## Build and sign
 
-## Build, prepare, and sign the initial disk
-
-Generate one external development trust directory and keep it outside Git:
+Generate development keys once using the shared guide. Export a fresh public
+configuration for each generation; never mutate an input used for an image.
 
 ```sh
-nix run .#ghaf-dev-keygen -- --output /secure/local/ghaf-dev-keys
 export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
-export SECURE_AB_GENERATION=1
-export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-x86-generation-$SECURE_AB_GENERATION"
-nix run .#ghaf-secure-ab-config -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --generation "$SECURE_AB_GENERATION" \
-  --output "$SECURE_AB_BUILD_CONFIG"
-
-timeout 2h nix build \
-  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
-  .#intel-laptop-debug-secure-ab \
-  -o result-x86-unsigned
+GENERATION=1
+PUBLIC="$PWD/secure-ab-x86-generation-$GENERATION"
+nix run .#ghaf-secure-ab-config -- --key-dir "$GHAF_DEV_KEY_DIR" \
+  --generation "$GENERATION" --output "$PUBLIC"
+timeout 2h nix build --override-input secure-ab-build-config "path:$PUBLIC" \
+  .#intel-laptop-debug-secure-ab -o result-x86-unsigned
+sudo nix run .#ghaf-sign-x86-image -- --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input result-x86-unsigned --output /var/tmp/ghaf-x86-signed
 ```
 
-The result is the unsigned disk image. Sign its ESP into another new output directory.
-The build requires external public trust. The signer checks that all four public trust files match
-the evaluation inventory, signs both systemd-boot paths and every UKI, and
-regenerates the bmap:
-
-```sh
-sudo nix run .#ghaf-sign-x86-image -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --input result-x86-unsigned \
-  --output /var/tmp/ghaf-x86-signed
-```
+The post-build signer requires root to mount the ESP. It checks all four public
+trust files against the evaluation inventory, signs both systemd-boot paths and
+every UKI, rejects Type-1 entries and regenerates the bmap in a new directory.
 
 ## Install and enroll
 
-Boot a Ghaf installer in UEFI Setup Mode. Make the signed directory and its
-enrollment files available locally, then run:
+Explicitly identify and authorize the destination disk before this destructive
+step and set `INSTALL_DISK` to its exact path. Boot the installer in UEFI
+Setup Mode and provide the signed directory and matching enrollment files:
 
 ```sh
-sudo env \
-  IMG_PATH=/var/tmp/ghaf-x86-signed \
+sudo env IMG_PATH=/var/tmp/ghaf-x86-signed \
   GHAF_SECUREBOOT_KEY_DIR=/var/tmp/ghaf-x86-signed \
-  ghaf-installer -s -d /dev/nvme0n1
+  ghaf-installer -s -d "$INSTALL_DISK"
 ```
 
-Do not add `-e`: the secure A/B image already contains LUKS. Before changing
-firmware variables, the installer mounts the written ESP read-only, rejects
-Type-1 entries, and verifies every loader and UKI against `db.crt`.
+Do not add `-e`: LUKS already exists. Before firmware changes the installer
+checks the written ESP read-only, rejects Type-1 entries and verifies all loaders
+and UKIs against `db.crt`. First boot replaces the empty development bootstrap
+password slot with TPM2/FIDO2 and recovery enrollment, removing the bootstrap
+slot last. This is not a production manufacturing credential flow.
 
-The initial LUKS password slot is the existing development bootstrap empty
-passphrase. On first boot, Ghaf enrolls TPM2 or FIDO2 plus a recovery key and
-removes that password slot. This is a development provisioning boundary, not a
-production manufacturing credential flow.
+## Updates and acceptance
 
-## Build and sign an update
+Export a fresh public input with a generation newer than the accepted value,
+then build `intel-laptop-debug-secure-ab-sysupdate` with the same pure override.
+Sign its manifest with `ghaf-sign-update` as in the shared guide. The exact
+target remains `intel-laptop-debug-secure-ab`. Fetch in `net-vm`; on the host,
+validate, dry-run and install in that order, stopping on errors, then reboot
+manually to observe the counted trial.
 
-Increment the generation and export a new public-only build configuration for
-every candidate. Never edit or reuse a configuration that produced an image:
-
-```sh
-export SECURE_AB_GENERATION=2
-export SECURE_AB_BUILD_CONFIG="$PWD/secure-ab-x86-generation-$SECURE_AB_GENERATION"
-nix run .#ghaf-secure-ab-config -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --generation "$SECURE_AB_GENERATION" \
-  --output "$SECURE_AB_BUILD_CONFIG"
-timeout 2h nix build \
-  --override-input secure-ab-build-config "path:$SECURE_AB_BUILD_CONFIG" \
-  .#intel-laptop-debug-secure-ab-sysupdate \
-  -o result-x86-update
-
-nix run .#ghaf-sign-update -- \
-  --key-dir "$GHAF_DEV_KEY_DIR" \
-  --input result-x86-update/ghaf_<version>_<hash>.manifest \
-  --output signed-x86-update
-```
-
-Install with `ota-update image install`. The target string must be exactly
-`intel-laptop-debug-secure-ab`. Validation, inactive-slot writes, the
-boot-counted trial, health gate, and rollback are shared with NVIDIA.
-
-## Acceptance boundary
-
-A successful Nix build proves payload and disk construction, but not hardware
-acceptance. Hardware acceptance still requires Secure Boot enabled, the empty
-bootstrap slot removed, signed A→B→A updates, wrong-target and downgrade
-rejection, corrupt-root rollback, power interruption at each transaction phase,
-and verification that the machine resets after an early boot failure. A kernel
-`panic=10` fallback is configured; a platform watchdog is not claimed until it
-is tested per laptop.
+Per laptop, require Secure Boot, bootstrap-slot removal, recovery unlock,
+signed A→B→A reuse, wrong-target/
+downgrade/tampering rejection, health and root/verity-corruption rollback, persist
+retention and power cuts at each transaction boundary. `panic=10` is configured;
+hard-hang reset/watchdog acceptance remains unproven until physically tested.

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -1,0 +1,96 @@
+---
+title: x86 Secure A/B Testing
+---
+{/*
+SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+*/}
+
+# x86 secure A/B testing
+
+This guide covers the Intel laptop secure A/B development canary. It does not
+replace the normal `intel-laptop-*` targets. The secure family is additive:
+
+| Artifact | Flake target |
+| --- | --- |
+| Initial encrypted, verity-backed disk | `intel-laptop-debug-secure-ab` |
+| A/B update payload | `intel-laptop-debug-secure-ab-sysupdate` |
+
+The initial target contains a Type-2-only ESP, one active root/verity pair, one
+empty pair, Btrfs persist, swap, and a LUKS2 container. EFI executables remain
+unsigned in the Nix result so private keys never enter the store.
+
+## Build and sign the initial disk
+
+Generate one external development trust directory and keep it outside Git:
+
+```sh
+nix run .#ghaf-dev-keygen -- --output /secure/local/ghaf-dev-keys
+export GHAF_DEV_KEY_DIR=/secure/local/ghaf-dev-keys
+export GHAF_UPDATE_GENERATION=1
+
+timeout 2h nix build --impure \
+  .#intel-laptop-debug-secure-ab \
+  -o result-x86-initial
+```
+
+Sign the ESP into a new output directory. The signer refuses CI-only images,
+checks that all four public trust files match the evaluation inventory, signs
+both systemd-boot paths and every UKI, and regenerates the bmap:
+
+```sh
+sudo nix run .#ghaf-sign-x86-image -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input result-x86-initial \
+  --output /var/tmp/ghaf-x86-signed
+```
+
+## Install and enroll
+
+Boot a Ghaf installer in UEFI Setup Mode. Make the signed directory and its
+enrollment files available locally, then run:
+
+```sh
+sudo env \
+  IMG_PATH=/var/tmp/ghaf-x86-signed \
+  GHAF_SECUREBOOT_KEY_DIR=/var/tmp/ghaf-x86-signed \
+  ghaf-installer -s -d /dev/nvme0n1
+```
+
+Do not add `-e`: the secure A/B image already contains LUKS. Before changing
+firmware variables, the installer mounts the written ESP read-only, rejects
+Type-1 entries, and verifies every loader and UKI against `db.crt`.
+
+The initial LUKS password slot is the existing development bootstrap empty
+passphrase. On first boot, Ghaf enrolls TPM2 or FIDO2 plus a recovery key and
+removes that password slot. This is a development provisioning boundary, not a
+production manufacturing credential flow.
+
+## Build and sign an update
+
+Increment the generation for every candidate:
+
+```sh
+export GHAF_UPDATE_GENERATION=2
+timeout 2h nix build --impure \
+  .#intel-laptop-debug-secure-ab-sysupdate \
+  -o result-x86-update
+
+nix run .#ghaf-sign-update -- \
+  --key-dir "$GHAF_DEV_KEY_DIR" \
+  --input result-x86-update/ghaf_<version>_<hash>.manifest \
+  --output signed-x86-update
+```
+
+Install with `ota-update image install`. The target string must be exactly
+`intel-laptop-debug-secure-ab`. Validation, inactive-slot writes, the
+boot-counted trial, health gate, and rollback are shared with NVIDIA.
+
+## Acceptance boundary
+
+A successful Nix build proves artifact construction only. Hardware acceptance
+still requires Secure Boot enabled, the empty bootstrap slot removed, signed
+A→B→A updates, wrong-target and downgrade rejection, corrupt-root rollback,
+power interruption at each transaction phase, and verification that the
+machine resets after an early boot failure. A kernel `panic=10` fallback is
+configured; a platform watchdog is not claimed until it is tested per laptop.

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -49,7 +49,7 @@ timeout 2h nix build \
 ```
 
 The result is the unsigned disk image. Sign its ESP into another new output directory.
-The signer refuses CI-only images, checks that all four public trust files match
+The build requires external public trust. The signer checks that all four public trust files match
 the evaluation inventory, signs both systemd-boot paths and every UKI, and
 regenerates the bmap:
 

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -60,7 +60,7 @@ Do not add `-e`: LUKS already exists. Before firmware changes the installer
 checks the written ESP read-only, rejects Type-1 entries and verifies all loaders
 and UKIs against `db.crt`. First boot replaces the empty development bootstrap
 password slot with TPM2/FIDO2 and recovery enrollment, removing the bootstrap
-slot last. This is not a production manufacturing credential flow.
+slot last.
 
 ## Updates and acceptance
 
@@ -72,7 +72,7 @@ validate, dry-run and install in that order, stopping on errors, then reboot
 manually to observe the counted trial.
 
 Per laptop, require Secure Boot, bootstrap-slot removal, recovery unlock,
-signed A→B→A reuse, wrong-target/
-downgrade/tampering rejection, health and root/verity-corruption rollback, persist
+signed A→B→A reuse, wrong-target/downgrade/tampering rejection,
+health and root/verity-corruption rollback, persist
 retention and power cuts at each transaction boundary. `panic=10` is configured;
-hard-hang reset/watchdog acceptance remains unproven until physically tested.
+hard-hang reset/watchdog testing is outstanding.

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -36,11 +36,12 @@ nix run .#ghaf-secure-ab-config -- --key-dir "$GHAF_DEV_KEY_DIR" \
   --generation "$GENERATION" --output "$PUBLIC"
 timeout 2h nix build --override-input secure-ab-build-config "path:$PUBLIC" \
   .#intel-laptop-debug-secure-ab -o result-x86-unsigned
-sudo nix run .#ghaf-sign-x86-image -- --key-dir "$GHAF_DEV_KEY_DIR" \
+nix run .#ghaf-sign-x86-image -- --key-dir "$GHAF_DEV_KEY_DIR" \
   --input result-x86-unsigned --output /var/tmp/ghaf-x86-signed
 ```
 
-The post-build signer requires root to mount the ESP. It checks all four public
+The post-build signer edits the ESP with offline FAT tools as an ordinary user.
+It checks all four public
 trust files against the evaluation inventory, signs both systemd-boot paths and
 every UKI, rejects Type-1 entries and regenerates the bmap in a new directory.
 

--- a/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/x86-secure-ab-testing.mdx
@@ -18,8 +18,8 @@ signing, transactions and acceptance rules.
 | Update payload | `intel-laptop-debug-secure-ab-sysupdate` |
 
 The initial build creates GPT, a Type-2-only ESP, active and empty root/verity
-pairs, Btrfs persist, swap and LUKS2 using regular files: no VM, root, mount,
-loop device or device mapper. EFI signing is separate so keys stay outside the
+pairs, Btrfs persist, swap and LUKS2 using stock tools inside a disposable
+Nix build VM. The build host requires KVM; its storage devices are not used. EFI signing is separate so keys stay outside the
 store. Each root is 50 GiB and each verity LV 1 GiB; with 12 GiB swap and 2 GiB
 persist the default disk needs approximately 121 GiB. Smaller images reject.
 

--- a/lib/installer-boot-lib.sh
+++ b/lib/installer-boot-lib.sh
@@ -79,6 +79,82 @@ find_esp_loader() {
   printf '%s\n' "$loader"
 }
 
+# Verify the entire executable x86/AArch64 UEFI boot chain against the db
+# certificate that will be enrolled. This must run before enrollment: enrolling
+# keys for an unsigned, differently signed, or Type-1 image can turn a successful
+# install into an immediately unbootable machine once Secure Boot is enabled.
+#
+# Type-1 entries are deliberately rejected. They authenticate the kernel at
+# best, while the initrd and editable command line remain separate unsigned
+# inputs. Secure Ghaf images use Type-2 UKIs under EFI/Linux instead.
+verify_secureboot_esp() {
+  local esp_device="$1" keys_dir="$2" mnt loader uki
+  local -a loaders=() ukis=()
+
+  [ -s "$keys_dir/db.crt" ] || {
+    echo "Missing Secure Boot verification certificate: $keys_dir/db.crt" >&2
+    return 1
+  }
+  command -v sbverify >/dev/null 2>&1 || {
+    echo "sbsigntool is not available in the installer environment." >&2
+    return 1
+  }
+
+  mnt="$(mktemp -d)"
+  if ! mount -t vfat -o ro "$esp_device" "$mnt" 2>/dev/null; then
+    echo "Could not mount ESP $esp_device for Secure Boot verification." >&2
+    rmdir "$mnt"
+    return 1
+  fi
+
+  for loader in \
+    "$mnt/EFI/systemd/systemd-bootx64.efi" \
+    "$mnt/EFI/systemd/systemd-bootaa64.efi" \
+    "$mnt/EFI/BOOT/BOOTX64.EFI" \
+    "$mnt/EFI/BOOT/BOOTAA64.EFI"; do
+    [ ! -f "$loader" ] || loaders+=("$loader")
+  done
+  if [ "${#loaders[@]}" -eq 0 ]; then
+    echo "No supported EFI loader found on $esp_device." >&2
+    umount "$mnt" 2>/dev/null || true
+    rmdir "$mnt" 2>/dev/null || true
+    return 1
+  fi
+
+  while IFS= read -r -d '' uki; do
+    ukis+=("$uki")
+  done < <(find "$mnt/EFI/Linux" -maxdepth 1 -type f -iname '*.efi' -print0 2>/dev/null)
+  if [ "${#ukis[@]}" -eq 0 ]; then
+    echo "No Type-2 UKI found under EFI/Linux on $esp_device." >&2
+    umount "$mnt" 2>/dev/null || true
+    rmdir "$mnt" 2>/dev/null || true
+    return 1
+  fi
+
+  if find "$mnt/loader/entries" -maxdepth 1 -type f -name '*.conf' -print -quit 2>/dev/null | grep -q .; then
+    echo "Type-1 boot entries remain on $esp_device; refusing Secure Boot enrollment." >&2
+    umount "$mnt" 2>/dev/null || true
+    rmdir "$mnt" 2>/dev/null || true
+    return 1
+  fi
+
+  for loader in "${loaders[@]}" "${ukis[@]}"; do
+    if ! sbverify --cert "$keys_dir/db.crt" "$loader" >/dev/null 2>&1; then
+      echo "EFI executable is not signed by $keys_dir/db.crt: ${loader#"$mnt/"}" >&2
+      umount "$mnt" 2>/dev/null || true
+      rmdir "$mnt" 2>/dev/null || true
+      return 1
+    fi
+  done
+
+  umount "$mnt" 2>/dev/null || {
+    echo "Could not unmount ESP after Secure Boot verification." >&2
+    return 1
+  }
+  rmdir "$mnt" 2>/dev/null || true
+  echo "Verified Secure Boot loader and ${#ukis[@]} UKI(s) against $keys_dir/db.crt."
+}
+
 # efibootmgr's own error text is the whole story when the variable store is
 # full, and every call here used to discard it into /dev/null -- which is why a
 # machine that would not boot looked identical to one that did.

--- a/modules/partitioning/flake-module.nix
+++ b/modules/partitioning/flake-module.nix
@@ -20,6 +20,10 @@ in
       ./btrfs-postboot.nix
     ];
     secure-ab-core.imports = secureAbCoreModules;
+    secure-ab-x86.imports = [
+      ./initial-verity-disk-x86.nix
+      ./secure-ab-x86.nix
+    ];
     verity-release-partition.imports = secureAbCoreModules ++ [
       ./btrfs-postboot.nix
     ];

--- a/modules/partitioning/initial-verity-disk-x86.nix
+++ b/modules/partitioning/initial-verity-disk-x86.nix
@@ -11,7 +11,17 @@
 }:
 let
   cfg = config.ghaf.partitioning.verity.initialDisk;
+  verityCfg = config.ghaf.partitioning.verity;
   diskoCfg = config.ghaf.partitioning.disko;
+  # ESP plus two fixed root/verity pairs, swap, persist, and conservative
+  # headroom for GPT, LUKS, and LVM metadata.
+  minimumImageSizeMiB =
+    500
+    + 2 * verityCfg.rootSlotSizeMiB
+    + 2 * verityCfg.veritySlotSizeMiB
+    + diskoCfg.swapSize
+    + diskoCfg.persistSize
+    + 4 * 1024;
   updateImage = config.system.build.ghafUpdateImage;
   verityLvmImage = config.system.build.verityLvmImage;
   trustInventory = pkgs.writeText "ghaf-secure-ab-public-trust.json" (
@@ -145,7 +155,13 @@ in
         assertion = config.ghaf.storage.encryption.enable && !config.ghaf.storage.encryption.deferred;
         message = "ghaf.partitioning.verity.initialDisk requires immediate LUKS configuration";
       }
+      {
+        assertion = diskoCfg.imageSize >= minimumImageSizeMiB;
+        message = "secure A/B imageSize is ${toString diskoCfg.imageSize} MiB but two fixed system slots and persistent volumes require at least ${toString minimumImageSizeMiB} MiB";
+      }
     ];
+
+    ghaf.partitioning.disko.imageSize = lib.mkDefault minimumImageSizeMiB;
 
     fileSystems."/boot" = lib.mkForce {
       device = "/dev/disk/by-label/ESP";

--- a/modules/partitioning/initial-verity-disk-x86.nix
+++ b/modules/partitioning/initial-verity-disk-x86.nix
@@ -27,7 +27,6 @@ let
   updateImage = config.system.build.ghafUpdateImage;
   trustInventory = pkgs.writeText "ghaf-secure-ab-public-trust.json" (
     builtins.toJSON {
-      external = config.ghaf.secureUpdate.externalPublicTrustConfigured;
       inherit (config.ghaf.secureUpdate) target generation publicTrustDigests;
     }
   );

--- a/modules/partitioning/initial-verity-disk-x86.nix
+++ b/modules/partitioning/initial-verity-disk-x86.nix
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# x86 bootstrap disk for the shared secure A/B payload. The image is emitted
+# unsigned; ghaf-sign-x86-image signs the ESP later, outside the Nix store.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.partitioning.verity.initialDisk;
+  diskoCfg = config.ghaf.partitioning.disko;
+  updateImage = config.system.build.ghafUpdateImage;
+  verityLvmImage = config.system.build.verityLvmImage;
+  trustInventory = pkgs.writeText "ghaf-secure-ab-public-trust.json" (
+    builtins.toJSON {
+      external = config.ghaf.secureUpdate.externalPublicTrustConfigured;
+      inherit (config.ghaf.secureUpdate) target generation publicTrustDigests;
+    }
+  );
+  buildPkgs = pkgs.pkgsBuildBuild;
+  vmTools = buildPkgs.vmTools.override {
+    rootModules = [
+      "virtiofs"
+      "virtio_pci"
+      "virtio_blk"
+      "virtio_balloon"
+      "virtio_rng"
+      "dm_mod"
+      "dm_crypt"
+    ];
+  };
+
+  image = vmTools.runInLinuxVM (
+    buildPkgs.stdenvNoCC.mkDerivation {
+      name = "ghaf-initial-verity-x86-disk";
+      __structuredAttrs = false;
+      buildInputs = with buildPkgs; [
+        bmaptool
+        btrfs-progs
+        coreutils
+        cryptsetup
+        dosfstools
+        gawk
+        gptfdisk
+        jq
+        lvm2
+        parted
+        systemd
+        util-linux
+        zstd
+      ];
+      memSize = 4096;
+
+      preVM = ''
+        set -efx
+        mkdir -p "$out"
+        ${buildPkgs.qemu}/bin/qemu-img create -f raw "$out/ghaf-image.raw" ${toString diskoCfg.imageSize}M
+      '';
+      QEMU_OPTS = ''-drive file="$out"/ghaf-image.raw,if=virtio,cache=unsafe,werror=report,format=raw'';
+      postVM = ''
+        bmaptool create "$out/ghaf-image.raw" -o "$out/ghaf-image.bmap"
+        cores="''${NIX_BUILD_CORES:-1}"
+        if [ "$cores" -gt 8 ]; then cores=8; fi
+        zstd -T"$cores" --compress "$out/ghaf-image.raw" -o "$out/ghaf-image.raw.zst" --rm
+        install -m 0644 ${trustInventory} "$out/public-trust.json"
+      '';
+
+      buildCommand = ''
+        set -efx
+        disk=/dev/vda
+        sgdisk --zap-all "$disk"
+        sgdisk --new=1:1MiB:+500MiB --typecode=1:ef00 --change-name=1:ESP "$disk"
+        sgdisk --new=2:0:0 --typecode=2:8e00 --change-name=2:disk-disk1-luks "$disk"
+        partprobe "$disk"
+        udevadm settle
+
+        mkfs.vfat -F 32 -n ESP /dev/vda1
+        mkdir -p /mnt/esp/EFI/systemd /mnt/esp/EFI/BOOT /mnt/esp/EFI/Linux /mnt/esp/loader
+        mount /dev/vda1 /mnt/esp
+        mkdir -p /mnt/esp/EFI/systemd /mnt/esp/EFI/BOOT /mnt/esp/EFI/Linux /mnt/esp/loader
+        install -m 0644 ${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi \
+          /mnt/esp/EFI/systemd/systemd-bootx64.efi
+        install -m 0644 ${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi \
+          /mnt/esp/EFI/BOOT/BOOTX64.EFI
+
+        manifest=$(find ${updateImage} -name '*.manifest' -print -quit)
+        uki=$(find ${updateImage} -name '*.efi' -print -quit)
+        version=$(jq -er '.version' "$manifest")
+        root_hash=$(jq -er '.root_verity_hash' "$manifest")
+        uki_name="ghaf-$version-''${root_hash:0:16}.efi"
+        install -m 0644 "$uki" "/mnt/esp/EFI/Linux/$uki_name"
+        printf 'timeout %s\ndefault %s\neditor no\n' \
+          ${
+            lib.escapeShellArg (
+              if config.boot.loader.timeout == null then "menu-force" else toString config.boot.loader.timeout
+            )
+          } \
+          "''${uki_name%.efi}" > /mnt/esp/loader/loader.conf
+        sync -f /mnt/esp
+        umount /mnt/esp
+
+        # The one-time empty development passphrase matches Ghaf's existing
+        # non-interactive x86 enrollment flow. First boot enrolls TPM/FIDO2 and
+        # a recovery key, then removes this password slot.
+        printf '\n' | cryptsetup luksFormat --batch-mode --type luks2 "$disk"2
+        printf '\n' | cryptsetup open "$disk"2 crypted
+        zstd -d ${verityLvmImage}/system.img.zst --stdout \
+          | dd of=/dev/mapper/crypted bs=4M conv=notrunc status=progress
+        pvresize /dev/mapper/crypted
+        vgchange -ay pool
+
+        root_mib=$(cat ${verityLvmImage}/root_size_mib)
+        verity_mib=$(cat ${verityLvmImage}/verity_size_mib)
+        DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n root_empty -L "''${root_mib}M" pool
+        DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n verity_empty -L "''${verity_mib}M" pool
+        DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n swap -L ${toString diskoCfg.swapSize}M pool
+        DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n persist -L ${toString diskoCfg.persistSize}M pool
+        vgmknodes pool
+        mkswap -L swap /dev/pool/swap
+        mkfs.btrfs -L persist /dev/pool/persist
+        vgchange -an pool
+        cryptsetup close crypted
+      '';
+    }
+  );
+in
+{
+  options.ghaf.partitioning.verity.initialDisk.enable =
+    lib.mkEnableOption "an initial x86 GPT/LUKS/LVM secure A/B disk image";
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.nixpkgs.hostPlatform.system == "x86_64-linux";
+        message = "ghaf.partitioning.verity.initialDisk is currently implemented only for x86_64-linux";
+      }
+      {
+        assertion = config.ghaf.partitioning.verity.enable;
+        message = "ghaf.partitioning.verity.initialDisk requires the verity update layout";
+      }
+      {
+        assertion = config.ghaf.storage.encryption.enable && !config.ghaf.storage.encryption.deferred;
+        message = "ghaf.partitioning.verity.initialDisk requires immediate LUKS configuration";
+      }
+    ];
+
+    fileSystems."/boot" = lib.mkForce {
+      device = "/dev/disk/by-label/ESP";
+      fsType = "vfat";
+      options = [ "umask=0077" ];
+    };
+
+    boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
+    system.build.ghafImage = lib.mkForce image;
+  };
+}

--- a/modules/partitioning/initial-verity-disk-x86.nix
+++ b/modules/partitioning/initial-verity-disk-x86.nix
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# x86 bootstrap disk for the shared secure A/B payload. The image is emitted
-# unsigned; ghaf-sign-x86-image signs the ESP later, outside the Nix store.
+# x86 bootstrap disk image for the shared secure A/B payload. GPT, FAT, LUKS,
+# and LVM are assembled from regular files in the Nix build sandbox without a
+# VM or kernel storage devices. The result is unsigned; ghaf-sign-x86-image
+# signs its ESP later, outside the Nix store.
 {
   config,
   lib,
@@ -23,7 +25,6 @@ let
     + diskoCfg.persistSize
     + 4 * 1024;
   updateImage = config.system.build.ghafUpdateImage;
-  verityLvmImage = config.system.build.verityLvmImage;
   trustInventory = pkgs.writeText "ghaf-secure-ab-public-trust.json" (
     builtins.toJSON {
       external = config.ghaf.secureUpdate.externalPublicTrustConfigured;
@@ -31,115 +32,27 @@ let
     }
   );
   buildPkgs = pkgs.pkgsBuildBuild;
-  vmTools = buildPkgs.vmTools.override {
-    rootModules = [
-      "virtiofs"
-      "virtio_pci"
-      "virtio_blk"
-      "virtio_balloon"
-      "virtio_rng"
-      "dm_mod"
-      "dm_crypt"
-    ];
-  };
-
-  image = vmTools.runInLinuxVM (
-    buildPkgs.stdenvNoCC.mkDerivation {
-      name = "ghaf-initial-verity-x86-disk";
-      __structuredAttrs = false;
-      buildInputs = with buildPkgs; [
-        bmaptool
-        btrfs-progs
-        coreutils
-        cryptsetup
-        dosfstools
-        gawk
-        gptfdisk
-        jq
-        lvm2
-        parted
-        systemd
-        util-linux
-        zstd
-      ];
-      memSize = 4096;
-
-      preVM = ''
-        set -efx
-        mkdir -p "$out"
-        ${buildPkgs.qemu}/bin/qemu-img create -f raw "$out/ghaf-image.raw" ${toString diskoCfg.imageSize}M
-      '';
-      QEMU_OPTS = ''-drive file="$out"/ghaf-image.raw,if=virtio,cache=unsafe,werror=report,format=raw'';
-      postVM = ''
-        bmaptool create "$out/ghaf-image.raw" -o "$out/ghaf-image.bmap"
-        cores="''${NIX_BUILD_CORES:-1}"
-        if [ "$cores" -gt 8 ]; then cores=8; fi
-        zstd -T"$cores" --compress "$out/ghaf-image.raw" -o "$out/ghaf-image.raw.zst" --rm
-        install -m 0644 ${trustInventory} "$out/public-trust.json"
-      '';
-
-      buildCommand = ''
-        set -efx
-        disk=/dev/vda
-        sgdisk --zap-all "$disk"
-        sgdisk --new=1:1MiB:+500MiB --typecode=1:ef00 --change-name=1:ESP "$disk"
-        sgdisk --new=2:0:0 --typecode=2:8e00 --change-name=2:disk-disk1-luks "$disk"
-        partprobe "$disk"
-        udevadm settle
-
-        mkfs.vfat -F 32 -n ESP /dev/vda1
-        mkdir -p /mnt/esp/EFI/systemd /mnt/esp/EFI/BOOT /mnt/esp/EFI/Linux /mnt/esp/loader
-        mount /dev/vda1 /mnt/esp
-        mkdir -p /mnt/esp/EFI/systemd /mnt/esp/EFI/BOOT /mnt/esp/EFI/Linux /mnt/esp/loader
-        install -m 0644 ${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi \
-          /mnt/esp/EFI/systemd/systemd-bootx64.efi
-        install -m 0644 ${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi \
-          /mnt/esp/EFI/BOOT/BOOTX64.EFI
-
-        manifest=$(find ${updateImage} -name '*.manifest' -print -quit)
-        uki=$(find ${updateImage} -name '*.efi' -print -quit)
-        version=$(jq -er '.version' "$manifest")
-        root_hash=$(jq -er '.root_verity_hash' "$manifest")
-        uki_name="ghaf-$version-''${root_hash:0:16}.efi"
-        install -m 0644 "$uki" "/mnt/esp/EFI/Linux/$uki_name"
-        printf 'timeout %s\ndefault %s\neditor no\n' \
-          ${
-            lib.escapeShellArg (
-              if config.boot.loader.timeout == null then "menu-force" else toString config.boot.loader.timeout
-            )
-          } \
-          "''${uki_name%.efi}" > /mnt/esp/loader/loader.conf
-        sync -f /mnt/esp
-        umount /mnt/esp
-
-        # The one-time empty development passphrase matches Ghaf's existing
-        # non-interactive x86 enrollment flow. First boot enrolls TPM/FIDO2 and
-        # a recovery key, then removes this password slot.
-        printf '\n' | cryptsetup luksFormat --batch-mode --type luks2 "$disk"2
-        printf '\n' | cryptsetup open "$disk"2 crypted
-        zstd -d ${verityLvmImage}/system.img.zst --stdout \
-          | dd of=/dev/mapper/crypted bs=4M conv=notrunc status=progress
-        pvresize /dev/mapper/crypted
-        vgchange -ay pool
-
-        root_mib=$(cat ${verityLvmImage}/root_size_mib)
-        verity_mib=$(cat ${verityLvmImage}/verity_size_mib)
-        DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n root_empty -L "''${root_mib}M" pool
-        DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n verity_empty -L "''${verity_mib}M" pool
-        DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n swap -L ${toString diskoCfg.swapSize}M pool
-        DM_DISABLE_UDEV=1 lvcreate -y -Zn -Wn -n persist -L ${toString diskoCfg.persistSize}M pool
-        vgmknodes pool
-        mkswap -L swap /dev/pool/swap
-        mkfs.btrfs -L persist /dev/pool/persist
-        vgchange -an pool
-        cryptsetup close crypted
-      '';
-    }
-  );
+  initialDiskImage = pkgs.runCommand "ghaf-x86-verity-disk" { } ''
+    ${lib.getExe buildPkgs.ghaf-prepare-x86-verity-disk} \
+      --update-dir ${updateImage} \
+      --systemd-boot ${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi \
+      --trust-inventory ${trustInventory} \
+      --image-size-mib ${toString diskoCfg.imageSize} \
+      --root-size-mib ${toString verityCfg.rootSlotSizeMiB} \
+      --verity-size-mib ${toString verityCfg.veritySlotSizeMiB} \
+      --swap-size-mib ${toString diskoCfg.swapSize} \
+      --persist-size-mib ${toString diskoCfg.persistSize} \
+      --boot-timeout ${
+        lib.escapeShellArg (
+          if config.boot.loader.timeout == null then "menu-force" else toString config.boot.loader.timeout
+        )
+      } \
+      --output "$out"
+  '';
 in
 {
   options.ghaf.partitioning.verity.initialDisk.enable =
-    lib.mkEnableOption "an initial x86 GPT/LUKS/LVM secure A/B disk image";
+    lib.mkEnableOption "an initial x86 GPT/FAT/LUKS/LVM secure A/B disk image builder";
 
   config = lib.mkIf cfg.enable {
     assertions = [
@@ -170,6 +83,6 @@ in
     };
 
     boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
-    system.build.ghafImage = lib.mkForce image;
+    system.build.ghafImage = lib.mkForce initialDiskImage;
   };
 }

--- a/modules/partitioning/initial-verity-disk-x86.nix
+++ b/modules/partitioning/initial-verity-disk-x86.nix
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # x86 bootstrap disk image for the shared secure A/B payload. GPT, FAT, LUKS,
-# and LVM are assembled from regular files in the Nix build sandbox without a
-# VM or kernel storage devices. The result is unsigned; ghaf-sign-x86-image
+# and LVM are assembled with stock tools inside a disposable build VM.
+# The result is unsigned; ghaf-sign-x86-image
 # signs its ESP later, outside the Nix store.
 {
   config,
@@ -31,23 +31,27 @@ let
     }
   );
   buildPkgs = pkgs.pkgsBuildBuild;
-  initialDiskImage = pkgs.runCommand "ghaf-x86-verity-disk" { } ''
-    ${lib.getExe buildPkgs.ghaf-prepare-x86-verity-disk} \
-      --update-dir ${updateImage} \
-      --systemd-boot ${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi \
-      --trust-inventory ${trustInventory} \
-      --image-size-mib ${toString diskoCfg.imageSize} \
-      --root-size-mib ${toString verityCfg.rootSlotSizeMiB} \
-      --verity-size-mib ${toString verityCfg.veritySlotSizeMiB} \
-      --swap-size-mib ${toString diskoCfg.swapSize} \
-      --persist-size-mib ${toString diskoCfg.persistSize} \
-      --boot-timeout ${
-        lib.escapeShellArg (
-          if config.boot.loader.timeout == null then "menu-force" else toString config.boot.loader.timeout
-        )
-      } \
-      --output "$out"
-  '';
+  initialDiskImage = buildPkgs.ghaf-prepare-x86-verity-disk.buildImage {
+    imageSizeMiB = diskoCfg.imageSize;
+    buildCommand = ''
+      ${lib.getExe buildPkgs.ghaf-prepare-x86-verity-disk} \
+        --disk /dev/vda \
+        --update-dir ${updateImage} \
+        --systemd-boot ${config.systemd.package}/lib/systemd/boot/efi/systemd-bootx64.efi \
+        --trust-inventory ${trustInventory} \
+        --image-size-mib ${toString diskoCfg.imageSize} \
+        --root-size-mib ${toString verityCfg.rootSlotSizeMiB} \
+        --verity-size-mib ${toString verityCfg.veritySlotSizeMiB} \
+        --swap-size-mib ${toString diskoCfg.swapSize} \
+        --persist-size-mib ${toString diskoCfg.persistSize} \
+        --boot-timeout ${
+          lib.escapeShellArg (
+            if config.boot.loader.timeout == null then "menu-force" else toString config.boot.loader.timeout
+          )
+        } \
+        --output "$out"
+    '';
+  };
 in
 {
   options.ghaf.partitioning.verity.initialDisk.enable =

--- a/modules/partitioning/secure-ab-x86.nix
+++ b/modules/partitioning/secure-ab-x86.nix
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ lib, ... }:
+{
+  _file = ./secure-ab-x86.nix;
+
+  # Enrollment material is supplied alongside the externally signed image.
+  # Keeping keysSource null prevents even public enrollment payloads from
+  # accidentally selecting a repository trust set different from the signer.
+  ghaf.host.secureboot = {
+    enable = true;
+    keysSource = lib.mkForce null;
+  };
+
+  ghaf.storage.encryption.deferred = lib.mkForce false;
+
+  # A Type-2 UKI authenticates its command line, so allowing interactive edits
+  # would be both ineffective and misleading.
+  boot.loader.systemd-boot.editor = false;
+  boot.kernelParams = [
+    "boot.panic_on_fail"
+    "panic=10"
+  ];
+}

--- a/modules/partitioning/secure-ab-x86.nix
+++ b/modules/partitioning/secure-ab-x86.nix
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 {
   _file = ./secure-ab-x86.nix;
 
@@ -13,6 +17,13 @@
   };
 
   ghaf.storage.encryption.deferred = lib.mkForce false;
+
+  # Preserve the established x86 storage policy, but apply it equally to both
+  # secure A/B slots instead of deriving their capacities from generation 1.
+  ghaf.partitioning.verity = {
+    rootSlotSizeMiB = config.ghaf.partitioning.disko.rootSize;
+    veritySlotSizeMiB = config.ghaf.partitioning.disko.veritySize;
+  };
 
   # A Type-2 UKI authenticates its command line, so allowing interactive edits
   # would be both ineffective and misleading.

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -21,6 +21,9 @@
     ghaf-intro = final.callPackage ./pkgs-by-name/ghaf-intro/package.nix { };
     ghaf-open = final.callPackage ./pkgs-by-name/ghaf-open/package.nix { };
     ghaf-powercontrol = final.callPackage ./ghaf-powercontrol/package.nix { };
+    ghaf-prepare-x86-verity-disk =
+      final.callPackage ./pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
+        { };
     ghaf-secure-ab-config = final.callPackage ./pkgs-by-name/ghaf-secure-ab-config/package.nix { };
     ghaf-update-manifest = final.callPackage ./pkgs-by-name/ghaf-update-manifest/package.nix { };
     ghaf-vms = final.callPackage ./pkgs-by-name/ghaf-vms/package.nix { };

--- a/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-lib.sh
+++ b/packages/pkgs-by-name/ghaf-installer-tui/ghaf-installer-lib.sh
@@ -342,13 +342,22 @@ system_in_setup_mode() {
   fi
 }
 
-# Enroll Secure Boot keys from /etc/ghaf/secureboot/keys
+# Verify the written image, then enroll its matching Secure Boot keys.
 # shellcheck disable=SC2329
 do_enroll_secureboot() {
-  local keys_dir="/etc/ghaf/secureboot/keys"
+  local dev="$1"
+  local keys_dir="${GHAF_SECUREBOOT_KEY_DIR:-/etc/ghaf/secureboot/keys}"
   local pk_auth="$keys_dir/PK.auth"
   local kek_auth="$keys_dir/KEK.auth"
   local db_auth="$keys_dir/db.auth"
+  local esp_dev
+
+  run_spin -q "Settling block devices..." udevadm settle
+  esp_dev="$(find_esp_device "$dev")" || {
+    show_error "Could not find ESP partition for Secure Boot verification."
+    return 1
+  }
+  verify_secureboot_esp "$esp_dev" "$keys_dir" || return 1
 
   # Verify the firmware is in Setup Mode before enrolling
   system_in_setup_mode || return 1

--- a/packages/pkgs-by-name/ghaf-installer-tui/package.nix
+++ b/packages/pkgs-by-name/ghaf-installer-tui/package.nix
@@ -17,6 +17,7 @@
   ncurses,
   parted,
   pv,
+  sbsigntool,
   systemd,
   util-linux,
   writeShellApplication,
@@ -49,6 +50,7 @@ writeShellApplication {
     ncurses
     parted # partprobe
     pv
+    sbsigntool # verify loaders and UKIs before enrolling matching keys
     systemd # udevadm
     util-linux
     zstd

--- a/packages/pkgs-by-name/ghaf-installer/ghaf-installer.sh
+++ b/packages/pkgs-by-name/ghaf-installer/ghaf-installer.sh
@@ -34,6 +34,9 @@ Environment:
   GHAF_QUEUE_MAX_WAIT   seconds to wait for an install server's download slot
                         before giving up (default 14400). A fleet server
                         staggers image downloads, so a long wait is normal.
+  GHAF_SECUREBOOT_KEY_DIR
+                        directory containing PK.auth, KEK.auth, db.auth, and
+                        db.crt (default /etc/ghaf/secureboot/keys)
 
 After a successful install the firmware is pointed at the disk that was just
 written -- a boot entry is created if none exists, put first in BootOrder, and
@@ -427,10 +430,17 @@ fi
 if [ "$SECUREBOOT_INSTALL" = true ]; then
   echo "Setting up Secure Boot enrollment..."
 
-  KEYS_DIR="/etc/ghaf/secureboot/keys"
+  KEYS_DIR="${GHAF_SECUREBOOT_KEY_DIR:-/etc/ghaf/secureboot/keys}"
   PK_AUTH="$KEYS_DIR/PK.auth"
   KEK_AUTH="$KEYS_DIR/KEK.auth"
   DB_AUTH="$KEYS_DIR/db.auth"
+
+  udevadm settle
+  ESP_DEVICE="$(find_esp_device)" || {
+    echo "Error: Could not find ESP partition for Secure Boot verification."
+    exit 1
+  }
+  verify_secureboot_esp "$ESP_DEVICE" "$KEYS_DIR" || exit 1
 
   if ! ensure_efivars; then
     echo "EFI variables not available. Ensure the installer booted in UEFI mode."

--- a/packages/pkgs-by-name/ghaf-installer/package.nix
+++ b/packages/pkgs-by-name/ghaf-installer/package.nix
@@ -14,6 +14,7 @@
   lvm2,
   ncurses,
   parted,
+  sbsigntool,
   systemd,
   util-linux,
   writeShellApplication,
@@ -39,6 +40,7 @@ writeShellApplication {
     lvm2 # Needed for vgchange, pvremove
     ncurses # Needed for `clear` command
     parted # Needed for partprobe
+    sbsigntool # verify loaders and UKIs before enrolling matching keys
     systemd # Needed for udevadm settle
     util-linux
     zstd

--- a/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/ghaf-prepare-x86-verity-disk.sh
+++ b/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/ghaf-prepare-x86-verity-disk.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: ghaf-prepare-x86-verity-disk \
+  --update-dir DIR --systemd-boot FILE --trust-inventory FILE \
+  --image-size-mib MIB --root-size-mib MIB --verity-size-mib MIB \
+  --swap-size-mib MIB --persist-size-mib MIB --boot-timeout VALUE \
+  [--output DIR] [--print-plan]
+
+Creates an unsigned x86 GPT/LUKS/LVM secure A/B disk image using regular
+files only. It needs no root privileges, loop devices, device mapper, mount,
+or VM. --print-plan validates all immutable inputs without creating an image.
+EOF
+  exit 2
+}
+
+update_dir=""
+systemd_boot=""
+trust_inventory=""
+image_size_mib=""
+root_size_mib=""
+verity_size_mib=""
+swap_size_mib=""
+persist_size_mib=""
+boot_timeout=""
+output=""
+print_plan=false
+
+while (($#)); do
+  case "$1" in
+  --update-dir)
+    update_dir="${2:-}"
+    shift 2
+    ;;
+  --systemd-boot)
+    systemd_boot="${2:-}"
+    shift 2
+    ;;
+  --trust-inventory)
+    trust_inventory="${2:-}"
+    shift 2
+    ;;
+  --image-size-mib)
+    image_size_mib="${2:-}"
+    shift 2
+    ;;
+  --root-size-mib)
+    root_size_mib="${2:-}"
+    shift 2
+    ;;
+  --verity-size-mib)
+    verity_size_mib="${2:-}"
+    shift 2
+    ;;
+  --swap-size-mib)
+    swap_size_mib="${2:-}"
+    shift 2
+    ;;
+  --persist-size-mib)
+    persist_size_mib="${2:-}"
+    shift 2
+    ;;
+  --boot-timeout)
+    boot_timeout="${2:-}"
+    shift 2
+    ;;
+  --output)
+    output="${2:-}"
+    shift 2
+    ;;
+  --print-plan)
+    print_plan=true
+    shift
+    ;;
+  *) usage ;;
+  esac
+done
+
+[[ -d $update_dir && -f $systemd_boot && -f $trust_inventory ]] || usage
+for value in "$image_size_mib" "$root_size_mib" "$verity_size_mib"; do
+  [[ $value =~ ^[1-9][0-9]*$ ]] || usage
+done
+for value in "$swap_size_mib" "$persist_size_mib"; do
+  [[ $value =~ ^[0-9]+$ ]] || usage
+done
+[[ $boot_timeout == menu-force || $boot_timeout =~ ^[0-9]+$ ]] || usage
+
+minimum_image_size_mib=$((\
+  500 + 2 * root_size_mib + 2 * verity_size_mib + swap_size_mib + persist_size_mib + 4 * 1024))
+if ((image_size_mib < minimum_image_size_mib)); then
+  echo "Image size is $image_size_mib MiB; at least $minimum_image_size_mib MiB is required" >&2
+  exit 1
+fi
+
+mapfile -d '' manifests < <(find -H "$update_dir" -maxdepth 1 -type f -name '*.manifest' -print0)
+mapfile -d '' ukis < <(find -H "$update_dir" -maxdepth 1 -type f -name '*.efi' -print0)
+if ((${#manifests[@]} != 1)); then
+  echo "Expected exactly one update manifest in $update_dir" >&2
+  exit 1
+fi
+if ((${#ukis[@]} != 1)); then
+  echo "Expected exactly one UKI in $update_dir" >&2
+  exit 1
+fi
+manifest=${manifests[0]}
+uki=${ukis[0]}
+
+lvm_plan=$(ghaf-initialize-verity-lvm \
+  --update-dir "$update_dir" \
+  --root-size-mib "$root_size_mib" \
+  --verity-size-mib "$verity_size_mib" \
+  --create-inactive-slots \
+  --swap-size-mib "$swap_size_mib" \
+  --persist-size-mib "$persist_size_mib" \
+  --print-plan)
+version=$(jq -er '.version | select(type == "string" and length > 0)' "$manifest")
+root_hash=$(jq -er '.root_verity_hash | select(type == "string" and test("^[0-9a-fA-F]{64}$"))' "$manifest")
+
+if $print_plan; then
+  jq -n \
+    --argjson image_size_mib "$image_size_mib" \
+    --argjson minimum_image_size_mib "$minimum_image_size_mib" \
+    --arg boot_timeout "$boot_timeout" \
+    --argjson lvm "$lvm_plan" \
+    '{image_size_mib: $image_size_mib, minimum_image_size_mib: $minimum_image_size_mib,
+      boot_timeout: $boot_timeout, lvm: $lvm}'
+  exit 0
+fi
+
+[[ -n $output ]] || usage
+[[ ! -e $output && ! -L $output ]] || {
+  echo "Refusing to overwrite $output" >&2
+  exit 1
+}
+output_parent=$(dirname -- "$output")
+[[ -d $output_parent ]] || {
+  echo "Output parent does not exist: $output_parent" >&2
+  exit 1
+}
+output=$(realpath -m -- "$output")
+
+work=$(mktemp -d)
+complete=false
+cleanup() {
+  status=$?
+  trap - EXIT
+  rm -rf -- "$work"
+  if ! $complete && [[ -d $output ]]; then
+    echo "Image preparation failed; partial output remains at $output" >&2
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+mkdir -m 0700 "$output"
+raw="$output/ghaf-image.raw"
+truncate -s "${image_size_mib}M" "$raw"
+last_partition_sector=$(((image_size_mib - 1) * 2048 - 1))
+sgdisk --zap-all "$raw"
+sgdisk \
+  --disk-guid=09A5D6A4-5FA3-4F54-AC76-0B02B636376F \
+  --new=1:1MiB:+500MiB \
+  --typecode=1:ef00 \
+  --change-name=1:ESP \
+  --partition-guid=1:7A9F13F8-0A61-46A1-9F5A-216D5FC1A028 \
+  --new=2:0:"$last_partition_sector" \
+  --typecode=2:8309 \
+  --change-name=2:disk-disk1-luks \
+  --partition-guid=2:3C05B9C2-6F7C-4B13-ACB7-47C615AAB14A \
+  "$raw"
+
+partition_sector() {
+  local partition=$1 field=$2 value
+  value=$(sgdisk -i "$partition" "$raw" | awk -v field="$field" \
+    '$1 " " $2 == field ":" { print $3; exit }')
+  [[ $value =~ ^[0-9]+$ ]] || {
+    echo "Could not read $field for GPT partition $partition" >&2
+    exit 1
+  }
+  printf '%s\n' "$value"
+}
+
+esp_first=$(partition_sector 1 "First sector")
+esp_last=$(partition_sector 1 "Last sector")
+luks_first=$(partition_sector 2 "First sector")
+luks_last=$(partition_sector 2 "Last sector")
+esp_size_bytes=$(((esp_last - esp_first + 1) * 512))
+luks_size_bytes=$(((luks_last - luks_first + 1) * 512))
+luks_header_size=$((32 * 1024 * 1024))
+plain_lvm_size=$((luks_size_bytes - luks_header_size))
+
+esp_image="$work/esp.img"
+truncate -s "$esp_size_bytes" "$esp_image"
+mkfs.vfat -F 32 -n ESP "$esp_image"
+for directory in EFI EFI/systemd EFI/BOOT EFI/Linux loader; do
+  mmd -i "$esp_image" "::$directory"
+done
+mcopy -i "$esp_image" "$systemd_boot" ::EFI/systemd/systemd-bootx64.efi
+mcopy -i "$esp_image" "$systemd_boot" ::EFI/BOOT/BOOTX64.EFI
+uki_name="ghaf-$version-${root_hash:0:16}.efi"
+mcopy -i "$esp_image" "$uki" "::EFI/Linux/$uki_name"
+printf 'timeout %s\ndefault %s\neditor no\n' \
+  "$boot_timeout" "${uki_name%.efi}" >"$work/loader.conf"
+mcopy -i "$esp_image" "$work/loader.conf" ::loader/loader.conf
+
+luks_image="$work/luks.img"
+truncate -s "$plain_lvm_size" "$luks_image"
+ghaf-initialize-verity-lvm \
+  --image "$luks_image" \
+  --update-dir "$update_dir" \
+  --root-size-mib "$root_size_mib" \
+  --verity-size-mib "$verity_size_mib" \
+  --create-inactive-slots \
+  --swap-size-mib "$swap_size_mib" \
+  --persist-size-mib "$persist_size_mib"
+
+# Keep compatibility with Ghaf's existing first-boot enrollment: it unlocks
+# this bootstrap slot with an empty passphrase, enrolls TPM2/FIDO2 and recovery
+# credentials, then removes the bootstrap slot last.
+: >"$work/bootstrap.key"
+ghaf-wrap-luks-image \
+  --image "$luks_image" \
+  --uuid 3E7F3D25-695A-429D-8D34-2D0A18979D7D \
+  --key-file "$work/bootstrap.key" \
+  --header-size-mib 32
+[[ $(stat -c%s "$luks_image") -eq $luks_size_bytes ]] || {
+  echo "LUKS image size does not match GPT partition size" >&2
+  exit 1
+}
+
+dd if="$esp_image" of="$raw" bs=4M seek="$((esp_first * 512))" \
+  oflag=seek_bytes conv=notrunc,sparse status=none
+dd if="$luks_image" of="$raw" bs=4M seek="$((luks_first * 512))" \
+  oflag=seek_bytes conv=notrunc,sparse status=none
+
+bmaptool create "$raw" -o "$output/ghaf-image.bmap"
+cores=${NIX_BUILD_CORES:-1}
+[[ $cores =~ ^[1-9][0-9]*$ ]] || cores=1
+if ((cores > 8)); then cores=8; fi
+zstd -T"$cores" --compress "$raw" -o "$output/ghaf-image.raw.zst" --rm
+install -m 0644 "$trust_inventory" "$output/public-trust.json"
+
+complete=true
+echo "Unsigned x86 image written to $output"

--- a/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/ghaf-prepare-x86-verity-disk.sh
+++ b/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/ghaf-prepare-x86-verity-disk.sh
@@ -18,63 +18,22 @@ EOF
   exit 2
 }
 
-update_dir=""
-systemd_boot=""
-trust_inventory=""
-image_size_mib=""
-root_size_mib=""
-verity_size_mib=""
-swap_size_mib=""
-persist_size_mib=""
-boot_timeout=""
-output=""
+update_dir="" systemd_boot="" trust_inventory="" output="" boot_timeout=""
+image_size_mib="" root_size_mib="" verity_size_mib="" swap_size_mib="" persist_size_mib=""
 print_plan=false
-
 while (($#)); do
   case "$1" in
-  --update-dir)
-    update_dir="${2:-}"
-    shift 2
-    ;;
-  --systemd-boot)
-    systemd_boot="${2:-}"
-    shift 2
-    ;;
-  --trust-inventory)
-    trust_inventory="${2:-}"
-    shift 2
-    ;;
-  --image-size-mib)
-    image_size_mib="${2:-}"
-    shift 2
-    ;;
-  --root-size-mib)
-    root_size_mib="${2:-}"
-    shift 2
-    ;;
-  --verity-size-mib)
-    verity_size_mib="${2:-}"
-    shift 2
-    ;;
-  --swap-size-mib)
-    swap_size_mib="${2:-}"
-    shift 2
-    ;;
-  --persist-size-mib)
-    persist_size_mib="${2:-}"
-    shift 2
-    ;;
-  --boot-timeout)
-    boot_timeout="${2:-}"
-    shift 2
-    ;;
-  --output)
-    output="${2:-}"
-    shift 2
-    ;;
   --print-plan)
     print_plan=true
     shift
+    ;;
+  --update-dir | --systemd-boot | --trust-inventory | --output | --boot-timeout | \
+    --image-size-mib | --root-size-mib | --verity-size-mib | --swap-size-mib | --persist-size-mib)
+    (($# >= 2)) || usage
+    # Only the fixed option whitelist above may select a destination variable.
+    option=${1#--}
+    printf -v "${option//-/_}" '%s' "$2"
+    shift 2
     ;;
   *) usage ;;
   esac
@@ -109,14 +68,13 @@ fi
 manifest=${manifests[0]}
 uki=${ukis[0]}
 
-lvm_plan=$(ghaf-initialize-verity-lvm \
-  --update-dir "$update_dir" \
-  --root-size-mib "$root_size_mib" \
-  --verity-size-mib "$verity_size_mib" \
-  --create-inactive-slots \
-  --swap-size-mib "$swap_size_mib" \
-  --persist-size-mib "$persist_size_mib" \
-  --print-plan)
+initialize_lvm() {
+  ghaf-initialize-verity-lvm --update-dir "$update_dir" \
+    --root-size-mib "$root_size_mib" --verity-size-mib "$verity_size_mib" \
+    --create-inactive-slots --swap-size-mib "$swap_size_mib" \
+    --persist-size-mib "$persist_size_mib" "$@"
+}
+lvm_plan=$(initialize_lvm --print-plan)
 version=$(jq -er '.version | select(type == "string" and length > 0)' "$manifest")
 root_hash=$(jq -er '.root_verity_hash | select(type == "string" and test("^[0-9a-fA-F]{64}$"))' "$manifest")
 
@@ -209,14 +167,7 @@ mcopy -i "$esp_image" "$work/loader.conf" ::loader/loader.conf
 
 luks_image="$work/luks.img"
 truncate -s "$plain_lvm_size" "$luks_image"
-ghaf-initialize-verity-lvm \
-  --image "$luks_image" \
-  --update-dir "$update_dir" \
-  --root-size-mib "$root_size_mib" \
-  --verity-size-mib "$verity_size_mib" \
-  --create-inactive-slots \
-  --swap-size-mib "$swap_size_mib" \
-  --persist-size-mib "$persist_size_mib"
+initialize_lvm --image "$luks_image"
 
 # Keep compatibility with Ghaf's existing first-boot enrollment: it unlocks
 # this bootstrap slot with an empty passphrase, enrolls TPM2/FIDO2 and recovery

--- a/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/ghaf-prepare-x86-verity-disk.sh
+++ b/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/ghaf-prepare-x86-verity-disk.sh
@@ -69,7 +69,7 @@ manifest=${manifests[0]}
 uki=${ukis[0]}
 
 initialize_lvm() {
-  ghaf-initialize-verity-lvm --update-dir "$update_dir" \
+  ghaf-initialize-verity-lvm --manifest "$manifest" \
     --root-size-mib "$root_size_mib" --verity-size-mib "$verity_size_mib" \
     --create-inactive-slots --swap-size-mib "$swap_size_mib" \
     --persist-size-mib "$persist_size_mib" "$@"
@@ -176,8 +176,7 @@ initialize_lvm --image "$luks_image"
 ghaf-wrap-luks-image \
   --image "$luks_image" \
   --uuid 3E7F3D25-695A-429D-8D34-2D0A18979D7D \
-  --key-file "$work/bootstrap.key" \
-  --header-size-mib 32
+  --key-file "$work/bootstrap.key"
 [[ $(stat -c%s "$luks_image") -eq $luks_size_bytes ]] || {
   echo "LUKS image size does not match GPT partition size" >&2
   exit 1

--- a/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/ghaf-prepare-x86-verity-disk.sh
+++ b/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/ghaf-prepare-x86-verity-disk.sh
@@ -9,16 +9,16 @@ Usage: ghaf-prepare-x86-verity-disk \
   --update-dir DIR --systemd-boot FILE --trust-inventory FILE \
   --image-size-mib MIB --root-size-mib MIB --verity-size-mib MIB \
   --swap-size-mib MIB --persist-size-mib MIB --boot-timeout VALUE \
-  [--output DIR] [--print-plan]
+  [--disk BLOCK_DEVICE --output DIR] [--print-plan]
 
-Creates an unsigned x86 GPT/LUKS/LVM secure A/B disk image using regular
-files only. It needs no root privileges, loop devices, device mapper, mount,
-or VM. --print-plan validates all immutable inputs without creating an image.
+Populates a disposable build-VM disk with unsigned x86 GPT/FAT/LUKS/LVM.
+--print-plan validates inputs without a VM. The Nix builder starts the VM
+and compresses the completed disk after it exits successfully.
 EOF
   exit 2
 }
 
-update_dir="" systemd_boot="" trust_inventory="" output="" boot_timeout=""
+disk="" update_dir="" systemd_boot="" trust_inventory="" output="" boot_timeout=""
 image_size_mib="" root_size_mib="" verity_size_mib="" swap_size_mib="" persist_size_mib=""
 print_plan=false
 while (($#)); do
@@ -27,7 +27,7 @@ while (($#)); do
     print_plan=true
     shift
     ;;
-  --update-dir | --systemd-boot | --trust-inventory | --output | --boot-timeout | \
+  --disk | --update-dir | --systemd-boot | --trust-inventory | --output | --boot-timeout | \
     --image-size-mib | --root-size-mib | --verity-size-mib | --swap-size-mib | --persist-size-mib)
     (($# >= 2)) || usage
     # Only the fixed option whitelist above may select a destination variable.
@@ -115,8 +115,13 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -m 0700 "$output"
-raw="$output/ghaf-image.raw"
-truncate -s "${image_size_mib}M" "$raw"
+[[ -b $disk && $EUID -eq 0 ]] || usage
+[[ $(blockdev --getsize64 "$disk") -eq $((image_size_mib * 1048576)) ]] || usage
+[[ -z $(wipefs --noheadings --output TYPE "$disk") ]] || {
+  echo "Refusing nonempty disk" >&2
+  exit 1
+}
+raw=$disk
 last_partition_sector=$(((image_size_mib - 1) * 2048 - 1))
 sgdisk --zap-all "$raw"
 sgdisk \
@@ -131,28 +136,13 @@ sgdisk \
   --partition-guid=2:3C05B9C2-6F7C-4B13-ACB7-47C615AAB14A \
   "$raw"
 
-partition_sector() {
-  local partition=$1 field=$2 value
-  value=$(sgdisk -i "$partition" "$raw" | awk -v field="$field" \
-    '$1 " " $2 == field ":" { print $3; exit }')
-  [[ $value =~ ^[0-9]+$ ]] || {
-    echo "Could not read $field for GPT partition $partition" >&2
-    exit 1
-  }
-  printf '%s\n' "$value"
+blockdev --rereadpt "$disk"
+esp_image="${disk}1"
+luks_image="${disk}2"
+[[ -b $esp_image && -b $luks_image ]] || {
+  echo "Partition devices missing" >&2
+  exit 1
 }
-
-esp_first=$(partition_sector 1 "First sector")
-esp_last=$(partition_sector 1 "Last sector")
-luks_first=$(partition_sector 2 "First sector")
-luks_last=$(partition_sector 2 "Last sector")
-esp_size_bytes=$(((esp_last - esp_first + 1) * 512))
-luks_size_bytes=$(((luks_last - luks_first + 1) * 512))
-luks_header_size=$((32 * 1024 * 1024))
-plain_lvm_size=$((luks_size_bytes - luks_header_size))
-
-esp_image="$work/esp.img"
-truncate -s "$esp_size_bytes" "$esp_image"
 mkfs.vfat -F 32 -n ESP "$esp_image"
 for directory in EFI EFI/systemd EFI/BOOT EFI/Linux loader; do
   mmd -i "$esp_image" "::$directory"
@@ -165,34 +155,12 @@ printf 'timeout %s\ndefault %s\neditor no\n' \
   "$boot_timeout" "${uki_name%.efi}" >"$work/loader.conf"
 mcopy -i "$esp_image" "$work/loader.conf" ::loader/loader.conf
 
-luks_image="$work/luks.img"
-truncate -s "$plain_lvm_size" "$luks_image"
-initialize_lvm --image "$luks_image"
-
-# Keep compatibility with Ghaf's existing first-boot enrollment: it unlocks
-# this bootstrap slot with an empty passphrase, enrolls TPM2/FIDO2 and recovery
-# credentials, then removes the bootstrap slot last.
+# The empty bootstrap passphrase is replaced by first-boot enrollment.
 : >"$work/bootstrap.key"
-ghaf-wrap-luks-image \
-  --image "$luks_image" \
-  --uuid 3E7F3D25-695A-429D-8D34-2D0A18979D7D \
-  --key-file "$work/bootstrap.key"
-[[ $(stat -c%s "$luks_image") -eq $luks_size_bytes ]] || {
-  echo "LUKS image size does not match GPT partition size" >&2
-  exit 1
-}
+initialize_lvm --image "$luks_image" \
+  --luks-uuid 3E7F3D25-695A-429D-8D34-2D0A18979D7D --key-file "$work/bootstrap.key"
 
-dd if="$esp_image" of="$raw" bs=4M seek="$((esp_first * 512))" \
-  oflag=seek_bytes conv=notrunc,sparse status=none
-dd if="$luks_image" of="$raw" bs=4M seek="$((luks_first * 512))" \
-  oflag=seek_bytes conv=notrunc,sparse status=none
-
-bmaptool create "$raw" -o "$output/ghaf-image.bmap"
-cores=${NIX_BUILD_CORES:-1}
-[[ $cores =~ ^[1-9][0-9]*$ ]] || cores=1
-if ((cores > 8)); then cores=8; fi
-zstd -T"$cores" --compress "$raw" -o "$output/ghaf-image.raw.zst" --rm
 install -m 0644 "$trust_inventory" "$output/public-trust.json"
 
 complete=true
-echo "Unsigned x86 image written to $output"
+echo "Unsigned x86 disk populated on $disk"

--- a/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
+++ b/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
@@ -17,6 +17,29 @@
   zstd,
 }:
 let
+  fixture = ''
+    mkdir payload
+    printf 'root\n' > root.raw
+    printf 'verity\n' > verity.raw
+    zstd root.raw -o payload/ghaf_root_1_deadbeef.raw.zst
+    zstd verity.raw -o payload/ghaf_verity_1_deadbeef.raw.zst
+    touch payload/ghaf_kernel_1_deadbeef.efi systemd-boot.efi
+    printf '{"target":"test","generation":1,"publicTrustDigests":{}}\n' > trust.json
+    cat > payload/ghaf_1_deadbeef.manifest <<'EOF'
+    {
+      "manifest_version": 2,
+      "version": "1",
+      "root_verity_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "root": { "file": "ghaf_root_1_deadbeef.raw.zst", "unpacked_size": 5 },
+      "verity": { "file": "ghaf_verity_1_deadbeef.raw.zst", "unpacked_size": 7 }
+    }
+    EOF
+    prepare() {
+      ghaf-prepare-x86-verity-disk --update-dir payload --systemd-boot systemd-boot.efi \
+        --trust-inventory trust.json --root-size-mib 1 --verity-size-mib 1 \
+        --boot-timeout menu-force "$@"
+    }
+  '';
   ghaf-prepare-x86-verity-disk = writeShellApplication {
     name = "ghaf-prepare-x86-verity-disk";
     runtimeInputs = [
@@ -52,33 +75,15 @@ ghaf-prepare-x86-verity-disk.overrideAttrs (old: {
           ];
         }
         ''
-          mkdir payload
-          printf 'root\n' > root.raw
-          printf 'verity\n' > verity.raw
-          zstd root.raw -o payload/ghaf_root_1_deadbeef.raw.zst
-          zstd verity.raw -o payload/ghaf_verity_1_deadbeef.raw.zst
-          touch payload/ghaf_kernel_1_deadbeef.efi systemd-boot.efi trust.json
-          cat > payload/ghaf_1_deadbeef.manifest <<'EOF'
-          {
-            "manifest_version": 2,
-            "version": "1",
-            "root_verity_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-            "root": { "file": "ghaf_root_1_deadbeef.raw.zst", "unpacked_size": 5 },
-            "verity": { "file": "ghaf_verity_1_deadbeef.raw.zst", "unpacked_size": 7 }
-          }
-          EOF
-          ghaf-prepare-x86-verity-disk \
-            --update-dir payload --systemd-boot systemd-boot.efi \
-            --trust-inventory trust.json --image-size-mib 4602 \
-            --root-size-mib 1 --verity-size-mib 1 --swap-size-mib 1 \
-            --persist-size-mib 1 --boot-timeout menu-force \
+          ${fixture}
+          prepare --image-size-mib 4602 --swap-size-mib 1 --persist-size-mib 1 \
             --print-plan > plan.json
           test "$(jq -r .minimum_image_size_mib plan.json)" = 4602
-          ! ghaf-prepare-x86-verity-disk \
-            --update-dir payload --systemd-boot systemd-boot.efi \
-            --trust-inventory trust.json --image-size-mib 4601 \
-            --root-size-mib 1 --verity-size-mib 1 --swap-size-mib 1 \
-            --persist-size-mib 1 --boot-timeout menu-force --print-plan
+          ! prepare --image-size-mib 4601 --swap-size-mib 1 --persist-size-mib 1 --print-plan
+          for option in --output --image-size-mib --PATH; do
+            ! ghaf-prepare-x86-verity-disk "$option" 2>error.log
+            grep -q '^Usage:' error.log
+          done
           touch "$out"
         '';
     tests.image =
@@ -93,27 +98,8 @@ ghaf-prepare-x86-verity-disk.overrideAttrs (old: {
           ];
         }
         ''
-          mkdir payload
-          printf 'root\n' > root.raw
-          printf 'verity\n' > verity.raw
-          zstd root.raw -o payload/ghaf_root_1_deadbeef.raw.zst
-          zstd verity.raw -o payload/ghaf_verity_1_deadbeef.raw.zst
-          touch payload/ghaf_kernel_1_deadbeef.efi systemd-boot.efi
-          printf '{"target":"test","generation":1,"publicTrustDigests":{}}\n' > trust.json
-          cat > payload/ghaf_1_deadbeef.manifest <<'EOF'
-          {
-            "manifest_version": 2,
-            "version": "1",
-            "root_verity_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-            "root": { "file": "ghaf_root_1_deadbeef.raw.zst", "unpacked_size": 5 },
-            "verity": { "file": "ghaf_verity_1_deadbeef.raw.zst", "unpacked_size": 7 }
-          }
-          EOF
-          ghaf-prepare-x86-verity-disk \
-            --update-dir payload --systemd-boot systemd-boot.efi \
-            --trust-inventory trust.json --image-size-mib 4600 \
-            --root-size-mib 1 --verity-size-mib 1 --swap-size-mib 0 \
-            --persist-size-mib 0 --boot-timeout menu-force --output "$out"
+          ${fixture}
+          prepare --image-size-mib 4600 --swap-size-mib 0 --persist-size-mib 0 --output "$out"
 
           test -s "$out/ghaf-image.raw.zst"
           test -s "$out/ghaf-image.bmap"

--- a/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
+++ b/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
@@ -99,7 +99,7 @@ ghaf-prepare-x86-verity-disk.overrideAttrs (old: {
           zstd root.raw -o payload/ghaf_root_1_deadbeef.raw.zst
           zstd verity.raw -o payload/ghaf_verity_1_deadbeef.raw.zst
           touch payload/ghaf_kernel_1_deadbeef.efi systemd-boot.efi
-          printf '{"external":false}\n' > trust.json
+          printf '{"target":"test","generation":1,"publicTrustDigests":{}}\n' > trust.json
           cat > payload/ghaf_1_deadbeef.manifest <<'EOF'
           {
             "manifest_version": 2,

--- a/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
+++ b/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  bmaptool,
+  coreutils,
+  cryptsetup,
+  dosfstools,
+  findutils,
+  gawk,
+  ghaf-initialize-verity-lvm,
+  ghaf-wrap-luks-image,
+  gptfdisk,
+  jq,
+  mtools,
+  runCommand,
+  writeShellApplication,
+  zstd,
+}:
+let
+  ghaf-prepare-x86-verity-disk = writeShellApplication {
+    name = "ghaf-prepare-x86-verity-disk";
+    runtimeInputs = [
+      bmaptool
+      coreutils
+      dosfstools
+      findutils
+      gawk
+      ghaf-initialize-verity-lvm
+      ghaf-wrap-luks-image
+      gptfdisk
+      jq
+      mtools
+      zstd
+    ];
+    text = builtins.readFile ./ghaf-prepare-x86-verity-disk.sh;
+    meta = {
+      description = "Build a Ghaf x86 secure A/B disk from regular files";
+      mainProgram = "ghaf-prepare-x86-verity-disk";
+      platforms = [ "x86_64-linux" ];
+    };
+  };
+in
+ghaf-prepare-x86-verity-disk.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests.plan =
+      runCommand "ghaf-prepare-x86-verity-disk-plan"
+        {
+          nativeBuildInputs = [
+            ghaf-prepare-x86-verity-disk
+            jq
+            zstd
+          ];
+        }
+        ''
+          mkdir payload
+          printf 'root\n' > root.raw
+          printf 'verity\n' > verity.raw
+          zstd root.raw -o payload/ghaf_root_1_deadbeef.raw.zst
+          zstd verity.raw -o payload/ghaf_verity_1_deadbeef.raw.zst
+          touch payload/ghaf_kernel_1_deadbeef.efi systemd-boot.efi trust.json
+          cat > payload/ghaf_1_deadbeef.manifest <<'EOF'
+          {
+            "manifest_version": 2,
+            "version": "1",
+            "root_verity_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "root": { "file": "ghaf_root_1_deadbeef.raw.zst", "unpacked_size": 5 },
+            "verity": { "file": "ghaf_verity_1_deadbeef.raw.zst", "unpacked_size": 7 }
+          }
+          EOF
+          ghaf-prepare-x86-verity-disk \
+            --update-dir payload --systemd-boot systemd-boot.efi \
+            --trust-inventory trust.json --image-size-mib 4602 \
+            --root-size-mib 1 --verity-size-mib 1 --swap-size-mib 1 \
+            --persist-size-mib 1 --boot-timeout menu-force \
+            --print-plan > plan.json
+          test "$(jq -r .minimum_image_size_mib plan.json)" = 4602
+          ! ghaf-prepare-x86-verity-disk \
+            --update-dir payload --systemd-boot systemd-boot.efi \
+            --trust-inventory trust.json --image-size-mib 4601 \
+            --root-size-mib 1 --verity-size-mib 1 --swap-size-mib 1 \
+            --persist-size-mib 1 --boot-timeout menu-force --print-plan
+          touch "$out"
+        '';
+    tests.image =
+      runCommand "ghaf-prepare-x86-verity-disk-image"
+        {
+          nativeBuildInputs = [
+            cryptsetup
+            ghaf-prepare-x86-verity-disk
+            gptfdisk
+            mtools
+            zstd
+          ];
+        }
+        ''
+          mkdir payload
+          printf 'root\n' > root.raw
+          printf 'verity\n' > verity.raw
+          zstd root.raw -o payload/ghaf_root_1_deadbeef.raw.zst
+          zstd verity.raw -o payload/ghaf_verity_1_deadbeef.raw.zst
+          touch payload/ghaf_kernel_1_deadbeef.efi systemd-boot.efi
+          printf '{"external":false}\n' > trust.json
+          cat > payload/ghaf_1_deadbeef.manifest <<'EOF'
+          {
+            "manifest_version": 2,
+            "version": "1",
+            "root_verity_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "root": { "file": "ghaf_root_1_deadbeef.raw.zst", "unpacked_size": 5 },
+            "verity": { "file": "ghaf_verity_1_deadbeef.raw.zst", "unpacked_size": 7 }
+          }
+          EOF
+          ghaf-prepare-x86-verity-disk \
+            --update-dir payload --systemd-boot systemd-boot.efi \
+            --trust-inventory trust.json --image-size-mib 4600 \
+            --root-size-mib 1 --verity-size-mib 1 --swap-size-mib 0 \
+            --persist-size-mib 0 --boot-timeout menu-force --output "$out"
+
+          test -s "$out/ghaf-image.raw.zst"
+          test -s "$out/ghaf-image.bmap"
+          cmp trust.json "$out/public-trust.json"
+          zstd --decompress "$out/ghaf-image.raw.zst" -o image.raw
+          sgdisk --verify image.raw
+          test "$(sgdisk -i 1 image.raw | awk '/Partition name:/ { print $3 }')" = "'ESP'"
+          test "$(sgdisk -i 2 image.raw | awk '/Partition name:/ { print $3 }')" = "'disk-disk1-luks'"
+          sgdisk -i 2 image.raw | grep -Fq \
+            'Partition GUID code: CA7D7CCB-63ED-4C53-861C-1742536059CC'
+          esp_first=$(sgdisk -i 1 image.raw | awk '/First sector:/ { print $3 }')
+          luks_first=$(sgdisk -i 2 image.raw | awk '/First sector:/ { print $3 }')
+          mdir -i "image.raw@@$((esp_first * 512))" ::EFI/Linux/ghaf-1-0123456789abcdef.efi
+          dd if=image.raw of=luks-header.img bs=512 skip="$luks_first" count=65536 status=none
+          cryptsetup isLuks --type luks2 luks-header.img
+        '';
+  };
+})

--- a/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
+++ b/packages/pkgs-by-name/ghaf-prepare-x86-verity-disk/package.nix
@@ -6,9 +6,10 @@
   cryptsetup,
   dosfstools,
   findutils,
-  gawk,
   ghaf-initialize-verity-lvm,
-  ghaf-wrap-luks-image,
+  ghaf-update-manifest,
+  pkgs,
+  util-linux,
   gptfdisk,
   jq,
   mtools,
@@ -25,39 +26,56 @@ let
     zstd verity.raw -o payload/ghaf_verity_1_deadbeef.raw.zst
     touch payload/ghaf_kernel_1_deadbeef.efi systemd-boot.efi
     printf '{"target":"test","generation":1,"publicTrustDigests":{}}\n' > trust.json
-    cat > payload/ghaf_1_deadbeef.manifest <<'EOF'
-    {
-      "manifest_version": 2,
-      "version": "1",
-      "root_verity_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-      "root": { "file": "ghaf_root_1_deadbeef.raw.zst", "unpacked_size": 5 },
-      "verity": { "file": "ghaf_verity_1_deadbeef.raw.zst", "unpacked_size": 7 }
-    }
-    EOF
+    printf '%064d\n' 0 > hash
+    ghaf-update-manifest generate --version 1 --system x86_64-linux --build-system x86_64-linux \
+      --target test --generation 1 --hash-file hash --root-image payload/ghaf_root_1_deadbeef.raw.zst \
+      --verity-image payload/ghaf_verity_1_deadbeef.raw.zst --kernel-image payload/ghaf_kernel_1_deadbeef.efi \
+      --root-unpacked-size 5 --verity-unpacked-size 7 --manifest payload/ghaf_1_deadbeef.manifest
     prepare() {
       ghaf-prepare-x86-verity-disk --update-dir payload --systemd-boot systemd-boot.efi \
         --trust-inventory trust.json --root-size-mib 1 --verity-size-mib 1 \
         --boot-timeout menu-force "$@"
     }
   '';
+  runVM = import ../../../lib/image-builder-vm.nix { inherit pkgs; };
+  buildImage =
+    { imageSizeMiB, buildCommand }:
+    runVM (
+      runCommand "ghaf-x86-verity-disk" {
+        nativeBuildInputs = [
+          ghaf-prepare-x86-verity-disk
+          ghaf-update-manifest
+          cryptsetup
+          gptfdisk
+          mtools
+          zstd
+          bmaptool
+        ];
+        preVM = ''
+          diskImage=$PWD/ghaf-image.raw
+          truncate -s ${toString imageSizeMiB}M "$diskImage"
+        '';
+        postVM = ''
+          bmaptool create "$diskImage" -o "$out/ghaf-image.bmap"
+          zstd --compress -T8 "$diskImage" -o "$out/ghaf-image.raw.zst"
+        '';
+      } buildCommand
+    );
   ghaf-prepare-x86-verity-disk = writeShellApplication {
     name = "ghaf-prepare-x86-verity-disk";
     runtimeInputs = [
-      bmaptool
       coreutils
       dosfstools
       findutils
-      gawk
       ghaf-initialize-verity-lvm
-      ghaf-wrap-luks-image
+      util-linux
       gptfdisk
       jq
       mtools
-      zstd
     ];
     text = builtins.readFile ./ghaf-prepare-x86-verity-disk.sh;
     meta = {
-      description = "Build a Ghaf x86 secure A/B disk from regular files";
+      description = "Populate a Ghaf x86 secure A/B disk inside a build VM";
       mainProgram = "ghaf-prepare-x86-verity-disk";
       platforms = [ "x86_64-linux" ];
     };
@@ -65,11 +83,13 @@ let
 in
 ghaf-prepare-x86-verity-disk.overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
+    inherit buildImage;
     tests.plan =
       runCommand "ghaf-prepare-x86-verity-disk-plan"
         {
           nativeBuildInputs = [
             ghaf-prepare-x86-verity-disk
+            ghaf-update-manifest
             jq
             zstd
           ];
@@ -86,35 +106,18 @@ ghaf-prepare-x86-verity-disk.overrideAttrs (old: {
           done
           touch "$out"
         '';
-    tests.image =
-      runCommand "ghaf-prepare-x86-verity-disk-image"
-        {
-          nativeBuildInputs = [
-            cryptsetup
-            ghaf-prepare-x86-verity-disk
-            gptfdisk
-            mtools
-            zstd
-          ];
-        }
-        ''
-          ${fixture}
-          prepare --image-size-mib 4600 --swap-size-mib 0 --persist-size-mib 0 --output "$out"
-
-          test -s "$out/ghaf-image.raw.zst"
-          test -s "$out/ghaf-image.bmap"
-          cmp trust.json "$out/public-trust.json"
-          zstd --decompress "$out/ghaf-image.raw.zst" -o image.raw
-          sgdisk --verify image.raw
-          test "$(sgdisk -i 1 image.raw | awk '/Partition name:/ { print $3 }')" = "'ESP'"
-          test "$(sgdisk -i 2 image.raw | awk '/Partition name:/ { print $3 }')" = "'disk-disk1-luks'"
-          sgdisk -i 2 image.raw | grep -Fq \
-            'Partition GUID code: CA7D7CCB-63ED-4C53-861C-1742536059CC'
-          esp_first=$(sgdisk -i 1 image.raw | awk '/First sector:/ { print $3 }')
-          luks_first=$(sgdisk -i 2 image.raw | awk '/First sector:/ { print $3 }')
-          mdir -i "image.raw@@$((esp_first * 512))" ::EFI/Linux/ghaf-1-0123456789abcdef.efi
-          dd if=image.raw of=luks-header.img bs=512 skip="$luks_first" count=65536 status=none
-          cryptsetup isLuks --type luks2 luks-header.img
-        '';
+    tests.image = buildImage {
+      imageSizeMiB = 4600;
+      buildCommand = ''
+        ${fixture}
+        prepare --disk /dev/vda --image-size-mib 4600 --swap-size-mib 0 --persist-size-mib 0 --output "$out"
+        cmp trust.json "$out/public-trust.json"
+        sgdisk --verify /dev/vda
+        sgdisk -i 2 /dev/vda | grep -Fq 'Partition GUID code: CA7D7CCB-63ED-4C53-861C-1742536059CC'
+        mdir -i /dev/vda1 ::EFI/Linux/ghaf-1-0000000000000000.efi
+        cryptsetup isLuks --type luks2 /dev/vda2
+        test "$(cryptsetup luksUUID /dev/vda2)" = 3e7f3d25-695a-429d-8d34-2d0a18979d7d
+      '';
+    };
   };
 })

--- a/packages/pkgs-by-name/ghaf-sign-x86-image/ghaf-sign-x86-image.sh
+++ b/packages/pkgs-by-name/ghaf-sign-x86-image/ghaf-sign-x86-image.sh
@@ -42,7 +42,7 @@ done
   exit 1
 }
 [[ $(jq -er '.external == true' "$input/public-trust.json") == true ]] || {
-  echo "Refusing to sign an x86 image evaluated with CI-only public trust; rebuild --impure with GHAF_DEV_KEY_DIR" >&2
+  echo "Refusing to sign an x86 image evaluated with CI-only public trust; rebuild with an external secure-ab-build-config input" >&2
   exit 1
 }
 for public_file in PK.crt KEK.crt db.crt update.pub; do
@@ -50,7 +50,7 @@ for public_file in PK.crt KEK.crt db.crt update.pub; do
   actual=$(sha256sum "$key_dir/$public_file")
   actual=${actual%% *}
   [[ $actual == "$expected" ]] || {
-    echo "Public trust mismatch for $public_file; rebuild the image with this exact GHAF_DEV_KEY_DIR" >&2
+    echo "Public trust mismatch for $public_file; rebuild with a secure-ab-build-config exported from this exact key directory" >&2
     exit 1
   }
 done

--- a/packages/pkgs-by-name/ghaf-sign-x86-image/ghaf-sign-x86-image.sh
+++ b/packages/pkgs-by-name/ghaf-sign-x86-image/ghaf-sign-x86-image.sh
@@ -41,10 +41,6 @@ done
   echo "Missing $input/public-trust.json; the image does not expose its evaluated trust inventory" >&2
   exit 1
 }
-[[ $(jq -er '.external == true' "$input/public-trust.json") == true ]] || {
-  echo "Refusing to sign an x86 image evaluated with CI-only public trust; rebuild with an external secure-ab-build-config input" >&2
-  exit 1
-}
 for public_file in PK.crt KEK.crt db.crt update.pub; do
   expected=$(jq -er --arg name "$public_file" '.publicTrustDigests[$name]' "$input/public-trust.json")
   actual=$(sha256sum "$key_dir/$public_file")

--- a/packages/pkgs-by-name/ghaf-sign-x86-image/ghaf-sign-x86-image.sh
+++ b/packages/pkgs-by-name/ghaf-sign-x86-image/ghaf-sign-x86-image.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+usage() {
+  echo "Usage: ghaf-sign-x86-image --key-dir DIR --input IMAGE_DIR --output DIR" >&2
+  exit 2
+}
+
+key_dir="" input="" output=""
+while (($#)); do
+  case "$1" in
+  --key-dir)
+    key_dir="${2:-}"
+    shift 2
+    ;;
+  --input)
+    input="${2:-}"
+    shift 2
+    ;;
+  --output)
+    output="${2:-}"
+    shift 2
+    ;;
+  *) usage ;;
+  esac
+done
+[[ -n $key_dir && -n $input && -n $output ]] || usage
+[[ $EUID -eq 0 ]] || {
+  echo "ghaf-sign-x86-image must run as root to mount the image ESP" >&2
+  exit 1
+}
+for required in db.key db.crt PK.crt KEK.crt update.pub PK.auth KEK.auth db.auth; do
+  [[ -s $key_dir/$required ]] || {
+    echo "Missing $key_dir/$required" >&2
+    exit 1
+  }
+done
+[[ -s $input/public-trust.json ]] || {
+  echo "Missing $input/public-trust.json; the image does not expose its evaluated trust inventory" >&2
+  exit 1
+}
+[[ $(jq -er '.external == true' "$input/public-trust.json") == true ]] || {
+  echo "Refusing to sign an x86 image evaluated with CI-only public trust; rebuild --impure with GHAF_DEV_KEY_DIR" >&2
+  exit 1
+}
+for public_file in PK.crt KEK.crt db.crt update.pub; do
+  expected=$(jq -er --arg name "$public_file" '.publicTrustDigests[$name]' "$input/public-trust.json")
+  actual=$(sha256sum "$key_dir/$public_file")
+  actual=${actual%% *}
+  [[ $actual == "$expected" ]] || {
+    echo "Public trust mismatch for $public_file; rebuild the image with this exact GHAF_DEV_KEY_DIR" >&2
+    exit 1
+  }
+done
+[[ -s $input/ghaf-image.raw.zst ]] || {
+  echo "Missing $input/ghaf-image.raw.zst" >&2
+  exit 1
+}
+[[ ! -e $output ]] || {
+  echo "Refusing to overwrite $output" >&2
+  exit 1
+}
+
+key_pub=$(mktemp)
+cert_pub=$(mktemp)
+work=$(mktemp -d)
+loop=""
+mounted=false
+cleanup() {
+  if $mounted; then
+    umount "$work/esp" || true
+  fi
+  if [[ -n $loop ]]; then
+    losetup -d "$loop" || true
+  fi
+  rm -f "$key_pub" "$cert_pub"
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+openssl pkey -in "$key_dir/db.key" -pubout -out "$key_pub"
+openssl x509 -in "$key_dir/db.crt" -pubkey -noout -out "$cert_pub"
+cmp -s "$key_pub" "$cert_pub" || {
+  echo "db.key does not match db.crt" >&2
+  exit 1
+}
+
+zstd -d "$input/ghaf-image.raw.zst" -o "$work/ghaf-image.raw"
+loop=$(losetup --find --show --partscan "$work/ghaf-image.raw")
+udevadm settle
+esp=$(
+  lsblk -nrpo NAME,PARTTYPE "$loop" |
+    awk 'tolower($2) == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" { print $1; exit }'
+)
+[[ -n $esp ]] || {
+  echo "No EFI system partition found in the image" >&2
+  exit 1
+}
+mkdir "$work/esp"
+mount -t vfat "$esp" "$work/esp"
+mounted=true
+
+sign_one() {
+  local file=$1 signed="$work/signed.efi"
+  sbsign --key "$key_dir/db.key" --cert "$key_dir/db.crt" \
+    --output "$signed" "$file"
+  sbverify --cert "$key_dir/db.crt" "$signed" >/dev/null
+  install -m 0644 "$signed" "$file"
+}
+
+for loader in \
+  "$work/esp/EFI/systemd/systemd-bootx64.efi" \
+  "$work/esp/EFI/BOOT/BOOTX64.EFI"; do
+  [[ -f $loader ]] || {
+    echo "Missing required x86 EFI loader: ${loader#"$work/esp/"}" >&2
+    exit 1
+  }
+  sign_one "$loader"
+done
+
+mapfile -d '' ukis < <(find "$work/esp/EFI/Linux" -maxdepth 1 -type f -iname '*.efi' -print0 2>/dev/null)
+((${#ukis[@]} > 0)) || {
+  echo "No Type-2 UKI found under EFI/Linux; refusing an incomplete Secure Boot image" >&2
+  exit 1
+}
+for uki in "${ukis[@]}"; do
+  sign_one "$uki"
+done
+
+if find "$work/esp/loader/entries" -maxdepth 1 -type f -name '*.conf' -print -quit 2>/dev/null | grep -q .; then
+  echo "Type-1 boot entries remain in loader/entries; refusing an image whose initrd/cmdline are not UKI-bound" >&2
+  exit 1
+fi
+
+sync -f "$work/esp"
+umount "$work/esp"
+mounted=false
+losetup -d "$loop"
+loop=""
+
+mkdir -m 0700 "$output"
+bmaptool create "$work/ghaf-image.raw" -o "$output/ghaf-image.bmap"
+zstd -T0 --compress "$work/ghaf-image.raw" -o "$output/ghaf-image.raw.zst"
+install -m 0644 \
+  "$key_dir/PK.auth" \
+  "$key_dir/KEK.auth" \
+  "$key_dir/db.auth" \
+  "$key_dir/db.crt" \
+  "$output/"
+install -m 0644 "$input/public-trust.json" "$output/"
+echo "Signed x86 image and matching enrollment payload written to $output"

--- a/packages/pkgs-by-name/ghaf-sign-x86-image/ghaf-sign-x86-image.sh
+++ b/packages/pkgs-by-name/ghaf-sign-x86-image/ghaf-sign-x86-image.sh
@@ -27,10 +27,6 @@ while (($#)); do
   esac
 done
 [[ -n $key_dir && -n $input && -n $output ]] || usage
-[[ $EUID -eq 0 ]] || {
-  echo "ghaf-sign-x86-image must run as root to mount the image ESP" >&2
-  exit 1
-}
 for required in db.key db.crt PK.crt KEK.crt update.pub PK.auth KEK.auth db.auth; do
   [[ -s $key_dir/$required ]] || {
     echo "Missing $key_dir/$required" >&2
@@ -59,21 +55,10 @@ done
   exit 1
 }
 
-key_pub=$(mktemp)
-cert_pub=$(mktemp)
 work=$(mktemp -d)
-loop=""
-mounted=false
-cleanup() {
-  if $mounted; then
-    umount "$work/esp" || true
-  fi
-  if [[ -n $loop ]]; then
-    losetup -d "$loop" || true
-  fi
-  rm -f "$key_pub" "$cert_pub"
-  rm -rf "$work"
-}
+key_pub="$work/key.pub"
+cert_pub="$work/cert.pub"
+cleanup() { rm -rf "$work"; }
 trap cleanup EXIT
 
 openssl pkey -in "$key_dir/db.key" -pubout -out "$key_pub"
@@ -84,26 +69,22 @@ cmp -s "$key_pub" "$cert_pub" || {
 }
 
 zstd -d "$input/ghaf-image.raw.zst" -o "$work/ghaf-image.raw"
-loop=$(losetup --find --show --partscan "$work/ghaf-image.raw")
-udevadm settle
-esp=$(
-  lsblk -nrpo NAME,PARTTYPE "$loop" |
-    awk 'tolower($2) == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" { print $1; exit }'
+esp_offset=$(
+  sfdisk --json "$work/ghaf-image.raw" |
+    jq -er '.partitiontable | .sectorsize as $sector |
+      [.partitions[] | select((.type | ascii_downcase) == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b")] |
+      if length == 1 then .[0].start * $sector else error("Expected exactly one ESP") end'
 )
-[[ -n $esp ]] || {
-  echo "No EFI system partition found in the image" >&2
-  exit 1
-}
+esp_image="$work/ghaf-image.raw@@$esp_offset"
 mkdir "$work/esp"
-mount -t vfat "$esp" "$work/esp"
-mounted=true
+mcopy -s -i "$esp_image" ::EFI ::loader "$work/esp/"
 
 sign_one() {
   local file=$1 signed="$work/signed.efi"
   sbsign --key "$key_dir/db.key" --cert "$key_dir/db.crt" \
     --output "$signed" "$file"
   sbverify --cert "$key_dir/db.crt" "$signed" >/dev/null
-  install -m 0644 "$signed" "$file"
+  mcopy -o -i "$esp_image" "$signed" "::${file#"$work/esp/"}"
 }
 
 for loader in \
@@ -130,11 +111,7 @@ if find "$work/esp/loader/entries" -maxdepth 1 -type f -name '*.conf' -print -qu
   exit 1
 fi
 
-sync -f "$work/esp"
-umount "$work/esp"
-mounted=false
-losetup -d "$loop"
-loop=""
+sync -f "$work/ghaf-image.raw"
 
 mkdir -m 0700 "$output"
 bmaptool create "$work/ghaf-image.raw" -o "$output/ghaf-image.bmap"

--- a/packages/pkgs-by-name/ghaf-sign-x86-image/package.nix
+++ b/packages/pkgs-by-name/ghaf-sign-x86-image/package.nix
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  bmaptool,
+  coreutils,
+  findutils,
+  gawk,
+  gnugrep,
+  jq,
+  openssl,
+  sbsigntool,
+  systemd,
+  util-linux,
+  writeShellApplication,
+  zstd,
+}:
+writeShellApplication {
+  name = "ghaf-sign-x86-image";
+  runtimeInputs = [
+    bmaptool
+    coreutils
+    findutils
+    gawk
+    gnugrep
+    jq
+    openssl
+    sbsigntool
+    systemd
+    util-linux
+    zstd
+  ];
+  text = builtins.readFile ./ghaf-sign-x86-image.sh;
+  meta.description = "Sign the EFI boot chain in a Ghaf x86 disk image outside the Nix store";
+}

--- a/packages/pkgs-by-name/ghaf-sign-x86-image/package.nix
+++ b/packages/pkgs-by-name/ghaf-sign-x86-image/package.nix
@@ -4,31 +4,101 @@
   bmaptool,
   coreutils,
   findutils,
-  gawk,
   gnugrep,
+  gptfdisk,
   jq,
+  mtools,
   openssl,
+  runCommand,
   sbsigntool,
   systemd,
   util-linux,
   writeShellApplication,
   zstd,
 }:
-writeShellApplication {
-  name = "ghaf-sign-x86-image";
-  runtimeInputs = [
-    bmaptool
-    coreutils
-    findutils
-    gawk
-    gnugrep
-    jq
-    openssl
-    sbsigntool
-    systemd
-    util-linux
-    zstd
-  ];
-  text = builtins.readFile ./ghaf-sign-x86-image.sh;
-  meta.description = "Sign the EFI boot chain in a Ghaf x86 disk image outside the Nix store";
-}
+let
+  signer = writeShellApplication {
+    name = "ghaf-sign-x86-image";
+    runtimeInputs = [
+      bmaptool
+      coreutils
+      findutils
+      gnugrep
+      jq
+      mtools
+      openssl
+      sbsigntool
+      util-linux
+      zstd
+    ];
+    text = builtins.readFile ./ghaf-sign-x86-image.sh;
+    meta.description = "Sign the EFI boot chain in a Ghaf x86 disk image outside the Nix store";
+  };
+in
+signer.overrideAttrs (old: {
+  passthru = (old.passthru or { }) // {
+    tests.sign =
+      runCommand "ghaf-sign-x86-image-test"
+        {
+          nativeBuildInputs = [
+            signer
+            gptfdisk
+            mtools
+            jq
+            openssl
+            sbsigntool
+            zstd
+          ];
+        }
+        ''
+          # Exercise real FAT and Authenticode operations without privileged devices.
+          test "$(id -u)" -ne 0
+          mkdir keys input
+          openssl req -new -x509 -newkey rsa:2048 -sha256 -nodes \
+            -subj /CN=signer-test/ -days 1 -keyout keys/db.key -out keys/db.crt >/dev/null 2>&1
+          for name in PK KEK; do cp keys/db.crt "keys/$name.crt"; done
+          for name in PK KEK db; do printf enrollment > "keys/$name.auth"; done
+          printf update-public-key > keys/update.pub
+          jq -n --arg digest "$(sha256sum keys/db.crt | cut -d' ' -f1)" \
+            --arg update "$(sha256sum keys/update.pub | cut -d' ' -f1)" \
+            '{publicTrustDigests: {"PK.crt": $digest, "KEK.crt": $digest, "db.crt": $digest, "update.pub": $update}}' \
+            > input/public-trust.json
+
+          truncate -s 20M disk.raw
+          sgdisk --new=1:1MiB:+16MiB --typecode=1:ef00 disk.raw
+          esp="disk.raw@@1048576"
+          mformat -i "$esp" -T 32768 -h 64 -s 32 ::
+          for directory in EFI EFI/systemd EFI/BOOT EFI/Linux loader loader/entries; do
+            mmd -i "$esp" "::$directory"
+          done
+          # A PE executable suffices here: this tests signing, not UKI bootability.
+          efi=${systemd}/lib/systemd/boot/efi/systemd-bootx64.efi
+          for name in EFI/systemd/systemd-bootx64.efi EFI/BOOT/BOOTX64.EFI EFI/Linux/ghaf-test.efi; do
+            mcopy -i "$esp" "$efi" "::$name"
+          done
+          zstd disk.raw -o input/ghaf-image.raw.zst
+          ghaf-sign-x86-image --key-dir keys --input input --output signed
+          test -s signed/ghaf-image.bmap
+          cmp input/public-trust.json signed/public-trust.json
+          zstd -d signed/ghaf-image.raw.zst -o signed.raw
+          for name in EFI/systemd/systemd-bootx64.efi EFI/BOOT/BOOTX64.EFI EFI/Linux/ghaf-test.efi; do
+            mcopy -o -i signed.raw@@1048576 "::$name" check.efi
+            sbverify --cert keys/db.crt check.efi
+          done
+
+          # A mixed Type-1/Type-2 ESP must never be published for enrollment.
+          printf legacy > legacy.conf
+          mcopy -i "$esp" legacy.conf ::loader/entries/legacy.conf
+          zstd -f disk.raw -o input/ghaf-image.raw.zst
+          ! ghaf-sign-x86-image --key-dir keys --input input --output rejected 2>error.log
+          grep -F 'Type-1 boot entries remain' error.log
+          test ! -e rejected
+
+          printf mismatched > keys/update.pub
+          ! ghaf-sign-x86-image --key-dir keys --input input --output wrong-trust 2>error.log
+          grep -F 'Public trust mismatch' error.log
+          test ! -e wrong-trust
+          touch "$out"
+        '';
+  };
+})

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -109,6 +109,36 @@ let
     ) machines
   );
 
+  # Secure A/B is deliberately an additive target family: legacy laptop names
+  # and artifacts remain unchanged while the trust and rollback contract is
+  # validated. Only axis-free targets that already opted into sysupdate are
+  # candidates, avoiding a combinatorial copy of platform-independent logic.
+  secure-targets = map (
+    t:
+    let
+      secureName = "${t.name}-secure-ab";
+    in
+    (t.extendHost [
+      self.nixosModules.secure-ab-x86
+      {
+        ghaf = {
+          secureUpdate = {
+            enable = true;
+            target = secureName;
+          };
+          partitioning.verity = {
+            enable = true;
+            initialDisk.enable = true;
+          };
+          boot-health.enable = true;
+        };
+      }
+    ])
+    // {
+      name = secureName;
+    }
+  ) (builtins.filter (x: x.buildSysupdateImage) target-configs);
+
   # Map all of the defined configurations to an installer image. Each installer
   # reuses the shared base NixOS evaluation and only overrides ISO contents.
   target-installers = map (
@@ -136,9 +166,29 @@ let
     }
   ) (builtins.filter (x: x.buildSysupdateImage) target-configs);
 
-  config-targets = target-configs ++ target-sysupdates;
+  secure-sysupdates = map (
+    t:
+    (t.extendHost [
+      {
+        ghaf = {
+          partitioning.verity.initialDisk.enable = lib.mkForce false;
+        };
+        boot.uki.tries = 3;
+      }
+    ])
+    // {
+      name = "${t.name}-sysupdate";
+    }
+  ) secure-targets;
+
+  config-targets = target-configs ++ target-sysupdates ++ secure-targets ++ secure-sysupdates;
   package-targets =
-    target-configs ++ target-installers ++ target-netboot-installers ++ target-sysupdates;
+    target-configs
+    ++ target-installers
+    ++ target-netboot-installers
+    ++ target-sysupdates
+    ++ secure-targets
+    ++ secure-sysupdates;
 in
 {
   flake = {


### PR DESCRIPTION
## Summary

x86 adapter on #2199; independent of sibling #2200. Adds Intel laptop secure
A/B initial-image and update targets without replacing normal laptop targets.

- Build GPT/FAT/LUKS2/LVM from regular files without root, VMs, mounts, loop
  devices or device mapper; fixed A/B slots, persist, swap and Type-2 UKIs.
- Require external public trust, sign EFI artifacts outside the build, and
  verify the written ESP before installer firmware enrollment.
- Uses the Rust LVM writer from tiiuae/ghafpkgs#378 through the shared pin,
  passing the selected manifest explicitly and using the fixed LUKS header.

Shared plan/image fixtures, LVM arguments and CLI option handling avoid
duplication. Platform instructions link to the shared setup/update contract.

## Validation

Sandboxed plan and 4.6 GiB image tests pass with the published dependency:
capacity bounds, missing/unknown options, GPT, ESP/UKI, LUKS2 header,
compression, bmap and trust inventory. Formatting, REUSE and whitespace
checks pass.
