### PR TITLE
refactor(microvm): tune compression, dedupe storeOnDisk config

### DIFF
--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -161,7 +161,7 @@ rec {
             };
             level = lib.mkOption {
               type = types.nullOr types.int;
-              default = null;
+              default = 4;
               description = ''
                 The compression level to use.
                 If set to `null` will use the default for each algorithm.

--- a/modules/microvm/common/microvm-store-mode.nix
+++ b/modules/microvm/common/microvm-store-mode.nix
@@ -26,7 +26,7 @@
       };
       level = lib.mkOption {
         type = lib.types.nullOr lib.types.int;
-        default = null;
+        default = 4;
         description = ''
           The compression level to use.
           If set to `null` will use the default for each algorithm.

--- a/modules/microvm/common/store-disk-erofs.nix
+++ b/modules/microvm/common/store-disk-erofs.nix
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared erofs storeOnDisk configuration for guest VMs. Imported by every VM
+# base module via vm-modules; only takes effect when storeOnDisk is enabled
+# globally (ghaf.virtualization.microvm.storeOnDisk.enable on the host).
+{
+  lib,
+  globalConfig,
+  ...
+}:
+let
+  cfg = globalConfig.storage.storeOnDisk;
+  compLevelSuffix = lib.optionalString (
+    cfg.compression.level != null
+  ) ",${toString cfg.compression.level}";
+in
+{
+  _file = ./store-disk-erofs.nix;
+
+  config = lib.mkIf (cfg.enable or false) {
+    microvm = {
+      storeOnDisk = true;
+      storeDiskType = "erofs";
+      # Defaults: -zlz4hc (all kernels), -Eztailpacking (5.16+), -Efragments (6.1+)
+      # -zzstd requires Linux 6.15+ due to -E48bit (extended addressing, needed for zstd)
+      # Setting storeDiskErofsFlags overrides the entire list; include defaults explicitly if needed.
+      storeDiskErofsFlags = [
+        "-Eztailpacking"
+        "-Efragments"
+        # no need to hammer all available cores
+        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
+      ]
+      ++ {
+        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
+        zstd = [
+          "-zzstd${compLevelSuffix}"
+          "-E48bit"
+        ];
+      }
+      .${cfg.compression.algorithm};
+    };
+  };
+}

--- a/modules/microvm/common/store-shared-virtiofs.nix
+++ b/modules/microvm/common/store-shared-virtiofs.nix
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared virtiofs /nix/store mount for guest VMs -- the fallback used when
+# storeOnDisk is disabled (the erofs counterpart lives in store-disk-erofs.nix).
+# Imported by every VM base module via vm-modules.
+{
+  config,
+  lib,
+  globalConfig,
+  ...
+}:
+let
+  cfg = config.ghaf.virtualization.microvm;
+  storeOnDiskEnabled = globalConfig.storage.storeOnDisk.enable or false;
+in
+{
+  _file = ./store-shared-virtiofs.nix;
+
+  options.ghaf.virtualization.microvm.roStoreCache = lib.mkOption {
+    type = lib.types.nullOr (
+      lib.types.enum [
+        "always"
+        "auto"
+        "never"
+      ]
+    );
+    default = "always";
+    description = ''
+      virtiofs cache mode for the read-only /nix/store share mounted when
+      storeOnDisk is disabled. Set to null to omit the cache setting
+      entirely and use the virtiofsd default.
+    '';
+  };
+
+  config = lib.mkIf (!storeOnDiskEnabled) {
+    microvm = {
+      shares = [
+        (
+          {
+            tag = "ro-store";
+            source = "/nix/store";
+            mountPoint = "/nix/.ro-store";
+            proto = "virtiofs";
+          }
+          // lib.optionalAttrs (cfg.roStoreCache != null) { cache = cfg.roStoreCache; }
+        )
+      ];
+      writableStoreOverlay = "/nix/.rw-store";
+    };
+  };
+}

--- a/modules/microvm/flake-module.nix
+++ b/modules/microvm/flake-module.nix
@@ -38,6 +38,8 @@
     vm-modules.imports = [
       ./common/microvm-store-mode.nix
       ./common/shared-directory.nix
+      ./common/store-disk-erofs.nix
+      ./common/store-shared-virtiofs.nix
       ./common/storagevm.nix
       ./common/vm-crosvm.nix
       ./common/vm-networking.nix

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -234,47 +234,6 @@ in
         mountPoint = "/etc/common";
         proto = "virtiofs";
       }
-    ]
-    # Shared store (when not using storeOnDisk)
-    ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
-      {
-        tag = "ro-store";
-        source = "/nix/store";
-        mountPoint = "/nix/.ro-store";
-        proto = "virtiofs";
-      }
     ];
