### PR TITLE
fix(logging): stop piping into an early-exiting grep under pipefail

### DIFF
--- a/modules/common/logging/fss-verify-classifier.sh
+++ b/modules/common/logging/fss-verify-classifier.sh
@@ -116,7 +116,7 @@ fss_append_tag() {
 
   if [ -z "$current" ]; then
     printf '%s' "$tag"
-  elif printf '%s\n' ",$current," | grep -Fq ",$tag,"; then
+  elif grep -Fq -- ",$tag," <<<",$current,"; then
     printf '%s' "$current"
   else
     printf '%s,%s' "$current" "$tag"
@@ -140,7 +140,7 @@ fss_append_unique_line() {
 
   if [ -z "$line" ]; then
     printf '%s' "$current"
-  elif printf '%s\n' "$current" | grep -Fxq "$line"; then
+  elif grep -Fxq -- "$line" <<<"$current"; then
     printf '%s' "$current"
   else
     fss_append_line "$current" "$line"
@@ -178,7 +178,7 @@ fss_unique_fail_paths_from_output() {
     FAIL:\ *)
       failure_path="${line#FAIL: }"
       failure_path="${failure_path%% *}"
-      if [ -n "$failure_path" ] && ! printf '%s\n' "$unique" | grep -Fxq "$failure_path"; then
+      if [ -n "$failure_path" ] && ! grep -Fxq -- "$failure_path" <<<"$unique"; then
         unique=$(fss_append_line "$unique" "$failure_path")
       fi
       ;;
@@ -310,15 +310,16 @@ fss_clock_jump_stamp_state() {
 # that have moved since. systemd emits six variants of this
 # (journal-verify.c:1266-1315). On the LIVE journal it is an artefact of the
 # file being open for append, not evidence of tampering.
+# Here-string avoids a pipefail/SIGPIPE misreport from grep -q's early exit.
 fss_output_has_counter_mismatch() {
-  printf '%s\n' "$1" |
-    grep -qE '(Object|Entry|Data|Field|Tag|Entry array) number mismatch \([0-9]+ != [0-9]+\)'
+  grep -qE '(Object|Entry|Data|Field|Tag|Entry array) number mismatch \([0-9]+ != [0-9]+\)' <<<"$1"
 }
 
 # Signatures that mean the content itself is wrong. Never retried away.
+# Here-string: a SIGPIPE-confused false negative here would let tampered
+# content through instead of failing closed.
 fss_output_has_tamper_signature() {
-  printf '%s\n' "$1" |
-    grep -qE 'Tag failed verification|Hash value mismatch|Older entry after newer tag|Epoch sequence|realtime timestamp out of synchronization'
+  grep -qE 'Tag failed verification|Hash value mismatch|Older entry after newer tag|Epoch sequence|realtime timestamp out of synchronization' <<<"$1"
 }
 
 # Whether an active-journal failure is worth re-verifying rather than believing
@@ -335,7 +336,7 @@ fss_active_failure_retryable() {
 fss_path_list_contains() {
   local path_list="$1"
   local needle="$2"
-  [ -n "$needle" ] && printf '%s\n' "$path_list" | grep -Fxq "$needle"
+  [ -n "$needle" ] && grep -Fxq -- "$needle" <<<"$path_list"
 }
 
 fss_merge_path_lists() {
@@ -381,7 +382,7 @@ fss_read_recorded_archive_list() {
 FSS_RECEIPT_SCHEMA_VERSION="v1"
 
 fss_valid_sha256() {
-  printf '%s' "$1" | grep -Eq '^[0-9a-f]{64}$'
+  grep -Eq '^[0-9a-f]{64}$' <<<"$1"
 }
 
 fss_current_boot_id() {

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -971,8 +971,9 @@ let
         receipted=0
         while IFS= read -r archive_path || [ -n "$archive_path" ]; do
           [ -n "$archive_path" ] || continue
+          # Here-string avoids a pipefail/SIGPIPE misreport from grep -q's early exit.
           if ! grep -Fxq "$archive_path" "$before_file" 2>/dev/null \
-            || printf '%s\n' "$failing_paths" | grep -Fxq "$archive_path"; then
+            || grep -Fxq -- "$archive_path" <<<"$failing_paths"; then
             record_recovery_receipt "$archive_path" "clock-jump-rekey"
             receipted=$(( receipted + 1 ))
           fi


### PR DESCRIPTION
## Description of Changes

`printf ... | grep -q ...` races under `set -o pipefail` (injected by
`pkgs.writeShellApplication`): `grep -q` exits as soon as it matches, and if
`printf` hasn't finished writing, it gets SIGPIPE'd. pipefail then reports the
pipeline's exit status from `printf`'s SIGPIPE, not grep's real result, so an
`if ... | grep -q ...` can silently take the wrong branch.

Root-caused via a real hardware occurrence on a separate branch: a literal
`printf: Broken pipe` line in production logs at the exact moment a de-dup
check misfired. These 8 instances predate that branch and are unrelated to
any open PR or feature work -- pure pre-existing correctness fix in shared
FSS library code (`fss-verify-classifier.sh`, `fss.nix`).

Found via two rounds of review, not one: an initial sweep caught 6 instances;
a second, more careful pass over the same file found 2 more, including
`fss_output_has_tamper_signature` -- there, a raced false negative would let
tampered journal content through instead of failing closed. Flagging the
two-pass history rather than claiming the first sweep was complete.

Fix: a here-string (`<<<`) instead of a pipe. bash fully materialises the
data before grep starts reading, so there's no live producer process left to
receive a SIGPIPE. Matching semantics are unchanged (verified per-instance:
`-x`/`-F`/`-E` behavior, trailing-newline handling, multi-line input).

Verified empirically, not just by code review: reproduced deterministically
on real hardware by widening the race window, 100/100 failures before the
fix, 0/100 after.

Not touched: `fss_resolve_live_journal_dir`'s `... | grep -m1 ...` -- its
result comes from what grep printed, already wrapped in `|| true`, so a
pipefail-confused exit status can't corrupt the assigned value the way it
does an `if`-guarded boolean check.

### Type of Change

- [x] Bug fix

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [x] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [x] Intel Laptop `x86_64`

### Installation Method

- [x] Can be updated with `nixos-rebuild ... switch`

### Test Steps To Verify:

1. `nix build .#checks.x86_64-linux.fss-classifier-unit` -- green.
2. `nix build .#checks.x86_64-linux.pre-commit` -- green.
3. Code review: every `printf | grep -q` site in the touched files replaced
   with an equivalent here-string; no other instance of the pattern remains.
