### PR TITLE
ci(slsa): start generating SLSA source VSA for commits on main

### DIFF
--- a/.github/workflows/source-vsa.yml
+++ b/.github/workflows/source-vsa.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Source VSA
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  source-vsa:
+    name: Issue Source VSA
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    concurrency:
+      group: source-vsa-${{ github.repository }}-${{ github.sha }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+
+      - name: Issue Source VSA
+        uses: tiiuae/ghaf-infra/.github/actions/source-vsa@69860c444723a0032fab66012ce702c48baa1221
+        with:
+          policy: slsa/source-vsa-policy.yaml
+          verified-level: SLSA_SOURCE_LEVEL_1

--- a/slsa/source-vsa-policy.yaml
+++ b/slsa/source-vsa-policy.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+verifier:
+  id: https://github.com/tiiuae/ghaf-infra/.github/actions/source-vsa
+
+workflowPath: .github/workflows/source-vsa.yml
+
+refs:
+  - refs/heads/main


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Add github action which uses the workflow defined in ghaf-infra as implemented here https://github.com/tiiuae/ghaf-infra/pull/1241.

The action generates source VSA bundle which is used for source attestation as per SLSA v1.2. The bundle is uploaded to ghcr where it can be pulled and verified by Jenkins CI. This will make the source tree SLSA level 1 compliant.

Ghaf-infra source VSA sample: https://github.com/tiiuae/ghaf-infra/pkgs/container/ghaf-infra%2Fsource-vsa

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [x] Infrastructure / CI/CD

## Related Issues / Tickets

https://github.com/tiiuae/ghaf-infra/pull/1241

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

