### PR TITLE
fix(logging): keep FSS verification working across clock corrections

### DIFF
--- a/docs/src/content/docs/ghaf/scs/fss.mdx
+++ b/docs/src/content/docs/ghaf/scs/fss.mdx
@@ -195,6 +195,22 @@ journalctl -o export > journal.export
 journalctl --verify --verify-key=<verification-key> --file=journal.export
 ```
 
+:::caution[Use Ghaf's `journalctl` for off-device verification]
+Ghaf vendors a systemd patch (`systemd-fss-verify-tolerate-repeated-epoch.patch`)
+so `journalctl --verify` tolerates more than one FSS TAG per FSPRG interval —
+legitimate when a sealed journal is rotated/restarted repeatedly inside one
+`sealInterval`, which the FSS-activation sequence does on every boot. Stock
+upstream `journalctl` rejects such an untampered archive with
+`Epoch sequence not continuous (N vs N)`.
+
+Until the patch is upstream, verify exported archives with Ghaf's `journalctl`
+(or the same patch applied). A `FAIL` with *equal* operands is this known
+divergence, not tampering. *Unequal* operands `(M vs N)`, `M < N`, are a real
+rollback and fail under both.
+
+TODO: drop this note once the patch is upstream -- [tiiuae/ghaf#2243](https://github.com/tiiuae/ghaf/issues/2243).
+:::
+
 ## Troubleshooting
 
 ### Verification Fails with "FAIL"

--- a/modules/common/logging/fss-verify-classifier.sh
+++ b/modules/common/logging/fss-verify-classifier.sh
@@ -54,11 +54,8 @@ fss_log() {
 
 fss_log_block() { cat; }
 
-# journald's Storage=persistent falls back to volatile at its own startup
-# (journald.conf(5)) and never re-evaluates -- resolve where it actually
-# landed via its open fd, not by guessing from file existence.
-# Falls back to the caller's default on any resolution failure; must not
-# abort the caller under errexit.
+# journald's persistent->volatile fallback (journald.conf(5)) is decided once
+# at its own startup; resolve where it actually landed via its open fd.
 fss_resolve_live_journal_dir() {
   local default_dir="$1" journald_pid journald_comm fd_target
 
@@ -70,8 +67,7 @@ fss_resolve_live_journal_dir() {
     ;;
   esac
 
-  # Guards against PID reuse between the lookup above and the fd walk below.
-  # comm is kernel-truncated to 15 chars, hence "systemd-journal" not "...ld".
+  # Guards against PID reuse; comm is truncated to "systemd-journal".
   journald_comm=$(cat "/proc/$journald_pid/comm" 2>/dev/null) || true
   if [ "$journald_comm" != "systemd-journal" ]; then
     printf '%s' "$default_dir"
@@ -92,10 +88,9 @@ fss_resolve_live_journal_dir() {
   fi
 }
 
-# Resolve the FSS key file by which candidate path actually has one.
-# Deliberately NOT derived from fss_resolve_live_journal_dir: `journalctl
-# --setup-keys` places the key independently of journald's live journal.
-# Defaults to persistent when neither exists, matching --setup-keys itself.
+# Resolve the FSS key file by which candidate path actually has one -- NOT
+# derived from fss_resolve_live_journal_dir: --setup-keys places it
+# independently of journald's live journal.
 fss_resolve_key_file() {
   local machine_id="$1"
   local persistent="/var/log/journal/$machine_id/fss"

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -106,12 +106,8 @@ let
   hostPersistentJournalPath = "/persist/var/log/journal";
   fssBasePath =
     if config.ghaf.type == "host" then "/persist/common/journal-fss" else "/etc/common/journal-fss";
-  # All FSS journalctl callers must use the SAME systemd as PID 1 / journald.
-  # journalctl --verify's integrity verdict depends on the journal-verify.c
-  # tag/epoch logic, and Ghaf vendors a patch to it
-  # (systemd-fss-verify-tolerate-repeated-epoch.patch, SSRCSP-8820). A verifier
-  # built from a different (unpatched) systemd would disagree with the sealing
-  # journald and report spurious "Epoch sequence not continuous" failures.
+  # FSS journalctl callers must use the same (patched) systemd as PID 1, or
+  # the verifier disagrees with the sealing journald.
   systemdPackage = config.systemd.package;
 
   fssTriagePackage =
@@ -1551,6 +1547,18 @@ let
             esac
     '';
   };