-
-    writableStoreOverlay = lib.mkIf (
-      !(globalConfig.storage.storeOnDisk.enable or false)
-    ) "/nix/.rw-store";
-  }
-  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
-    let
-      compLevelSuffix = lib.optionalString (
-        globalConfig.storage.storeOnDisk.compression.level != null
-      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
-    in
-    {
-      storeOnDisk = true;
-      storeDiskType = "erofs";
-      # Defaults: -zlz4hc (all kernels), -Eztailpacking (5.16+), -Efragments (6.1+)
-      # -zzstd requires Linux 6.15+ due to -E48bit (extended addressing, needed for zstd)
-      # Setting storeDiskErofsFlags overrides the entire list; include defaults explicitly if needed.
-      storeDiskErofsFlags = [
-        "-Eztailpacking"
-        "-Efragments"
-        # no need to hammer all available cores
-        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
-      ]
-      ++ {
-        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
-        zstd = [
-          "-zzstd${compLevelSuffix}"
-          "-E48bit"
-        ];
-      }
-      .${globalConfig.storage.storeOnDisk.compression.algorithm};
-    }
-  );
+  };
 }

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -453,21 +453,7 @@ in
             mountPoint = "/etc/common";
             proto = "virtiofs";
           }
-        ]
-        # Shared store (when not using storeOnDisk)
-        ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
-          {
-            tag = "ro-store";
-            source = "/nix/store";
-            mountPoint = "/nix/.ro-store";
-            proto = "virtiofs";
-            cache = "always";
-          }
         ];
-
-        writableStoreOverlay = lib.mkIf (
-          !(globalConfig.storage.storeOnDisk.enable or false)
-        ) "/nix/.rw-store";
 
         qemu =
           let
@@ -500,34 +486,6 @@ in
 
             machine = effectiveMachine;
           };
-      }
-      // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
-        let
-          compLevelSuffix = lib.optionalString (
-            globalConfig.storage.storeOnDisk.compression.level != null
-          ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
-        in
-        {
-          storeOnDisk = true;
-          storeDiskType = "erofs";
-          # Defaults: -zlz4hc (all kernels), -Eztailpacking (5.16+), -Efragments (6.1+)
-          # -zzstd requires Linux 6.15+ due to -E48bit (extended addressing, needed for zstd)
-          # Setting storeDiskErofsFlags overrides the entire list; include defaults explicitly if needed.
-          storeDiskErofsFlags = [
-            "-Eztailpacking"
-            "-Efragments"
-            # no need to hammer all available cores
-            "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
-          ]
-          ++ {
-            lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
-            zstd = [
-              "-zzstd${compLevelSuffix}"
-              "-E48bit"
-            ];
-          }
-          .${globalConfig.storage.storeOnDisk.compression.algorithm};
-        }
-      );
+      };
     };
 }

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -242,21 +242,7 @@ in
         mountPoint = "/etc/common";
         proto = "virtiofs";
       }
-    ]
-    # Shared store (when not using storeOnDisk)
-    ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
-      {
-        tag = "ro-store";
-        source = "/nix/store";
-        mountPoint = "/nix/.ro-store";
-        proto = "virtiofs";
-        cache = "always";
-      }
     ];
