### PR TITLE
fix(logging): stop a stale clock reading from failing FSS verify

### DIFF
--- a/modules/common/logging/common.nix
+++ b/modules/common/logging/common.nix
@@ -354,10 +354,7 @@ let
         real="$(date +%s)"
         up="$(cut -d' ' -f1 /proc/uptime)"
 
-        drift="$(awk -v r1="$last_real" -v r2="$real" -v u1="$last_up" -v u2="$up" \
-          'BEGIN{print (r2-r1) - (u2-u1)}')"
-
-        abs="$(awk -v d="$drift" 'BEGIN{print (d<0)?-d:d}')"
+        abs="$(fss_clock_drift_abs "$last_real" "$last_up" "$real" "$up")"
 
         raw="$(read_journald_since_cursor)"
         seen_cursor="$(cursor_from_output "$raw")"

--- a/modules/common/logging/fss-verify-classifier.sh
+++ b/modules/common/logging/fss-verify-classifier.sh
@@ -191,6 +191,13 @@ fss_unique_fail_paths_from_output() {
 # Clock-jump and FSS re-key predicates. Pure, so they are testable: see
 # tests/logging/test_scripts/fss-classifier-cases.nix.
 
+# |d(realtime) - d(monotonic)| between two samples, in seconds: the amount the wall
+# clock was set. Shared by the watcher and the setup script's guard.
+fss_clock_drift_abs() {
+  awk -v r1="$1" -v u1="$2" -v r2="$3" -v u2="$4" \
+    'BEGIN{d=(r2-r1)-(u2-u1); print (d<0)?-d:d}'
+}
+
 # Epochs of journald's backward-jump attestations, from --output=short-unix
 # lines on stdin. Excludes the monotonic variant, which does not move realtime
 # and so cannot leave the FSPRG sealing epoch ahead of it.

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -819,6 +819,7 @@ let
       verification_key_diverged_from_sealing_key() {
         local key="$1" active_journal probe_output probe_exit
 
+        FSS_DIVERGED_FUTURE_TAG_US=""
         active_journal="$JOURNAL_DIR/system.journal"
         [ -f "$active_journal" ] || return 1
 
@@ -828,7 +829,10 @@ let
         [ "$probe_exit" -eq 0 ] && return 1
 
         case "''${probe_output,,}" in
-        *"tag failed verification"* | *"bad message"*) return 0 ;;
+        *"tag failed verification"* | *"bad message"*)
+          FSS_DIVERGED_FUTURE_TAG_US=$(fss_max_future_tag_epoch_us "$probe_output")
+          return 0
+          ;;
         *) return 1 ;;
         esac
       }
@@ -1081,7 +1085,8 @@ let
           # re-execs the setup script and does not return.
           recover_from_time_poisoned_sealing "$verify_output" || true
           if [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ] \
-            && verification_key_diverged_from_sealing_key "$verify_key"; then
+            && verification_key_diverged_from_sealing_key "$verify_key" \
+            && [ -z "$FSS_DIVERGED_FUTURE_TAG_US" ]; then
             fss_log fail "FSS verification key does not match the sealing key in use"
             fss_log fail "  verification key: $VERIFY_KEY_FILE"
             fss_log fail "  sealing key:      $FSS_KEY_FILE"
@@ -1090,6 +1095,10 @@ let
             fss_log fail "FSS state is re-provisioned by hand."
             fss_log fail "Recovery discards sealed history: archive and clear the journal,"
             fss_log fail "remove both keys above, then reboot so setup regenerates the pair."
+          elif [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ] && [ -n "$FSS_DIVERGED_FUTURE_TAG_US" ]; then
+            # Sub-margin future tag: recover declined by design and the divergence probe
+            # would misreport it -- same "Bad message" from journalctl.
+            fss_log fail "Active journal has entries older than its sealing tag (epoch starts $(date -u -d "@$(( FSS_DIVERGED_FUTURE_TAG_US / 1000000 ))" +%FT%TZ)); self-heals once this journal rotates"
           else
             fss_log fail "Live active-journal verification failed after FSS activation"
           fi

--- a/modules/common/logging/fss.nix
+++ b/modules/common/logging/fss.nix
@@ -161,6 +161,7 @@ let
       REKEY_HISTORY_FILE="$KEY_DIR/rekey-history"
       PRE_ACTIVATION_MAX_RECEIPTS="${toString cfg.activation.maxReceipts}"
       RECOVERY_MAX_RECEIPTS="${toString config.ghaf.logging.recovery.maxReceipts}"
