### PR TITLE
bump(jetpack-nixos): rebase on upstream

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -546,16 +546,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1787661902,
-        "narHash": "sha256-mJmAXcM7JUbt8sdF8CpKcQzuBIQA0fld8HGWADc3eTs=",
+        "lastModified": 1788849184,
+        "narHash": "sha256-StOZunkbZPsLbhq3rUOZNbXtrmPCVrMZvvpcCq7wjYA=",
         "owner": "tiiuae",
         "repo": "jetpack-nixos",
-        "rev": "5a30003720b195428fbceb01c117a157605c249c",
+        "rev": "4cf2ef780aac474bc20662d23371354c0c7fd361",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
-        "ref": "august-rebase",
+        "ref": "september-rebase",
         "repo": "jetpack-nixos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -155,7 +155,7 @@
     # Nvidia Orin support for NixOS
     jetpack-nixos = {
       #url = "github:anduril/jetpack-nixos";
-      url = "github:tiiuae/jetpack-nixos/august-rebase";
+      url = "github:tiiuae/jetpack-nixos/september-rebase";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/guest-module.nix
+++ b/modules/reference/hardware/jetpack/nvidia-jetson-orin/virtualization/passthrough/payload/guest-module.nix
@@ -134,9 +134,6 @@ in
               # Keep the R5's flip-completion binding across modesets, or the
               # desktop session after the greeter never sees a completion.
               (srcDir + "/patches/0024-nvkms-keep-flip-completion-binding.patch")
-              # Kernel 6.12.103 removed drm_fb_helper_alloc_info(); without this
-              # the tegra fbdev in nvidia-oot does not compile at all.
-              (srcDir + "/patches/0025-tegra-fbdev-use-core-allocated-fb-info.patch")
             ]
             # disp-vm has no guest-owned host1x syncpoints.
             ++ lib.optional payload.noSyncpointPatch (


### PR DESCRIPTION
* Jetpack-nixos input rebased against upstream
  - Includes Jetson BSP from 36.5 to 36.5.2
* Upstream kernel from 6.6.129 to 6.6.155
  - Includes a patch for OP-TEE (optee_notif_wait()-timeout)

<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change

- [ ] New feature
- [x] Bug fix
- [x] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:
Everything works as before, except:
- uefi version is 36.5.2
- kenel version is 6.6.155
