### PR TITLE
refactor: trim closure size

### DIFF
--- a/lib/builders/installer-common.nix
+++ b/lib/builders/installer-common.nix
@@ -69,6 +69,7 @@ in
     };
 
     ghaf.theming.enable = true;
+    ghaf.locales.enable = true;
 
     ghaf.graphics.boot = {
       enable = true;

--- a/modules/common/common.nix
+++ b/modules/common/common.nix
@@ -195,6 +195,13 @@ in
         themselves.
       '';
     };
+    locales.enable = lib.mkEnableOption ''
+      the full glibc locale archive (~220 MiB, `i18n.extraLocales = "all"`).
+
+      Only needed on VMs that can render UI text in a locale other than
+      `i18n.defaultLocale`. Left disabled on headless VMs (net-vm, audio-vm,
+      admin-vm, ...), which have no UI to localise.
+    '';
   };
   config = {
 
@@ -307,7 +314,7 @@ in
     i18n = {
       defaultLocale = "en_US.UTF-8";
       imperativeLocale = true;
-      extraLocales = "all";
+      extraLocales = lib.mkIf config.ghaf.locales.enable "all";
     };
   };
 }

--- a/modules/common/theming/default.nix
+++ b/modules/common/theming/default.nix
@@ -151,11 +151,7 @@ in
     iconTheme = {
       package = lib.mkOption {
         type = lib.types.nullOr lib.types.package;
-        default = pkgs.papirus-icon-theme.override {
-          color = "grey";
-          # The following fixes a cross-compilation issue
-          inherit (pkgs.buildPackages) papirus-folders;
-        };
+        default = pkgs.papirus-icon-theme;
         description = "Icon theme package. If null, stylix icon theming will not be used";
       };
       light = lib.mkOption {

--- a/modules/common/theming/default.nix
+++ b/modules/common/theming/default.nix
@@ -121,6 +121,10 @@ in
   options.ghaf.theming = {
     enable = lib.mkEnableOption "shared system theming (stylix)";
 
+    stylix.enable = lib.mkEnableOption "stylix module globally" // {
+      default = true;
+    };
+
     polarity = lib.mkOption {
       type = lib.types.enum [
         "light"
@@ -281,7 +285,7 @@ in
     lib.mkMerge [
       {
         stylix = {
-          enable = true;
+          enable = cfg.stylix.enable;
 
           # Currently unused
           targets.nixos-icons.enable = lib.mkDefault false;

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -122,6 +122,8 @@ in
           };
         };
 
+        locales.enable = lib.mkDefault false;
+
         graphics.boot.enable = lib.mkDefault config.ghaf.global-config.graphics.boot.enable;
 
         services = {

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -115,6 +115,8 @@ in
 
         theming = {
           enable = lib.mkDefault config.ghaf.global-config.theming.enable;
+          stylix.enable = false; # Host has no use for UI theming other than plymouth
+          gtkQtTheme.enable = false;
           plymouth = {
             enable = lib.mkDefault true;
             bootLabel = lib.mkDefault "Starting Ghaf...";
@@ -191,6 +193,14 @@ in
           logLevel = if config.ghaf.global-config.spire.debug then "DEBUG" else "INFO";
           trustBundlePath = "/persist/common/spire/bundle.pem";
         };
+      };
+
+      # nixpkgs defaults all three to true for every NixOS system, desktop or
+      # not. They are pure XDG desktop plumbing.
+      xdg = {
+        icons.enable = lib.mkForce false;
+        mime.enable = lib.mkForce false;
+        autostart.enable = lib.mkForce false;
       };
 
       # Create required host directories

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -226,6 +226,7 @@ in
         };
 
         theming.enable = lib.mkDefault (globalConfig.theming.enable or false);
+        locales.enable = lib.mkDefault true;
 
         # System
         type = "app-vm";

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -94,6 +94,7 @@ in
         bootLabel = lib.mkDefault "Starting desktop...";
       };
     };
+    locales.enable = lib.mkDefault true;
 
     # Profiles - from globalConfig
     profiles = {

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -209,6 +209,9 @@ in
     # Common namespace - from hostConfig
     common = hostConfig.common or { };
 
+    # Enable for now but could possibly be removed
+    locales.enable = lib.mkDefault true;
+
     # Note: reference.services is NOT set here - it should come via extraModules
     # from hardware.definition.netvm.extraModules if needed
   };

--- a/modules/reference/desktop/applications.nix
+++ b/modules/reference/desktop/applications.nix
@@ -24,7 +24,7 @@ in
       {
         # Default desktop files are always preferred
         environment.systemPackages = with pkgs; [
-          gnome-calculator
+          cosmic-ext-calculator
           sticky-notes
         ];
       }

--- a/overlays/custom-packages/cosmic/cosmic-ext-calculator/default.nix
+++ b/overlays/custom-packages/cosmic/cosmic-ext-calculator/default.nix
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# We fast-forward to 0.2.1 here, as nixpkgs upstream is still on 0.2.0
+{ prev }:
+let
+  src = prev.fetchFromGitHub {
+    owner = "cosmic-utils";
+    repo = "cosmic-ext-calculator";
+    tag = "0.2.1";
+    hash = "sha256-t8xuM0B2eh2AbAhDgSOGapTwmmm9eC+wHsqwq4Jn5yU=";
+  };
+in
+prev.cosmic-ext-calculator.overrideAttrs (_oldAttrs: {
+  inherit src;
+  # Explicitly remove unneeded patch
+  patches = [ ];
+  cargoDeps = prev.rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-a4WckNyKXS71dT0uYbO7tUUmD0Dw8vSzrPp29O4aiAk=";
+  };
+})

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -11,6 +11,7 @@
   chromium = import ./chromium { inherit prev; };
   cosmic-applets = import ./cosmic/cosmic-applets { inherit prev; };
   cosmic-comp = import ./cosmic/cosmic-comp { inherit prev; };
+  cosmic-ext-calculator = import ./cosmic/cosmic-ext-calculator { inherit prev; };
   cosmic-greeter = import ./cosmic/cosmic-greeter { inherit prev; };
   cosmic-initial-setup = import ./cosmic/cosmic-initial-setup { inherit prev; };
   cosmic-osd = import ./cosmic/cosmic-osd { inherit prev; };
@@ -27,6 +28,7 @@
   pipewire = import ./pipewire { inherit prev; };
   qt6Packages = import ./qt6Packages { inherit prev; };
   spire4ghaf = import ./spire4ghaf { inherit prev; };
+  tuned = import ./tuned { inherit prev; };
   udiskie = import ./udiskie { inherit prev; };
   waypipe = import ./waypipe { inherit prev; };
   yad = import ./yad { inherit prev; };

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -25,6 +25,7 @@
   libsForQt5 = import ./libsForQt5 { inherit prev; };
   mbrola-voices = import ./mbrola-voices { inherit prev; };
   osquery-with-hostname = import ./osquery-with-hostname { inherit prev; };
+  papirus-icon-theme = import ./papirus-icon-theme { inherit prev; };
   pipewire = import ./pipewire { inherit prev; };
   qt6Packages = import ./qt6Packages { inherit prev; };
   spire4ghaf = import ./spire4ghaf { inherit prev; };

--- a/overlays/custom-packages/papirus-icon-theme/default.nix
+++ b/overlays/custom-packages/papirus-icon-theme/default.nix
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ prev }:
+(prev.papirus-icon-theme.override {
+  color = "grey";
+  # Fixes a cross-compilation issue: papirus-folders is a build-time tool and
+  # must run on the build platform, not the target.
+  inherit (prev.buildPackages) papirus-folders;
+}).overrideAttrs
+  (old: {
+    # breeze-icons (KDE) is only pulled in as an icon fallback (Papirus's
+    # index.theme sets Inherits=breeze/breeze-dark). Dropping it saves
+    # ~880 MiB per closure it's part of; Papirus itself is comprehensive
+    # enough that the fallback is rarely exercised.
+    propagatedBuildInputs = builtins.filter (
+      p: (p.pname or "") != "breeze-icons"
+    ) old.propagatedBuildInputs;
+  })

--- a/overlays/custom-packages/tuned/default.nix
+++ b/overlays/custom-packages/tuned/default.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{ prev }:
+prev.tuned.overrideAttrs (old: {
+  # Neither is actually imported by tuned's code (pyperf's "perf" module is
+  # unrelated to the kernel's tools/perf bindings tuned optionally imports).
+  propagatedBuildInputs = builtins.filter (
+    p:
+    !(builtins.elem (p.pname or "") [
+      "tuna"
+      "pyperf"
+    ])
+  ) old.propagatedBuildInputs;
+})

--- a/packages/pkgs-by-name/fingwit/package.nix
+++ b/packages/pkgs-by-name/fingwit/package.nix
@@ -41,7 +41,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   buildInputs = [
     gtk3
-    xapp
+    # Only libxapp's core is needed here; app-lib-only drops the panel
+    # applets/scripts/sn-watcher that pull in mate-panel, gtk4, gstreamer...
+    # shrinking xapp's closure from ~1.3 GiB to ~290 MiB.
+    (xapp.overrideAttrs (old: {
+      mesonFlags = (old.mesonFlags or [ ]) ++ [ "-Dapp-lib-only=true" ];
+      preFixup = ""; # upstream wraps xapp-sn-watcher here, which app-lib-only no longer builds
+    }))
     glib
     pam
   ];

--- a/targets/vm/flake-module.nix
+++ b/targets/vm/flake-module.nix
@@ -99,7 +99,7 @@ let
             in
             {
               environment.systemPackages = lib.optionals withGraphics [
-                pkgs.gnome-calculator
+                pkgs.cosmic-ext-calculator
               ];
 
               ghaf = {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Overall cleanup and trimming of several packages, modules, etc.

1. Switch default calculator to `cosmic-ext-calculator`.
   Matches the native COSMIC toolkit; fast-forwards to 0.2.1 ahead of nixpkgs.
2. Build `xapp` with `app-lib-only` for fingwit.
   The mate/xfce panel bits xapp normally builds aren't necessary for fingwit.
3. Drop unused `tuna` and `pyperf` dependencies from `tuned`.
4. Drop the `breeze-icons` fallback from `papirus-icon-theme`.
   Only used as an icon fallback, but it drags in all of Qt6. Saves ~880 MiB per closure.
5. Gate the full glibc locale archive behind `ghaf.locales.enable`.
   Only VMs with a UI need it, headless system VMs don't.
6. Decouple stylix from theming; disable stylix, gtk/qt theming, and XDG icons/mime/autostart on host.
   Host has no use for any of these.

## Results:

| Target | Metric | Before | After | Change |
|---|---|---|---|---|
| intel-laptop-debug | closure | 15.35 GiB | 15.06 GiB | -1.9% |
| intel-laptop-debug | raw image (`.raw.zst`) | 6.6 GiB | 6.6 GiB | ~0% |
| intel-laptop-storeDisk-debug | raw image | 22.50 GiB | 22.14 GiB | -1.6% |


### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Evaluate the new calculator app - ideally it doesn't crash, and can calculate
2. Verify `fingwit` fingerprint app still works as it should
3. Verify power profiles can still be changed:
   - gui-vm taskbar top right, change from power save to performance or any other way
   - verify changes take effect (e.g. switching from performance to power save should dim the screen)
4. (system wide) verify no obvious icons are missing in any app (random check is fine)