-
-    writableStoreOverlay = lib.mkIf (
-      !(globalConfig.storage.storeOnDisk.enable or false)
-    ) "/nix/.rw-store";
 
     qemu = lib.mkIf (!isCrosvm) {
       machine =
@@ -275,33 +261,5 @@ in
       "--battery"
       "type=goldfish"
     ];
-  }
-  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
-    let
-      compLevelSuffix = lib.optionalString (
-        globalConfig.storage.storeOnDisk.compression.level != null
-      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
-    in
-    {
-      storeOnDisk = true;
-      storeDiskType = "erofs";
-      # Defaults: -zlz4hc (all kernels), -Eztailpacking (5.16+), -Efragments (6.1+)
-      # -zzstd requires Linux 6.15+ due to -E48bit (extended addressing, needed for zstd)
-      # Setting storeDiskErofsFlags overrides the entire list; include defaults explicitly if needed.
-      storeDiskErofsFlags = [
-        "-Eztailpacking"
-        "-Efragments"
-        # no need to hammer all available cores
-        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
-      ]
-      ++ {
-        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
-        zstd = [
-          "-zzstd${compLevelSuffix}"
-          "-E48bit"
-        ];
-      }
-      .${globalConfig.storage.storeOnDisk.compression.algorithm};
-    }
-  );
+  };
 }

--- a/modules/microvm/sysvms/dispvm-base.nix
+++ b/modules/microvm/sysvms/dispvm-base.nix
@@ -170,20 +170,7 @@ in
         mountPoint = "/etc/common";
         proto = "virtiofs";
       }
-    ]
-    # Shared store (when not using storeOnDisk)
-    ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
-      {
-        tag = "ro-store";
-        source = "/nix/store";
-        mountPoint = "/nix/.ro-store";
-        proto = "virtiofs";
-      }
     ];
-
-    writableStoreOverlay = lib.mkIf (
-      !(globalConfig.storage.storeOnDisk.enable or false)
-    ) "/nix/.rw-store";
 
     qemu = {
       machine =
@@ -193,29 +180,5 @@ in
         }
         .${globalConfig.platform.hostSystem or "aarch64-linux"};
     };
-  }
-  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
-    let
-      compLevelSuffix = lib.optionalString (
-        globalConfig.storage.storeOnDisk.compression.level != null
-      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
-    in
-    {
-      storeOnDisk = true;
-      storeDiskType = "erofs";
-      storeDiskErofsFlags = [
-        "-Eztailpacking"
-        "-Efragments"
-        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
-      ]
-      ++ {
-        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
-        zstd = [
-          "-zzstd${compLevelSuffix}"
-          "-E48bit"
-        ];
-      }
-      .${globalConfig.storage.storeOnDisk.compression.algorithm};
-    }
-  );
+  };
 }

--- a/modules/microvm/sysvms/gpuvm-base.nix
+++ b/modules/microvm/sysvms/gpuvm-base.nix
@@ -256,20 +256,7 @@ in
         mountPoint = "/etc/common";
         proto = "virtiofs";
       }
-    ]
-    # Shared store (when not using storeOnDisk)
-    ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
-      {
-        tag = "ro-store";
-        source = "/nix/store";
-        mountPoint = "/nix/.ro-store";
-        proto = "virtiofs";
-      }
     ];
-
-    writableStoreOverlay = lib.mkIf (
-      !(globalConfig.storage.storeOnDisk.enable or false)
-    ) "/nix/.rw-store";
 
     qemu = {
       machine =
@@ -279,29 +266,5 @@ in
         }
         .${globalConfig.platform.hostSystem or "aarch64-linux"};
     };
-  }
-  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
-    let
-      compLevelSuffix = lib.optionalString (
-        globalConfig.storage.storeOnDisk.compression.level != null
-      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
-    in
-    {
-      storeOnDisk = true;
-      storeDiskType = "erofs";
-      storeDiskErofsFlags = [
-        "-Eztailpacking"
-        "-Efragments"
-        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
-      ]
-      ++ {
-        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
-        zstd = [
-          "-zzstd${compLevelSuffix}"
-          "-E48bit"
-        ];
-      }
-      .${globalConfig.storage.storeOnDisk.compression.algorithm};
-    }
-  );
+  };
 }

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -395,21 +395,7 @@ in
         mountPoint = "/etc/common";
         proto = "virtiofs";
       }
