### PR TITLE
fix(orin): shutdown is now actually sent to the vms

### DIFF
--- a/modules/common/services/power.nix
+++ b/modules/common/services/power.nix
@@ -740,668 +740,640 @@ in
     };
   };
 
-  config = mkIf cfg.enable (mkMerge [
+  config = mkMerge [
+    # VM lifecycle, not suspend/resume: gate on host.enable so it still applies
+    # where the power-manager feature flag is off (Orin), which costs 150s per VM.
+    (mkIf cfg.host.enable {
+      systemd.services = mkMerge [
+        # Replace microvm.nix's ExecStop, which sends a Ctrl+Alt+Del that headless
+        # guests reject ("Input handler not found for event type key") and then polls
+        # unbounded for a guest nothing asked to stop. Per VM class; 150s -> 30s.
+        (mkIf useGivc (
+          lib.listToAttrs (
+            map (
+              vmName:
+              nameValuePair "microvm@${vmName}" {
+                serviceConfig = {
+                  TimeoutStopSec = "30";
+                  ExecStop =
+                    let
+                      sysvm-stop = pkgs.writeShellScript "sysvm-stop" ''
+                        # Activation restarts units synchronously, so a graceful stop would
+                        # block it. Detect a live switch-to-configuration and just SIGTERM.
+                        jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
+                        if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
+                          && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
+                          echo "switch-to-configuration activation in progress, skipping guest poweroff for '${vmName}'"
+                          kill -15 $MAINPID 2>/dev/null
+                          while kill -0 $MAINPID 2>/dev/null; do
+                            sleep 1
+                          done
+                          exit 0
+                        fi
 
-    {
-      assertions = [
-        {
-          assertion = cfg.vm.enable -> (!cfg.host.enable);
-          message = "Enabling the VM power management profile ('ghaf.services.power-manager.vm.enable') requires the 'host' profile to be disabled.";
-        }
-        {
-          assertion = cfg.vm.fakeSuspend -> useGivc;
-          message = "Enabling the VM fake suspend ('ghaf.services.power-manager.vm.fakeSuspend') requires GIVC to be enabled in the system.";
-        }
-        {
-          assertion = cfg.vm.fakeSuspend -> (!cfg.gui.enable);
-          message = "Enabling the VM fake suspend ('ghaf.services.power-manager.vm.fakeSuspend') requires the GUI power management profile to be disabled.";
-        }
-        {
-          assertion = cfg.vm.fakeSuspend -> (!cfg.vm.powerOffOnSuspend);
-          message = "Enabling the VM fake suspend ('ghaf.services.power-manager.vm.fakeSuspend') requires the option ('ghaf.services.power-manager.vm.powerOffOnSuspend') to be disabled.";
-        }
-        {
-          assertion = cfg.vm.pciSuspend -> (!cfg.vm.powerOffOnSuspend);
-          message = "Enabling the VM pci suspend ('ghaf.services.power-manager.vm.pciSuspend') requires the option ('ghaf.services.power-manager.vm.powerOffOnSuspend') to be disabled.";
-        }
-      ];
-    }
+                        # GUI VM sets HandlePowerKey=ignore, so ACPI cannot stop it. givc can;
+                        # its admin coordinator is up because admin-vm is shutdownLast.
+                        echo "Starting poweroff target for system VM '${vmName}'"
+                        ${givc-cli} start service --vm '${vmName}' poweroff.target &
 
-    # VM power management
-    (mkIf cfg.vm.enable {
-
-      assertions = [
-        {
-          assertion = cfg.vm.pciSuspend -> (config.microvm.socket != null);
-          message = "PCI suspend ('ghaf.services.power-manager.vm.pciSuspend') requires a microvm socket (config.microvm.socket).";
-        }
-      ];
-
-      systemd.sleep.settings.Sleep = genericSleepConf;
-
-      powerManagement = optionalAttrs cfg.vm.enable {
-        powerDownCommands = optionalString cfg.vm.pciSuspend ''
-          if ! ${getExe' pkgs.systemd "systemctl"} list-jobs | grep -qE 'poweroff.target.*start|reboot.target.*start'; then
-            echo "Stopping configured suspend services..."
-            ${concatMapStringsSep "\n" (service: ''
-              echo "Stopping service ${service}..."
-              systemctl stop ${service}
-            '') cfg.vm.pciSuspendServices}
-            ${optionalString (cfg.suspend.extraSuspendCommands != "") ''
-              # config.ghaf.services.power-manager.suspend.extraSuspendCommands
-              echo "Executing configured extra suspend commands..."
-              ${cfg.suspend.extraSuspendCommands}
-            ''}
-          fi
-        '';
-        resumeCommands =
-          optionalString cfg.vm.pciSuspend (
-            concatMapStringsSep "\n" (service: ''
-              echo "Starting service ${service}..."
-              systemctl start ${service}
-            '') cfg.vm.pciSuspendServices
+                        echo "Waiting for system VM '${vmName}' with QEMU PID=$MAINPID to stop"
+                        while kill -0 $MAINPID 2>/dev/null; do
+                          sleep 1
+                        done
+                        echo "System VM '${vmName}' with QEMU PID=$MAINPID stopped"
+                      '';
+                    in
+                    [
+                      # Clear microvm.nix ExecStop, then run with full privileges
+                      "+${sysvm-stop}"
+                    ];
+                };
+              }
+            ) givcShutdownVms
           )
-          # The GUI profile runs these from resume-actions.service below.
-          # Running them here too races two copies of every resume hook.
-          + optionalString (cfg.suspend.extraResumeCommands != "" && !cfg.gui.enable) ''
-            # config.ghaf.services.power-manager.suspend.extraResumeCommands
-            ${cfg.suspend.extraResumeCommands}
-          '';
-      };
+        ))
+        # Every other qemu VM: QMP system_powerdown, so the guest runs its own systemd
+        # poweroff (journald flush+seal) instead of being SIGTERMed mid-write.
+        (lib.listToAttrs (
+          map (
+            vmName:
+            nameValuePair "microvm@${vmName}" {
+              serviceConfig = {
+                TimeoutStopSec = lib.mkDefault "30";
+                ExecStop =
+                  let
+                    vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${vmName};
+                    qmpSocket =
+                      if vmConfig != null && (vmConfig.microvm.socket or null) != null then
+                        "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
+                      else
+                        "";
+                    # Half of TimeoutStopSec: log before the stop timeout SIGKILLs, so it is
+                    # not a silent surprise in the journal.
+                    qmpAcpiGraceSec = 15;
+                    qmp-stop = pkgs.writeShellScript "qmp-stop" ''
+                      # See sysvm-stop.
+                      jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
+                      if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
+                        && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
+                        echo "switch-to-configuration activation in progress, SIGTERM '${vmName}'"
+                        kill -15 $MAINPID 2>/dev/null
+                        while kill -0 $MAINPID 2>/dev/null; do
+                          sleep 1
+                        done
+                        exit 0
+                      fi
 
-      systemd.services.systemd-suspend.serviceConfig = {
+                      socket='${qmpSocket}'
+                      if [ -n "$socket" ] && [ -S "$socket" ]; then
+                        # -t1 bounds socat: microvm.nix's own wait here is unbounded.
+                        echo "QMP system_powerdown -> '${vmName}' ($socket)"
+                        printf '{"execute":"qmp_capabilities"}\n{"execute":"system_powerdown"}\n' \
+                          | ${pkgs.socat}/bin/socat -t1 - "UNIX-CONNECT:$socket" \
+                          || echo "WARN: QMP system_powerdown to '${vmName}' failed; relying on stop timeout" >&2
+                      else
+                        echo "WARN: no QMP socket for '${vmName}' ('$socket'); SIGTERM fallback" >&2
+                        kill -15 $MAINPID 2>/dev/null
+                      fi
 
-        # Suspend actions for the VMs
-        ExecStart =
-          optionals (!cfg.gui.enable) [
-            "" # always clear the default systemd-sleep
-          ]
-          ++ optionals cfg.vm.fakeSuspend [
-            "${getExe guest-fake-suspend}"
-          ]
-          ++ optionals (!cfg.vm.fakeSuspend) [
-            "${pkgs.coreutils}/bin/true"
-          ];
+                      echo "Waiting for VM '${vmName}' with QEMU PID=$MAINPID to stop"
+                      waited=0
+                      acpi_timeout_logged=0
+                      while kill -0 $MAINPID 2>/dev/null; do
+                        sleep 1
+                        waited=$((waited + 1))
+                        if [ "$acpi_timeout_logged" = 0 ] && [ "$waited" -ge ${toString qmpAcpiGraceSec} ]; then
+                          acpi_timeout_logged=1
+                          echo "WARN: guest '${vmName}' has not responded to ACPI poweroff after ''${waited}s; will be forced by stop timeout if it does not exit" >&2
+                        fi
+                      done
+                      echo "VM '${vmName}' with QEMU PID=$MAINPID stopped"
+                    '';
+                  in
+                  [
+                    # Clear microvm.nix ExecStop, then run with full privileges
+                    "+${qmp-stop}"
+                  ];
+              };
+            }
+          ) qmpShutdownVms
+        ))
+        # Crosvm guests use the same ACPI power-button path, delivered through
+        # the Crosvm control socket instead of QMP.
+        (lib.listToAttrs (
+          map (
+            vmName:
+            nameValuePair "microvm@${vmName}" {
+              serviceConfig = {
+                TimeoutStopSec = lib.mkDefault "30";
+                ExecStop =
+                  let
+                    vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${vmName};
+                    controlSocket =
+                      if vmConfig != null && (vmConfig.microvm.socket or null) != null then
+                        "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
+                      else
+                        "";
+                    crosvmPackage = vmConfig.microvm.crosvm.package;
+                    crosvmAcpiGraceSec = 15;
+                    crosvmStopDeadlineSec = 25;
+                    crosvm-stop = pkgs.writeShellScript "crosvm-stop" ''
+                      set -u
+                      pid="''${MAINPID:-}"
+                      if [ -z "$pid" ]; then
+                        echo "Crosvm '${vmName}' has no MAINPID; nothing to stop"
+                        exit 0
+                      fi
 
-        # Pre-suspend actions for the VM.
-        #
-        # `-` because an ExecStartPre failure takes the whole unit down, and losing the
-        # guest's fake suspend -- which is what stops its watchdogs firing on resume -- is
-        # far worse than a PCI device that did not reach low power.
-        ExecStartPre = optionals cfg.vm.pciSuspend [
-          "-${getExe guest-power-actions} suspend"
-        ];
-      };
+                      # See sysvm-stop: a graceful stop would serialize 25s per VM into
+                      # switch-to-configuration.
+                      jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
+                      if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
+                        && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
+                        echo "switch-to-configuration activation in progress, SIGTERM '${vmName}'"
+                        kill -15 "$pid" 2>/dev/null || true
+                        while kill -0 "$pid" 2>/dev/null; do
+                          sleep 1
+                        done
+                        exit 0
+                      fi
+
+                      if [ -n '${controlSocket}' ] && [ -S '${controlSocket}' ]; then
+                        echo "Crosvm powerbtn -> '${vmName}' (${controlSocket})"
+                        # This VM's own package, so the control protocol matches.
+                        if ! ${crosvmPackage}/bin/crosvm --no-syslog powerbtn '${controlSocket}'; then
+                          echo "WARN: Crosvm powerbtn for '${vmName}' failed; sending SIGTERM" >&2
+                          kill -15 "$pid" 2>/dev/null || true
+                        fi
+                      else
+                        echo "WARN: no Crosvm control socket for '${vmName}'; SIGTERM fallback" >&2
+                        kill -15 "$pid" 2>/dev/null || true
+                      fi
+
+                      echo "Waiting for Crosvm '${vmName}' with PID=$pid to stop"
+                      waited=0
+                      grace_logged=0
+                      while kill -0 "$pid" 2>/dev/null; do
+                        sleep 1
+                        waited=$((waited + 1))
+                        if [ "$grace_logged" = 0 ] && [ "$waited" -ge ${toString crosvmAcpiGraceSec} ]; then
+                          grace_logged=1
+                          echo "WARN: guest '${vmName}' has not stopped after ''${waited}s; systemd will force it at the stop timeout" >&2
+                        fi
+                        if [ "$waited" -ge ${toString crosvmStopDeadlineSec} ]; then
+                          echo "ERROR: Crosvm '${vmName}' with PID=$pid did not stop within ''${waited}s" >&2
+                          exit 1
+                        fi
+                      done
+                      echo "Crosvm '${vmName}' with PID=$pid stopped"
+                    '';
+                  in
+                  [
+                    ""
+                    "+${crosvm-stop}"
+                  ];
+              };
+            }
+          ) crosvmShutdownVms
+        ))
+        (lib.listToAttrs (
+          map
+            (
+              vmName:
+              lib.nameValuePair "microvm@${vmName}" {
+                before = map (n: "microvm@${n}.service") (
+                  lib.filter (n: n != vmName) (lib.attrNames config.microvm.vms)
+                );
+                # admin-vm aggregates logs and stops last, so it has the most journal
+                # to flush+seal.
+                serviceConfig.TimeoutStopSec = "60";
+              }
+            )
+            (
+              lib.attrNames (
+                lib.filterAttrs (
+                  _: vm:
+                  let
+                    vmConfig = lib.ghaf.vm.getConfig vm;
+                  in
+                  vmConfig != null && vmConfig.ghaf.shutdownLast
+                ) config.microvm.vms
+              )
+            )
+        ))
+      ];
     })
 
-    # GUI power management profile
-    (mkIf cfg.gui.enable {
-      # Shutdown displays early before suspend
-      powerManagement = {
-        powerDownCommands = lib.mkBefore (
-          ''
-            if ${getExe' pkgs.systemd "systemctl"} list-jobs | grep -qE 'poweroff.target.*start|reboot.target.*start'; then
-              _is_shutdown=0
-            else
-              _is_shutdown=1
-              ${optionalString cfg.gui.fakeDisplaySuspend ''
-                ${getExe ghaf-powercontrol} fake-turn-off-displays '*'
+    (mkIf cfg.enable (mkMerge [
+
+      {
+        assertions = [
+          {
+            assertion = cfg.vm.enable -> (!cfg.host.enable);
+            message = "Enabling the VM power management profile ('ghaf.services.power-manager.vm.enable') requires the 'host' profile to be disabled.";
+          }
+          {
+            assertion = cfg.vm.fakeSuspend -> useGivc;
+            message = "Enabling the VM fake suspend ('ghaf.services.power-manager.vm.fakeSuspend') requires GIVC to be enabled in the system.";
+          }
+          {
+            assertion = cfg.vm.fakeSuspend -> (!cfg.gui.enable);
+            message = "Enabling the VM fake suspend ('ghaf.services.power-manager.vm.fakeSuspend') requires the GUI power management profile to be disabled.";
+          }
+          {
+            assertion = cfg.vm.fakeSuspend -> (!cfg.vm.powerOffOnSuspend);
+            message = "Enabling the VM fake suspend ('ghaf.services.power-manager.vm.fakeSuspend') requires the option ('ghaf.services.power-manager.vm.powerOffOnSuspend') to be disabled.";
+          }
+          {
+            assertion = cfg.vm.pciSuspend -> (!cfg.vm.powerOffOnSuspend);
+            message = "Enabling the VM pci suspend ('ghaf.services.power-manager.vm.pciSuspend') requires the option ('ghaf.services.power-manager.vm.powerOffOnSuspend') to be disabled.";
+          }
+        ];
+      }
+
+      # VM power management
+      (mkIf cfg.vm.enable {
+
+        assertions = [
+          {
+            assertion = cfg.vm.pciSuspend -> (config.microvm.socket != null);
+            message = "PCI suspend ('ghaf.services.power-manager.vm.pciSuspend') requires a microvm socket (config.microvm.socket).";
+          }
+        ];
+
+        systemd.sleep.settings.Sleep = genericSleepConf;
+
+        powerManagement = optionalAttrs cfg.vm.enable {
+          powerDownCommands = optionalString cfg.vm.pciSuspend ''
+            if ! ${getExe' pkgs.systemd "systemctl"} list-jobs | grep -qE 'poweroff.target.*start|reboot.target.*start'; then
+              echo "Stopping configured suspend services..."
+              ${concatMapStringsSep "\n" (service: ''
+                echo "Stopping service ${service}..."
+                systemctl stop ${service}
+              '') cfg.vm.pciSuspendServices}
+              ${optionalString (cfg.suspend.extraSuspendCommands != "") ''
+                # config.ghaf.services.power-manager.suspend.extraSuspendCommands
+                echo "Executing configured extra suspend commands..."
+                ${cfg.suspend.extraSuspendCommands}
               ''}
             fi
-          ''
-          + optionalString (cfg.suspend.extraSuspendCommands != "") ''
-            # config.ghaf.services.power-manager.suspend.extraSuspendCommands
-            if [ $_is_shutdown -ne 0 ]; then
-              ${cfg.suspend.extraSuspendCommands}
-            fi
-          ''
+          '';
+          resumeCommands =
+            optionalString cfg.vm.pciSuspend (
+              concatMapStringsSep "\n" (service: ''
+                echo "Starting service ${service}..."
+                systemctl start ${service}
+              '') cfg.vm.pciSuspendServices
+            )
+            # The GUI profile runs these from resume-actions.service below.
+            # Running them here too races two copies of every resume hook.
+            + optionalString (cfg.suspend.extraResumeCommands != "" && !cfg.gui.enable) ''
+              # config.ghaf.services.power-manager.suspend.extraResumeCommands
+              ${cfg.suspend.extraResumeCommands}
+            '';
+        };
+
+        systemd.services.systemd-suspend.serviceConfig = {
+
+          # Suspend actions for the VMs
+          ExecStart =
+            optionals (!cfg.gui.enable) [
+              "" # always clear the default systemd-sleep
+            ]
+            ++ optionals cfg.vm.fakeSuspend [
+              "${getExe guest-fake-suspend}"
+            ]
+            ++ optionals (!cfg.vm.fakeSuspend) [
+              "${pkgs.coreutils}/bin/true"
+            ];
+
+          # Pre-suspend actions for the VM.
+          #
+          # `-` because an ExecStartPre failure takes the whole unit down, and losing the
+          # guest's fake suspend -- which is what stops its watchdogs firing on resume -- is
+          # far worse than a PCI device that did not reach low power.
+          ExecStartPre = optionals cfg.vm.pciSuspend [
+            "-${getExe guest-power-actions} suspend"
+          ];
+        };
+      })
+
+      # GUI power management profile
+      (mkIf cfg.gui.enable {
+        # Shutdown displays early before suspend
+        powerManagement = {
+          powerDownCommands = lib.mkBefore (
+            ''
+              if ${getExe' pkgs.systemd "systemctl"} list-jobs | grep -qE 'poweroff.target.*start|reboot.target.*start'; then
+                _is_shutdown=0
+              else
+                _is_shutdown=1
+                ${optionalString cfg.gui.fakeDisplaySuspend ''
+                  ${getExe ghaf-powercontrol} fake-turn-off-displays '*'
+                ''}
+              fi
+            ''
+            + optionalString (cfg.suspend.extraSuspendCommands != "") ''
+              # config.ghaf.services.power-manager.suspend.extraSuspendCommands
+              if [ $_is_shutdown -ne 0 ]; then
+                ${cfg.suspend.extraSuspendCommands}
+              fi
+            ''
+          );
+        };
+
+        # Allow the host power manager to stop the GUI VM gracefully through GIVC.
+        # Unlike the other system VMs, GUI VM ignores the ACPI power button and
+        # therefore cannot use the host's QMP system_powerdown path.
+        givc.sysvm.capabilities.services = optionals (cfg.vm.enable && useGivc) (
+          [ "poweroff.target" ]
+          ++ optionals cfg.gui.gpuSuspend [
+            "gpu-suspend.service"
+            "resume-actions.service"
+          ]
         );
-      };
 
-      # Allow the host power manager to stop the GUI VM gracefully through GIVC.
-      # Unlike the other system VMs, GUI VM ignores the ACPI power button and
-      # therefore cannot use the host's QMP system_powerdown path.
-      givc.sysvm.capabilities.services = optionals (cfg.vm.enable && useGivc) (
-        [ "poweroff.target" ]
-        ++ optionals cfg.gui.gpuSuspend [
-          "gpu-suspend.service"
-          "resume-actions.service"
-        ]
-      );
-
-      # Override systemd actions for suspend, poweroff, and reboot
-      systemd.services = optionalAttrs (cfg.vm.enable && useGivc) (
-        {
-          systemd-suspend.serviceConfig.ExecStart = [
-            ""
-            "${getExe gui-vm-suspend}"
-          ];
-
-          # Intercept reboot or poweroff actions and relay it to the host
-          gui-shutdown-interceptor = {
-            description = "Ghaf GUI Shutdown Interceptor";
-            wantedBy = [
-              "shutdown.target"
+        # Override systemd actions for suspend, poweroff, and reboot
+        systemd.services = optionalAttrs (cfg.vm.enable && useGivc) (
+          {
+            systemd-suspend.serviceConfig.ExecStart = [
+              ""
+              "${getExe gui-vm-suspend}"
             ];
-            before = [
-              "shutdown.target"
-            ];
-            unitConfig.DefaultDependencies = false;
-            serviceConfig = {
-              Type = "oneshot";
-              ExecStart = "${getExe guest-shutdown-interceptor}";
-              TimeoutSec = 5;
+
+            # Intercept reboot or poweroff actions and relay it to the host
+            gui-shutdown-interceptor = {
+              description = "Ghaf GUI Shutdown Interceptor";
+              wantedBy = [
+                "shutdown.target"
+              ];
+              before = [
+                "shutdown.target"
+              ];
+              unitConfig.DefaultDependencies = false;
+              serviceConfig = {
+                Type = "oneshot";
+                ExecStart = "${getExe guest-shutdown-interceptor}";
+                TimeoutSec = 5;
+              };
             };
-          };
 
-          resume-actions = {
-            description = "Resume Actions";
-            # QEMU stops sleep.target on wake, which runs ExecStop below.
-            # With Crosvm GPU suspend, the host instead starts this service
-            # explicitly after confirming wake. Crosvm without GPU suspend
-            # still needs the normal sleep.target lifecycle.
-            wantedBy = optionals (!(config.microvm.hypervisor == "crosvm" && cfg.gui.gpuSuspend)) [
-              "sleep.target"
-            ];
-            before = optionals (!(config.microvm.hypervisor == "crosvm" && cfg.gui.gpuSuspend)) [
-              "sleep.target"
-            ];
-            unitConfig = {
-              DefaultDependencies = false;
-              StopWhenUnneeded = true;
-            };
-            serviceConfig = {
-              Type = "oneshot";
-              RemainAfterExit = true;
-              ExecStop =
-                let
-                  resumeActions = pkgs.writeShellScriptBin "resume-actions" ''
-                    ${optionalString cfg.gui.fakeDisplaySuspend ''
-                      ${getExe ghaf-powercontrol} fake-turn-on-displays '*'
-                    ''}
-
-                    # config.ghaf.services.power-manager.suspend.extraResumeCommands
-                    ${cfg.suspend.extraResumeCommands}
-                  '';
-                in
-                getExe resumeActions;
-            };
-          };
-        }
-        // optionalAttrs cfg.gui.gpuSuspend {
-          gpu-suspend = {
-            description = "GPU suspend for GUI VM";
-            serviceConfig = {
-              Type = "oneshot";
-              ExecStart =
-                let
-                  guestGpuSuspend = pkgs.writeShellApplication {
-                    name = "guest-gpu-suspend";
-                    runtimeInputs = [
-                      pkgs.coreutils
-                    ];
-                    text = ''
-                      echo "Activating kernel GPU suspend"
-                      # Use pm_test_delay as a fallback timeout if the socket wakeup signal is not received
-                      echo ${toString cfg.gui.gpuSuspendDuration} > /sys/module/suspend/parameters/pm_test_delay
-                      # Limit pm_test suspend/resume to the GPU and serial wakeup device
-                      echo 1 > /sys/module/suspend/parameters/pm_test_gpu_only
-                      echo devices > /sys/power/pm_test
-                      # Enable ttyS1 as the wakeup source used by the host
-                      echo enabled > /sys/class/tty/ttyS1/power/wakeup
-                      cat /dev/ttyS1 > /dev/null &
-                      # Arm wakeup_count so incoming ttyS1 data is treated as a wakeup event
-                      wc=$(cat /sys/power/wakeup_count)
-                      echo "$wc" > /sys/power/wakeup_count
-                      # Enter suspend and wait for the host wakeup signal
-                      echo freeze > /sys/power/state
-                      echo "GPU resumed"
-                      echo 0 > /sys/module/suspend/parameters/pm_test_gpu_only
-                    '';
-                  };
-                in
-                getExe guestGpuSuspend;
-            };
-          };
-        }
-      );
-
-      # Logind configuration for desktop
-      services.logind.settings.Login =
-        let
-          lidEvent = if cfg.suspend.enable then "suspend" else "lock";
-        in
-        mkDefault {
-          HandleLidSwitch = lidEvent;
-          HandleLidSwitchDocked = "ignore";
-          # Below keys are usually handled by host anyway
-          HandleSuspendKey = "ignore";
-          HandleHibernateKey = "ignore";
-          HandlePowerKey = "ignore";
-          HandlePowerKeyLongPress = "ignore";
-          KillUserProcesses = true;
-          UserStopDelaySec = 0;
-          # Limit delay from inhibitors that leak across suspend/resume cycles
-          # May be caused by net.reactivated.Fprint
-          # TODO: Investigate root cause
-          InhibitDelayMaxSec = 1;
-        };
-    })
-
-    (optionalAttrs (options ? microvm && options.microvm ? qemu) {
-      # Serial device (ttyS1) for wakeup from kernel GPU suspend.
-      # `isa-serial` is an x86 ISA device; aarch64 QEMU (virt machine, no ISA bus)
-      # rejects it and the VM fails to start, so gate the wake device on x86. On
-      # aarch64 the guest resumes via the fallback timeout (see gpuSuspendDuration).
-      microvm.qemu.extraArgs =
-        mkIf
-          (
-            cfg.gui.enable
-            && cfg.vm.enable
-            && cfg.gui.gpuSuspend
-            && pkgs.stdenv.hostPlatform.isx86_64
-            && config.microvm.hypervisor == "qemu"
-          )
-          [
-            "-chardev"
-            "socket,id=wake0,path=vm-wake.sock,server=on,wait=off"
-            "-device"
-            "isa-serial,chardev=wake0,index=1"
-          ];
-    })
-
-    (optionalAttrs (options ? microvm && options.microvm ? crosvm) {
-      # Crosvm can inject the ACPI wake event directly over its control socket.
-      # Keep the guest kernel timer as a fallback if that command is unavailable.
-      microvm.crosvm.extraArgs = mkIf (
-        cfg.gui.enable
-        && cfg.vm.enable
-        && cfg.gui.gpuSuspend
-        && pkgs.stdenv.hostPlatform.isx86_64
-        && config.microvm.hypervisor == "crosvm"
-      ) [ "--s2idle" ];
-    })
-
-    # Host power management
-    (mkIf cfg.host.enable {
-      # Host still handles power buttons in most situations
-      services.logind.settings.Login = {
-        HandleLidSwitch = mkDefault "ignore";
-        # Disable accidental poweroff with light touch
-        HandlePowerKey = mkDefault "ignore";
-      };
-
-      # We can accomplish the same via systemd.sleep.settings.Sleep MemorySleepMode
-      # but it seems keyboard wakeup stops functioning with that approach
-      boot.kernelParams = optionals (cfg.suspend.mode != null && cfg.suspend.mode != "auto") [
-        "mem_sleep_default=${cfg.suspend.mode}"
-      ];
-
-      systemd = {
-        sleep.settings.Sleep = genericSleepConf;
-
-        targets = optionalAttrs cfg.suspend.enable {
-          "pre-sleep-actions" = {
-            description = "Target for pre-sleep host actions";
-            unitConfig.StopWhenUnneeded = true;
-            wantedBy = [ "sleep.target" ];
-            partOf = [ "sleep.target" ];
-            wants =
-              map (vmName: "pre-sleep-poweroff@${vmName}.service") powerOffVms
-              ++ map (vmName: "pre-sleep-fake-suspend@${vmName}.service") fakeSuspendVms
-              ++ map (vmName: "pre-sleep-pci-suspend@${vmName}.service") pciSuspendVms
-              ++ map (vmName: "pre-sleep-gpu-suspend@${vmName}.service") gpuSuspendVms;
-          };
-          "post-resume-actions" = {
-            description = "Target for post-resume host actions";
-            unitConfig.StopWhenUnneeded = true;
-            wantedBy = [ "sleep.target" ];
-            wants =
-              map (vmName: "post-resume-poweroff@${vmName}.service") powerOffVms
-              ++ map (vmName: "post-resume-fake-suspend@${vmName}.service") fakeSuspendVms
-              ++ map (vmName: "post-resume-pci-suspend@${vmName}.service") pciSuspendVms
-              ++ map (vmName: "post-resume-gpu-suspend@${vmName}.service") gpuSuspendVms;
-          };
-        };
-
-        services = mkMerge [
-          (optionalAttrs (cfg.suspend.mode == "auto" && cfg.suspend.s2idleModels != [ ]) {
-            set-mem-sleep = {
-              description = "Automatic s2idle mem_sleep Mode Selection";
-              wantedBy = [ "sysinit.target" ];
-              before = [ "sysinit.target" ];
+            resume-actions = {
+              description = "Resume Actions";
+              # QEMU stops sleep.target on wake, which runs ExecStop below.
+              # With Crosvm GPU suspend, the host instead starts this service
+              # explicitly after confirming wake. Crosvm without GPU suspend
+              # still needs the normal sleep.target lifecycle.
+              wantedBy = optionals (!(config.microvm.hypervisor == "crosvm" && cfg.gui.gpuSuspend)) [
+                "sleep.target"
+              ];
+              before = optionals (!(config.microvm.hypervisor == "crosvm" && cfg.gui.gpuSuspend)) [
+                "sleep.target"
+              ];
               unitConfig = {
                 DefaultDependencies = false;
-                ConditionPathExists = [
-                  "/sys/power/mem_sleep"
-                  "/sys/class/dmi/id/board_vendor"
-                  "/sys/class/dmi/id/board_name"
-                ];
+                StopWhenUnneeded = true;
               };
               serviceConfig = {
                 Type = "oneshot";
-                ExecStart = "+''${getExe host-set-mem-sleep}";
+                RemainAfterExit = true;
+                ExecStop =
+                  let
+                    resumeActions = pkgs.writeShellScriptBin "resume-actions" ''
+                      ${optionalString cfg.gui.fakeDisplaySuspend ''
+                        ${getExe ghaf-powercontrol} fake-turn-on-displays '*'
+                      ''}
+
+                      # config.ghaf.services.power-manager.suspend.extraResumeCommands
+                      ${cfg.suspend.extraResumeCommands}
+                    '';
+                  in
+                  getExe resumeActions;
               };
             };
-          })
-          # suspend/resume action units
-          (optionalAttrs cfg.suspend.enable (
-            lib.listToAttrs (
-              flatten (
-                map
-                  (suspendAction: [
-                    (nameValuePair "pre-sleep-${suspendAction}@" {
-                      description = "pre-sleep ${suspendAction} action for '%i'";
-                      partOf = [ "pre-sleep-actions.target" ];
-                      before = [ "sleep.target" ];
-                      after = optionals (suspendAction == "pci-suspend") [ "pre-sleep-fake-suspend@%i.service" ];
-                      serviceConfig = {
-                        Type = "oneshot";
-                        ExecStart = "${getExe host-suspend-actions} %i ${suspendAction} suspend";
-                      };
-                    })
-                    (nameValuePair "post-resume-${suspendAction}@" {
-                      description = "post-resume ${suspendAction} action for '%i'";
-                      partOf = [ "post-resume-actions.target" ];
-                      after = [ "suspend.target" ];
-                      # Reattach PCI before waking guest services so drivers and
-                      # NetworkManager never race a still-detached VFIO device.
-                      before = optionals (suspendAction == "pci-suspend") [
-                        "post-resume-fake-suspend@%i.service"
+          }
+          // optionalAttrs cfg.gui.gpuSuspend {
+            gpu-suspend = {
+              description = "GPU suspend for GUI VM";
+              serviceConfig = {
+                Type = "oneshot";
+                ExecStart =
+                  let
+                    guestGpuSuspend = pkgs.writeShellApplication {
+                      name = "guest-gpu-suspend";
+                      runtimeInputs = [
+                        pkgs.coreutils
                       ];
-                      serviceConfig = {
-                        Type = "oneshot";
-                        ExecStart = "${getExe host-suspend-actions} %i ${suspendAction} resume";
-                      };
-                    })
-                  ])
-                  [
-                    "poweroff"
-                    "fake-suspend"
-                    "pci-suspend"
-                    "gpu-suspend"
-                  ]
-              )
+                      text = ''
+                        echo "Activating kernel GPU suspend"
+                        # Use pm_test_delay as a fallback timeout if the socket wakeup signal is not received
+                        echo ${toString cfg.gui.gpuSuspendDuration} > /sys/module/suspend/parameters/pm_test_delay
+                        # Limit pm_test suspend/resume to the GPU and serial wakeup device
+                        echo 1 > /sys/module/suspend/parameters/pm_test_gpu_only
+                        echo devices > /sys/power/pm_test
+                        # Enable ttyS1 as the wakeup source used by the host
+                        echo enabled > /sys/class/tty/ttyS1/power/wakeup
+                        cat /dev/ttyS1 > /dev/null &
+                        # Arm wakeup_count so incoming ttyS1 data is treated as a wakeup event
+                        wc=$(cat /sys/power/wakeup_count)
+                        echo "$wc" > /sys/power/wakeup_count
+                        # Enter suspend and wait for the host wakeup signal
+                        echo freeze > /sys/power/state
+                        echo "GPU resumed"
+                        echo 0 > /sys/module/suspend/parameters/pm_test_gpu_only
+                      '';
+                    };
+                  in
+                  getExe guestGpuSuspend;
+              };
+            };
+          }
+        );
+
+        # Logind configuration for desktop
+        services.logind.settings.Login =
+          let
+            lidEvent = if cfg.suspend.enable then "suspend" else "lock";
+          in
+          mkDefault {
+            HandleLidSwitch = lidEvent;
+            HandleLidSwitchDocked = "ignore";
+            # Below keys are usually handled by host anyway
+            HandleSuspendKey = "ignore";
+            HandleHibernateKey = "ignore";
+            HandlePowerKey = "ignore";
+            HandlePowerKeyLongPress = "ignore";
+            KillUserProcesses = true;
+            UserStopDelaySec = 0;
+            # Limit delay from inhibitors that leak across suspend/resume cycles
+            # May be caused by net.reactivated.Fprint
+            # TODO: Investigate root cause
+            InhibitDelayMaxSec = 1;
+          };
+      })
+
+      (optionalAttrs (options ? microvm && options.microvm ? qemu) {
+        # Serial device (ttyS1) for wakeup from kernel GPU suspend.
+        # `isa-serial` is an x86 ISA device; aarch64 QEMU (virt machine, no ISA bus)
+        # rejects it and the VM fails to start, so gate the wake device on x86. On
+        # aarch64 the guest resumes via the fallback timeout (see gpuSuspendDuration).
+        microvm.qemu.extraArgs =
+          mkIf
+            (
+              cfg.gui.enable
+              && cfg.vm.enable
+              && cfg.gui.gpuSuspend
+              && pkgs.stdenv.hostPlatform.isx86_64
+              && config.microvm.hypervisor == "qemu"
             )
-            // optionalAttrs cfg.usbSuspend {
-              pre-sleep-usb = {
-                description = "USB suspend actions before sleep";
-                partOf = [ "pre-sleep-actions.target" ];
-                wantedBy = [ "pre-sleep-actions.target" ];
-                before = [ "sleep.target" ];
+            [
+              "-chardev"
+              "socket,id=wake0,path=vm-wake.sock,server=on,wait=off"
+              "-device"
+              "isa-serial,chardev=wake0,index=1"
+            ];
+      })
+
+      (optionalAttrs (options ? microvm && options.microvm ? crosvm) {
+        # Crosvm can inject the ACPI wake event directly over its control socket.
+        # Keep the guest kernel timer as a fallback if that command is unavailable.
+        microvm.crosvm.extraArgs = mkIf (
+          cfg.gui.enable
+          && cfg.vm.enable
+          && cfg.gui.gpuSuspend
+          && pkgs.stdenv.hostPlatform.isx86_64
+          && config.microvm.hypervisor == "crosvm"
+        ) [ "--s2idle" ];
+      })
+
+      # Host power management
+      (mkIf cfg.host.enable {
+        # Host still handles power buttons in most situations
+        services.logind.settings.Login = {
+          HandleLidSwitch = mkDefault "ignore";
+          # Disable accidental poweroff with light touch
+          HandlePowerKey = mkDefault "ignore";
+        };
+
+        # We can accomplish the same via systemd.sleep.settings.Sleep MemorySleepMode
+        # but it seems keyboard wakeup stops functioning with that approach
+        boot.kernelParams = optionals (cfg.suspend.mode != null && cfg.suspend.mode != "auto") [
+          "mem_sleep_default=${cfg.suspend.mode}"
+        ];
+
+        systemd = {
+          sleep.settings.Sleep = genericSleepConf;
+
+          targets = optionalAttrs cfg.suspend.enable {
+            "pre-sleep-actions" = {
+              description = "Target for pre-sleep host actions";
+              unitConfig.StopWhenUnneeded = true;
+              wantedBy = [ "sleep.target" ];
+              partOf = [ "sleep.target" ];
+              wants =
+                map (vmName: "pre-sleep-poweroff@${vmName}.service") powerOffVms
+                ++ map (vmName: "pre-sleep-fake-suspend@${vmName}.service") fakeSuspendVms
+                ++ map (vmName: "pre-sleep-pci-suspend@${vmName}.service") pciSuspendVms
+                ++ map (vmName: "pre-sleep-gpu-suspend@${vmName}.service") gpuSuspendVms;
+            };
+            "post-resume-actions" = {
+              description = "Target for post-resume host actions";
+              unitConfig.StopWhenUnneeded = true;
+              wantedBy = [ "sleep.target" ];
+              wants =
+                map (vmName: "post-resume-poweroff@${vmName}.service") powerOffVms
+                ++ map (vmName: "post-resume-fake-suspend@${vmName}.service") fakeSuspendVms
+                ++ map (vmName: "post-resume-pci-suspend@${vmName}.service") pciSuspendVms
+                ++ map (vmName: "post-resume-gpu-suspend@${vmName}.service") gpuSuspendVms;
+            };
+          };
+
+          services = mkMerge [
+            (optionalAttrs (cfg.suspend.mode == "auto" && cfg.suspend.s2idleModels != [ ]) {
+              set-mem-sleep = {
+                description = "Automatic s2idle mem_sleep Mode Selection";
+                wantedBy = [ "sysinit.target" ];
+                before = [ "sysinit.target" ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  ConditionPathExists = [
+                    "/sys/power/mem_sleep"
+                    "/sys/class/dmi/id/board_vendor"
+                    "/sys/class/dmi/id/board_name"
+                  ];
+                };
                 serviceConfig = {
                   Type = "oneshot";
-                  ExecStart = "${getExe' deviceManagerPackage "vhotplugcli"} usb suspend";
+                  ExecStart = "+''${getExe host-set-mem-sleep}";
                 };
               };
-
-              post-resume-usb = {
-                description = "USB resume actions after wakeup";
-                partOf = [ "post-resume-actions.target" ];
-                wantedBy = [ "post-resume-actions.target" ];
-                after = [ "suspend.target" ];
-                serviceConfig = {
-                  Type = "oneshot";
-                  ExecStart = "${getExe' deviceManagerPackage "vhotplugcli"} usb resume";
-                };
-              };
-            }
-          ))
-          # Override microvm’s default shutdown behavior
-          #
-          # By default, microvm attempts to shut down the VM by sending a Ctrl+Alt+Del
-          # sequence and waiting for a socket disconnect:
-          #   https://github.com/microvm-nix/microvm.nix/blob/main/lib/runners/qemu.nix
-          #
-          # In our setup, this does not work because microvm uses socat to wait for input
-          # from stdio, which is /dev/null under systemd. As a result, the command returns
-          # immediately, systemd sees the process as still active, and kills it with SIGTERM.
-          #
-          # We replace ExecStop with custom logic, by VM class, then wait for the
-          # QEMU process ($MAINPID) to exit:
-          #   - GUI VM (ignores ACPI, relays power events): start poweroff.target via givc.
-          #   - every other VM: send QMP system_powerdown so the guest runs its own
-          #     ACPI poweroff and flushes/seals journald before QEMU exits.
-          # We also shorten TimeoutStopSec from the microvm default (150s) to 30s.
-          (mkIf useGivc (
-            lib.listToAttrs (
-              map (
-                vmName:
-                nameValuePair "microvm@${vmName}" {
-                  serviceConfig = {
-                    TimeoutStopSec = "30";
-                    ExecStop =
-                      let
-                        sysvm-stop = pkgs.writeShellScript "sysvm-stop" ''
-                          # During switch-to-configuration activation (local nixos-rebuild
-                          # switch or the remote ghaf-build-helper path), affected system VMs
-                          # may be restarted as part of host service changes. switch-to-
-                          # configuration restarts changed units synchronously, one at a time,
-                          # so its process is guaranteed to still be alive on this host for the
-                          # entire time this ExecStop script blocks that restart -- regardless
-                          # of how activation was invoked. Detect that directly instead of
-                          # keying off one hardcoded remote-only unit name. Ordinary manual
-                          # stops/restarts (no activation in progress) still use graceful
-                          # shutdown.
-                          jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
-                          if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
-                            && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
-                            echo "switch-to-configuration activation in progress, skipping guest poweroff for '${vmName}'"
-                            kill -15 $MAINPID 2>/dev/null
-                            while kill -0 $MAINPID 2>/dev/null; do
-                              sleep 1
-                            done
-                            exit 0
-                          fi
-
-                          # GUI VM ignores the ACPI power button (HandlePowerKey=ignore) and
-                          # relays power events via its interceptor, so it cannot be powered off
-                          # with a QMP/ACPI button; deliver poweroff.target through givc instead.
-                          # The admin coordinator is alive here because admin-vm is shutdownLast.
-                          echo "Starting poweroff target for system VM '${vmName}'"
-                          ${givc-cli} start service --vm '${vmName}' poweroff.target &
-
-                          echo "Waiting for system VM '${vmName}' with QEMU PID=$MAINPID to stop"
-                          while kill -0 $MAINPID 2>/dev/null; do
-                            sleep 1
-                          done
-                          echo "System VM '${vmName}' with QEMU PID=$MAINPID stopped"
-                        '';
-                      in
-                      [
-                        # Clear previous microvm ExecStop logic
-                        ""
-                        # '+' allows the sysvm-stop script to be executed with full privileges
-                        "+${sysvm-stop}"
-                      ];
-                  };
-                }
-              ) givcShutdownVms
-            )
-          ))
-          # All ACPI-capable VMs: host-side QMP system_powerdown. The guest runs its
-          # own unprivileged systemd poweroff (journald flush+seal) before QEMU
-          # exits — no SIGTERM-mid-write corruption, no new guest privilege, no
-          # admin coordinator dependency.
-          (lib.listToAttrs (
-            map (
-              vmName:
-              nameValuePair "microvm@${vmName}" {
-                serviceConfig = {
-                  TimeoutStopSec = lib.mkDefault "30";
-                  ExecStop =
-                    let
-                      vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${vmName};
-                      qmpSocket =
-                        if vmConfig != null && (vmConfig.microvm.socket or null) != null then
-                          "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
-                        else
-                          "";
-                      # Half of TimeoutStopSec: how long to wait for the guest to respond to
-                      # ACPI before logging that it hasn't, so an eventual SIGKILL from
-                      # systemd's stop timeout isn't a silent surprise in the unit's journal.
-                      qmpAcpiGraceSec = 15;
-                      qmp-stop = pkgs.writeShellScript "qmp-stop" ''
-                        # See sysvm-stop for why this checks for a live switch-to-configuration
-                        # process instead of one hardcoded remote-only unit name.
-                        jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
-                        if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
-                          && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
-                          echo "switch-to-configuration activation in progress, SIGTERM '${vmName}'"
-                          kill -15 $MAINPID 2>/dev/null
-                          while kill -0 $MAINPID 2>/dev/null; do
-                            sleep 1
-                          done
-                          exit 0
-                        fi
-
-                        socket='${qmpSocket}'
-                        if [ -n "$socket" ] && [ -S "$socket" ]; then
-                          # ACPI poweroff via QEMU QMP: the guest does its own clean systemd
-                          # shutdown (journald flush+seal) before QEMU exits. A bounded socat
-                          # (-t1) avoids microvm's trailing-`cat` /dev/null stdio trap.
-                          echo "QMP system_powerdown -> '${vmName}' ($socket)"
-                          printf '{"execute":"qmp_capabilities"}\n{"execute":"system_powerdown"}\n' \
-                            | ${pkgs.socat}/bin/socat -t1 - "UNIX-CONNECT:$socket" \
-                            || echo "WARN: QMP system_powerdown to '${vmName}' failed; relying on stop timeout" >&2
-                        else
-                          echo "WARN: no QMP socket for '${vmName}' ('$socket'); SIGTERM fallback" >&2
-                          kill -15 $MAINPID 2>/dev/null
-                        fi
-
-                        echo "Waiting for VM '${vmName}' with QEMU PID=$MAINPID to stop"
-                        waited=0
-                        acpi_timeout_logged=0
-                        while kill -0 $MAINPID 2>/dev/null; do
-                          sleep 1
-                          waited=$((waited + 1))
-                          if [ "$acpi_timeout_logged" = 0 ] && [ "$waited" -ge ${toString qmpAcpiGraceSec} ]; then
-                            acpi_timeout_logged=1
-                            echo "WARN: guest '${vmName}' has not responded to ACPI poweroff after ''${waited}s; will be forced by stop timeout if it does not exit" >&2
-                          fi
-                        done
-                        echo "VM '${vmName}' with QEMU PID=$MAINPID stopped"
-                      '';
-                    in
+            })
+            # suspend/resume action units
+            (optionalAttrs cfg.suspend.enable (
+              lib.listToAttrs (
+                flatten (
+                  map
+                    (suspendAction: [
+                      (nameValuePair "pre-sleep-${suspendAction}@" {
+                        description = "pre-sleep ${suspendAction} action for '%i'";
+                        partOf = [ "pre-sleep-actions.target" ];
+                        before = [ "sleep.target" ];
+                        after = optionals (suspendAction == "pci-suspend") [ "pre-sleep-fake-suspend@%i.service" ];
+                        serviceConfig = {
+                          Type = "oneshot";
+                          ExecStart = "${getExe host-suspend-actions} %i ${suspendAction} suspend";
+                        };
+                      })
+                      (nameValuePair "post-resume-${suspendAction}@" {
+                        description = "post-resume ${suspendAction} action for '%i'";
+                        partOf = [ "post-resume-actions.target" ];
+                        after = [ "suspend.target" ];
+                        # Reattach PCI before waking guest services so drivers and
+                        # NetworkManager never race a still-detached VFIO device.
+                        before = optionals (suspendAction == "pci-suspend") [
+                          "post-resume-fake-suspend@%i.service"
+                        ];
+                        serviceConfig = {
+                          Type = "oneshot";
+                          ExecStart = "${getExe host-suspend-actions} %i ${suspendAction} resume";
+                        };
+                      })
+                    ])
                     [
-                      # Clear previous microvm ExecStop logic
-                      ""
-                      # '+' runs the qmp-stop script with full privileges
-                      "+${qmp-stop}"
-                    ];
-                };
-              }
-            ) qmpShutdownVms
-          ))
-          # Crosvm guests use the same ACPI power-button path, delivered through
-          # the Crosvm control socket instead of QMP.
-          (lib.listToAttrs (
-            map (
-              vmName:
-              nameValuePair "microvm@${vmName}" {
-                serviceConfig = {
-                  TimeoutStopSec = lib.mkDefault "30";
-                  ExecStop =
-                    let
-                      vmConfig = lib.ghaf.vm.getConfig config.microvm.vms.${vmName};
-                      controlSocket =
-                        if vmConfig != null && (vmConfig.microvm.socket or null) != null then
-                          "${config.microvm.stateDir}/${vmName}/${vmConfig.microvm.socket}"
-                        else
-                          "";
-                      crosvmPackage = vmConfig.microvm.crosvm.package;
-                      crosvmAcpiGraceSec = 15;
-                      crosvmStopDeadlineSec = 25;
-                      crosvm-stop = pkgs.writeShellScript "crosvm-stop" ''
-                        set -u
-                        pid="''${MAINPID:-}"
-                        if [ -z "$pid" ]; then
-                          echo "Crosvm '${vmName}' has no MAINPID; nothing to stop"
-                          exit 0
-                        fi
-
-                        # Keep host activation bounded: switch-to-configuration
-                        # restarts changed units synchronously, so graceful guest
-                        # shutdown here would serialize up to 25 seconds per VM.
-                        jobs=$(${getExe' pkgs.systemd "systemctl"} list-jobs 2>/dev/null || true)
-                        if ! echo "$jobs" | grep -qiE '(sleep|suspend|poweroff|reboot|halt)\.target.*start' \
-                          && ${getExe' pkgs.procps "pgrep"} -f 'bin/switch-to-configuration (switch|test)' >/dev/null 2>&1; then
-                          echo "switch-to-configuration activation in progress, SIGTERM '${vmName}'"
-                          kill -15 "$pid" 2>/dev/null || true
-                          while kill -0 "$pid" 2>/dev/null; do
-                            sleep 1
-                          done
-                          exit 0
-                        fi
-
-                        if [ -n '${controlSocket}' ] && [ -S '${controlSocket}' ]; then
-                          echo "Crosvm powerbtn -> '${vmName}' (${controlSocket})"
-                          # Use the package from this VM's evaluated configuration
-                          # so the control protocol matches the running process.
-                          if ! ${crosvmPackage}/bin/crosvm --no-syslog powerbtn '${controlSocket}'; then
-                            echo "WARN: Crosvm powerbtn for '${vmName}' failed; sending SIGTERM" >&2
-                            kill -15 "$pid" 2>/dev/null || true
-                          fi
-                        else
-                          echo "WARN: no Crosvm control socket for '${vmName}'; SIGTERM fallback" >&2
-                          kill -15 "$pid" 2>/dev/null || true
-                        fi
-
-                        echo "Waiting for Crosvm '${vmName}' with PID=$pid to stop"
-                        waited=0
-                        grace_logged=0
-                        while kill -0 "$pid" 2>/dev/null; do
-                          sleep 1
-                          waited=$((waited + 1))
-                          if [ "$grace_logged" = 0 ] && [ "$waited" -ge ${toString crosvmAcpiGraceSec} ]; then
-                            grace_logged=1
-                            echo "WARN: guest '${vmName}' has not stopped after ''${waited}s; systemd will force it at the stop timeout" >&2
-                          fi
-                          if [ "$waited" -ge ${toString crosvmStopDeadlineSec} ]; then
-                            echo "ERROR: Crosvm '${vmName}' with PID=$pid did not stop within ''${waited}s" >&2
-                            exit 1
-                          fi
-                        done
-                        echo "Crosvm '${vmName}' with PID=$pid stopped"
-                      '';
-                    in
-                    [
-                      ""
-                      "+${crosvm-stop}"
-                    ];
-                };
-              }
-            ) crosvmShutdownVms
-          ))
-          # Handle VMs with shutdownLast enabled
-          (lib.listToAttrs (
-            map
-              (
-                vmName:
-                lib.nameValuePair "microvm@${vmName}" {
-                  before = map (n: "microvm@${n}.service") (
-                    lib.filter (n: n != vmName) (lib.attrNames config.microvm.vms)
-                  );
-                  # The shutdown-last VM is the log aggregator (admin-vm): it stops
-                  # after every other VM and has the most journal to flush+seal, so
-                  # give it more time before the stop timeout SIGKILLs QEMU.
-                  serviceConfig.TimeoutStopSec = "60";
-                }
-              )
-              (
-                lib.attrNames (
-                  lib.filterAttrs (
-                    _: vm:
-                    let
-                      vmConfig = lib.ghaf.vm.getConfig vm;
-                    in
-                    vmConfig != null && vmConfig.ghaf.shutdownLast
-                  ) config.microvm.vms
+                      "poweroff"
+                      "fake-suspend"
+                      "pci-suspend"
+                      "gpu-suspend"
+                    ]
                 )
               )
-          ))
-        ];
-      };
-    })
-  ]);
+              // optionalAttrs cfg.usbSuspend {
+                pre-sleep-usb = {
+                  description = "USB suspend actions before sleep";
+                  partOf = [ "pre-sleep-actions.target" ];
+                  wantedBy = [ "pre-sleep-actions.target" ];
+                  before = [ "sleep.target" ];
+                  serviceConfig = {
+                    Type = "oneshot";
+                    ExecStart = "${getExe' deviceManagerPackage "vhotplugcli"} usb suspend";
+                  };
+                };
+
+                post-resume-usb = {
+                  description = "USB resume actions after wakeup";
+                  partOf = [ "post-resume-actions.target" ];
+                  wantedBy = [ "post-resume-actions.target" ];
+                  after = [ "suspend.target" ];
+                  serviceConfig = {
+                    Type = "oneshot";
+                    ExecStart = "${getExe' deviceManagerPackage "vhotplugcli"} usb resume";
+                  };
+                };
+              }
+            ))
+          ];
+        };
+      })
+    ]))
+  ];
 }


### PR DESCRIPTION
Previously Ctrl+Alt+Del was sent, but this was rejected by QEMU, becuse the vms are headless and do not have a keyboard to handle the keypress. Now the system_powerdown command is sent, which is accepted and the vms shutdown gracefully. There is a backup 30 second timer per vm, so that if they really hang they will be reaped before the 150 default time out from microvm.

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->

1. ...