+
+  # Seal + archive via --rotate (no restart) so a later teardown can't strand
+  # a sealed file STATE_ONLINE. Best-effort; shared by both finalizer units.
+  sealRotateScript = pkgs.writeShellApplication {
+    name = "journal-fss-seal-rotate";
+    runtimeInputs = [ systemdPackage ];
+    text = ''
+      journalctl --sync 2>/dev/null || true
+      journalctl --rotate 2>/dev/null || true
+      journalctl --sync 2>/dev/null || true
+    '';
+  };
 in
 {
   _file = ./fss.nix;
@@ -2080,6 +2088,60 @@ in
               ];
             };
           };
+
+          # Runs early in shutdown, before microVM teardown can force-kill
+          # journald mid-offline-close.
+          journal-fss-shutdown-finalize = {
+            description = "Seal and archive FSS journals before shutdown";
+            documentation = [ "man:journalctl(1)" ];
+
+            wantedBy = [ "multi-user.target" ];
+            # After journald at start => ExecStop runs before journald stops.
+            after = [
+              "systemd-journald.service"
+              "journal-fss-setup.service"
+            ];
+            # Out of the normal stop wave, so ExecStop runs late in shutdown.
+            before = [ "shutdown.target" ];
+            conflicts = [ "shutdown.target" ];
+
+            unitConfig = {
+              DefaultDependencies = false;
+              # Only meaningful once FSS keys exist (skips the host, which has none).
+              ConditionPathExists = "${cfg.keyPath}/initialized";
+            };
+
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = "${pkgs.coreutils}/bin/true";
+              ExecStop = [
+                (getExe sealRotateScript)
+                # Drop journald's sockets so PID 1 can't reactivate it later.
+                # --no-block: this unit stops before journald, so a blocking
+                # stop would deadlock.
+                "-${systemdPackage}/bin/systemctl stop --no-block systemd-journald.socket systemd-journald-dev-log.socket"
+              ];
+              # Bounded well under the microVM stop timeout (crosvm, ~30s).
+              TimeoutStopSec = "25s";
+            };
+          };
+
+          # Archives pre-step content under the journald that wrote it, before
+          # the reboot. Fires on any step; cheap.
+          journal-fss-clockstep-rotate = {
+            description = "Seal and archive FSS journals on a wall-clock step";
+            documentation = [ "man:journalctl(1)" ];
+            after = [
+              "systemd-journald.service"
+              "journal-fss-setup.service"
+            ];
+            unitConfig.ConditionPathExists = "${cfg.keyPath}/initialized";
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = getExe sealRotateScript;
+            };
+          };
         };
 
         # Timer for periodic verification
@@ -2096,6 +2158,16 @@ in
           }
           // optionalAttrs cfg.verifyOnBoot {
             OnBootSec = "10min";
+          };
+        };
+
+        timers.journal-fss-clockstep-rotate = {
+          description = "Seal FSS journals when the wall clock is stepped";
+          documentation = [ "man:journalctl(1)" ];
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnClockChange = true;
+            Unit = "journal-fss-clockstep-rotate.service";
           };
         };
       };

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -106,8 +106,20 @@ let
   hostPersistentJournalPath = "/persist/var/log/journal";
   fssBasePath =
     if config.ghaf.type == "host" then "/persist/common/journal-fss" else "/etc/common/journal-fss";
+  # All FSS journalctl callers must use the SAME systemd as PID 1 / journald.
+  # journalctl --verify's integrity verdict depends on the journal-verify.c
+  # tag/epoch logic, and Ghaf vendors a patch to it
+  # (systemd-fss-verify-tolerate-repeated-epoch.patch, SSRCSP-8820). A verifier
+  # built from a different (unpatched) systemd would disagree with the sealing
+  # journald and report spurious "Epoch sequence not continuous" failures.
+  systemdPackage = config.systemd.package;
+
   fssTriagePackage =