-    ]
-    # Shared store (when not using storeOnDisk)
-    ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
-      {
-        tag = "ro-store";
-        source = "/nix/store";
-        mountPoint = "/nix/.ro-store";
-        proto = "virtiofs";
-        cache = "always";
-      }
     ];
-
-    writableStoreOverlay = lib.mkIf (
-      !(globalConfig.storage.storeOnDisk.enable or false)
-    ) "/nix/.rw-store";
 
     qemu = lib.mkIf (!isCrosvm) {
       extraArgs = [
@@ -429,33 +415,5 @@ in
       "--battery"
       "type=goldfish"
     ];
-  }
-  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
-    let
-      compLevelSuffix = lib.optionalString (
-        globalConfig.storage.storeOnDisk.compression.level != null
-      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
-    in
-    {
-      storeOnDisk = true;
-      storeDiskType = "erofs";
-      # Defaults: -zlz4hc (all kernels), -Eztailpacking (5.16+), -Efragments (6.1+)
-      # -zzstd requires Linux 6.15+ due to -E48bit (extended addressing, needed for zstd)
-      # Setting storeDiskErofsFlags overrides the entire list; include defaults explicitly if needed.
-      storeDiskErofsFlags = [
-        "-Eztailpacking"
-        "-Efragments"
-        # no need to hammer all available cores
-        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
-      ]
-      ++ {
-        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
-        zstd = [
-          "-zzstd${compLevelSuffix}"
-          "-E48bit"
-        ];
-      }
-      .${globalConfig.storage.storeOnDisk.compression.algorithm};
-    }
-  );
+  };
 }

--- a/modules/microvm/sysvms/idsvm/idsvm-base.nix
+++ b/modules/microvm/sysvms/idsvm/idsvm-base.nix
@@ -113,47 +113,5 @@ in
     # Sensible defaults - can be overridden via vmConfig
     vcpu = lib.mkDefault 2;
     mem = lib.mkDefault 512;
-
-    # Shared store (when not using storeOnDisk)
-    shares = lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
-      {
-        tag = "ro-store";
-        source = "/nix/store";
-        mountPoint = "/nix/.ro-store";
-        proto = "virtiofs";
-      }
-    ];
-
-    writableStoreOverlay = lib.mkIf (
-      !(globalConfig.storage.storeOnDisk.enable or false)
-    ) "/nix/.rw-store";
-  }
-  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
-    let
-      compLevelSuffix = lib.optionalString (
-        globalConfig.storage.storeOnDisk.compression.level != null
-      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
-    in
-    {
-      storeOnDisk = true;
-      storeDiskType = "erofs";
-      # Defaults: -zlz4hc (all kernels), -Eztailpacking (5.16+), -Efragments (6.1+)
-      # -zzstd requires Linux 6.15+ due to -E48bit (extended addressing, needed for zstd)
-      # Setting storeDiskErofsFlags overrides the entire list; include defaults explicitly if needed.
-      storeDiskErofsFlags = [
-        "-Eztailpacking"
-        "-Efragments"
-        # no need to hammer all available cores
-        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
-      ]
-      ++ {
-        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
-        zstd = [
-          "-zzstd${compLevelSuffix}"
-          "-E48bit"
-        ];
-      }
-      .${globalConfig.storage.storeOnDisk.compression.algorithm};
-    }
-  );
+  };
 }

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -281,21 +281,7 @@ in
         mountPoint = "/persist/sysupdate";
         proto = "virtiofs";
       }
-    ]
-    # Shared store (when not using storeOnDisk)
-    ++ lib.optionals (!(globalConfig.storage.storeOnDisk.enable or false)) [
-      {
-        tag = "ro-store";
-        source = "/nix/store";
-        mountPoint = "/nix/.ro-store";
-        proto = "virtiofs";
-        cache = "always";
-      }
     ];
