### PR TITLE
fix(time): bound the clock barrier on RTC-backed x86 boards

### DIFF
--- a/modules/common/security/spire/agent.nix
+++ b/modules/common/security/spire/agent.nix
@@ -193,9 +193,9 @@ let
       pkgs.systemd
     ];
     text = ''
-      # Same gate as the server-side refresh: with ghaf.time.requireSync = false
-      # the barrier releases on a timeout without the clock ever being trusted,
-      # and restarting the agents then just re-mints the same bad identities.
+      # Same gate as the server-side refresh: with requireSync false (the x86
+      # default) the barrier can release on a timeout with the clock still
+      # untrusted, and restarting the agents then just re-mints bad identities.
       sync_state="$(cat /run/ghaf-clock-synced 2>/dev/null || echo missing)"
       if [ "$sync_state" != "synchronised" ]; then
         echo "spire-reattest-agents: clock barrier reports '$sync_state', not 'synchronised';" \

--- a/modules/common/security/spire/server.nix
+++ b/modules/common/security/spire/server.nix
@@ -116,11 +116,11 @@ let
       spire-package
     ];
     text = ''
-      # Only meaningful once the clock is actually trusted. With
-      # ghaf.time.requireSync = false the barrier releases on a timeout and
-      # writes "released" instead, and rotating onto a CA minted against a clock
-      # we already know is wrong would buy nothing. Say so rather than exiting
-      # quietly, so "no refresh happened" is never mistaken for "refreshed".
+      # Only meaningful once the clock is actually trusted. With requireSync
+      # false (the x86 default) the barrier can release on a timeout, writing
+      # "released"; rotating onto a CA minted against a known-wrong clock buys
+      # nothing. Say so rather than exiting quietly, so "no refresh happened" is
+      # never mistaken for "refreshed".
       sync_state="$(cat /run/ghaf-clock-synced 2>/dev/null || echo missing)"
       if [ "$sync_state" != "synchronised" ]; then
         echo "spire-refresh-identity: clock barrier reports '$sync_state', not 'synchronised';" \

--- a/modules/common/time/default.nix
+++ b/modules/common/time/default.nix
@@ -38,19 +38,23 @@ in
 
     requireSync = mkOption {
       type = types.bool;
-      default = true;
+      default = pkgs.stdenv.hostPlatform.isAarch64;
+      defaultText = lib.literalExpression "pkgs.stdenv.hostPlatform.isAarch64";
       description = ''
-        Whether the clock barrier blocks indefinitely until the system clock is
-        actually synchronised.
+        Whether the clock barrier blocks indefinitely, or releases after
+        `syncWaitSeconds` even while the clock is still unsynchronised.
 
-        With no RTC backup cell the clock is wrong -- not merely imprecise -- for
-        the first seconds of every boot, and a plausibility range cannot detect
-        that: the fallback epoch reads as an ordinary recent date. Only
-        `NTPSynchronized` distinguishes the two.
+        On a board with no RTC backup cell the boot clock is wrong, not just
+        imprecise, and only `NTPSynchronized` can tell -- so the barrier must
+        hold, or consumers gated on `ghaf-clock-synced.target` (SPIRE among them)
+        mint credentials that are already expired once the clock is corrected.
+        A board with a battery-backed RTC boots at roughly the right time, so an
+        unbounded wait there only stalls those consumers when offline, for no gain.
 
-        Leave this on. Turn it off only for a device with no reachable time
-        source at all, accepting that consumers gated on
-        `ghaf-clock-synced.target` may then run against an untrusted clock.
+        The default uses architecture as a proxy for "has a battery-backed RTC":
+        aarch64 is Jetson/Orin, which has none; x86 keeps its RTC across a cold
+        boot. A board that breaks this assumption sets `requireSync` explicitly
+        in its hardware module.
       '';
     };
 


### PR DESCRIPTION
## Problem

`ghaf.time.requireSync` defaulted to `true` everywhere, which makes
`ghaf-wait-time-sync.service` set `TimeoutStartSec=infinity` and block until
`NTPSynchronized=yes`.

On an x86 laptop with **no reachable time source** (booted offline), that barrier
never releases. Every consumer ordered after `ghaf-clock-synced.target` — SPIRE
attestation, SPIRE CA rotation, anything else on that target — then sits blocked
for as long as the machine stays offline, with no user-facing symptom (the
desktop is fully usable throughout).

Measured on hardware (System76 Darter Pro, zero network):

| | behaviour |
|---|---|
| before (`requireSync = true`) | unbounded — observed hanging 14m39s; separately killed at 12m50s during shutdown, never completed on its own |
| after (`requireSync = false` on this x86 host) | bounded — self-releases at exactly `syncWaitSeconds` (180s) with the documented `releasing clock barrier unsynchronised` warning, `Finished` cleanly |

## Change

The unbounded wait only earns its keep where the boot clock is *untrustworthy*,
i.e. a board with no RTC backup cell — the case the module was written for
(Jetson/Orin boot at a fixed fallback epoch). A board with a battery-backed RTC
boots at approximately the right time, so holding the barrier open when offline
just stalls those consumers for no gain.

`requireSync` now defaults to `pkgs.stdenv.hostPlatform.isAarch64`:

- **aarch64** → `true` — Jetson/Orin, no backup cell, barrier stays unbounded (unchanged)
- **x86** → `false` — RTC survives a cold boot, barrier releases on the `syncWaitSeconds` bound

`modules/common/time` is in the aggregate `nixosModules.common` that the host and
every microVM pull in, so host and guests move together per architecture. Verified
by eval:

| config | host | VMs |
|---|---|---|
| `intel-laptop-debug` | `false` | `false` (gui-vm, net-vm) |
| `nvidia-jetson-orin-agx-debug` | `true` | `true` (gpu-vm) |

## Review notes

- **Architecture is a proxy, not the real fact.** A future aarch64 board with a
  real backed RTC, or an x86 board without one, would be misclassified. The
  escape hatch is a per-board `ghaf.time.requireSync` override in the hardware
  module — documented in the option description.
- **Dead RTC coin cell on x86** is the edge case: the clock is then wrong at boot
  and the 180s release lets consumers proceed against it. Impact is bounded —
  `spire-refresh-identity` and `spire-reattest-agents` both refuse to act when
  `/run/ghaf-clock-synced` reads `released` rather than `synchronised`, so CA
  rotation and re-attestation stay gated regardless of this default.

## Validation

- `nix fmt -- --fail-on-change` — clean
- `nix develop --command reuse lint` — compliant
- `nix flake check` — pass