### PR TITLE
feat(active-directory): Active Directory Login with GPO-Based Access Control

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -167,6 +167,7 @@ export default defineConfig({
                         "ghaf/dev/guides/extending-targets",
                         "ghaf/dev/guides/downstream-setup",
                         "ghaf/dev/guides/migration",
+                        "ghaf/dev/guides/ad-login",
                       ],
                     },
                     {

--- a/docs/src/content/docs/ghaf/dev/guides/ad-login.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/ad-login.mdx
@@ -1,0 +1,340 @@
+---
+title: "Active Directory Login with GPO Access Control"
+---
+{/*
+SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+*/}
+
+# Active Directory Login with GPO Access Control
+
+This guide covers configuring Ghaf devices for Active Directory (AD) authentication with Group Policy Object (GPO) based access control, so that only authorized AD users can log in.
+
+## Overview
+
+Ghaf uses SSSD (System Security Services Daemon) to integrate with Active Directory. SSSD handles user authentication via Kerberos, identity lookups via LDAP, and access control via GPO evaluation.
+
+### GPO Access Control
+
+SSSD's `ad_gpo_access_control` setting determines how the client handles Windows GPO "logon rights" policies:
+
+| Setting | Behavior |
+|---------|----------|
+| `disabled` | Ignores GPO entirely — any domain user can log in |
+| `permissive` | Evaluates GPO but only logs results, does not block |
+| `enforcing` | Strictly enforces GPO — denies login if user lacks rights |
+
+When set to `enforcing`, SSSD:
+
+1. Queries AD for GPOs linked to the computer object
+2. Parses the "User Rights Assignment" section
+3. Checks for "Allow log on locally" (`SeInteractiveLogonRight`)
+4. Denies login if the user is not allowed (or is explicitly denied)
+
+## Prerequisites
+
+- An Active Directory domain controller with DNS configured
+- Domain Admin or delegated GPO management permissions
+- Test users created in AD (at least one allowed, one denied)
+- Network connectivity from the Ghaf device to the domain controller
+- An explicit `ghaf.users.active-directory.domains` configuration for your environment
+
+## Client-Side Configuration
+
+### Enabling the AD Users Profile
+
+In your target configuration, enable the `ad-users` profile and define at least one AD domain explicitly:
+
+```nix
+ghaf = {
+  users.profile = {
+    homed-user.enable = false;
+    ad-users.enable = true;
+    mutable-users.enable = false;
+  };
+
+  users.active-directory.domains = {
+    "example.com" = {
+      description = "Production Active Directory";
+      authProvider = "krb5";
+      idProvider = "ad";
+      dnsProvider = {
+        name = "dc1.example.com";
+        ipAddress = "192.0.2.10";
+      };
+      ad = {
+        domain = "example.com";
+        controllers = [ "dc1.example.com" ];
+        gpoAccessControl = "enforcing";
+        dyndnsUpdate = false;
+        extraConfig = ''
+          # AD site for GPO discovery
+          ad_site = Default-First-Site-Name
+          # Deny access if no GPO is found (default: false)
+          ad_gpo_implicit_deny = true
+          # Map display manager PAM services to interactive logon rights
+          ad_gpo_map_interactive = +greetd, +cosmic-greeter
+        '';
+      };
+      krb5 = {
+        realm = "EXAMPLE.COM";
+        server = [ "dc1.example.com" ];
+        kpasswd = [ "dc1.example.com" ];
+      };
+      ldap = {
+        uri = [ "ldap://dc1.example.com" ];
+        schema = "ad";
+        idMapping = false;
+        extraConfig = ''
+          ldap_user_name = uid
+          ldap_user_uid_number = uidNumber
+          ldap_user_gid_number = gidNumber
+          ldap_user_home_directory = homeDirectory
+          ldap_user_shell = loginShell
+        '';
+      };
+    };
+  };
+};
+```
+
+**File:** your site-specific target or profile module
+
+Ghaf does not ship a default AD domain. This keeps stock images independent of any particular directory service and forces the domain join target to be configured intentionally.
+
+### SSSD GPO Settings
+
+The AD users module wires SSSD to the domains you define under `ghaf.users.active-directory.domains`. The key GPO-related settings live in each domain's `ad` block:
+
+```nix
+ad = {
+  domain = "example.com";
+  controllers = [ "dc.example.com" ];
+  gpoAccessControl = "enforcing";
+  dyndnsUpdate = false;
+  extraConfig = ''
+    # AD site for GPO discovery
+    ad_site = Default-First-Site-Name
+    # Deny access if no GPO is found (default: false)
+    ad_gpo_implicit_deny = true
+    # Map display manager PAM services to interactive logon rights
+    ad_gpo_map_interactive = +greetd, +cosmic-greeter
+  '';
+};
+```
+
+| Option | Purpose |
+|--------|---------|
+| `gpoAccessControl = "enforcing"` | Enable strict GPO evaluation |
+| `ad_gpo_implicit_deny = true` | Deny login when no applicable GPO is found |
+| `ad_gpo_map_interactive` | Map Ghaf display manager services to the Windows "interactive logon" right |
+
+### PAM Strict Access
+
+The SSSD service module (`modules/common/services/sssd.nix`) enables `sssdStrictAccess` on the interactive PAM entrypoints Ghaf exposes, including the display manager and the standard `login`/`sshd` stacks. This ensures that SSSD account-phase deny decisions (from GPO evaluation) are enforced consistently for graphical, TTY, and SSH logins.
+
+### Additional SSSD GPO Options
+
+These can be added to `extraConfig` if needed:
+
+```nix
+extraConfig = ''
+  # Continue if GPO can't be read (default: false)
+  ad_gpo_ignore_unreadable = true
+  # GPO cache timeout in seconds (default: 5)
+  ad_gpo_cache_timeout = 5
+'';
+```
+
+### Build and Flash
+
+1. Ensure the `ad-users` profile is enabled in your target configuration
+2. Define at least one `ghaf.users.active-directory.domains.<name>` entry for your environment
+3. Build the image for your target device
+4. Flash the image to the device
+
+## AD Server-Side Setup
+
+### Step 1: Open Group Policy Management
+
+On the domain controller, open Group Policy Management:
+
+```
+Server Manager → Tools → Group Policy Management
+```
+
+Or run: `gpmc.msc`
+
+### Step 2: Create a New GPO
+
+1. In the left pane, expand `Forest: example.com` → `Domains` → `example.com`
+2. Right-click on the domain (or a specific OU containing the target computer)
+3. Select **"Create a GPO in this domain, and Link it here..."**
+4. Name it descriptively, e.g. `Ghaf Device Login Restriction`
+5. Click OK
+
+### Step 3: Edit the GPO
+
+1. Right-click the new GPO → **Edit**
+2. Navigate to:
+   ```
+   Computer Configuration
+   └── Policies
+       └── Windows Settings
+           └── Security Settings
+               └── Local Policies
+                   └── User Rights Assignment
+   ```
+
+### Step 4: Configure "Allow log on locally"
+
+1. Double-click **"Allow log on locally"**
+2. Check **"Define these policy settings"**
+3. Click **"Add User or Group..."**
+4. Add the specific user(s) who should be allowed:
+   - Click "Browse..."
+   - Enter the username
+   - Click "Check Names" to verify
+   - Click OK
+5. Consider also adding:
+   - `BUILTIN\Administrators` (if admins should retain access)
+   - `Domain Admins` (for emergency access)
+6. Click OK to save
+
+### Step 5: Link GPO to Target
+
+If targeting specific computers rather than the entire domain:
+
+**Option A: Dedicated OU**
+1. Create a new OU (e.g. `Ghaf Devices`)
+2. Move the computer object to this OU
+3. Link the GPO to this OU only
+
+**Option B: WMI Filter**
+1. Right-click "WMI Filters" → New
+2. Create a filter matching the computer name:
+   ```sql
+   SELECT * FROM Win32_ComputerSystem WHERE Name = '<device-hostname>'
+   ```
+3. Apply the filter to the GPO
+
+**Option C: Security Filtering**
+1. Select the GPO
+2. In "Security Filtering", remove "Authenticated Users"
+3. Add only the specific computer object
+
+### Step 6: Force GPO Update
+
+On the AD server:
+```powershell
+gpupdate /force
+```
+
+### Computer Object OU Placement
+
+GPOs **cannot** be linked to the default `Computers` container in AD. If the Ghaf device's computer object is in the default container, the GPO will not apply. Move the computer object to a proper OU before linking the GPO.
+
+To check:
+1. Open Active Directory Users and Computers (`dsa.msc`)
+2. Right-click the domain → Find → change dropdown to "Computers"
+3. Search for the device hostname
+4. Right-click the computer → Properties → Object tab
+5. Check the Canonical name (OU path)
+
+## Verification and Testing
+
+### On the Device
+
+1. Boot the device — the provisioning TUI appears
+2. Join the domain using admin credentials
+3. Reboot, or restart SSSD:
+   ```bash
+   systemctl restart sssd
+   ```
+
+### Test Cases
+
+| Test | User | Expected Result |
+|------|------|-----------------|
+| 1 | Allowed user (listed in GPO) | Login succeeds |
+| 2 | Denied user (not in GPO) | Login denied |
+| 3 | Domain Admin (if added to GPO) | Login succeeds |
+
+### Expected Behavior
+
+**Allowed user:** Normal login flow, user session starts.
+
+**Denied user:** Login attempt fails with access denied. SSSD logs show GPO denial:
+```
+ad_gpo_access_check: User [denieduser] is not allowed by GPO to log in
+pam_sss: Access denied for user denieduser
+```
+
+## Troubleshooting
+
+### Check SSSD Logs
+
+```bash
+# Follow SSSD logs in real-time
+journalctl -u sssd -f
+
+# Check for GPO-specific messages
+journalctl -u sssd | grep -i gpo
+
+# Check PAM/greeter related messages
+journalctl -b | grep -iE 'pam|sss|greetd|cosmic'
+```
+
+### Clear SSSD Cache
+
+If GPO changes are not reflected:
+```bash
+sss_cache -E
+systemctl restart sssd
+```
+
+### Verify GPO Cache
+
+```bash
+# Check if GPOs are being downloaded
+ls -la /var/lib/sss/gpo_cache/
+
+# View cached GPO files
+find /var/lib/sss/gpo_cache/ -type f -exec cat {} \;
+```
+
+### AD Server Diagnostics
+
+```powershell
+# Check GPO application status
+gpresult /r /scope:computer
+
+# Force GPO update
+gpupdate /force /target:computer
+
+# List all GPOs in domain
+Get-GPO -All | Select-Object DisplayName, GpoStatus
+
+# Generate GPO report
+Get-GPOReport -Name "Ghaf Device Login Restriction" -ReportType HTML -Path "C:\gpo_report.html"
+```
+
+### Common Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| GPO not applied | Computer in default "Computers" container | Move computer to a proper OU, link GPO there |
+| All users denied | "Allow log on locally" empty or misconfigured | Verify GPO settings, add required users |
+| GPO ignored | `gpoAccessControl` still set to `permissive` | Verify configuration, rebuild image |
+| Denied user can still log in | `sssdStrictAccess` not enabled in PAM | Verify SSSD module PAM configuration |
+| Cache stale | Old GPO data cached locally | Run `sss_cache -E && systemctl restart sssd` |
+| DNS issues | Device cannot reach domain controller | Check network and DNS settings |
+| GPO link disabled | Link exists but is not enabled | Right-click GPO link → Link Enabled |
+| Inheritance blocked | Parent OU blocks GPO inheritance | Set GPO to "Enforced" |
+| Security filtering empty | No computers in GPO scope | Add "Authenticated Users" to Security Filtering |
+
+## References
+
+- [SSSD AD GPO Integration](https://sssd.io/docs/ad/ad-gpo-integration.html)
+- [Microsoft GPO User Rights Assignment](https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/user-rights-assignment)
+- [SSSD man page: sssd-ad](https://man.archlinux.org/man/sssd-ad.5)

--- a/docs/src/content/docs/ghaf/dev/guides/ad-login.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/ad-login.mdx
@@ -72,8 +72,10 @@ ghaf = {
           ad_site = Default-First-Site-Name
           # Deny access if no GPO is found (default: false)
           ad_gpo_implicit_deny = true
-          # Map display manager PAM services to interactive logon rights
-          ad_gpo_map_interactive = +greetd, +cosmic-greeter
+          # Map display manager and su PAM services to interactive logon rights
+          ad_gpo_map_interactive = +login, +greetd, +cosmic-greeter, +su, +su-l
+          # Map SSH PAM service to remote interactive logon rights
+          ad_gpo_map_remote_interactive = +sshd
         '';
       };
       krb5 = {
@@ -117,8 +119,10 @@ ad = {
     ad_site = Default-First-Site-Name
     # Deny access if no GPO is found (default: false)
     ad_gpo_implicit_deny = true
-    # Map display manager PAM services to interactive logon rights
-    ad_gpo_map_interactive = +greetd, +cosmic-greeter
+    # Map display manager and su PAM services to interactive logon rights
+    ad_gpo_map_interactive = +login, +greetd, +cosmic-greeter, +su, +su-l
+    # Map SSH PAM service to remote interactive logon rights
+    ad_gpo_map_remote_interactive = +sshd
   '';
 };
 ```
@@ -127,11 +131,23 @@ ad = {
 |--------|---------|
 | `gpoAccessControl = "enforcing"` | Enable strict GPO evaluation |
 | `ad_gpo_implicit_deny = true` | Deny login when no applicable GPO is found |
-| `ad_gpo_map_interactive` | Map Ghaf display manager services to the Windows "interactive logon" right |
+| `ad_gpo_map_interactive` | Map Ghaf display manager, login, and su services to the Windows "interactive logon" right |
+| `ad_gpo_map_remote_interactive` | Map SSH PAM service to the Windows "remote interactive logon" right |
 
 ### PAM Strict Access
 
-The SSSD service module (`modules/common/services/sssd.nix`) enables `sssdStrictAccess` on the interactive PAM entrypoints Ghaf exposes, including the display manager and the standard `login`/`sshd` stacks. This ensures that SSSD account-phase deny decisions (from GPO evaluation) are enforced consistently for graphical, TTY, and SSH logins.
+The SSSD service module (`modules/common/services/sssd.nix`) enables `sssdStrictAccess` on the interactive PAM entrypoints Ghaf exposes, including the display manager, `su`/`su-l`, and the standard `login`/`sshd` stacks. This ensures that SSSD account-phase deny decisions (from GPO evaluation) are enforced consistently for graphical, TTY, switch-user, and SSH logins.
+
+### Sudo Privileges for AD Groups
+
+To grant sudo privileges to specific Active Directory administrative groups, add the group rule to `security.sudo.extraConfig`:
+
+```nix
+security.sudo.extraConfig = ''
+  %<ad-group-name> ALL=(ALL) ALL
+  %<ad-group-name>@<domain> ALL=(ALL) ALL
+'';
+```
 
 ### Additional SSSD GPO Options
 
@@ -247,7 +263,7 @@ To check:
 
 1. Boot the device — the provisioning TUI appears
 2. Join the domain using admin credentials
-3. Reboot, or restart SSSD:
+3. SSSD starts automatically upon domain enrollment (triggered by `systemd.paths.sssd-keytab` when `/etc/krb5.keytab` is created). If needed, you can also restart it manually:
    ```bash
    systemctl restart sssd
    ```

--- a/docs/src/content/docs/ghaf/dev/guides/index.mdx
+++ b/docs/src/content/docs/ghaf/dev/guides/index.mdx
@@ -26,6 +26,12 @@ Welcome to the Ghaf Framework developer guides. These guides cover common develo
 | [Downstream Setup](/ghaf/dev/guides/downstream-setup) | Setting up a downstream project |
 | [Migration Guide](/ghaf/dev/guides/migration) | Migrating from legacy patterns |
 
+## Active Directory
+
+| Guide | Description |
+|-------|-------------|
+| [AD Login with GPO](/ghaf/dev/guides/ad-login) | Configure AD authentication and GPO-based access control |
+
 ## Quick Links
 
 ### For Ghaf Core Developers

--- a/modules/common/services/sssd.nix
+++ b/modules/common/services/sssd.nix
@@ -27,6 +27,42 @@ let
     lib.attrValues cfg.domains
   );
   hasKerberosRealm = lib.any (d: d.krb5.realm != null) (lib.attrValues cfg.domains);
+  strictAccessPamServices = lib.unique (
+    lib.filter (serviceName: serviceName != null) (
+      [
+        cfg.pam.displayManagerService
+        "cosmic-greeter"
+        "login"
+      ]
+      ++ lib.optional config.services.openssh.enable "sshd"
+    )
+  );
+  mkStrictAccessPamService =
+    serviceName:
+    {
+      makeHomeDir = true;
+      # Enforce SSSD account decisions (e.g. AD GPO deny) on every interactive login path.
+      sssdStrictAccess = lib.mkDefault true;
+    }
+    // optionalAttrs (serviceName == cfg.pam.displayManagerService) {
+      rules = {
+        auth = {
+          # Disable ccreds pam modules to avoid conflicts with SSSD
+          ccreds-store.enable = lib.mkForce false;
+          ccreds-validate.enable = lib.mkForce false;
+
+          # Allow both unix and sss auth
+          unix.control = lib.mkForce "sufficient";
+          sss.control = lib.mkForce "sufficient";
+        };
+      };
+
+      # Disable Kerberos pam modules
+      rules.auth.krb5.enable = lib.mkForce false;
+      rules.account.krb5.enable = lib.mkForce false;
+      rules.password.krb5.enable = lib.mkForce false;
+      rules.session.krb5.enable = lib.mkForce false;
+    };
 
   # SSSD configuration template
   sssdConfig = ''
@@ -334,32 +370,21 @@ in
       })
     ];
 
-    # PAM configuration for the service that actually authenticates domain users.
-    # See ghaf.services.sssd.pam.displayManagerService: this is `login` by
-    # default, because greetd and the other display managers now substack it
-    # rather than carrying their own rule set.
-    security.pam.services = optionalAttrs (cfg.pam.displayManagerService != null) {
-      "${cfg.pam.displayManagerService}" = {
-        makeHomeDir = true;
-        rules = {
-          auth = {
-            # Disable ccreds pam modules to avoid conflicts with SSSD
-            ccreds-store.enable = lib.mkForce false;
-            ccreds-validate.enable = lib.mkForce false;
-
-            # Allow both unix and sss auth
-            unix.control = lib.mkForce "sufficient";
-            sss.control = lib.mkForce "sufficient";
-          };
-        };
-
-        # Disable Kerberos pam modules
-        rules.auth.krb5.enable = lib.mkForce false;
-        rules.account.krb5.enable = lib.mkForce false;
-        rules.password.krb5.enable = lib.mkForce false;
-        rules.session.krb5.enable = lib.mkForce false;
-      };
-    };
+    # PAM configuration for all interactive login entrypoints.
+    #
+    # The full rule set (unix/sss sufficient, ccreds and krb5 disabled) is only
+    # applied to ghaf.services.sssd.pam.displayManagerService, which defaults to
+    # `login`: greetd and the other display managers now set
+    # `useDefaultRules = false` and reduce their stacks to `substack login`, so
+    # they carry no rules to override and forcing rules there would abort
+    # evaluation. The remaining services only get `sssdStrictAccess`, so that an
+    # SSSD account-phase deny (e.g. an AD GPO deny) fails the login on every
+    # entrypoint that authenticates domain users.
+    security.pam.services = lib.listToAttrs (
+      map (
+        serviceName: lib.nameValuePair serviceName (mkStrictAccessPamService serviceName)
+      ) strictAccessPamServices
+    );
 
     # Kerberos configuration '/etc/krb5.conf' auto-populated from domain settings
     security.krb5 = optionalAttrs hasKerberosRealm {

--- a/modules/common/services/sssd.nix
+++ b/modules/common/services/sssd.nix
@@ -33,6 +33,8 @@ let
         cfg.pam.displayManagerService
         "cosmic-greeter"
         "login"
+        "su"
+        "su-l"
       ]
       ++ lib.optional config.services.openssh.enable "sshd"
     )
@@ -320,8 +322,21 @@ in
       config = sssdConfig;
     };
 
+    # Watch for the Kerberos keytab creation on first boot and start SSSD automatically
+    systemd.paths.sssd-keytab = lib.mkIf hasKerberosRealm {
+      description = "Watch Kerberos keytab and trigger SSSD on domain enrollment";
+      wantedBy = [ "multi-user.target" ];
+      pathConfig = {
+        PathChanged = "/etc/krb5.keytab";
+        Unit = "sssd.service";
+      };
+    };
+
     # SSSD service dependencies
     systemd.services.sssd = {
+      unitConfig = lib.mkIf hasKerberosRealm {
+        ConditionPathExists = "/etc/krb5.keytab";
+      };
       before = [
         "greetd.service"
         "cosmic-greeter.service"

--- a/modules/common/users/ad-users.nix
+++ b/modules/common/users/ad-users.nix
@@ -9,6 +9,7 @@ let
   cfg = config.ghaf.users.adUsers;
   inherit (lib)
     mkEnableOption
+    mkIf
     ;
 in
 {
@@ -18,51 +19,22 @@ in
     enable = mkEnableOption "Active Directory user configuration";
   };
 
-  config = {
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.ghaf.users.active-directory.domains != { };
+        message = ''
+          The Active Directory users profile requires at least one
+          ghaf.users.active-directory.domains entry.
+        '';
+      }
+    ];
 
     # Enable SSSD for Active Directory integration
     ghaf.services.sssd = {
-      inherit (cfg) enable;
+      enable = true;
       debugLevel = 6;
       inherit (config.ghaf.users.active-directory) domains;
-    };
-
-    # TODO: Move this to profile config
-    # Active Directory domain test configuration
-    ghaf.users.active-directory.domains = {
-      "ghaf-test.com" = {
-        description = "Active Directory test domain";
-        authProvider = "krb5";
-        idProvider = "ad";
-        dnsProvider = {
-          name = "vm-ghaf-dev-dc.ghaf-test.com";
-          ipAddress = "10.52.33.4";
-        };
-        ad = {
-          domain = "ghaf-test.com";
-          controllers = [ "vm-ghaf-dev-dc.ghaf-test.com" ];
-          gpoAccessControl = "permissive";
-          dyndnsUpdate = false;
-        };
-        krb5 = {
-          realm = "GHAF-TEST.COM";
-          server = [ "vm-ghaf-dev-dc.ghaf-test.com" ];
-          kpasswd = [ "vm-ghaf-dev-dc.ghaf-test.com" ];
-        };
-        ldap = {
-          uri = [ "ldap://vm-ghaf-dev-dc.ghaf-test.com" ];
-          schema = "ad";
-          idMapping = false;
-          extraConfig = ''
-            # RFC2307 User and group attribute mappings
-            ldap_user_name = uid
-            ldap_user_uid_number = uidNumber
-            ldap_user_gid_number = gidNumber
-            ldap_user_home_directory = homeDirectory
-            ldap_user_shell = loginShell
-          '';
-        };
-      };
     };
   };
 }

--- a/modules/common/users/ad-users.nix
+++ b/modules/common/users/ad-users.nix
@@ -36,5 +36,6 @@ in
       debugLevel = 6;
       inherit (config.ghaf.users.active-directory) domains;
     };
+
   };
 }

--- a/modules/desktop/guivm/boot-ui.nix
+++ b/modules/desktop/guivm/boot-ui.nix
@@ -16,19 +16,30 @@
   ...
 }:
 let
-  # Wait for UID>=1000 session to become active with valid seat
+  # Wait for a real non-root user session, not the display-manager greeter.
   wait-for-session = pkgs.writeShellApplication {
     name = "wait-for-session";
     runtimeInputs = [
+      pkgs.coreutils
       pkgs.systemd
       pkgs.jq
     ];
     text = ''
+      set -euo pipefail
+
       echo "Waiting for user to login..."
-      USER_ID=1
-      while [ "$USER_ID" -lt 1000 ]; do
-        tmp_id=$(loginctl list-sessions --json=short | jq -e '.[] | select(.seat != null) | .uid') || true
-        [[ "$tmp_id" =~ ^[0-9]+$ ]] && USER_ID="$tmp_id" || USER_ID=1
+      USER_ID=0
+      while [ "$USER_ID" -eq 0 ]; do
+        active_session="$(loginctl show-seat seat0 -p ActiveSession --value 2>/dev/null || true)"
+        tmp_id="$(loginctl show-session "$active_session" -p User --value 2>/dev/null || true)"
+        seat="$(loginctl show-session "$active_session" -p Seat --value 2>/dev/null || true)"
+        session_class="$(loginctl show-session "$active_session" -p Class --value 2>/dev/null || true)"
+
+        if [[ "$tmp_id" =~ ^[0-9]+$ ]] && [ "$tmp_id" -gt 0 ] && [ -n "$seat" ] && [ "$session_class" = "user" ]; then
+          USER_ID="$tmp_id"
+        else
+          USER_ID=0
+        fi
         sleep 1
       done
       echo "User with ID=$USER_ID is now active"

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -31,6 +31,28 @@ let
     else
       config.ghaf.users;
   hasLoginUser = userConfig.homedUser.enable || userConfig.adUsers.enable;
+  loginUserHasDynamicUid = userConfig.adUsers.enable;
+  loginUserUid = toString (userConfig.homedUser.uid or 1000);
+  loginUserSessionDir = "/run/ghaf/session";
+  loginUserUidFile = "${loginUserSessionDir}/gui-vm-user.uid";
+  sharedVmDirectoryPaths = [
+    "/persist/storagevm/shared/shares"
+  ]
+  ++ map (n: "/persist/storagevm/shared/shares/Unsafe ${n} share/") cfg.sharedVmDirectory.vms;
+  xdgRuleFor =
+    xdgPath:
+    if loginUserHasDynamicUid then
+      # AD users keep their directory service UID, so the handoff path cannot be pre-owned by a fixed local user.
+      "D ${xdgPath} 0733 root root -"
+    else
+      "D ${xdgPath} 0700 ${loginUserUid} users -";
+  sharedDirRuleFor =
+    path:
+    if loginUserHasDynamicUid then
+      # AD logins need host directories that AppVMs can access before the active GUI UID is known.
+      "d ${path} 0770 root users"
+    else
+      "d ${path} 0760 ${loginUserUid} users";
   hasAudioVmAcpiPath =
     (lib.hasAttr "audio-vm" config.microvm.vms)
     && (config.ghaf.hardware.definition.audio.acpiPath != null);
@@ -232,12 +254,11 @@ in
               if xdgPathsAttempt.success then xdgPathsAttempt.value else [ ]
             ) vmsWithXdg
           );
-          xdgRules = map (
-            xdgPath: "D ${xdgPath} 0700 ${toString config.ghaf.users.homedUser.uid} users -"
-          ) xdgDirs;
+          xdgRules = map xdgRuleFor xdgDirs;
         in
         [
           "d /persist/common 0755 root root -"
+          "d /persist/common/ghaf 0755 root root -"
           "d /persist/sysupdate 0755 root root -"
           "d /persist/storagevm 0755 root root -"
           "d /persist/storagevm/img 0700 microvm kvm -"
@@ -329,15 +350,88 @@ in
       systemd.tmpfiles.rules =
         let
           vmDirs = map (
-            n:
-            "d /persist/storagevm/shared/shares/Unsafe\\x20${n}\\x20share/ 0760 ${toString config.ghaf.users.homedUser.uid} users"
+            n: sharedDirRuleFor "/persist/storagevm/shared/shares/Unsafe\\x20${n}\\x20share/"
           ) cfg.sharedVmDirectory.vms;
         in
         [
           "d /persist/storagevm/shared 0755 root root"
-          "d /persist/storagevm/shared/shares 0760 ${toString config.ghaf.users.homedUser.uid} users"
+          (sharedDirRuleFor "/persist/storagevm/shared/shares")
         ]
         ++ vmDirs;
+    })
+    (mkIf (cfg.sharedVmDirectory.enable && loginUserHasDynamicUid) {
+      systemd.tmpfiles.rules = [
+        "d /run/ghaf 0755 root root -"
+        "d /run/ghaf/session 0750 root root -"
+      ];
+
+      systemd.services."shared-vm-directory-acl" =
+        let
+          aclSetupScript = pkgs.writeShellApplication {
+            name = "shared-vm-directory-acl";
+            runtimeInputs = with pkgs; [
+              acl
+              coreutils
+              findutils
+            ];
+            text = ''
+              set -euo pipefail
+
+              uid_file=${lib.escapeShellArg loginUserUidFile}
+              current_uid=""
+
+              if [ -r "$uid_file" ]; then
+                current_uid="$(tr -d '[:space:]' < "$uid_file")"
+                case "$current_uid" in
+                  ""|*[!0-9]*)
+                    echo "Ignoring invalid GUI VM login UID: '$current_uid'" >&2
+                    current_uid=""
+                    ;;
+                esac
+              fi
+
+              apply_shared_acl() {
+                local path="$1"
+
+                install -d -m 0770 -o root -g users "$path"
+                chmod 0770 "$path"
+                chgrp users "$path"
+                setfacl -Rb "$path"
+                setfacl -R -m "g:users:rwX,o::---" "$path"
+                find "$path" -type d -exec setfacl -m "g:users:rwx,o::---,d:g:users:rwx,d:o::---" '{}' +
+
+                if [ -n "$current_uid" ]; then
+                  setfacl -R -m "u:$current_uid:rwX,g:users:rwX,o::---" "$path"
+                  find "$path" -type d -exec setfacl -m "u:$current_uid:rwx,g:users:rwx,o::---,d:u:$current_uid:rwx,d:g:users:rwx,d:o::---" '{}' +
+                fi
+              }
+
+              for path in ${lib.concatMapStringsSep " " lib.escapeShellArg sharedVmDirectoryPaths}; do
+                apply_shared_acl "$path"
+              done
+            '';
+          };
+        in
+        {
+          enable = true;
+          description = "Apply shared folder ACLs for the active GUI login";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "local-fs.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = lib.getExe aclSetupScript;
+          };
+        };
+
+      systemd.paths."shared-vm-directory-acl" = {
+        description = "Watch GUI login UID handoff and refresh shared folder ACLs";
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "shared-vm-directory-acl.service" ];
+        pathConfig = {
+          PathChanged = loginUserSessionDir;
+          Unit = "shared-vm-directory-acl.service";
+        };
+      };
     })
     (mkIf
       (

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -40,6 +40,17 @@
 }:
 let
   vmName = "gui-vm";
+  guiSessionShareEnabled = hostConfig.users.profile.ad-users.enable or false;
+  guiSessionUidFile = "/run/ghaf/session/gui-vm-user.uid";
+  activeDirectoryDomains = lib.mapAttrs (
+    _: domain:
+    domain
+    // {
+      # This is a read-only option in the AD domain module, so forwarding
+      # evaluated host config verbatim would redefine the module default.
+      ldap = removeAttrs (domain.ldap or { }) [ "enableSasl" ];
+    }
+  ) (hostConfig.users.active-directory.domains or { });
   fprintEnabled = lib.ghaf.features.isEnabledFor globalConfig "fprint" vmName;
   yubikeyEnabled = lib.ghaf.features.isEnabledFor globalConfig "yubikey" vmName;
   brightnessEnabled = lib.ghaf.features.isEnabledFor globalConfig "brightness" vmName;
@@ -70,6 +81,50 @@ let
       }";
     }
   ) virtualApps;
+
+  sync-active-gui-user = pkgs.writeShellApplication {
+    name = "sync-active-gui-user";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.systemd
+    ];
+    text = ''
+      set -euo pipefail
+
+      uid_file=${lib.escapeShellArg guiSessionUidFile}
+      uid_dir="$(dirname "$uid_file")"
+      tmp_file=""
+
+      cleanup() {
+        if [ -n "$tmp_file" ]; then
+          rm -f "$tmp_file"
+        fi
+      }
+
+      clear_uid_file() {
+        rm -f "$uid_file"
+      }
+
+      trap cleanup EXIT
+
+      active_session="$(loginctl show-seat seat0 -p ActiveSession --value 2>/dev/null || true)"
+      user_id="$(loginctl show-session "$active_session" -p User --value 2>/dev/null || true)"
+      seat="$(loginctl show-session "$active_session" -p Seat --value 2>/dev/null || true)"
+      session_class="$(loginctl show-session "$active_session" -p Class --value 2>/dev/null || true)"
+
+      if [[ ! "$user_id" =~ ^[0-9]+$ ]] || [ "$user_id" -eq 0 ] || [ -z "$seat" ] || [ "$session_class" != "user" ]; then
+        clear_uid_file
+        exit 0
+      fi
+
+      install -d -m 0750 "$uid_dir"
+      tmp_file="$(mktemp "$uid_dir/.gui-vm-user.uid.XXXXXX")"
+      printf '%s\n' "$user_id" > "$tmp_file"
+      chmod 0640 "$tmp_file"
+      mv -f "$tmp_file" "$uid_file"
+      tmp_file=""
+    '';
+  };
 in
 {
   _file = ./guivm-base.nix;
@@ -109,6 +164,7 @@ in
       profile = hostConfig.users.profile or { };
       admin = hostConfig.users.admin or { };
       managed = hostConfig.users.managed or [ ];
+      active-directory.domains = activeDirectoryDomains;
       adUsers = {
         enable = hostConfig.users.profile.ad-users.enable or false;
       };
@@ -326,6 +382,40 @@ in
 
   systemd = {
     packages = [ pkgs.blueman ];
+    services."sync-active-gui-user" = lib.mkIf guiSessionShareEnabled {
+      description = "Export the active GUI login UID to the host runtime share";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "local-fs.target"
+        "systemd-logind.service"
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = lib.getExe sync-active-gui-user;
+      };
+    };
+
+    paths."sync-active-gui-user" = lib.mkIf guiSessionShareEnabled {
+      description = "Watch GUI login state changes and refresh the exported login UID";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "sync-active-gui-user.service" ];
+      pathConfig = {
+        PathChanged = [
+          "/run/systemd/seats/seat0"
+          "/run/systemd/sessions"
+        ];
+        Unit = "sync-active-gui-user.service";
+      };
+    };
+  };
+
+  fileSystems = lib.optionalAttrs guiSessionShareEnabled {
+    "/run/ghaf/session".options = [
+      "rw"
+      "nodev"
+      "nosuid"
+      "noexec"
+    ];
   };
 
   environment = {
@@ -394,6 +484,14 @@ in
         tag = "ghaf-common";
         source = "/persist/common";
         mountPoint = "/etc/common";
+        proto = "virtiofs";
+      }
+    ]
+    ++ lib.optionals guiSessionShareEnabled [
+      {
+        tag = "ghaf-session";
+        source = "/run/ghaf/session";
+        mountPoint = "/run/ghaf/session";
         proto = "virtiofs";
       }
     ];

--- a/modules/reference/profiles/mvp-user-trial.nix
+++ b/modules/reference/profiles/mvp-user-trial.nix
@@ -7,6 +7,14 @@
 }:
 let
   cfg = config.ghaf.reference.profiles.mvp-user-trial;
+  # Active Directory configuration
+  enableAD = false;
+  adDomain = "ghaf-test.com";
+  # AD Domain controller URL
+  dcUrl = "vm-ghaf-dev-dc.ghaf-test.com";
+  # AD Domain controller IP address
+  dcIp = "10.52.33.4";
+
 in
 {
   _file = ./mvp-user-trial.nix;
@@ -20,9 +28,48 @@ in
 
       # Setup user profiles
       users.profile = {
-        homed-user.enable = true;
-        ad-users.enable = false;
+        homed-user.enable = !enableAD;
+        ad-users.enable = enableAD;
         mutable-users.enable = false;
+      };
+
+      users.active-directory.domains = lib.mkIf enableAD {
+        ${adDomain} = {
+          description = "Active Directory test domain";
+          authProvider = "krb5";
+          idProvider = "ad";
+          dnsProvider = {
+            name = dcUrl;
+            ipAddress = dcIp;
+          };
+          ad = {
+            domain = adDomain;
+            controllers = [ dcUrl ];
+            gpoAccessControl = "enforcing";
+            dyndnsUpdate = false;
+            extraConfig = ''
+              # AD site for GPO discovery
+              ad_site = Default-First-Site-Name
+              # Deny access if no GPO is found (default: false)
+              ad_gpo_implicit_deny = true
+              # Map display manager and su PAM services to interactive logon rights
+              ad_gpo_map_interactive = +login, +greetd, +cosmic-greeter, +su, +su-l
+              # Map SSH PAM service to remote interactive logon rights
+              ad_gpo_map_remote_interactive = +sshd
+            '';
+          };
+          krb5 = {
+            realm = lib.toUpper adDomain;
+            server = [ dcUrl ];
+            kpasswd = [ dcUrl ];
+          };
+          ldap = {
+            uri = [ "ldap://${dcUrl}" ];
+            schema = "ad";
+            idMapping = true;
+          };
+        };
+
       };
 
       virtualization = {
@@ -217,6 +264,13 @@ in
         # Enable kill switch
         kill-switch.enable = true;
       };
+    };
+    # Grant sudo privileges to the ghaf-admins AD group
+    security.sudo = lib.mkIf enableAD {
+      extraConfig = ''
+        %ghaf-admins ALL=(ALL) ALL
+        %ghaf-admins@ghaf-test.com ALL=(ALL) ALL
+      '';
     };
   };
 }


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

> **Note**: This is a unified PR that incorporates **#1864** with verified end-to-end functionality.
## Description of Changes
Enable Active Directory (AD) and SSSD GPO-based access control so that only users explicitly granted logon rights via Group Policy can log into Ghaf devices through graphical display managers (`greetd`, `cosmic-greeter`), TTY (`login`), SSH (`sshd`), and switch user (`su`/`su-l`).
## Changes
- **Automatic SSSD Startup**: Added `systemd.paths.sssd-keytab` path watcher to automatically trigger `sssd.service` as soon as `/etc/krb5.keytab` is created during domain enrollment, conditioning SSSD startup on keytab presence.
- **PAM Strict Access**: Enabled `sssdStrictAccess` across interactive PAM services (`greetd`, `cosmic-greeter`, `login`, `su`, `su-l`, and `sshd`) to strictly enforce SSSD account-phase access decisions (from GPO evaluation) at login and user-switching time.
- **GPO Logon Rights Mapping**:
  - Mapped display manager, login, and su services to interactive logon rights (`ad_gpo_map_interactive = +login, +greetd, +cosmic-greeter, +su, +su-l`).
  - Mapped SSH to remote interactive logon rights (`ad_gpo_map_remote_interactive = +sshd`).
  - Configured GPO enforcement (`gpoAccessControl = "enforcing"`, `ad_gpo_implicit_deny = true`, and `ad_site = Default-First-Site-Name`).
- **Trial Target Profile (`mvp-user-trial`)**: Switched from `homed-user` to `ad-users` profile, configured domain controller settings, and granted sudo privileges to the `%ghaf-admins` AD group.
- **Documentation**: Updated the developer guide (`docs/src/content/docs/ghaf/dev/guides/ad-login.mdx`) with the expanded PAM/GPO mappings, keytab auto-trigger setup, and sudo configuration instructions.
## AD Server-Side Setup
High-level setup performed on the domain controller:
1. Created Group Policy Object (GPO) for Ghaf device login restrictions.
2. Moved the device under test from the default "Computers" container to an OU linked with the GPO.
3. Created two AD groups: `ghaf-users` and `ghaf-admins`.
4. Created two test users:
   - `ghaf-sa-user` (member of `ghaf-admins`)
   - `ghaf-sd-user` (member of `ghaf-users`)
5. Configured User Rights Assignment in GPO:
   - **"Allow log on locally"**: Allowed both `ghaf-sa-user` and `ghaf-sd-user`.
   - **"Allow log on through Remote Desktop Services" / Remote Interactive**: Allowed `ghaf-sa-user` only.
## Verification and Results
- **SSSD Automatic Startup**: Verified `sssd.service` automatically starts upon domain enrollment when `/etc/krb5.keytab` is created without requiring a manual reboot.
- **Local Login**: Verified both `ghaf-sa-user` and `ghaf-sd-user` can successfully log in locally via graphical greeter (`greetd`, `cosmic-greeter`) and console TTY.
- **Remote SSH Login**:
  - Verified `ghaf-sa-user` successfully logs in remotely via SSH.
  - Verified `ghaf-sd-user` is denied remote SSH access as enforced by GPO policy.
- **Client-Side Sudo Privileges**: Verified `ghaf-sa-user` (member of `%ghaf-admins`) is granted sudo access on the client, whereas non-admin users cannot execute sudo commands.

### Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [x] Intel Laptop (low mem) `x86_64`

### Installation Method

- [x] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Enable AD in 
`mvp-user-trial.nix`
 by setting `enableAD = true` with the target AD server configuration.
2. Build and flash image
3. Obtain AD domain enrollment credentials along with the admin (ghaf-sa-user) and non-admin (ghaf-sd-user) user accounts.
4. Join the AD domain during initial device provisioning.
5. Ask AD admin to enroll the device under test in the GPO OU.
6. Verify local login succeeds for both admin and non-admin users.
7. Verify sudo privilege escalation fails for the non-admin user.
8. Verify sudo privilege escalation succeeds for the admin user (ghaf-admins).
9. Verify remote SSH access to gui-vm is denied for the non-admin user via GPO policy.
10. Verify remote SSH access to gui-vm is permitted for the admin user.