-
-    writableStoreOverlay = lib.mkIf (
-      !(globalConfig.storage.storeOnDisk.enable or false)
-    ) "/nix/.rw-store";
 
     qemu = lib.mkIf (!isCrosvm) {
       machine =
@@ -310,33 +296,5 @@ in
         "qemu-xhci"
       ];
     };
-  }
-  // lib.optionalAttrs (globalConfig.storage.storeOnDisk.enable or false) (
-    let
-      compLevelSuffix = lib.optionalString (
-        globalConfig.storage.storeOnDisk.compression.level != null
-      ) ",${toString globalConfig.storage.storeOnDisk.compression.level}";
-    in
-    {
-      storeOnDisk = true;
-      storeDiskType = "erofs";
-      # Defaults: -zlz4hc (all kernels), -Eztailpacking (5.16+), -Efragments (6.1+)
-      # -zzstd requires Linux 6.15+ due to -E48bit (extended addressing, needed for zstd)
-      # Setting storeDiskErofsFlags overrides the entire list; include defaults explicitly if needed.
-      storeDiskErofsFlags = [
-        "-Eztailpacking"
-        "-Efragments"
-        # no need to hammer all available cores
-        "--workers=$(( (NIX_BUILD_CORES < 1 || NIX_BUILD_CORES > 4) ? 4 : NIX_BUILD_CORES ))"
-      ]
-      ++ {
-        lz4hc = [ "-zlz4hc${compLevelSuffix}" ];
-        zstd = [
-          "-zzstd${compLevelSuffix}"
-          "-E48bit"
-        ];
-      }
-      .${globalConfig.storage.storeOnDisk.compression.algorithm};
-    }
-  );
+  };
 }

--- a/modules/partitioning/disko-debug-partition.nix
+++ b/modules/partitioning/disko-debug-partition.nix
@@ -124,7 +124,7 @@ in
         if [ "$cores" -gt 8 ]; then
           cores=8
         fi