+      RECOVERY_CLOCK_THRESHOLD_SECONDS="${toString config.ghaf.logging.recovery.thresholdSeconds}"
       UNCLEAN_SHUTDOWN_MAX_RECEIPTS="${toString cfg.uncleanShutdown.maxReceipts}"
       ACTIVATION_FAILED=0
       ACTIVATION_RESTARTED_THIS_RUN=0
@@ -1022,8 +1023,12 @@ let
 
       verify_live_sealing_after_activation() {
         local verify_key verify_output verify_exit marker probe_scope
+        local guard_real1 guard_up1 guard_real2 guard_up2 guard_drift
 
         [ "$ACTIVATION_ENABLED" = 1 ] || return 0
+
+        guard_real1="$(date +%s)"
+        guard_up1="$(cut -d' ' -f1 /proc/uptime)"
 
         if [ "$ACTIVATION_RESTARTED_THIS_RUN" = 1 ]; then
           # Activation boundary, once per boot: verify everything, as before.
@@ -1053,6 +1058,18 @@ let
           verify_output=$(journalctl --verify --verify-key="$verify_key" 2>&1) || verify_exit=$?
         fi
         fss_classify_verify_output "$verify_output"
+
+        # The verify calls take real time; a clock step inside them poisons the verdict.
+        # Defer instead: recover's dependency, the verify timer and the next boot re-check.
+        guard_real2="$(date +%s)"
+        guard_up2="$(cut -d' ' -f1 /proc/uptime)"
+        guard_drift="$(fss_clock_drift_abs "$guard_real1" "$guard_up1" "$guard_real2" "$guard_up2")"
+        if awk -v d="$guard_drift" -v t="$RECOVERY_CLOCK_THRESHOLD_SECONDS" \
+          'BEGIN{t=(t<1)?1:t; exit !(d>=t)}'; then
+          fss_log warn "Clock moved during live sealing verification; deferring this verdict rather than trusting evidence gathered across two clock readings"
+          write_live_probe_state unclean
+          return 0
+        fi
 
         if [ -n "$FSS_ACTIVE_SYSTEM_FAILURES" ] \
           || [ -n "$FSS_OTHER_FAILURES" ] \


### PR DESCRIPTION
## Description of Changes

`verify_live_sealing_after_activation` could commit to a pass/fail verdict using evidence gathered across two different clock readings, since its verify calls take real time -- a clock step mid-verdict produced a false "key pair has diverged" failure. Detects the clock moving mid-verdict and defers instead; safe, since `journal-fss-setup` is reliably re-entrant.

Second commit: a separate, pre-existing bug in the same function -- a future-tagged entry under the re-key margin was misreported as diverged instead of self-healing. Names the sealing tag's epoch instead of guessing at a delta; no security posture change.

- Defer, don't fail: recover's dependency, the verify timer, and the next boot all re-check anyway.
- Threshold clamped to >=1s: 0 is a valid watcher tuning that would otherwise fire on every call.
- Second commit's earlier "already past the tag" branch was dropped -- confirmed unreachable via any real code path.

No public interface changes.

Companion to https://github.com/tiiuae/ghaf/pull/2248; recommended to merge with or before it.

### Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Update
- [ ] Improvement / Refactor
- [ ] Documentation
- [ ] Infrastructure / CI/CD

## Related Issues / Tickets

ghaf#2092

## Checklist

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md) followed
- [ ] Ghaf documentation updated with the commit
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets

- [ ] Orin AGX `aarch64`
- [ ] Orin NX `aarch64`
- [x] Intel Laptop `x86_64`
- [ ] Intel Laptop (low mem) `x86_64`

### Installation Method

- [ ] Requires full re-installation
- [x] Can be updated with `nixos-rebuild ... switch`
- [ ] Other:

### Test Steps To Verify:

1. Reproduce the same round-trip as ghaf#2092.
2. Confirm a deferred-verdict log line instead of a false divergence failure.
3. A round-trip test run confirmed the guard firing correctly on real hardware.
4. Combined campaign: zero false divergence across 5 clock-correction cycles.

**HW-verified:** on dell-7330 (A2/B2/B3 images, 2026-09-12/13); evidence available on request.

**Merge order:** merges cleanly onto the current heads of #2239/#2245/#2246; no shared hunks. Recommend #2246 alongside.
