### PR TITLE
refactor(orin): Use lib.getExe for the flash script output name

### DIFF
--- a/targets/nvidia-jetson-orin/flake-module.nix
+++ b/targets/nvidia-jetson-orin/flake-module.nix
@@ -502,12 +502,6 @@ let
           )
         ];
       };
-      # Read the board name off a fixpoint that is already forced for `noSB`
-      # rather than forcing `t.hostConfiguration` as a third one. The added
-      # modules do not touch `som`/`carrierBoard`, so the string is identical by
-      # construction. Each extra fixpoint is a full re-evaluation -- see
-      # `extendModules` in nixpkgs lib/modules.nix, which shares nothing.
-      innerName = noSBCfg.config.hardware.nvidia-jetpack.name;
       noSB = noSBCfg.pkgs.nvidia-jetpack.signedFlashScript;
       # Targets that already enable secureboot unconditionally get the identical
       # derivation back from `mkForce true`, so skip the second fixpoint entirely.
@@ -574,9 +568,9 @@ let
           esac
         done
         if [ "$sb" = 1 ]; then
-          exec ${withSB}/bin/flash-signed-${innerName} "''${args[@]}"
+          exec ${lib.getExe withSB} "''${args[@]}"
         else
-          exec ${noSB}/bin/flash-signed-${innerName} "''${args[@]}"
+          exec ${lib.getExe noSB} "''${args[@]}"
         fi
       '';
     };


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

`signedFlashScript` uses `writeShellApplication`, so `meta.mainProgram` is automatically set to the filename of the output script. We can use `lib.getExe` to directly get the path to the executable.

`innerName` is therefore not needed since `config.hardware.nvidia-jetpack.name` is already read by the `signedFlashScript` definition.

This change also allows to easily switch to a different flash script variant (ex: legacyFlashScript).


### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Update
- [x] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

N/A
<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets

- [x] Orin AGX `aarch64`
- [x] Orin NX `aarch64`
- [ ] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [ ] Can be updated with `nixos-rebuild ... switch`
- [x] Other: can be verified without building an image

### Test Steps To Verify:

This is a refactor of the flash target for all Orin profiles. It should not cause any visible changes in the target output.

To verify the absence of side effects:
1. Build the flash script package for any Orin target. Note the derivation output hash
```
$ git checkout main
$ nix build --print-out-paths .#nvidia-jetson-orin-agx64-debug-from-x86_64-flash-script
/nix/store/an3v4lmvsjsfn4g2nidw5zf4c6wvlvcm-flash-ghaf-host
```
2. Apply this PR's commit
```
$ git checkout refactor/flash-script-exe
```
4. Rebuild the flash target
```
$ nix build --print-out-paths .#nvidia-jetson-orin-agx64-debug-from-x86_64-flash-script
/nix/store/an3v4lmvsjsfn4g2nidw5zf4c6wvlvcm-flash-ghaf-host
```
-> There should be no changes in the result, i.e. the output hash remains the same. 
This must be true for all NVIDIA Orin targets.