-    pkgs.fss-triage or (pkgs.callPackage ../../../packages/pkgs-by-name/fss-triage/package.nix { });
+    (pkgs.fss-triage or (pkgs.callPackage ../../../packages/pkgs-by-name/fss-triage/package.nix { }))
+    .override
+      {
+        systemd = systemdPackage;
+      };
 
   preparePersistentJournalScript = pkgs.writeShellApplication {
     name = "journal-fss-prepare-persistent-journal";
@@ -122,14 +134,15 @@ let
   # Script to setup FSS keys on first boot
   setupScript = pkgs.writeShellApplication {
     name = "journal-fss-setup";
-    runtimeInputs = with pkgs; [
-      systemd
-      coreutils
-      gawk
-      findutils
-      gnugrep
-      util-linux
-    ];
+    runtimeInputs =
+      (with pkgs; [
+        coreutils
+        gawk
+        findutils
+        gnugrep
+        util-linux
+      ])
+      ++ [ systemdPackage ];
     # /etc/fss-verify-classifier.sh is populated at runtime (see environment.etc
     # below); shellcheck cannot follow it statically.
     excludeShellChecks = [ "SC1091" ];
@@ -769,13 +782,8 @@ let
         fi
 
         if [ "$restart_ok" = 1 ]; then
-          # systemd-analyze cat-config queries the merged config right after
-          # restarting journald; caught at exactly the wrong moment, it can
-          # still read the pre-restart config and report Seal=no even though
-          # journald picks up the runtime drop-in within a second or two.
-          # Mirrors the re-verify-before-believing-it pattern already used for
-          # live-journal counter mismatches: retry briefly rather than failing
-          # the whole boot closed on a check taken too early.
+          # cat-config can read the pre-restart config for a second or two
+          # after the restart; retry briefly rather than failing closed early.
           local confirm_attempt=1
           local confirm_retries=3
           while [ "$confirm_attempt" -le "$confirm_retries" ]; do
@@ -1209,9 +1217,8 @@ let
         chmod 0400 "$VERIFY_KEY_FILE"
       }
 
-      # JOURNAL_DIR and FSS_KEY_FILE are resolved independently -- journald's
-      # live journal and journalctl --setup-keys' key placement can each
-      # land persistent-vs-volatile differently on the same boot.
+      # Resolved independently: journald's live journal and --setup-keys' key
+      # placement can land persistent-vs-volatile differently on the same boot.
       JOURNAL_DIR=$(fss_resolve_live_journal_dir "/var/log/journal/$MACHINE_ID")
       FSS_KEY_FILE=$(fss_resolve_key_file "$MACHINE_ID")
       if [ "$JOURNAL_DIR" != "/var/log/journal/$MACHINE_ID" ]; then
@@ -1308,8 +1315,7 @@ let
       # Securely remove setup output (contains sensitive key material)
       shred -u "$KEY_DIR/setup-output.txt" 2>/dev/null || rm -f "$KEY_DIR/setup-output.txt"
 
-      # Re-resolve: --setup-keys may have placed it somewhere the
-      # pre-generation guess above didn't anticipate.
+      # Re-resolve: --setup-keys may not match the pre-generation guess.
       FSS_KEY_FILE=$(fss_resolve_key_file "$MACHINE_ID")
 
       # Verify sealing key was created
@@ -1359,13 +1365,14 @@ let
   # Script to verify journal integrity
   verifyScript = pkgs.writeShellApplication {
     name = "journal-fss-verify";
-    runtimeInputs = with pkgs; [
-      systemd
-      coreutils
-      util-linux
-      gnugrep
-      gawk
-    ];
+    runtimeInputs =
+      (with pkgs; [
+        coreutils
+        util-linux
+        gnugrep
+        gawk
+      ])
+      ++ [ systemdPackage ];
     # /etc/fss-verify-classifier.sh is populated at runtime (see environment.etc
     # above); shellcheck cannot follow it statically.
     excludeShellChecks = [ "SC1091" ];

--- a/modules/common/systemd/base.nix
+++ b/modules/common/systemd/base.nix
@@ -72,9 +72,16 @@ let
       }
     )).overrideAttrs
       (prevAttrs: {
-        patches = prevAttrs.patches ++ [
-          ./systemd-boot-double-dtb-buffer-size.patch
-        ];
+        patches = prevAttrs.patches ++ [ ./systemd-boot-double-dtb-buffer-size.patch ];
+        # Tolerate repeated same-epoch FSS TAGs in `journalctl --verify` (a forward
+        # clock correction re-tags a sealed file within one FSPRG interval).
+        # TODO: remove once upstreamed -- https://github.com/tiiuae/ghaf/issues/2243
+        postPatch = (prevAttrs.postPatch or "") + ''
+          substituteInPlace src/libsystemd/sd-journal/journal-verify.c \
+            --replace-fail \
+              'if (!(n_tags == 0 || (n_tags == 1 && le64toh(o->tag.epoch) == last_epoch)' \
+              'if (!(n_tags == 0 || le64toh(o->tag.epoch) == last_epoch'
+        '';
       });
 
   # Definition of suppressed system units in systemd configuration. This removes the units and has priority.