-        ${lib.getExe pkgs.zstd} -T''${cores} --compress "$out/${diskName}.raw" -o "$out/ghaf-image.raw.zst" --rm
+        ${lib.getExe pkgs.zstd} -T''${cores} -4 --long --compress "$out/${diskName}.raw" -o "$out/ghaf-image.raw.zst" --rm
       '';
       devices = {
         disk."${diskName}" = {

--- a/modules/partitioning/disko-debug-partition.nix
+++ b/modules/partitioning/disko-debug-partition.nix
@@ -41,13 +41,30 @@ in
   options.ghaf.partitioning.disko = {
     enable = lib.mkEnableOption "the disko partitioning scheme";
 
-    imageBuilder.compression = lib.mkOption {
-      type = lib.types.enum [
-        "none"
-        "zstd"
-      ];
-      description = "Compression algorithm used for the install image";
-      default = "zstd";
+    imageBuilder.compression = {
+      algorithm = lib.mkOption {
+        type = lib.types.enum [
+          "none"
+          "zstd"
+        ];
+        description = "Compression algorithm used for the install image";
+        default = "zstd";
+      };
+
+      level = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = 4;
+        description = ''
+          zstd compression level used for the install image.
+          The guest `/nix/store` erofs level
+          (`ghaf.virtualization.microvm.storeOnDisk.compression.level`) follows
+          this by default when it also uses zstd, since both are then on the
+          same libzstd level scale. Set explicitly to tune the image and the
+          store independently.
+          If set to `null`, zstd's own default level is used.
+        '';
+        example = 19;
+      };
     };
 
     rootSize = lib.mkOption {
@@ -110,6 +127,10 @@ in
 
     ghaf.partitioning.btrfs-postboot.enable = true;
 
+    ghaf.virtualization.microvm.storeOnDisk.compression.level = lib.mkIf (
+      config.ghaf.virtualization.microvm.storeOnDisk.compression.algorithm == "zstd"
+    ) (lib.mkDefault cfg.imageBuilder.compression.level);
+
     ghaf.storage.encryption.partitionDevice =
       lib.mkDefault
         config.disko.devices.disk."${diskName}".content.partitions.luks.device;
@@ -118,13 +139,17 @@ in
       !config.ghaf.partitioning.verity.enable
     ) config.system.build.diskoImages;
     disko = {
-      imageBuilder.extraPostVM = lib.mkIf (cfg.imageBuilder.compression == "zstd") ''
+      imageBuilder.extraPostVM = lib.mkIf (cfg.imageBuilder.compression.algorithm == "zstd") ''
         ${lib.getExe pkgs.bmaptool} create "$out/${diskName}.raw" -o "$out/ghaf-image.bmap"
         cores="''${NIX_BUILD_CORES:-1}"
         if [ "$cores" -gt 8 ]; then
           cores=8
         fi
-        ${lib.getExe pkgs.zstd} -T''${cores} -4 --long --compress "$out/${diskName}.raw" -o "$out/ghaf-image.raw.zst" --rm
+        ${lib.getExe pkgs.zstd} -T''${cores} ${
+          lib.optionalString (
+            cfg.imageBuilder.compression.level != null
+          ) "-${toString cfg.imageBuilder.compression.level}"
+        } --long --compress "$out/${diskName}.raw" -o "$out/ghaf-image.raw.zst" --rm
       '';
       devices = {
         disk."${diskName}" = {


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

- Raise outer image (`level 4`, `--long`) and erofs (`level 4`) compression
  Level 4 compression seems to offer the best size/speed ratio with `--long` enabled
  `--long` catches duplicate content spread too far apart for the default window to see. Uses marginally more memory for compress and decompress
  Also experimented with `zstd --exclude-compressed` option for the outer img - it makes sense on paper for storeDisk targets, which have pre-compressed `erofs` nix stores, but in practice, if these are skipped, then the final outer img becomes larger, and `--long` loses its benefit.
- Extract duplicated erofs/virtiofs storeOnDisk configs into shared vm-modules
- disko: added comp level as a configurable attr, coupled erofs compression level to it

### Note
- With the refactoring done in `modules/microvm/common/store-shared-virtiofs.nix`, the following VMs now have their **cache** policy set to **always** for the shared `/nix/store`:
   - dispvm
   - gpuvm
   - adminvm
   - idsvm
   
<details>
<summary>Cache policy settings explanation</summary>

- **`never`** - The client should never cache file data and all I/O should be directly forwarded to the server.
   This policy must be selected when file contents may change without the knowledge of the FUSE client (i.e., the file system does not have exclusive access to the directory)
- **`metadata`** - This is almost same as Never, but it allows page cache of directories, dentries and attr cache in guest.
   In other words, it acts like `cache=never` for normal files, and like `cache=always` for directories, besides, metadata like dentries and attrs are kept as well.
   This policy can be used if:
   1. the client wants to use Never policy but it's performance in I/O is not good enough
   2. the file system has exclusive access to the directory
   3. cache directory content and other fs metadata can make a difference on performance.
- **`auto`** - Default.
   The client is free to choose when and how to cache file data.
   By default the FUSE protocol uses close-to-open consistency. This means that any cached contents of the file are invalidated the next time that file is opened.
- **`always`** - The client should always cache file data.
   This means that the FUSE client will not invalidate any cached data that was returned by the file system the last time the file was opened.
   This policy should only be selected when the file system has exclusive access to the directory.

Virtiofs cache policy descriptions taken from here:
https://gitlab.com/virtio-fs/virtiofsd/-/blob/main/src/passthrough/mod.rs#L95
</details>

## Results from compression changes

| Target | Before | After | Change |
|---|---|---|---|
| intel-laptop-debug | 6.52 GiB | 6.22 GiB | -4.54% |
| intel-laptop-storeDisk-debug | 22.14 GiB | 21.77 GiB | -1.65% |

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. Sanity check - ghaf still boots, all VMs start and work as they should
