### PR TITLE
fix(logging): retry sealing confirmation after journald restart

### DIFF
--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -768,11 +768,28 @@ let
           return 0
         fi
 
-        if [ "$restart_ok" = 1 ] && fss_sealing_active_in_config; then
-          ACTIVATION_RESTARTED_THIS_RUN=1
-          write_activation_state active
-          fss_log info "Confirmed journald sealing is active after restart"
-          return 0
+        if [ "$restart_ok" = 1 ]; then
+          # systemd-analyze cat-config queries the merged config right after
+          # restarting journald; caught at exactly the wrong moment, it can
+          # still read the pre-restart config and report Seal=no even though
+          # journald picks up the runtime drop-in within a second or two.
+          # Mirrors the re-verify-before-believing-it pattern already used for
+          # live-journal counter mismatches: retry briefly rather than failing
+          # the whole boot closed on a check taken too early.
+          local confirm_attempt=1
+          local confirm_retries=3
+          while [ "$confirm_attempt" -le "$confirm_retries" ]; do
+            if fss_sealing_active_in_config; then
+              ACTIVATION_RESTARTED_THIS_RUN=1
+              write_activation_state active
+              fss_log info "Confirmed journald sealing is active after restart"
+              return 0
+            fi
+            [ "$confirm_attempt" -eq "$confirm_retries" ] && break
+            fss_log info "Sealing not yet confirmed on attempt $confirm_attempt; retrying"
+            confirm_attempt=$((confirm_attempt + 1))
+            sleep 1
+          done
         fi
 
         fss_log fail "Journald sealing could not be confirmed after restart; failing closed"


### PR DESCRIPTION
## Summary
- `journal-fss-setup` confirms `Seal=yes` took effect via `systemd-analyze cat-config` immediately after restarting journald; caught at the wrong moment, that check can still see the pre-restart config and record `activation_state=failed` even though journald settles within a second or two.
- Once written, `activation_state=failed` is never rechecked — `journal-fss-verify` trusts it for the rest of the boot regardless of what live verification would show.
- Seen on `business-vm` (SSRCSP-8820): triage showed `activation_state=failed` for the current boot, while journald's effective `Seal` was `yes` and a direct `journalctl --verify` against the real key passed cleanly (only the expected pre-activation-boundary warning). Sealing was fine; the one-shot confirmation just looked too early.
- Retries the confirmation briefly (3 attempts, 1s apart) before failing closed, mirroring the existing re-verify-before-believing-it pattern used for live-journal counter mismatches (d9328b9f).

## Test plan
- [x] `nix build .#checks.x86_64-linux.fss-classifier-unit` — pass
- [x] `nix build .#checks.x86_64-linux.fss-test` — pass
- [x] `nix build .#checks.x86_64-linux.logging-fss` (full VM integration) — pass
- [ ] Re-run against `business-vm` hardware to confirm this actually closes SSRCSP-8820 (not yet done — the retry count/interval is a starting guess, not hardware-tuned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)