--- a/modules/development/debug-tools.nix
+++ b/modules/development/debug-tools.nix
@@ -12,7 +12,11 @@ let
   sysbench-test-script = pkgs.callPackage ./scripts/sysbench_test.nix { };
   sysbench-fileio-test-script = pkgs.callPackage ./scripts/sysbench_fileio_test.nix { };
   nvpmodel-check = pkgs.callPackage ./scripts/nvpmodel_check.nix { };
-  fss-test = pkgs.callPackage ../../tests/logging/test_scripts/fss-test.nix { };
+  # Use the same systemd as PID 1 so fss-test's journalctl --verify agrees with
+  # the sealing journald (Ghaf vendors a journal-verify.c patch, SSRCSP-8820).
+  fss-test = pkgs.callPackage ../../tests/logging/test_scripts/fss-test.nix {
+    systemd = config.systemd.package;
+  };
 
   inherit (lib) mkEnableOption mkIf rmDesktopEntries;
 in

--- a/tests/logging/default.nix
+++ b/tests/logging/default.nix
@@ -25,6 +25,16 @@
 let
   fssSetupTest = import ./test_scripts/fss_setup.nix;
   fssVerificationTest = import ./test_scripts/fss_verification.nix;
+
+  # Same journal-verify.c tolerance as modules/common/systemd/base.nix.
+  patchedSystemd = pkgs.systemd.overrideAttrs (prev: {
+    postPatch = (prev.postPatch or "") + ''
+      substituteInPlace src/libsystemd/sd-journal/journal-verify.c \
+        --replace-fail \
+          'if (!(n_tags == 0 || (n_tags == 1 && le64toh(o->tag.epoch) == last_epoch)' \
+          'if (!(n_tags == 0 || le64toh(o->tag.epoch) == last_epoch'
+    '';
+  });
 in
 pkgs.testers.nixosTest {
   name = "logging-fss";
@@ -59,6 +69,8 @@ pkgs.testers.nixosTest {
       };
 
       config = {
+        systemd.package = patchedSystemd;
+
         # Enable FSS with short seal interval for testing
         ghaf.logging.enable = true;
         ghaf.logging.fss = {
@@ -82,14 +94,14 @@ pkgs.testers.nixosTest {
           "d /persist/common/journal-fss/test-host 0700 root root - -"
         ];
 
-        # Test utilities
+        # fss-test/fss-triage must verify with the same patched systemd as the node.
         environment.systemPackages = with pkgs; [
           coreutils
           gnugrep
           util-linux
-          (callPackage ./test_scripts/fss-test.nix { })
+          (callPackage ./test_scripts/fss-test.nix { systemd = patchedSystemd; })
           (callPackage ./test_scripts/fss-classifier-cases.nix { })
-          (callPackage ../../packages/pkgs-by-name/fss-triage/package.nix { })
+          (callPackage ../../packages/pkgs-by-name/fss-triage/package.nix { systemd = patchedSystemd; })
         ];
       };
     };

--- a/tests/logging/test_scripts/fss_verification.nix
+++ b/tests/logging/test_scripts/fss_verification.nix
@@ -64,6 +64,164 @@ _: ''
               raise Exception(f"Journal verification found critical failures: {output}")
           print(f"Journal verification completed (exit code: {exit_code})")
 
+  with subtest("Forward clock correction leaves sealed journals raw-verifiable (SSRCSP-8820 verify-side)"):
+      # Without the vendored patch, a forward step + activation churn piles up
+      # same-epoch TAGs and the archive fails permanently. Bar: raw
+      # journalctl --verify has no FAIL lines and no corruption signature.
+      if not skip_if_setup_failed("verify-side raw-verify"):
+          vkey = machine.succeed(f"tr -d '[:space:]' < {verify_key_path}").strip()
+          machine.succeed("""
+            bash -lc '
+              set -euo pipefail
+              timedatectl set-ntp false 2>/dev/null || true
+              journalctl --rotate; journalctl --sync
+              date -s "@$(( $(date +%s) + 200 ))" >/dev/null
+              logger -t fss-test "vs 1"; logger -t fss-test "vs 2"; journalctl --sync
+              journalctl --rotate; journalctl --sync
+              journalctl --rotate; journalctl --sync
+              systemctl restart systemd-journald; sleep 1; journalctl --sync
+            '
+          """)
+          exit_code, output = machine.execute(
+              "journalctl --verify --verify-key=" + vkey + " 2>&1"
+          )
+          machine.succeed("timedatectl set-ntp true 2>/dev/null || true")
+          bad = [
+              ln
+              for ln in output.splitlines()
+              if ("FAIL:" in ln)
+              or ("Epoch sequence not continuous" in ln)
+              or ("Epoch sequence out of synchronization" in ln)
+              or ("Tag failed verification" in ln)
+              or ("Bad message" in ln)
+              or ("Hash value mismatch" in ln)
+              or ("references invalid" in ln)
+              or ("File corruption detected" in ln)
+              or ("Invalid object" in ln)
+          ]
+          if bad:
+              raise Exception(
+                  "raw journalctl --verify not clean after forward correction:\n"
+                  + "\n".join(bad)
+                  + "\n--- full ---\n"
+                  + output
+              )
+          print("verify-side: raw journalctl --verify clean after a forward correction")
+
+  with subtest("Verify still rejects tampered sealed archives (SSRCSP-8820 verify-side adversarial)"):
+      # The relaxation must not blind --verify to real tampering: pick a genuine
+      # sealed TAG-tail archive, mutate copies, assert --verify still rejects
+      # each (epoch rollback, tag seqnum, tag HMAC, sealed-region flip,
+      # tail-tag header, truncation).
+      if not skip_if_setup_failed("verify-side adversarial"):
+          vkey = machine.succeed(f"tr -d '[:space:]' < {verify_key_path}").strip()
+          mid = machine.succeed("cat /etc/machine-id").strip()
+          machine.succeed(f"""
+            bash -lc '
+              set -euo pipefail
+              work=/root/fss-adversarial
+              rm -rf "$work"; mkdir -p "$work"
+              key={vkey}
+
+              archives() {{ ls -t /var/log/journal/{mid}/system@*.journal 2>/dev/null || true; }}
+              # journal Header: compatible_flags = LE u32 @ 8; bit0 = HEADER_COMPATIBLE_SEALED.
+              sealed_flag() {{ od -An -tu4 -j8 -N4 "$1" | tr -d " "; }}
+              # tail_object_offset = LE u64 @ 136; object type byte is the first byte of the object.
+              # OBJECT_TAG = 7 (UNUSED0 DATA1 FIELD2 ENTRY3 DATA_HT4 FIELD_HT5 ENTRY_ARRAY6 TAG7).
+              tail_off() {{ od -An -tu8 -j136 -N8 "$1" | tr -d " "; }}
+              type_at() {{ od -An -tu1 -j"$2" -N1 "$1" | tr -d " "; }}
+
+              pick_sealed_tag_archive() {{
+                local x fl t
+                for x in $(archives); do
+                  fl=$(sealed_flag "$x"); [ -n "$fl" ] || continue
+                  [ $(( fl & 1 )) -eq 1 ] || continue          # HEADER_COMPATIBLE_SEALED
+                  t=$(tail_off "$x"); [ -n "$t" ] && [ "$t" -gt 0 ] || continue
+                  [ "$(type_at "$x" "$t")" = 7 ] || continue    # tail object is OBJECT_TAG
+                  journalctl --file="$x" --verify --verify-key="$key" >"$work/probe.out" 2>&1 || continue
+                  printf "%s" "$x"; return 0
+                done
+                return 1
+              }}
+
+              timedatectl set-ntp false 2>/dev/null || true
+              src=""
+              for attempt in 1 2 3; do
+                for i in $(seq 1 60); do logger -t fss-adv "seed $attempt $i"; done
+                journalctl --sync; journalctl --rotate; journalctl --sync
+                src=$(pick_sealed_tag_archive || true)
+                [ -n "$src" ] && break
+              done
+              timedatectl set-ntp true 2>/dev/null || true
+              if [ -z "$src" ]; then
+                echo "ADVERSARIAL SETUP FAIL: no sealed archive with a TAG tail to tamper with" >&2
+                for x in $(archives); do
+                  echo "  $x sealed_flag=$(sealed_flag "$x") tail_off=$(tail_off "$x") tail_type=$(type_at "$x" "$(tail_off "$x")")" >&2
+                  journalctl --file="$x" --verify --verify-key="$key" 2>&1 | sed "s/^/    /" >&2 || true
+                done
+                exit 1
+              fi
+              echo "adversarial source: $src ($(stat -c %s "$src") bytes)"
+              toff=$(tail_off "$src")
+
+              expect_reject() {{
+                # exit 0 from --verify = PASSED (bad for us); non-zero = rejected (good)
+                local f="$1" label="$2"
+                if journalctl --file="$f" --verify --verify-key="$key" >"$f.out" 2>&1; then
+                  echo "ADVERSARIAL FAIL [$label]: journalctl --verify accepted a tampered archive" >&2
+                  cat "$f.out" >&2
+                  exit 1
+                fi
+                if ! grep -qE "FAIL:|Bad message|Epoch sequence|Tag failed verification|Hash value mismatch|Invalid object|File corruption|corrupt|truncated|invalid|Failed to open|No data available|references (invalid|a bad)" "$f.out"; then
+                  echo "ADVERSARIAL FAIL [$label]: rejected but with no corruption signature" >&2
+                  cat "$f.out" >&2
+                  exit 1
+                fi
+                echo "adversarial ok [$label]: $(grep -m1 -oE \"FAIL:.*|Bad message|Epoch sequence[^\\)]*\\)|Tag failed verification|Hash value mismatch\" \"$f.out\" || true)"
+              }}
+
+              # (1) tag epoch field (toff+24) -> zero. Rejects via epoch-gate or HMAC;
+              #     skip if already 0.
+              cur_epoch=$(od -An -tu8 -j$((toff + 24)) -N8 "$src" | tr -d " ")
+              if [ -n "$cur_epoch" ] && [ "$cur_epoch" -gt 0 ]; then
+                f="$work/rollback.journal"; cp "$src" "$f"
+                dd if=/dev/zero of="$f" bs=1 seek=$((toff + 24)) count=8 conv=notrunc status=none
+                expect_reject "$f" "epoch-rollback"
+              else
+                echo "adversarial skip [epoch-rollback]: tail tag epoch already 0"
+              fi
+
+              # (2) tag seqnum field (toff+16) -> zero. Rejects.
+              f="$work/seqnum.journal"; cp "$src" "$f"
+              dd if=/dev/zero of="$f" bs=1 seek=$((toff + 16)) count=8 conv=notrunc status=none
+              expect_reject "$f" "tag-seqnum"
+
+              # (3) tag HMAC (toff+40, 8B) -> randomize. Rejects.
+              f="$work/hmac.journal"; cp "$src" "$f"
+              dd if=/dev/urandom of="$f" bs=1 seek=$((toff + 40)) count=8 conv=notrunc status=none
+              expect_reject "$f" "tag-hmac-flip"
+
+              # (4) sealed region before the tag (toff-24, 24B) -> randomize. Rejects.
+              f="$work/regionflip.journal"; cp "$src" "$f"
+              off=$(( toff > 24 ? toff - 24 : 0 ))
+              dd if=/dev/urandom of="$f" bs=1 seek=$off count=24 conv=notrunc status=none
+              expect_reject "$f" "sealed-region-flip"
+
+              # (5) tail tag ObjectHeader (toff, 16B) -> zero. Rejects.
+              f="$work/badhdr.journal"; cp "$src" "$f"
+              dd if=/dev/zero of="$f" bs=1 seek=$toff count=16 conv=notrunc status=none
+              expect_reject "$f" "tail-tag-bad-header"
+
+              # (6) truncate 40B off EOF. Rejects.
+              f="$work/truncated.journal"; cp "$src" "$f"
+              truncate -s -40 "$f"
+              expect_reject "$f" "truncation"
+
+              rm -rf "$work"
+              echo "verify-side: all adversarial tamper cases still rejected"
+            '
+          """)
+
   with subtest("Classifier + policy cover all failure branches"):
       # The case table lives in tests/logging/test_scripts/fss-classifier-cases.nix
       # so the same assertions also run VM-free as


### PR DESCRIPTION
## Description of Changes

Relaxes the `journalctl --verify` `SEALED_CONTINUOUS` epoch gate to tolerate the several
same-epoch FSS TAGs journald legitimately writes when a sealed journal is rotated or
restarted repeatedly within one interval — today that trips a permanent
`Epoch sequence not continuous (E vs E)` on untampered archives and aborts the rest of the
file's verification. Adds a per-guest `journal-fss-shutdown-finalize` unit (+ an
`OnClockChange` companion) that seals and archives every open journal and stops journald's
listeners before a clock-step reboot, so no `system.journal` is left `STATE_ONLINE` to be
KEEP+APPEND-reopened with a straddling closing tag. Also fixes two independent false-negative
bugs in FSS activation confirmation (journal storage-location guessing, and a Seal=yes check
run too early after a restart). The verify-side change is a one-line `substituteInPlace`
against systemd's source, pending upstream (tracked in #2243); the host-side counterpart is a
separate `ghaf-sfo-laptop` PR.

