### PR TITLE
fix(orin): cross compile execline and s6 error fix

### DIFF
--- a/overlays/README.md
+++ b/overlays/README.md
@@ -35,6 +35,7 @@ from staging and main into a tiiuae maintained version of nixpkgs
 
 The status of the integration in nixpkgs can be tracked using the [Pull Request Tracker](https://nixpk.gs/pr-tracker.html)
 
+
 ## Carried patches in ghaf packages
 
 - [qemu: Battery, AC adapter, lid](https://github.com/blochl/qemu/pull/3)
@@ -62,6 +63,12 @@ The status of the integration in nixpkgs can be tracked using the [Pull Request 
   grep -q 'type -p g-ir-scanner || true' \
     <our-pin>/pkgs/development/libraries/gobject-introspection/wrapper.nix
   ```
+- [execline: prepend target triple to pkg-config calls when cross](https://github.com/NixOS/nixpkgs/pull/560025)
+
+  `overlays/cross-compilation/default.nix` adds `buildPackages.pkg-config` to
+  `execline` and `s6`'s `nativeBuildInputs`.
+  This is caused by missing `${stdenv.cc.targetPrefix}` in `build-skaware-package.nix` of nixpkgs. execline also misses `targetPrefix` in `postInstall` function its `pkg-config` wrapper.
+  The fix solves both issues.
 
 ## Inputs pinned to an unmerged PR
 

--- a/overlays/cross-compilation/default.nix
+++ b/overlays/cross-compilation/default.nix
@@ -14,6 +14,12 @@
       ) [ final.buildPackages.pkg-config ];
   });
 
+  execline = prev.execline.overrideAttrs (oldAttrs: {
+    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
+      final.buildPackages.buildPackages.pkg-config
+    ];
+  });
+
   # Remove gfortran from FFTW to avoid cross-compiling the entire Fortran
   # toolchain. FFTW is pulled in by PipeWire for audio processing. The Fortran
   # wrapper generation is only needed when building docs (--disable-doc already
@@ -53,7 +59,7 @@
     (_pythonFinal: pythonPrev: {
       tpm2-pytss = pythonPrev.tpm2-pytss.overrideAttrs (
         oldAttrs:
-        final.lib.optionalAttrs (oldAttrs.version == "3.0.0rc1") {
+        final.lib.optionalAttrs (oldAttrs.version == "3.0.0") {
           patches = builtins.filter (patch: !(final.lib.hasSuffix "cross.patch" (toString patch))) (
             oldAttrs.patches or [ ]
           );
@@ -67,6 +73,12 @@
       });
     })
   ];
+
+  s6 = (prev.s6.override { inherit (final) execline; }).overrideAttrs (oldAttrs: {
+    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
+      final.buildPackages.buildPackages.pkg-config
+    ];
+  });
 
   # Fix swtpm cross-compilation.
   # swtpm 0.10.1-unstable-2026-05-21 switched its local CA from gnutls certtool

--- a/overlays/flake-module.nix
+++ b/overlays/flake-module.nix
@@ -2,11 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Flake module for exporting overlays
-{
-  inputs,
-  ...
-}:
-{
+{ inputs, ... }: {
   flake.overlays = {
     cross-compilation = import ./cross-compilation;
     custom-packages = import ./custom-packages;


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
The target nvidia-jetson-orin-agx-accelerated-guivm-debug-from-x86_64 builds started to fail after nixpkgs flake bump. This is due to the cosmic reader, execline and s6 dependency package pkg-config had cross compile problems. A simple cross compile fix solved this issue. 
 
<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->
https://jira.tii.ae/browse/SSRCSP-8886
## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [X] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Build nvidia-jetson-orin-agx-accelerated-guivm-debug-from-x86_64
2. Successfully builds and image runs on agx.