Validation (Dell Latitude 7330): 12-correction field-cadence gate — zero new failing
`system@` archives on all 5 FSS VMs — plus the tamper suite (forgeries still rejected), the
FSS re-key regressions, and a forward/backward spot-check on the rebuilt image.

Fixes SSRCSP-8820.

Known follow-up, not caused by this change: `journal-fss-verify` can be left degraded after
two consecutive backward operator re-keys (periodic verify doesn't try retained keys) —
tracked in #2092.

### Type of Change

- [x] Bug fix

## Related Issues / Tickets

Fixes SSRCSP-8820. Related: #2092, #2243 (tracks upstreaming the systemd source change).

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [x] Intel Laptop `x86_64`

<!-- FSS/journald logic is target-independent (no arch-specific code), but only x86
hardware (Dell Latitude 7330) has actually been run against this change. -->

### Installation Method

- [x] Can be updated with `nixos-rebuild ... switch`

<!-- No partitioning/bootloader/kernel/microVM-topology change; a reboot afterward
restarts the FSS guests so the new units + systemd package take effect everywhere. -->

### Test Steps To Verify:

1. Deploy to an FSS-enabled target (`switch` + reboot, or reflash).
2. Force a forward and a backward wall-clock correction through your normal test harness.
3. On each FSS-enabled VM (net/audio/gui/admin/flatpak): `journalctl -u journal-fss-verify`
   shows no new FAILED verdicts; `journalctl --verify --verify-key=<verification-key>
   --file=<archived journal>` passes on the freshly-closed archive.
4. Confirm forgeries are still rejected: bit-flip an archived journal or backdate a seal
   tag — both must still FAIL.
5. `nix build .#checks.x86_64-linux.logging-fss .#checks.x86_64-linux.fss-classifier-unit`
   — both green.

---

_Commits reorganized 2026-09-11 into 3 logical groups per review: activation
false-negatives, the verify-side epoch tolerance, and the guest shutdown/clock-step
finalizer._

_2026-09-11 update: rebased onto current `main` (was 18 commits stale). Per round-2
review, dropped the vendored `.patch` for a one-line `substituteInPlace` in
`base.nix`/the test's systemd override, and trimmed commit/comment verbosity — build
verified (`journal-verify.c` still compiles, patched condition applies cleanly).
Pointing the upstream-tracking TODOs at an actual upstream systemd PR instead of
`#2243` is a deliberately held follow-up, sequenced after this and a related HW
campaign finish; not forgotten._
